### PR TITLE
use canoncial

### DIFF
--- a/packages/client/components/Action/Action.tsx
+++ b/packages/client/components/Action/Action.tsx
@@ -72,8 +72,6 @@ const Action = memo(() => {
             component={VerifyEmail}
           />
           <Route path='/reset-password/:token' component={SetNewPassword} />
-          {/*Legacy route, still referenced by old invite emails*/}
-          <Route path='/invitation/:inviteToken' component={TeamInvitation} />
           <Route path='/team-invitation/:token' component={TeamInvitation} />
           <Route path='/invitation-link/:token' component={InvitationLink} />
           <Route component={PrivateRoutes} />

--- a/packages/client/components/AuthenticationPage.tsx
+++ b/packages/client/components/AuthenticationPage.tsx
@@ -5,6 +5,7 @@ import useRouter from '../hooks/useRouter'
 import getValidRedirectParam from '../utils/getValidRedirectParam'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useDocumentTitle from '../hooks/useDocumentTitle'
+import useCanonical from 'hooks/useCanonical'
 
 interface Props {
   page: AuthPageSlug
@@ -16,6 +17,7 @@ const AuthenticationPage = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {authObj} = atmosphere
   useDocumentTitle('Sign Up for Free Online Retrospectives | Parabol', 'Sign Up')
+  useCanonical(page)
   if (authObj) {
     const nextUrl = getValidRedirectParam() || '/me'
     // always replace otherwise they could get stuck in a back-button loop

--- a/packages/client/components/DemoMeeting.tsx
+++ b/packages/client/components/DemoMeeting.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import AtmosphereProvider from './AtmosphereProvider/AtmosphereProvider'
 import useMetaTagContent from '../hooks/useMetaTagContent'
 import DemoMeetingRoot from './DemoMeetingRoot'
+import useCanonical from 'hooks/useCanonical'
 
 const CONTENT =
   'Parabol offers effective sprint retrospectives for free. Try a 2-minute demo, no account needed. Simulated colleagues illustrate Parabol’s powerful features including multi-user grouping, rich text editing, and gorgeous meeting summaries.'
 
 const DemoMeeting = () => {
   useMetaTagContent(CONTENT)
+  useCanonical('retrospective-demo')
   return (
     <AtmosphereProvider isDemo>
       <DemoMeetingRoot />

--- a/packages/client/components/DemoSummary.tsx
+++ b/packages/client/components/DemoSummary.tsx
@@ -1,18 +1,20 @@
-import React, {Component} from 'react'
-import AtmosphereProvider from './AtmosphereProvider/AtmosphereProvider'
+import useCanonical from 'hooks/useCanonical'
+import React, {useEffect} from 'react'
 import NewMeetingSummaryRoot from '../modules/summary/components/NewMeetingSummaryRoot'
+import AtmosphereProvider from './AtmosphereProvider/AtmosphereProvider'
 
-class DemoSummary extends Component {
-  componentWillUnmount() {
-    window.localStorage.removeItem('retroDemo')
-  }
-  render() {
-    return (
-      <AtmosphereProvider isDemo>
-        <NewMeetingSummaryRoot />
-      </AtmosphereProvider>
-    )
-  }
+const DemoSummary = () => {
+  useCanonical('retrospective-demo-summary')
+  useEffect(() => {
+    return () => {
+      window.localStorage.removeItem('retroDemo')
+    }
+  }, [])
+  return (
+    <AtmosphereProvider isDemo>
+      <NewMeetingSummaryRoot />
+    </AtmosphereProvider>
+  )
 }
 
 export default DemoSummary

--- a/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
+++ b/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
@@ -12,6 +12,7 @@ import useAtmosphere from '../../hooks/useAtmosphere'
 import ErrorAlert from '../ErrorAlert/ErrorAlert'
 import {RouteComponentProps} from 'react-router'
 import TeamInvitationWrapper from '../TeamInvitationWrapper'
+import useCanonical from 'hooks/useCanonical'
 
 interface Props extends RouteComponentProps<{token: string}> {}
 
@@ -49,6 +50,7 @@ const SetNewPassword = (props: Props) => {
   const {params} = match
   const {token} = params
   const atmosphere = useAtmosphere()
+  useCanonical('reset-password')
   const {onCompleted, onError, error, submitting, submitMutation} = useMutationProps()
   const {fields, onChange, setDirtyField, validateField} = useForm({
     password: {

--- a/packages/client/components/VerifyEmail.tsx
+++ b/packages/client/components/VerifyEmail.tsx
@@ -11,6 +11,7 @@ import Ellipsis from './Ellipsis/Ellipsis'
 import InvitationCenteredCopy from './InvitationCenteredCopy'
 import InvitationDialogCopy from './InvitationDialogCopy'
 import InviteDialog from './InviteDialog'
+import useCanonical from 'hooks/useCanonical'
 
 interface Props
   extends RouteComponentProps<{verificationToken: string; invitationToken?: string}> {}
@@ -21,6 +22,7 @@ const VerifyEmail = (props: Props) => {
   const {verificationToken, invitationToken} = params
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, error, submitMutation} = useMutationProps()
+  useCanonical('verify-email')
   useEffect(() => {
     submitMutation()
     VerifyEmailMutation(

--- a/packages/client/hooks/useCanonical.ts
+++ b/packages/client/hooks/useCanonical.ts
@@ -1,0 +1,16 @@
+import {useEffect} from 'react'
+
+const useCanonical = (hint: string) => {
+  useEffect(() => {
+    const {origin} = window.location
+    const link = document.createElement('link')
+    link.rel = 'canonical'
+    link.href = `${origin}/${hint}`
+    document.head.appendChild(link)
+    return () => {
+      document.head.removeChild(link)
+    }
+  }, [hint])
+}
+
+export default useCanonical


### PR DESCRIPTION
fix #3578 

uses a rel=canonical for all public routes. this is useful because some links may point to e.g. /signin?foo=1 and we want the search engine to be sure that it knows /signin is the desired route.