### PR TITLE
Dockerize rethinkdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Action is a Node.js application based upon the
 $ git clone https://github.com/ParabolInc/action.git
 $ cd action
 $ cp packages/server/.env.example packages/server/.env # Add your own vars here
-$ rethinkdb &
+$ rethinkdb & # Or if you prefer docker: $ docker-compose up -d db
 $ yarn
 $ yarn quickstart
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+
+services:
+  db:
+    image: rethinkdb:latest
+    ports:
+      - '8080:8080'
+      - '29015:29015'
+      - '28015:28015'


### PR DESCRIPTION
Some people (✋) prefer to run db services in isolated containers to avoid "polluting" their system.

This PR:
- adds a simple `docker-compose.yml` file with `db` (rethinkdb) service 
- adds a comment to README.md with an alternative to run rethinkdb inside a docker container