### PR TITLE
Fix #3582 timebox to deadline label

### DIFF
--- a/packages/client/components/StageTimerControl.tsx
+++ b/packages/client/components/StageTimerControl.tsx
@@ -7,7 +7,7 @@ import useMenu from '../hooks/useMenu'
 import {MenuPosition} from '../hooks/useCoords'
 import lazyPreload from '../utils/lazyPreload'
 import styled from '@emotion/styled'
-import {ElementWidth} from '../types/constEnums'
+import {ElementWidth, MeetingLabels} from '../types/constEnums'
 import {StageTimerControl_meeting} from '__generated__/StageTimerControl_meeting.graphql'
 
 interface Props {
@@ -35,6 +35,7 @@ const StageTimerControl = (props: Props) => {
   const connectedMemberCount = meetingMembers.filter((member) => member.user.isConnected).length
   const color = scheduledEndTime ? 'green' : 'midGray'
   const icon = isAsync ? 'event' : 'timer'
+  const label = isAsync ? MeetingLabels.DEADLINE : MeetingLabels.TIMER
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu<HTMLDivElement>(
     MenuPosition.LOWER_LEFT,
     {
@@ -46,7 +47,7 @@ const StageTimerControl = (props: Props) => {
   return (
     <>
       <TimerButton onMouseEnter={StageTimerModal.preload} onClick={togglePortal}>
-        <IconLabel ref={originRef} icon={icon} iconColor={color} label={'Timer'} />
+        <IconLabel ref={originRef} icon={icon} iconColor={color} label={label} />
       </TimerButton>
       {menuPortal(
         <StageTimerModal

--- a/packages/client/components/StageTimerControl.tsx
+++ b/packages/client/components/StageTimerControl.tsx
@@ -35,7 +35,7 @@ const StageTimerControl = (props: Props) => {
   const connectedMemberCount = meetingMembers.filter((member) => member.user.isConnected).length
   const color = scheduledEndTime ? 'green' : 'midGray'
   const icon = isAsync ? 'event' : 'timer'
-  const label = isAsync ? MeetingLabels.DEADLINE : MeetingLabels.TIMER
+  const label = isAsync ? MeetingLabels.TIME_LIMIT : MeetingLabels.TIMER
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu<HTMLDivElement>(
     MenuPosition.LOWER_LEFT,
     {

--- a/packages/client/components/StageTimerModalEditTimeEnd.tsx
+++ b/packages/client/components/StageTimerModalEditTimeEnd.tsx
@@ -63,7 +63,7 @@ const StageTimerModalEditTimeEnd = (props: Props) => {
     <Modal>
       <EndTimer onClick={endTimer}>
         <StyledIcon>stop</StyledIcon>
-        <Label>End {MeetingLabels.DEADLINE}</Label>
+        <Label>End {MeetingLabels.TIME_LIMIT}</Label>
       </EndTimer>
       <HR />
       <StageTimerModalEndTime

--- a/packages/client/components/StageTimerModalEditTimeEnd.tsx
+++ b/packages/client/components/StageTimerModalEditTimeEnd.tsx
@@ -12,6 +12,7 @@ import MenuItemHR from './MenuItemHR'
 import StageTimerModalEndTime from './StageTimerModalEndTime'
 import {StageTimerModalEditTimeEnd_facilitator} from '../__generated__/StageTimerModalEditTimeEnd_facilitator.graphql'
 import {PALETTE} from '../styles/paletteV2'
+import {MeetingLabels} from '../types/constEnums'
 
 interface Props {
   closePortal: () => void
@@ -62,7 +63,7 @@ const StageTimerModalEditTimeEnd = (props: Props) => {
     <Modal>
       <EndTimer onClick={endTimer}>
         <StyledIcon>stop</StyledIcon>
-        <Label>End Timebox</Label>
+        <Label>End {MeetingLabels.DEADLINE}</Label>
       </EndTimer>
       <HR />
       <StageTimerModalEndTime

--- a/packages/client/components/StageTimerModalEditTimeLimit.tsx
+++ b/packages/client/components/StageTimerModalEditTimeLimit.tsx
@@ -11,6 +11,7 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import MenuItemHR from './MenuItemHR'
 import {PALETTE} from '../styles/paletteV2'
+import {MeetingLabels} from '../types/constEnums'
 
 interface Props {
   meetingId: string
@@ -60,7 +61,7 @@ const StageTimerModalEditTimeLimit = (props: Props) => {
     <Modal>
       <EndTimer onClick={endTimer}>
         <StyledIcon>timer_off</StyledIcon>
-        <Label>End Timer</Label>
+        <Label>End {MeetingLabels.TIMER}</Label>
       </EndTimer>
       <HR />
       <StageTimerModalTimeLimit

--- a/packages/client/components/StageTimerModalEndTime.tsx
+++ b/packages/client/components/StageTimerModalEndTime.tsx
@@ -89,7 +89,7 @@ const StageTimerModalEndTime = (props: Props) => {
       <ErrorMessage error={error} />
       <StyledButton onClick={startTimer}>
         {scheduledEndTime ? 'Update ' : 'Start '}
-        {MeetingLabels.DEADLINE}
+        {MeetingLabels.TIME_LIMIT}
       </StyledButton>
     </SetLimit>
   )

--- a/packages/client/components/StageTimerModalEndTime.tsx
+++ b/packages/client/components/StageTimerModalEndTime.tsx
@@ -15,6 +15,7 @@ import StageTimerModalEndTimeHour from './StageTimerModalEndTimeHour'
 import StageTimerModalEndTimeSlackToggle from './StageTimerModalEndTimeSlackToggle'
 import {StageTimerModalEndTime_facilitator} from '../__generated__/StageTimerModalEndTime_facilitator.graphql'
 import NotificationErrorMessage from '../modules/notifications/components/NotificationErrorMessage'
+import {MeetingLabels} from '../types/constEnums'
 
 interface Props {
   closePortal: () => void
@@ -87,7 +88,8 @@ const StageTimerModalEndTime = (props: Props) => {
       </Row>
       <ErrorMessage error={error} />
       <StyledButton onClick={startTimer}>
-        {scheduledEndTime ? 'Update Timebox' : 'Start Timebox'}
+        {scheduledEndTime ? 'Update ' : 'Start '}
+        {MeetingLabels.DEADLINE}
       </StyledButton>
     </SetLimit>
   )

--- a/packages/client/components/StageTimerModalTimeLimit.tsx
+++ b/packages/client/components/StageTimerModalTimeLimit.tsx
@@ -16,6 +16,7 @@ import useMutationProps from '../hooks/useMutationProps'
 import StyledError from './StyledError'
 import Icon from './Icon'
 import {PALETTE} from '../styles/paletteV2'
+import {MeetingLabels} from '../types/constEnums'
 
 interface Props {
   closePortal: () => void
@@ -104,7 +105,7 @@ const StageTimerModalTimeLimit = (props: Props) => {
         />
       )}
       <StyledButton onClick={startTimer}>
-        {scheduledEndTime ? 'Add Time' : 'Start Timer'}
+        {scheduledEndTime ? 'Add Time' : `Start ${MeetingLabels.TIMER}`}
       </StyledButton>
       {error && <StyledError>{error}</StyledError>}
     </SetLimit>

--- a/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationRow.tsx
@@ -9,6 +9,7 @@ import useMutationProps from '../../../../hooks/useMutationProps'
 import SetSlackNotificationMutation from '../../../../mutations/SetSlackNotificationMutation'
 import StyledError from '../../../../components/StyledError'
 import {SlackNotificationEventEnum} from '../../../../types/graphql'
+import {MeetingLabels} from '../../../../types/constEnums'
 
 interface Props {
   event: SlackNotificationEventEnum
@@ -20,8 +21,8 @@ interface Props {
 const labelLookup = {
   [SlackNotificationEventEnum.meetingEnd]: 'Meeting End',
   [SlackNotificationEventEnum.meetingStart]: 'Meeting Start',
-  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_END]: 'Meeting Time Limit Ended',
-  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_START]: 'Meeting Time Limit Started'
+  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_END]: `Meeting ${MeetingLabels.DEADLINE} Ended`,
+  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_START]: `Meeting ${MeetingLabels.DEADLINE} Started`
 }
 
 const Row = styled('div')({

--- a/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationRow.tsx
@@ -21,8 +21,8 @@ interface Props {
 const labelLookup = {
   [SlackNotificationEventEnum.meetingEnd]: 'Meeting End',
   [SlackNotificationEventEnum.meetingStart]: 'Meeting Start',
-  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_END]: `Meeting ${MeetingLabels.DEADLINE} Ended`,
-  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_START]: `Meeting ${MeetingLabels.DEADLINE} Started`
+  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_END]: `Meeting ${MeetingLabels.TIME_LIMIT} Ended`,
+  [SlackNotificationEventEnum.MEETING_STAGE_TIME_LIMIT_START]: `Meeting ${MeetingLabels.TIME_LIMIT} Started`
 }
 
 const Row = styled('div')({

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -149,6 +149,11 @@ export const enum MathEnum {
   MAX_INT = 2147483647
 }
 
+export const enum MeetingLabels {
+  DEADLINE = 'Deadline',
+  TIMER = 'Timer'
+}
+
 export const enum MeetingSettingsDefaults {
   RETROSPECTIVE_TOTAL_VOTES = 5,
   RETROSPECTIVE_MAX_VOTES_PER_GROUP = 3

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -150,7 +150,7 @@ export const enum MathEnum {
 }
 
 export const enum MeetingLabels {
-  DEADLINE = 'Deadline',
+  TIME_LIMIT = 'Time Limit',
   TIMER = 'Timer'
 }
 

--- a/packages/server/graphql/mutations/setStageTimer.ts
+++ b/packages/server/graphql/mutations/setStageTimer.ts
@@ -11,7 +11,7 @@ import ScheduledJobMeetingStageTimeLimit from '../../database/types/ScheduledJob
 import removeScheduledJobs from './helpers/removeScheduledJobs'
 import {notifySlackTimeLimitStart} from './helpers/notifySlack'
 import sendSegmentEvent from '../../utils/sendSegmentEvent'
-import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import {MeetingLabels, SubscriptionChannel} from 'parabol-client/types/constEnums'
 
 const BAD_CLOCK_THRESH = 2000
 const AVG_PING = 150
@@ -125,9 +125,13 @@ export default {
       timeRemaining,
       viewCount
     }
-    const stoppedOrStarted = newScheduledEndTime ? 'Meeting Timer Started' : 'Meeting Timer Stopped'
+    const stoppedOrStarted = newScheduledEndTime
+      ? `Meeting ${MeetingLabels.TIMER} Started`
+      : `Meeting ${MeetingLabels.TIMER} Stopped`
     const eventName =
-      scheduledEndTime && newScheduledEndTime ? 'Meeting Timer Updated' : stoppedOrStarted
+      scheduledEndTime && newScheduledEndTime
+        ? `Meeting ${MeetingLabels.TIMER} Updated`
+        : stoppedOrStarted
     publish(SubscriptionChannel.MEETING, meetingId, 'SetStageTimerPayload', data, subOptions)
     sendSegmentEvent(eventName, viewerId, segmentOptions).catch()
     return data


### PR DESCRIPTION
Fixes #3582

### Tests
- [x] The label “Timebox” changed to “Time Limit” in the bottom bar control and menu
- [x] We now use constants everywhere for “Timer” and “Time Limit”
- [x] The “Meeting Timer Started” event name did not change; it shouldn’t break metrics in Amplitude

### Note
- The deadline notification is not being pushed to Slack, see issue #3619. We can fix that here or defer for backlog ranking.