### PR TITLE
remove Google Tag Manager

### DIFF
--- a/packages/server/createSSR.ts
+++ b/packages/server/createSSR.ts
@@ -17,7 +17,6 @@ export const getClientKeys = () => {
     atlassian: process.env.ATLASSIAN_CLIENT_ID,
     cdn: webpackPublicPath,
     github: process.env.GITHUB_CLIENT_ID,
-    googleTagManagerId: process.env.GOOGLE_TAG_MANAGER_CONTAINER_ID,
     google: process.env.GOOGLE_OAUTH_CLIENT_ID,
     segment: process.env.SEGMENT_WRITE_KEY,
     sentry: process.env.SENTRY_DSN,

--- a/packages/server/template.html
+++ b/packages/server/template.html
@@ -2,22 +2,6 @@
 <html lang="en">
 
 <head>
-  <!-- Google Tag Manager -->
-  <script>
-    gtmId = window.__ACTION__.googleTagManagerId
-    gtmIdValidation = /^GTM-[A-Z0-9]+$/
-    if (gtmId && gtmIdValidation.test(gtmId)) {
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || []; w[l].push({
-          'gtm.start':
-            new Date().getTime(), event: 'gtm.js'
-        }); var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
-            'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
-      })(window, document, 'script', 'dataLayer', gtmId)
-    }
-  </script>
-  <!-- End Google Tag Manager -->
   <title>Free Online Retrospectives | Parabol</title>
   <meta charset="utf-8" />
   <meta name="viewport"


### PR DESCRIPTION
I want to merge our www.parabol.co and `action-production` instance configurations on Segment in order to eliminate the chance for error/cookie conflict. As part of this, I'd need to deliver GTM via Segment, vs. natively in the Segment template.

@mattkrick can we sneak this into v5.5.0?