### PR TITLE
Fix #3648 resource links

### DIFF
--- a/packages/client/components/MeetingHelp/ActionMeetingAgendaItemsHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/ActionMeetingAgendaItemsHelpMenu.tsx
@@ -4,6 +4,7 @@ import HelpMenuCopy from './HelpMenuCopy'
 import HelpMenuLink from './HelpMenuLink'
 import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -24,7 +25,7 @@ const ActionMeetingAgendaItemsHelpMenu = forwardRef((_props: Props, ref: any) =>
       </HelpMenuCopy>
       <HelpMenuLink
         copy='Learn more'
-        href='https://www.parabol.co/getting-started-guide/action-meetings-101#team-agenda'
+        href={`${ExternalLinks.GETTING_STARTED_CHECK_INS}#team-agenda`}
       />
     </HelpMenuContent>
   )

--- a/packages/client/components/MeetingHelp/ActionMeetingFirstCallHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/ActionMeetingFirstCallHelpMenu.tsx
@@ -4,6 +4,7 @@ import HelpMenuCopy from './HelpMenuCopy'
 import HelpMenuLink from './HelpMenuLink'
 import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -21,7 +22,7 @@ const ActionMeetingFirstCallHelpMenu = forwardRef((_props: Props, ref: any) => {
       </HelpMenuCopy>
       <HelpMenuLink
         copy='Learn more'
-        href='https://www.parabol.co/getting-started-guide/action-meetings-101#team-agenda'
+        href={`${ExternalLinks.GETTING_STARTED_CHECK_INS}#team-agenda`}
       />
     </HelpMenuContent>
   )

--- a/packages/client/components/MeetingHelp/ActionMeetingLastCallHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/ActionMeetingLastCallHelpMenu.tsx
@@ -4,6 +4,7 @@ import HelpMenuCopy from './HelpMenuCopy'
 import HelpMenuLink from './HelpMenuLink'
 import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -18,7 +19,7 @@ const ActionMeetingLastCallHelpMenu = forwardRef((_props: Props, ref: any) => {
       </HelpMenuCopy>
       <HelpMenuLink
         copy='Learn more'
-        href='https://www.parabol.co/getting-started-guide/action-meetings-101#team-agenda'
+        href={`${ExternalLinks.GETTING_STARTED_CHECK_INS}#team-agenda`}
       />
     </HelpMenuContent>
   )

--- a/packages/client/components/MeetingHelp/ActionMeetingLobbyHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/ActionMeetingLobbyHelpMenu.tsx
@@ -15,7 +15,7 @@ const ActionMeetingLobbyHelpMenu = forwardRef((_props: Props, ref: any) => {
     <HelpMenuContent closePortal={closePortal}>
       <HelpMenuCopy>{'To learn more about how to run a Check-in Meeting, see our '}</HelpMenuCopy>
       <div>
-        <HelpMenuLink copy='Getting Started Guide' href={ExternalLinks.GETTING_STARTED_ACTION} />
+        <HelpMenuLink copy='Getting Started Guide' href={ExternalLinks.GETTING_STARTED_CHECK_INS} />
         {' for running a Check-in Meeting.'}
       </div>
     </HelpMenuContent>

--- a/packages/client/components/MeetingHelp/CheckInHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/CheckInHelpMenu.tsx
@@ -7,12 +7,11 @@ import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {MeetingTypeEnum, NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
 import {CHECKIN} from '../../utils/constants'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
+import {ExternalLinks} from '../../types/constEnums'
 
 const linkLookup = {
-  [MeetingTypeEnum.action]:
-    'https://www.parabol.co/getting-started-guide/action-meetings-101#social-check-in',
-  [MeetingTypeEnum.retrospective]:
-    'https://www.parabol.co/getting-started-guide/retrospective-meetings-101#social-check-in'
+  [MeetingTypeEnum.action]: `${ExternalLinks.GETTING_STARTED_CHECK_INS}#social-check-in`,
+  [MeetingTypeEnum.retrospective]: `${ExternalLinks.GETTING_STARTED_RETROS}#social-check-in`
 }
 
 interface Props {

--- a/packages/client/components/MeetingHelp/DiscussHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/DiscussHelpMenu.tsx
@@ -7,6 +7,7 @@ import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
 import {DISCUSS} from '../../utils/constants'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -24,10 +25,7 @@ const DiscussHelpMenu = forwardRef((_props: Props, ref: any) => {
         Sometimes the next task is to schedule a time to discuss a topic more in depth at a later
         time.
       </HelpMenuCopy>
-      <HelpMenuLink
-        copy='Learn More'
-        href='https://www.parabol.co/getting-started-guide/retrospective-meetings-101#discuss'
-      />
+      <HelpMenuLink copy='Learn More' href={`${ExternalLinks.GETTING_STARTED_RETROS}#discuss`} />
     </HelpMenuContent>
   )
 })

--- a/packages/client/components/MeetingHelp/GroupHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/GroupHelpMenu.tsx
@@ -7,6 +7,7 @@ import HelpMenuHeader from './HelpMenuHeader'
 import HelpMenuCopy from './HelpMenuCopy'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
 import HelpMenuLink from './HelpMenuLink'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -21,10 +22,7 @@ const GroupHelpMenu = forwardRef((_props: Props, ref: any) => {
       </HelpMenuCopy>
       <HelpMenuCopy>To group, drag and drop a card onto another card or group.</HelpMenuCopy>
       <HelpMenuCopy>Tap group headings to edit.</HelpMenuCopy>
-      <HelpMenuLink
-        copy='Learn More'
-        href='https://www.parabol.co/getting-started-guide/retrospective-meetings-101#group'
-      />
+      <HelpMenuLink copy='Learn More' href={`${ExternalLinks.GETTING_STARTED_RETROS}#group`} />
     </HelpMenuContent>
   )
 })

--- a/packages/client/components/MeetingHelp/ReflectHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/ReflectHelpMenu.tsx
@@ -7,6 +7,7 @@ import HelpMenuHeader from './HelpMenuHeader'
 import HelpMenuCopy from './HelpMenuCopy'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
 import HelpMenuLink from './HelpMenuLink'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -24,10 +25,7 @@ const ReflectHelpMenu = forwardRef((_props: Props, ref: any) => {
         During this phase nobody can see your reflections. After this phase reflections will be
         visible, but remain anonymous.
       </HelpMenuCopy>
-      <HelpMenuLink
-        copy='Learn More'
-        href='https://www.parabol.co/getting-started-guide/retrospective-meetings-101#reflect'
-      />
+      <HelpMenuLink copy='Learn More' href={`${ExternalLinks.GETTING_STARTED_RETROS}#reflect`} />
     </HelpMenuContent>
   )
 })

--- a/packages/client/components/MeetingHelp/UpdatesHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/UpdatesHelpMenu.tsx
@@ -6,6 +6,7 @@ import HelpMenuLink from './HelpMenuLink'
 import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -27,7 +28,7 @@ const UpdatesHelpMenu = forwardRef((_props: Props, ref: any) => {
       </HelpMenuCopy>
       <HelpMenuLink
         copy='Learn More'
-        href={`https://www.parabol.co/getting-started-guide/action-meetings-101#solo-updates`}
+        href={`${ExternalLinks.GETTING_STARTED_CHECK_INS}#solo-updates`}
       />
     </HelpMenuContent>
   )

--- a/packages/client/components/MeetingHelp/VoteHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/VoteHelpMenu.tsx
@@ -7,6 +7,7 @@ import useSegmentTrack from '../../hooks/useSegmentTrack'
 import {NewMeetingPhaseTypeEnum, SegmentClientEventEnum} from '../../types/graphql'
 import {VOTE} from '../../utils/constants'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
+import {ExternalLinks} from '../../types/constEnums'
 
 interface Props {}
 
@@ -25,10 +26,7 @@ const VoteHelpMenu = forwardRef((_props: Props, ref: any) => {
       <HelpMenuCopy>
         To vote, simply tap on the thumb-up icon above a group. Toggle votes to remove.
       </HelpMenuCopy>
-      <HelpMenuLink
-        copy='Learn More'
-        href='https://www.parabol.co/getting-started-guide/retrospective-meetings-101#vote'
-      />
+      <HelpMenuLink copy='Learn More' href={`${ExternalLinks.GETTING_STARTED_RETROS}#vote`} />
     </HelpMenuContent>
   )
 })

--- a/packages/client/components/NewMeetingHowToSteps.tsx
+++ b/packages/client/components/NewMeetingHowToSteps.tsx
@@ -24,7 +24,7 @@ const STEPS = {
 
 const LINKS = {
   [MeetingTypeEnum.retrospective]: ExternalLinks.GETTING_STARTED_RETROS,
-  [MeetingTypeEnum.action]: ExternalLinks.GETTING_STARTED_ACTION
+  [MeetingTypeEnum.action]: ExternalLinks.GETTING_STARTED_CHECK_INS
 }
 
 const TITLES = {

--- a/packages/client/modules/email/containers/TeamInvite/TeamInvite.tsx
+++ b/packages/client/modules/email/containers/TeamInvite/TeamInvite.tsx
@@ -8,6 +8,7 @@ import EmptySpace from '../../components/EmptySpace/EmptySpace'
 import Header from '../../components/Header/Header'
 import Layout from '../../components/Layout/Layout'
 import emailDir from '../../emailDir'
+import {ExternalLinks} from '../../../../types/constEnums'
 
 const innerMaxWidth = 480
 
@@ -103,11 +104,7 @@ const TeamInvite = (props) => {
             'Parabol is software for remote teams to run online retrospective and check-in meetings. See the video and links below:'
           }
         </p>
-        <a
-          href='https://www.parabol.co/getting-started-guide/retrospective-meetings-101'
-          style={videoLinkStyle}
-          title='Retro 101'
-        >
+        <a href={ExternalLinks.GETTING_STARTED_RETROS} style={videoLinkStyle} title='Retro 101'>
           <img crossOrigin='' alt='' src={videoGraphicSrc} style={videoGraphicStyle} />
         </a>
         <EmptySpace height={24} />
@@ -115,7 +112,7 @@ const TeamInvite = (props) => {
           {'Learn more about Parabol meetings:'}
           <br />
           <a
-            href='https://www.parabol.co/getting-started-guide/retrospective-meetings-101'
+            href={ExternalLinks.GETTING_STARTED_RETROS}
             style={emailLinkStyle}
             title='Getting Started: Retro 101'
           >
@@ -123,7 +120,7 @@ const TeamInvite = (props) => {
           </a>
           <br />
           <a
-            href='https://www.parabol.co/getting-started-guide/action-meetings-101'
+            href={ExternalLinks.GETTING_STARTED_CHECK_INS}
             style={emailLinkStyle}
             title='Leveling Up: Check-in 101'
           >

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -84,8 +84,8 @@ export const enum ElementHeight {
 
 export const enum ExternalLinks {
   PRICING_LINK = 'https://www.parabol.co/pricing/',
-  GETTING_STARTED_RETROS = 'https://www.parabol.co/getting-started-guide/retrospective-meetings-101',
-  GETTING_STARTED_ACTION = 'https://www.parabol.co/getting-started-guide/action-meetings-101',
+  GETTING_STARTED_RETROS = 'https://www.parabol.co/resources/retrospective-meetings',
+  GETTING_STARTED_CHECK_INS = 'https://www.parabol.co/resources/check-in-meetings',
   RESOURCES = 'https://www.parabol.co/resources',
   SUPPORT = 'https://www.parabol.co/support'
 }


### PR DESCRIPTION
Fixes #3648 

### Tests
The Learn More link in the help menu for each phase in a meeting opens to the correct URL and content anchor (e.g. [https://www.parabol.co/resources/retrospective-meetings#vote](https://www.parabol.co/resources/retrospective-meetings#vote))
- [ ] In all phases of the Retro meeting
- [ ] In all phases of the Check-in meeting

The Retro and Check-in links work in the Invite email
- [ ] Tap the video graphic, it goes to the Retro 101 page
- [ ] Tap the links, they go to the respective Retro and Check-in 101 pages