### PR TITLE
Changed README.md and package.json to get a working dev and production environment and added data-cy properties to some components for manipulation in Cypress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ _Remember: if RethinkDB is running locally, you can reach its dashboard at
 
 ### Development 
 ```bash
+$ yarn build:relay
+$ yarn db:migrate
 $ yarn dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $ cd action
 $ cp packages/server/.env.example packages/server/.env # Add your own vars here
 $ rethinkdb &
 $ yarn
+$ yarn postdeploy
 $ yarn quickstart
 ```
 _Remember: if RethinkDB is running locally, you can reach its dashboard at

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:relay": "yarn workspace parabol-server build:relay",
     "db:migrate": "yarn workspace parabol-server db:migrate",
     "quickstart": "yarn workspace parabol-server quickstart",
+    "postdeploy": "yarn workspace parabol-server postdeploy",
     "debug": "yarn workspace parabol-server debug",
     "debug:prod": "yarn workspace parabol-server debug:prod",
     "dev": "yarn workspace parabol-server dev",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "heroku-postbuild": "echo 'Skipping build'",
     "build": "yarn workspace parabol-server build",
     "build:relay": "yarn workspace parabol-server build:relay",
+    "db:migrate": "yarn workspace parabol-server db:migrate",
     "quickstart": "yarn workspace parabol-server quickstart",
     "debug": "yarn workspace parabol-server debug",
     "debug:prod": "yarn workspace parabol-server debug:prod",

--- a/packages/client/components/BaseButton.tsx
+++ b/packages/client/components/BaseButton.tsx
@@ -41,7 +41,7 @@ export interface BaseButtonProps extends PlainButtonProps {
   size?: 'small' | 'medium' | 'large'
   children?: ReactNode
   className?: string
-  buttonName?: string
+  dataCy?: string
   elevationHovered?: Elevation
   elevationResting?: Elevation
   elevationPressed?: Elevation
@@ -68,7 +68,7 @@ const BaseButton = forwardRef((props: BaseButtonProps, ref: Ref<HTMLButtonElemen
     onMouseEnter,
     style,
     waiting,
-    buttonName
+    dataCy
   } = props
   const hasDisabledStyles = !!(disabled || waiting)
 
@@ -99,7 +99,7 @@ const BaseButton = forwardRef((props: BaseButtonProps, ref: Ref<HTMLButtonElemen
   return (
     <ButtonRoot
       {...props}
-      data-cy={buttonName}
+      data-cy={dataCy}
       aria-label={ariaLabel}
       className={className}
       disabled={hasDisabledStyles}

--- a/packages/client/components/BaseButton.tsx
+++ b/packages/client/components/BaseButton.tsx
@@ -41,6 +41,7 @@ export interface BaseButtonProps extends PlainButtonProps {
   size?: 'small' | 'medium' | 'large'
   children?: ReactNode
   className?: string
+  buttonName?: string
   elevationHovered?: Elevation
   elevationResting?: Elevation
   elevationPressed?: Elevation
@@ -66,7 +67,8 @@ const BaseButton = forwardRef((props: BaseButtonProps, ref: Ref<HTMLButtonElemen
     onClick,
     onMouseEnter,
     style,
-    waiting
+    waiting,
+    buttonName
   } = props
   const hasDisabledStyles = !!(disabled || waiting)
 
@@ -97,6 +99,7 @@ const BaseButton = forwardRef((props: BaseButtonProps, ref: Ref<HTMLButtonElemen
   return (
     <ButtonRoot
       {...props}
+      data-cy={buttonName}
       aria-label={ariaLabel}
       className={className}
       disabled={hasDisabledStyles}

--- a/packages/client/components/BeginDemoModal.tsx
+++ b/packages/client/components/BeginDemoModal.tsx
@@ -52,7 +52,7 @@ const BeginDemoModal = (props: Props) => {
         Try Parabol for yourself by holding a 2-minute retrospective meeting with our simulated
         colleagues
       </StyledCopy>
-      <PrimaryButton buttonName='start-demo-button' onClick={onClick} size='medium'>
+      <PrimaryButton dataCy='start-demo-button' onClick={onClick} size='medium'>
         Start Demo
       </PrimaryButton>
     </StyledDialogContainer>

--- a/packages/client/components/BeginDemoModal.tsx
+++ b/packages/client/components/BeginDemoModal.tsx
@@ -52,7 +52,7 @@ const BeginDemoModal = (props: Props) => {
         Try Parabol for yourself by holding a 2-minute retrospective meeting with our simulated
         colleagues
       </StyledCopy>
-      <PrimaryButton onClick={onClick} size='medium'>
+      <PrimaryButton buttonName='start-demo-button' onClick={onClick} size='medium'>
         Start Demo
       </PrimaryButton>
     </StyledDialogContainer>

--- a/packages/client/components/NewMeetingSidebar.tsx
+++ b/packages/client/components/NewMeetingSidebar.tsx
@@ -101,7 +101,7 @@ const NewMeetingSidebar = (props: Props) => {
 
   return (
     <SidebarParent>
-      <SidebarHeader>
+      <SidebarHeader data-cy="sidebar-header">
         <StyledToggle onClick={toggleSidebar} />
         <div>
           {isFacilitator ? (

--- a/packages/client/components/PrimaryButton.tsx
+++ b/packages/client/components/PrimaryButton.tsx
@@ -6,12 +6,11 @@ import {Radius} from 'types/constEnums'
 import {Elevation} from 'styles/elevation'
 
 const StyledBaseButton = styled(BaseButton)((props: BaseButtonProps) => {
-  const {disabled, waiting, buttonName} = props
+  const {disabled, waiting} = props
   const visuallyDisabled = disabled || waiting
   return {
     backgroundImage: visuallyDisabled ? PALETTE.GRADIENT_WARM_LIGHTENED : PALETTE.GRADIENT_WARM,
     borderRadius: Radius.BUTTON_PILL,
-    buttonName,
     color: '#FFFFFF',
     fontWeight: 600,
     opacity: visuallyDisabled ? 1 : undefined,

--- a/packages/client/components/PrimaryButton.tsx
+++ b/packages/client/components/PrimaryButton.tsx
@@ -6,11 +6,12 @@ import {Radius} from 'types/constEnums'
 import {Elevation} from 'styles/elevation'
 
 const StyledBaseButton = styled(BaseButton)((props: BaseButtonProps) => {
-  const {disabled, waiting} = props
+  const {disabled, waiting, buttonName} = props
   const visuallyDisabled = disabled || waiting
   return {
     backgroundImage: visuallyDisabled ? PALETTE.GRADIENT_WARM_LIGHTENED : PALETTE.GRADIENT_WARM,
     borderRadius: Radius.BUTTON_PILL,
+    buttonName,
     color: '#FFFFFF',
     fontWeight: 600,
     opacity: visuallyDisabled ? 1 : undefined,


### PR DESCRIPTION
Added yarn db:migrate as a command in the root package.json to make it more convenient to run. 

Added yarn db:migrate and yarn build:relay under the Development tab in the README, as these are necessary to get yarn dev running.

Added a data-cy property 'start-demo-button' to BeginDemoModal, passing it through props as buttonName.

Added a data-cy property "sidebar-header" to NewMeetingSideBar
