### PR TITLE
don't trust __dirname

### DIFF
--- a/packages/server/utils/serveStatic.ts
+++ b/packages/server/utils/serveStatic.ts
@@ -5,8 +5,18 @@ import pipeStreamOverResponse from '../pipeStreamOverResponse'
 import PROD from '../PROD'
 import StaticServer from './StaticServer'
 
-// this is relative to where the server is built
-const PROJECT_ROOT = path.join(__dirname, '..')
+// __dirname should be /dev, but during HMR it becomes its true path
+// so, anytime HMR reloads this file, we want to double check we're in the right place
+const getProjectRoot = () => {
+  let cd = __dirname
+  while (cd !== '/') {
+    if (fs.existsSync(path.join(cd, 'yarn.lock'))) return cd
+    cd = path.join(cd, '..')
+  }
+  return cd
+}
+
+const PROJECT_ROOT = getProjectRoot()
 const staticPaths = {
   [path.join(PROJECT_ROOT, 'build')]: true,
   [path.join(PROJECT_ROOT, 'static')]: true,


### PR DESCRIPTION
This fixes the nondeterministic __dirname bug that occurs during HMR, as found by @NikAiyer!

TEST
- [ ] start up the server in dev mode, visit a page, then edit `serveStatic.ts`, notice the HMR swaps out the file. hit refresh in the browser & the page still loads