### PR TITLE
Fix #3056 action to check-in

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,7 +17,7 @@
 - **Node version:** `node --version`
 - **NPM version:** `npm --version`
 - **RethinkDB version:** `rethinkdb --version`
-- **Estimated effort:** X points ([see CONTRIBUTING.md](https://github.com/ParabolInc/action/blob/master/CONTRIBUTING.md#points-and-sizes))
+- **Estimated effort:** X points ([see CONTRIBUTING.md](https://github.com/ParabolInc/parabol/blob/master/CONTRIBUTING.md#points-and-sizes))
 
 ### Acceptance Criteria (optional)
 Users can:
@@ -35,4 +35,4 @@ Users can:
    - Do that
    - Cannot do that
 
-- **Estimated effort:** X points ([see CONTRIBUTING.md](https://github.com/ParabolInc/action/blob/master/CONTRIBUTING.md#points-and-sizes))
+- **Estimated effort:** X points ([see CONTRIBUTING.md](https://github.com/ParabolInc/parabol/blob/master/CONTRIBUTING.md#points-and-sizes))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ how it works:
    one of the project maintainers, we’ll tally up the points for your work.
 
 2. We’ll add a row to the
-   [Parabol Action Contributors Scoreboard](https://docs.google.com/spreadsheets/d/1V1KZJn6oKFsqrYwqr430rO3hkIkekSY7oYFzX3cVty4).
+   [Parabol Contributors Scoreboard](https://docs.google.com/spreadsheets/d/1V1KZJn6oKFsqrYwqr430rO3hkIkekSY7oYFzX3cVty4).
    If you’re working as a team, we’ll divide the points among you equally
    unless your team has requested an alternate distribution in the issue
    comments.
@@ -67,7 +67,7 @@ how it works:
 ## Points and sizes
 
 Before you begin working on an issue, you size it. Most issues will have a
-*SWAG* sizing from one of the Action maintainers, but it’s up to you to
+*SWAG* sizing from one of the Parabol maintainers, but it’s up to you to
 adjust it to what you think is fair.
 
 |  Points  | Individual *or* team effort required |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ To get started, simply follow these steps:
 
    1. **Find a project:** review the projects listed under the
    “Help Requested” list on the
-   [Equity For Effort Projects Board](https://github.com/ParabolInc/action/projects/1)
+   [Equity For Effort Projects Board](https://github.com/ParabolInc/parabol/projects/1)
    and select one you're interested in working on.
 
    2. **Bid on it:** leave a comment on the project saying how many points
@@ -48,7 +48,7 @@ how it works:
 
 1. When we've verified your eligibility to participate within the E4E program
    and you've had an issue is merged into the
-   [Parabol Inc Action Repository](https://github.com/ParabolInc/action) by
+   [Parabol Inc Repository](https://github.com/ParabolInc/parabol) by
    one of the project maintainers, we’ll tally up the points for your work.
 
 2. We’ll add a row to the

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Action
 
 [![Slack Status](http://slackin.parabol.co/badge.svg)](http://slackin.parabol.co/)
-[![CircleCI](https://circleci.com/gh/ParabolInc/action.svg?style=svg)](https://circleci.com/gh/ParabolInc/action)
-[![codecov](https://codecov.io/gh/ParabolInc/action/branch/master/graph/badge.svg)](https://codecov.io/gh/ParabolInc/action)
+[![CircleCI](https://circleci.com/gh/ParabolInc/parabol.svg?style=svg)](https://circleci.com/gh/ParabolInc/parabol)
+[![codecov](https://codecov.io/gh/ParabolInc/parabol/branch/master/graph/badge.svg)](https://codecov.io/gh/ParabolInc/parabol)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
-[![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/parabol-inc/action)
+[![StackShare](https://img.shields.io/badge/tech-stack-0690fa.svg?style=flat)](https://stackshare.io/parabol-inc/parabol-multiplayer-web-app)
 
 ## Overview
 
@@ -58,11 +58,11 @@ Action is a Node.js application based upon the
  - Redis
  - yarn
  - watchman (for Relay)
- 
+
 #### Source code
 
 ```bash
-$ git clone https://github.com/ParabolInc/action.git
+$ git clone https://github.com/ParabolInc/parabol.git
 $ cd action
 $ cp packages/server/.env.example packages/server/.env # Add your own vars here
 $ rethinkdb &
@@ -72,7 +72,7 @@ $ yarn quickstart
 _Remember: if RethinkDB is running locally, you can reach its dashboard at
 [http://localhost:8080](http://localhost:8080) by default._
 
-### Development 
+### Development
 ```bash
 $ yarn dev
 ```
@@ -111,7 +111,7 @@ Authored and maintained by [Parabol](http://parabol.co).
 ### License
 
 Copyright (c) 2016-present, Parabol, Inc.
- 
+
 This codebase is dual-licensed under the GNU AFFERO GENERAL PUBLIC LICENSE,
 Version 3.0 while holding, at Parabol's sole discretion, the right to create
 new licenses. For details please read [LICENSE](LICENSE).

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "action",
   "description": "An open-source app for building smarter, more agile teams.",
-  "repository": "https://github.com/ParabolInc/action",
+  "repository": "https://github.com/ParabolInc/parabol",
   "scripts": {
     "dokku": {
       "predeploy": "yarn workspace parabol-server db:migrate",

--- a/docs/developmentTips.md
+++ b/docs/developmentTips.md
@@ -5,6 +5,6 @@
 
 To ignore the persisted state (i.e. don't auto-login), comment out this line:
 
-https://github.com/ParabolInc/action/blob/210489c7a50d5f4476e0ce626f0a72d2ed213da6/src/client/makeStore.js#L51
+https://github.com/ParabolInc/parabol/blob/210489c7a50d5f4476e0ce626f0a72d2ed213da6/src/client/makeStore.js#L51
 
 It's the equivalent of being cookie-free.

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "version": "4.23.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParabolInc/action"
+    "url": "https://github.com/ParabolInc/parabol"
   },
-  "homepage": "https://github.com/ParabolInc/action",
+  "homepage": "https://github.com/ParabolInc/parabol",
   "bugs": {
-    "url": "https://github.com/ParabolInc/action/issues"
+    "url": "https://github.com/ParabolInc/parabol/issues"
   },
   "engines": {
     "node": "^13.6.0",

--- a/packages/client/components/ActionMeetingLastCall.tsx
+++ b/packages/client/components/ActionMeetingLastCall.tsx
@@ -107,7 +107,7 @@ const ActionMeetingLastCall = (props: Props) => {
               onClick={endMeeting}
               disabled={!!endedAt}
             >
-              End Action Meeting
+              End Check-in Meeting
             </PrimaryButton>
           ) : (
             <MeetingFacilitationHint>

--- a/packages/client/components/MeetingHelp/ActionMeetingLobbyHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/ActionMeetingLobbyHelpMenu.tsx
@@ -13,10 +13,10 @@ const ActionMeetingLobbyHelpMenu = forwardRef((_props: Props, ref: any) => {
   useSegmentTrack(SegmentClientEventEnum.HelpMenuOpen, {phase: NewMeetingPhaseTypeEnum.lobby})
   return (
     <HelpMenuContent closePortal={closePortal}>
-      <HelpMenuCopy>{'To learn more about how to run an Action Meeting, see our '}</HelpMenuCopy>
+      <HelpMenuCopy>{'To learn more about how to run a Check-in Meeting, see our '}</HelpMenuCopy>
       <div>
         <HelpMenuLink copy='Getting Started Guide' href={ExternalLinks.GETTING_STARTED_ACTION} />
-        {' for running an Action Meeting.'}
+        {' for running a Check-in Meeting.'}
       </div>
     </HelpMenuContent>
   )

--- a/packages/client/components/MeetingHelp/CheckInHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/CheckInHelpMenu.tsx
@@ -28,7 +28,7 @@ const CheckInHelpMenu = forwardRef((props: Props, ref: any) => {
       <HelpMenuHeader>{phaseLabelLookup[CHECKIN]}</HelpMenuHeader>
       <HelpMenuCopy>
         {
-          'The Social Check-In is an opportunity to quickly share some personal context with your team.'
+          'The Social Check-in is an opportunity to quickly share some personal context with your team.'
         }
       </HelpMenuCopy>
       <HelpMenuCopy>

--- a/packages/client/components/MeetingHelp/DemoDiscussHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/DemoDiscussHelpMenu.tsx
@@ -19,7 +19,7 @@ const DemoDiscussHelpMenu = forwardRef((_props: Props, ref: any) => {
         Take action by assigning next steps.
       </DelayedCopy>
       <DelayedCopy show={permShow} thresh={2}>
-        Track task progress with our Action meeting. (It’s Free!)
+        Track task progress with our Check-in meeting. (It’s Free!)
       </DelayedCopy>
       <DelayedCopy show={permShow} thresh={3} margin={'0'}>
         When you’re ready, end the demo to see the summary.

--- a/packages/client/components/MeetingPhaseWrapper.tsx
+++ b/packages/client/components/MeetingPhaseWrapper.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 const MeetingPhaseWrapper = styled('div')({
   display: 'flex',
   justifyContent: 'space-around',
-  // https://github.com/ParabolInc/action/issues/3525
+  // https://github.com/ParabolInc/parabol/issues/3525
   overflow: 'hidden',
   height: '100%',
   margin: '0 auto',

--- a/packages/client/components/NewMeetingHowToSteps.tsx
+++ b/packages/client/components/NewMeetingHowToSteps.tsx
@@ -29,7 +29,7 @@ const LINKS = {
 
 const TITLES = {
   [MeetingTypeEnum.retrospective]: 'How to Run a Retro Meeting',
-  [MeetingTypeEnum.action]: 'How to Run an Action Meeting'
+  [MeetingTypeEnum.action]: 'How to Run a Check-in Meeting'
 }
 
 const LearnMoreLink = styled(LinkButton)({

--- a/packages/client/components/NewMeetingMeetingSelector.tsx
+++ b/packages/client/components/NewMeetingMeetingSelector.tsx
@@ -38,7 +38,7 @@ const MeetingTitle = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
 
 const TITLES = {
   [MeetingTypeEnum.retrospective]: 'Retro Meeting',
-  [MeetingTypeEnum.action]: 'Action Meeting'
+  [MeetingTypeEnum.action]: 'Check-in Meeting'
 }
 
 const NewMeetingMeetingSelector = (props: Props) => {

--- a/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
@@ -61,7 +61,7 @@ const NewMeetingSettingsToggleCheckIn = (props: Props) => {
   return (
     <ButtonRow onClick={toggleCheckIn}>
       <StyledCheckbox active={hasCheckIn} />
-      <Label>{'Include Social Check-In Phase'}</Label>
+      <Label>{'Include Social Check-in Phase'}</Label>
     </ButtonRow>
   )
 }

--- a/packages/client/components/SuggestedActionTryActionMeeting.tsx
+++ b/packages/client/components/SuggestedActionTryActionMeeting.tsx
@@ -30,8 +30,8 @@ class SuggestedActionTryActionMeeting extends Component<Props> {
         iconName='change_history'
         suggestedActionId={suggestedActionId}
       >
-        <SuggestedActionCopy>Hold your first Action Meeting with {teamName}</SuggestedActionCopy>
-        <SuggestedActionButton onClick={this.onClick}>Start Action Meeting</SuggestedActionButton>
+        <SuggestedActionCopy>Hold your first Check-in Meeting with {teamName}</SuggestedActionCopy>
+        <SuggestedActionButton onClick={this.onClick}>Start Check-in Meeting</SuggestedActionButton>
       </SuggestedActionCard>
     )
   }

--- a/packages/client/components/TaskFooterIntegrateMenu.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenu.tsx
@@ -27,7 +27,7 @@ const TaskFooterIntegrateMenu = (props: Props) => {
   const {menuProps, mutationProps, task, viewer} = props
   const {id: viewerId, userOnTeam} = viewer
   // not 100% sure how this could be, maybe if we manually deleted a user?
-  // https://github.com/ParabolInc/action/issues/2980
+  // https://github.com/ParabolInc/parabol/issues/2980
   if (!userOnTeam) return null
   const {atlassianAuth, githubAuth, preferredName, suggestedIntegrations} = userOnTeam
   const {teamId, userId} = task

--- a/packages/client/components/TaskIntegrationLink.tsx
+++ b/packages/client/components/TaskIntegrationLink.tsx
@@ -47,7 +47,7 @@ const TaskIntegrationLink = (props: Props) => {
     const {nameWithOwner, issueNumber} = integration
     const href =
       nameWithOwner === 'ParabolInc/ParabolDemo'
-        ? 'https://github.com/ParabolInc/action'
+        ? 'https://github.com/ParabolInc/parabol'
         : `https://www.github.com/${nameWithOwner}/issues/${issueNumber}`
     return (
       <StyledLink

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ContactUsFooter.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ContactUsFooter.tsx
@@ -61,7 +61,7 @@ const ContactUsFooter = (props: Props) => {
               rel='noopener noreferrer'
               style={linkStyle}
               target='_blank'
-              title='How to Navigate Uncertainty using the Action Rhythm'
+              title='Navigate uncertainty with the Parabol Rhythm'
             >
               Learn More
             </a>

--- a/packages/client/modules/email/containers/TeamInvite/TeamInvite.tsx
+++ b/packages/client/modules/email/containers/TeamInvite/TeamInvite.tsx
@@ -49,7 +49,7 @@ const TeamInvite = (props) => {
   )
   const nameOrEmail = inviteeName || inviteeEmailBlock
   const meetingCopyLabelLookup = {
-    action: 'an Action Meeting',
+    action: 'a Check-in Meeting',
     retrospective: 'a Retrospective Meeting'
   }
   return (
@@ -125,9 +125,9 @@ const TeamInvite = (props) => {
           <a
             href='https://www.parabol.co/getting-started-guide/action-meetings-101'
             style={emailLinkStyle}
-            title='Leveling Up: Action 101'
+            title='Leveling Up: Check-in 101'
           >
-            {'Leveling Up: Action 101'}
+            {'Leveling Up: Check-in 101'}
           </a>
         </p>
         <p style={emailCopyStyle}>

--- a/packages/client/mutations/PromoteNewMeetingFacilitatorMutation.ts
+++ b/packages/client/mutations/PromoteNewMeetingFacilitatorMutation.ts
@@ -10,7 +10,7 @@ graphql`
       defaultFacilitatorUserId
       facilitatorUserId
       facilitator {
-        # https://github.com/ParabolInc/action/issues/2984
+        # https://github.com/ParabolInc/parabol/issues/2984
         ...StageTimerModalEndTimeSlackToggle_facilitator
         userId
         preferredName

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,11 +6,11 @@
   "version": "4.23.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParabolInc/action"
+    "url": "https://github.com/ParabolInc/parabol"
   },
-  "homepage": "https://github.com/ParabolInc/action",
+  "homepage": "https://github.com/ParabolInc/parabol",
   "bugs": {
-    "url": "https://github.com/ParabolInc/action/issues"
+    "url": "https://github.com/ParabolInc/parabol/issues"
   },
   "scripts": {
     "storybook": "start-storybook -p 6006 -c .storybook",

--- a/packages/client/stories/Elevation.stories.js
+++ b/packages/client/stories/Elevation.stories.js
@@ -59,7 +59,7 @@ const RenderBlock = () => (
       <br />
       {makeLink(
         'See our custom elevation values for common UI components',
-        'https://github.com/ParabolInc/action/blob/master/src/universal/styles/elevation.js'
+        'https://github.com/ParabolInc/parabol/blob/master/src/universal/styles/elevation.js'
       )}
       <br />
       {makeLink(

--- a/packages/client/stories/MeetingComponents.stories.js
+++ b/packages/client/stories/MeetingComponents.stories.js
@@ -38,7 +38,7 @@ storiesOf('Meeting Components', module)
       />
     </RetroBackground>
   ))
-  .add('Action Agenda Heading', () => (
+  .add('Check-in Agenda Heading', () => (
     <RetroBackground>
       <StoryContainer
         render={() => (

--- a/packages/client/stories/MeetingComponents.stories.js
+++ b/packages/client/stories/MeetingComponents.stories.js
@@ -12,13 +12,13 @@ import StoryContainer from './components/StoryContainer'
 import LabelHeading from '../components/LabelHeading/LabelHeading'
 
 storiesOf('Meeting Components', module)
-  .add('Social Check-In Heading', () => (
+  .add('Social Check-in Heading', () => (
     <RetroBackground>
       <StoryContainer
         render={() => (
           <div>
-            <LabelHeading>{'Social Check-In'}</LabelHeading>
-            <MeetingPhaseHeading>{'Terry’s Check-In'}</MeetingPhaseHeading>
+            <LabelHeading>{'Social Check-in'}</LabelHeading>
+            <MeetingPhaseHeading>{'Terry’s Check-in'}</MeetingPhaseHeading>
             <MeetingCopy margin='0'>{'Terry, share your response to today’s prompt.'}</MeetingCopy>
           </div>
         )}

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -10,7 +10,7 @@ export const APP_NAME = 'Action'
 export const APP_WEBPACK_PUBLIC_PATH_DEFAULT = '/static/'
 
 /* Meeting Misc. */
-export const MEETING_NAME = 'Action Meeting'
+export const MEETING_NAME = 'Check-in Meeting'
 export const MEETING_SUMMARY_LABEL = 'Summary'
 export const AGENDA_ITEM_LABEL = 'Agenda Topic'
 export const RETRO_TOPIC_LABEL = 'Topic'
@@ -93,7 +93,7 @@ export const FAILED = 'FAILED'
 /* character limits */
 export const TASK_MAX_CHARS = 51200
 
-/* Action Tags */
+/* Task tags */
 export const tags = [
   {
     name: 'private',

--- a/packages/client/utils/meetings/lookups.ts
+++ b/packages/client/utils/meetings/lookups.ts
@@ -16,7 +16,7 @@ import {
 
 /* These are the labels show to the viewer */
 export const phaseLabelLookup = {
-  [CHECKIN]: 'Social Check-In',
+  [CHECKIN]: 'Social Check-in',
   [REFLECT]: 'Reflect',
   [GROUP]: 'Group',
   [VOTE]: 'Vote',

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -6,11 +6,11 @@
   "version": "4.23.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParabolInc/action"
+    "url": "https://github.com/ParabolInc/parabol"
   },
-  "homepage": "https://github.com/ParabolInc/action",
+  "homepage": "https://github.com/ParabolInc/parabol",
   "bugs": {
-    "url": "https://github.com/ParabolInc/action/issues"
+    "url": "https://github.com/ParabolInc/parabol/issues"
   },
   "main": "index.js",
   "scripts": {

--- a/packages/server/ICSHandler.ts
+++ b/packages/server/ICSHandler.ts
@@ -9,7 +9,7 @@ const ICSHandler = (res: HttpResponse, req: HttpRequest) => {
   const icsText = createICS(startDate, meetingUrl, teamName)
   res
     .writeHeader('content-type', 'text/calendar')
-    .writeHeader('content-disposition', 'attachment; filename=Parabol Action Meeting.ics')
+    .writeHeader('content-disposition', 'attachment; filename=Parabol Check-in Meeting.ics')
     .end(icsText)
 }
 

--- a/packages/server/database/migrations/20191111140628-meetingNames.ts
+++ b/packages/server/database/migrations/20191111140628-meetingNames.ts
@@ -7,7 +7,7 @@ export const up = async function(r: R) {
       name: r.branch(
         row('meetingType').eq('retrospective'),
         r('Retro #').add(row('meetingNumber').coerceTo('string')),
-        r('Check-in meeting #').add(row('meetingNumber').coerceTo('string'))
+        r('Action meeting #').add(row('meetingNumber').coerceTo('string'))
       )
     }))
     .run()

--- a/packages/server/database/migrations/20191111140628-meetingNames.ts
+++ b/packages/server/database/migrations/20191111140628-meetingNames.ts
@@ -7,7 +7,7 @@ export const up = async function(r: R) {
       name: r.branch(
         row('meetingType').eq('retrospective'),
         r('Retro #').add(row('meetingNumber').coerceTo('string')),
-        r('Action meeting #').add(row('meetingNumber').coerceTo('string'))
+        r('Check-in meeting #').add(row('meetingNumber').coerceTo('string'))
       )
     }))
     .run()

--- a/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
+++ b/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
@@ -4,13 +4,10 @@ export const up = async function(r: R) {
   try {
     await r
       .table('NewMeeting')
-      .filter((meeting) => meeting('name').match('Action meeting'))
-      .update(
-        (meeting) => ({
-          name: r.js(`${meeting}("name").replace("Action meeting", "Check-in")`)
-        }),
-        {nonAtomic: true}
-      )
+      .filter((meeting) => meeting('name').match('Action meeting #'))
+      .update((row) => ({
+        name: r('Check-in #').add(row('meetingNumber').coerceTo('string'))
+      }))
       .run()
   } catch (e) {
     console.log(e)
@@ -21,13 +18,10 @@ export const down = async function(r: R) {
   try {
     await r
       .table('NewMeeting')
-      .filter((meeting) => meeting('name').match('Check-in'))
-      .update(
-        (meeting) => ({
-          name: r.js(`${meeting}("name").replace("Check-in", "Action meeting")`)
-        }),
-        {nonAtomic: true}
-      )
+      .filter((meeting) => meeting('name').match('Check-in #'))
+      .update((row) => ({
+        name: r('Action meeting #').add(row('meetingNumber').coerceTo('string'))
+      }))
       .run()
   } catch (e) {
     console.log(e)

--- a/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
+++ b/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
@@ -1,23 +1,33 @@
-export const up = function(r) {
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
   try {
     await r
       .table('NewMeeting')
-      .update((meeting) => ({
-        name: r.js(`${meeting}("name").replace("Action meeting", "Check-in")`)
-      }))
+      .filter((meeting) => meeting('name').match('Action meeting'))
+      .update(
+        (meeting) => ({
+          name: r.js(`${meeting}("name").replace("Action meeting", "Check-in")`)
+        }),
+        {nonAtomic: true}
+      )
       .run()
   } catch (e) {
     console.log(e)
   }
 }
 
-export const down = function(r) {
+export const down = async function(r) {
   try {
     await r
       .table('NewMeeting')
-      .update((meeting) => ({
-        name: r.js(`${meeting}("name").replace("Check-in", "Action meeting")`)
-      }))
+      .filter((meeting) => meeting('name').match('Check-in'))
+      .update(
+        (meeting) => ({
+          name: r.js(`${meeting}("name").replace("Check-in", "Action meeting")`)
+        }),
+        {nonAtomic: true}
+      )
       .run()
   } catch (e) {
     console.log(e)

--- a/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
+++ b/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
@@ -17,7 +17,7 @@ export const up = async function(r: R) {
   }
 }
 
-export const down = async function(r) {
+export const down = async function(r: R) {
   try {
     await r
       .table('NewMeeting')

--- a/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
+++ b/packages/server/database/migrations/20200303123942-actionToCheckIn.ts
@@ -1,0 +1,25 @@
+export const up = function(r) {
+  try {
+    await r
+      .table('NewMeeting')
+      .update((meeting) => ({
+        name: r.js(`${meeting}("name").replace("Action meeting", "Check-in")`)
+      }))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = function(r) {
+  try {
+    await r
+      .table('NewMeeting')
+      .update((meeting) => ({
+        name: r.js(`${meeting}("name").replace("Check-in", "Action meeting")`)
+      }))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/types/Meeting.ts
+++ b/packages/server/database/types/Meeting.ts
@@ -13,7 +13,7 @@ interface Input {
 }
 
 const namePrefix = {
-  [MeetingTypeEnum.action]: 'Check-in meeting',
+  [MeetingTypeEnum.action]: 'Check-in',
   [MeetingTypeEnum.retrospective]: 'Retro'
 }
 // export type MeetingTypeEnum = 'action' | 'retrospective'

--- a/packages/server/database/types/Meeting.ts
+++ b/packages/server/database/types/Meeting.ts
@@ -13,7 +13,7 @@ interface Input {
 }
 
 const namePrefix = {
-  [MeetingTypeEnum.action]: 'Action meeting',
+  [MeetingTypeEnum.action]: 'Check-in meeting',
   [MeetingTypeEnum.retrospective]: 'Retro'
 }
 // export type MeetingTypeEnum = 'action' | 'retrospective'

--- a/packages/server/database/types/MeetingAction.ts
+++ b/packages/server/database/types/MeetingAction.ts
@@ -20,7 +20,7 @@ export default class MeetingAction extends Meeting {
       phases,
       facilitatorUserId,
       meetingType: MeetingTypeEnum.action,
-      name: name ?? `Action meeting #${meetingCount + 1}`
+      name: name ?? `Check-in meeting #${meetingCount + 1}`
     })
   }
 }

--- a/packages/server/database/types/MeetingAction.ts
+++ b/packages/server/database/types/MeetingAction.ts
@@ -20,7 +20,7 @@ export default class MeetingAction extends Meeting {
       phases,
       facilitatorUserId,
       meetingType: MeetingTypeEnum.action,
-      name: name ?? `Check-in meeting #${meetingCount + 1}`
+      name: name ?? `Check-in #${meetingCount + 1}`
     })
   }
 }

--- a/packages/server/graphql/types/NewMeetingPhaseTypeEnum.ts
+++ b/packages/server/graphql/types/NewMeetingPhaseTypeEnum.ts
@@ -20,7 +20,7 @@ const NewMeetingPhaseTypeEnum = new GraphQLEnumType({
     [LOBBY]: {},
     // Generic
     [CHECKIN]: {},
-    // Action
+    // Check-in
     [UPDATES]: {},
     [FIRST_CALL]: {},
     [AGENDA_ITEMS]: {},

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,11 +6,11 @@
   "version": "4.23.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParabolInc/action"
+    "url": "https://github.com/ParabolInc/parabol"
   },
-  "homepage": "https://github.com/ParabolInc/action",
+  "homepage": "https://github.com/ParabolInc/parabol",
   "bugs": {
-    "url": "https://github.com/ParabolInc/action/issues"
+    "url": "https://github.com/ParabolInc/parabol/issues"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=production pm2-runtime start pm2.config.js",


### PR DESCRIPTION
Fixes #3056 

### Tests
- [ ] UI labels are updated
  - Lobby type picker and how-to copy
  - Last call end meeting control
  - Demo and check-in meeting help menus
  - Team invite to an active check-in
  - Links to Check-in 101 webpage
  - Suggested action on timeline
- [ ] Meetings are automatically named `Check-in #123` instead of `Action meeting #123`
  - Meeting sidebar
  - Summary
  - Timeline events
- [ ] Migration updates meeting names in the database (e.g. `Action meeting #123` becomes `Check-in #123`)
- [ ] Updates instances of repo name from `ParabolInc/action` to `ParabolInc/parabol`