### PR TITLE
ignore quantity changes for enterprise orgs

### DIFF
--- a/packages/client/modules/invoice/components/InvoiceLineItem/InvoiceLineItemDetails.tsx
+++ b/packages/client/modules/invoice/components/InvoiceLineItem/InvoiceLineItemDetails.tsx
@@ -18,7 +18,7 @@ const detailDescriptionMaker = {
     if (!detail.endAt) {
       return `${detail.email} has been paused since ${makeDateString(detail.startAt)}`
     } else if (!detail.startAt) {
-      return `${detail.email} was paused until ${makeDateString(detail.startAt)}`
+      return `${detail.email} was paused until ${makeDateString(detail.endAt)}`
     }
     return `${detail.email} was paused from ${makeDateString(detail.startAt)} to ${makeDateString(
       detail.endAt


### PR DESCRIPTION
We had a couple bugs with invoices. this fixes those.

fix #3803

TEST
- [ ] create an enterprise organization with 49 seats
- [ ] turn on the ultrahook webhook listener
- [ ] add a user to the enterprise org
- [ ] verify that the quantity in stripe is still 49
- [ ] remove that user & verify that the quantity is still 49
- [ ] create a pro org & invite 1 person
- [ ] put that person on pause & see the pause show up on the upcoming invoice
- [ ] remove the person, verify that the invoice does not change

