### PR TITLE
Docker Compose for localhost

### DIFF
--- a/docker/local.yml
+++ b/docker/local.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+    redis:
+        image: 'redis:alpine'
+        ports:
+            - '6379:6379'
+    rethinkdb:
+        image: 'rethinkdb'
+        ports:
+            - '28015:28015'
+            - '29015:29015'
+            - '8080:8080'

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
     "heroku-postbuild": "echo 'Skipping build'",
     "build": "yarn workspace parabol-server build",
     "build:relay": "yarn workspace parabol-server build:relay",
-    "quickstart": "yarn workspace parabol-server quickstart",
+    "quickstart": "yarn dev:system-dependencies && yarn workspace parabol-server quickstart",
     "debug": "yarn workspace parabol-server debug",
     "debug:prod": "yarn workspace parabol-server debug:prod",
     "dev": "yarn workspace parabol-server dev",
+    "dev:system-dependencies": "docker-compose --file=docker/local.yml up --detach",
     "lint": "lerna run --parallel lint",
     "test": "yarn workspace parabol-cypress test",
     "typecheck": "lerna run --parallel typecheck"


### PR DESCRIPTION
Runs Redis and Rethink DB through docker.

Also automatically added `dev:system-dependencies` into package.json and called it in the `quickstart` script.