### PR TITLE
long mass invite links if not production

### DIFF
--- a/packages/client/components/MassInvitationTokenLink.tsx
+++ b/packages/client/components/MassInvitationTokenLink.tsx
@@ -56,8 +56,12 @@ const MassInvitationTokenLink = (props: Props) => {
     }
     doFetch().catch()
   }, [])
+  const HOST = window.location.host
+  const isDevelopment = HOST != 'action.parabol.co'
   const displayToken = isTokenValid ? token : '············'
-  const linkLabel = `prbl.in/${displayToken}`
+  const linkLabel = isDevelopment
+    ? `${HOST}/invitation-link/${displayToken}`
+    : `prbl.in/${displayToken}`
   const url = __PRODUCTION__ ? `https://${linkLabel}` : makeHref(`/invitation-link/${token}`)
   return (
     <StyledCopyShortLink


### PR DESCRIPTION
Replace the 'prbl.in' shorturl with `${HOST}/invitation-link/${TOKEN}` on non-production 

Closes #3631