### PR TITLE
fix ghost snack, killed meeting summary, meet status, start retro mid…

### DIFF
--- a/packages/client/components/SelectMeetingDropdownItem.tsx
+++ b/packages/client/components/SelectMeetingDropdownItem.tsx
@@ -6,6 +6,7 @@ import {createFragmentContainer} from 'react-relay'
 import useRouter from '~/hooks/useRouter'
 import {PALETTE} from '~/styles/paletteV2'
 import {ICON_SIZE} from '~/styles/typographyV2'
+import getMeetingPhase from '~/utils/getMeetingPhase'
 import {meetingTypeToIcon, phaseLabelLookup} from '~/utils/meetings/lookups'
 import {SelectMeetingDropdownItem_meeting} from '~/__generated__/SelectMeetingDropdownItem_meeting.graphql'
 import Icon from './Icon'
@@ -44,18 +45,6 @@ const Action = styled(Icon)({
   textAlign: 'right',
   padding: 16
 })
-
-interface Phase {
-  stages: ReadonlyArray<{
-    isComplete: boolean
-  }>
-}
-
-const getMeetingPhase = <T extends Phase>(phases: readonly T[]) => {
-  return (phases.find((phase) => {
-    return !phase.stages.every((stage) => stage.isComplete)
-  }) as unknown) as T
-}
 
 interface Props {
   meeting: SelectMeetingDropdownItem_meeting

--- a/packages/client/components/SnackbarMessage.tsx
+++ b/packages/client/components/SnackbarMessage.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
+import React, {useEffect} from 'react'
 import {TransitionStatus} from '../hooks/useTransition'
+import {DECELERATE} from '../styles/animation'
+import {snackbarShadow} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV2'
 import {Radius, ZIndex} from '../types/constEnums'
-import React from 'react'
-import {DECELERATE} from '../styles/animation'
 import {SnackAction} from './Snackbar'
 import SnackbarMessageAction from './SnackbarMessageAction'
-import {snackbarShadow} from '../styles/elevation'
 
 interface Props {
   onTransitionEnd: () => void
@@ -46,6 +46,16 @@ const MessageStyles = styled('div')<{status: TransitionStatus}>(({status}) => ({
   zIndex: ZIndex.SNACKBAR
 }))
 
+const useTransitionEnd = (
+  timeout: number,
+  status: TransitionStatus,
+  onTransitionEnd: () => void
+) => {
+  useEffect(() => {
+    setTimeout(onTransitionEnd, timeout)
+  }, [status])
+}
+
 const SnackbarMessage = (props: Props) => {
   const {
     action,
@@ -57,11 +67,11 @@ const SnackbarMessage = (props: Props) => {
     onMouseEnter,
     onMouseLeave
   } = props
+  useTransitionEnd(300, status, onTransitionEnd)
   return (
     <Space>
       <MessageStyles
         status={status}
-        onTransitionEnd={onTransitionEnd}
         onClick={dismissSnack}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}

--- a/packages/client/hooks/useTransition.ts
+++ b/packages/client/hooks/useTransition.ts
@@ -1,17 +1,7 @@
 import {useMemo, useRef} from 'react'
-import useForceUpdate from './useForceUpdate'
-import useEventCallback from './useEventCallback'
 import requestDoubleAnimationFrame from '../components/RetroReflectPhase/requestDoubleAnimationFrame'
-
-// const getValidChildren = (children: ReactNode) => {
-//   const validChildren = [] as ReactElement<any>[]
-//   Children.forEach(children, (child) => {
-//     if (isValidElement(child)) {
-//       validChildren.push(child)
-//     }
-//   })
-//   return validChildren
-// }
+import useEventCallback from './useEventCallback'
+import useForceUpdate from './useForceUpdate'
 
 export enum TransitionStatus {
   MOUNTED,
@@ -32,9 +22,9 @@ const useTransition = <T extends {key: Key}>(children: T[]) => {
   const previousTransitionChildrenRef = useRef<TransitionChild<T>[]>([])
   const forceUpdate = useForceUpdate()
 
-  const transitionEndFactory = useEventCallback((key: Key) => (e: React.TransitionEvent) => {
-    // animations must live in the outermost element
-    if (e.target !== e.currentTarget) return
+  const transitionEndFactory = useEventCallback((key: Key) => (e?: React.TransitionEvent) => {
+    // animations must live in the outermost element if triggered on onTransitionEnd
+    if (e && e.target !== e.currentTarget) return
     const idx = previousTransitionChildrenRef.current.findIndex(
       (tChild) => tChild.child.key === key
     )

--- a/packages/client/utils/getMeetingPhase.ts
+++ b/packages/client/utils/getMeetingPhase.ts
@@ -1,0 +1,13 @@
+interface Phase {
+  stages: ReadonlyArray<{
+    isComplete: boolean
+  }>
+}
+
+const getMeetingPhase = <T extends Phase>(phases: readonly T[]) => {
+  return (phases.find((phase) => {
+    return !phase.stages.every((stage) => stage.isComplete)
+  }) as unknown) as T
+}
+
+export default getMeetingPhase

--- a/packages/server/database/types/TimelineEventCheckinComplete.ts
+++ b/packages/server/database/types/TimelineEventCheckinComplete.ts
@@ -1,0 +1,25 @@
+import {TimelineEventEnum} from 'parabol-client/types/graphql'
+import TimelineEvent from './TimelineEvent'
+
+interface Input {
+  id?: string
+  createdAt?: Date
+  interactionCount?: number
+  seenCount?: number
+  userId: string
+  teamId: string
+  orgId: string
+  meetingId: string
+}
+export default class TimelineEventCheckinComplete extends TimelineEvent {
+  teamId: string
+  meetingId: string
+  orgId: string
+  constructor(input: Input) {
+    super({...input, type: TimelineEventEnum.actionComplete})
+    const {teamId, orgId, meetingId} = input
+    this.teamId = teamId
+    this.orgId = orgId
+    this.meetingId = meetingId
+  }
+}

--- a/packages/server/database/types/TimelineEventRetroComplete.ts
+++ b/packages/server/database/types/TimelineEventRetroComplete.ts
@@ -1,0 +1,25 @@
+import {TimelineEventEnum} from 'parabol-client/types/graphql'
+import TimelineEvent from './TimelineEvent'
+
+interface Input {
+  id?: string
+  createdAt?: Date
+  interactionCount?: number
+  seenCount?: number
+  userId: string
+  teamId: string
+  orgId: string
+  meetingId: string
+}
+export default class TimelineEventRetroComplete extends TimelineEvent {
+  teamId: string
+  meetingId: string
+  orgId: string
+  constructor(input: Input) {
+    super({...input, type: TimelineEventEnum.retroComplete})
+    const {teamId, orgId, meetingId} = input
+    this.teamId = teamId
+    this.orgId = orgId
+    this.meetingId = meetingId
+  }
+}

--- a/packages/server/graphql/mutations/endNewMeeting.ts
+++ b/packages/server/graphql/mutations/endNewMeeting.ts
@@ -1,7 +1,5 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import extractTextFromDraftString from 'parabol-client/utils/draftjs/extractTextFromDraftString'
-import shortid from 'shortid'
 import {
   MeetingTypeEnum,
   NewMeetingPhaseTypeEnum,
@@ -15,13 +13,18 @@ import {
   LAST_CALL,
   RETROSPECTIVE
 } from 'parabol-client/utils/constants'
+import extractTextFromDraftString from 'parabol-client/utils/draftjs/extractTextFromDraftString'
+import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 import getRethink from '../../database/rethinkDriver'
 import GenericMeetingPhase from '../../database/types/GenericMeetingPhase'
 import Meeting from '../../database/types/Meeting'
 import MeetingAction from '../../database/types/MeetingAction'
+import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import ReflectPhase from '../../database/types/ReflectPhase'
 import Task from '../../database/types/Task'
+import TimelineEventCheckinComplete from '../../database/types/TimelineEventCheckinComplete'
+import TimelineEventRetroComplete from '../../database/types/TimelineEventRetroComplete'
 import archiveTasksForDB from '../../safeMutations/archiveTasksForDB'
 import removeSuggestedAction from '../../safeMutations/removeSuggestedAction'
 import {getUserId, isTeamMember} from '../../utils/authorization'
@@ -30,15 +33,13 @@ import sendSegmentEvent, {sendSegmentIdentify} from '../../utils/sendSegmentEven
 import standardError from '../../utils/standardError'
 import {DataLoaderWorker, GQLContext} from '../graphql'
 import EndNewMeetingPayload from '../types/EndNewMeetingPayload'
-import {COMPLETED_ACTION_MEETING, COMPLETED_RETRO_MEETING} from '../types/TimelineEventTypeEnum'
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import {endSlackMeeting} from './helpers/notifySlack'
-import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 
 const timelineEventLookup = {
-  [RETROSPECTIVE]: COMPLETED_RETRO_MEETING,
-  [ACTION]: COMPLETED_ACTION_MEETING
-}
+  [RETROSPECTIVE]: TimelineEventRetroComplete,
+  [ACTION]: TimelineEventCheckinComplete
+} as const
 
 const suggestedActionLookup = {
   [MeetingTypeEnum.retrospective]: SuggestedActionTypeEnum.tryRetroMeeting,
@@ -226,6 +227,20 @@ const getIsKill = (meetingType: MeetingTypeEnum, phase: GenericMeetingPhase) => 
   }
 }
 
+const getMeetingTemplateName = async (
+  meetingType: MeetingTypeEnum,
+  phases: any[],
+  dataLoader: DataLoaderWorker
+) => {
+  if (meetingType !== MeetingTypeEnum.retrospective) return undefined
+  const reflectPhase = phases.find(
+    (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.reflect
+  ) as ReflectPhase
+  const {promptTemplateId} = reflectPhase
+  const template = await dataLoader.get('reflectTemplates').load(promptTemplateId)
+  return template.name
+}
+
 export default {
   type: new GraphQLNonNull(EndNewMeetingPayload),
   description: 'Finish a new meeting',
@@ -252,7 +267,6 @@ export default {
     const {endedAt, facilitatorStageId, meetingNumber, phases, teamId, meetingType} = meeting
 
     // VALIDATION
-    // called by endOldMeetings, SU is OK
     if (!isTeamMember(authToken, teamId) && authToken.rol !== 'su') {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
@@ -263,7 +277,8 @@ export default {
     if (!currentStageRes) {
       return standardError(new Error('Cannot find facilitator stage'), {userId: viewerId})
     }
-    const {stage, phase} = currentStageRes
+    const {stage} = currentStageRes
+    const phase = getMeetingPhase(phases)
     stage.isComplete = true
     stage.endAt = now
 
@@ -304,33 +319,25 @@ export default {
       teamId,
       meetingNumber
     }
-    let meetingTemplateName
-    if (meetingType === MeetingTypeEnum.retrospective) {
-      const reflectPhase = phases.find(
-        (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.reflect
-      ) as ReflectPhase
-      const {promptTemplateId} = reflectPhase
-      const template = await dataLoader.get('reflectTemplates').load(promptTemplateId)
-      meetingTemplateName = template.name
-    }
+    const meetingTemplateName = await getMeetingTemplateName(meetingType, phases, dataLoader)
     const segmentData = {...traits, meetingType, meetingTemplateName}
     const facilitatorSegmentData = {...segmentData, wasFacilitator: true}
     sendSegmentEvent('Meeting Completed', facilitatorUserId, facilitatorSegmentData).catch()
     sendSegmentEvent('Meeting Completed', nonFacilitators, segmentData).catch()
     sendSegmentIdentify(presentMemberUserIds).catch()
-    sendNewMeetingSummary(completedMeeting, context).catch(console.log)
 
-    const events = meetingMembers.map((meetingMember) => ({
-      id: shortid.generate(),
-      createdAt: now,
-      interactionCount: 0,
-      seenCount: 0,
-      type: timelineEventLookup[meetingType],
-      userId: meetingMember.userId,
-      teamId,
-      orgId: team.orgId,
-      meetingId
-    }))
+    sendNewMeetingSummary(completedMeeting, context).catch(console.log)
+    const TimelineEvent = timelineEventLookup[meetingType]
+
+    const events = meetingMembers.map(
+      (meetingMember) =>
+        new TimelineEvent({
+          userId: meetingMember.userId,
+          teamId,
+          orgId: team.orgId,
+          meetingId
+        })
+    )
     await r
       .table('TimelineEvent')
       .insert(events)

--- a/packages/server/graphql/mutations/helpers/addTeamMemberToMeetings.ts
+++ b/packages/server/graphql/mutations/helpers/addTeamMemberToMeetings.ts
@@ -1,12 +1,12 @@
-import createMeetingMembers from './createMeetingMembers'
-import getRethink from '../../../database/rethinkDriver'
-import CheckInStage from '../../../database/types/CheckInStage'
-import UpdatesStage from '../../../database/types/UpdatesStage'
-import CheckInPhase from '../../../database/types/CheckInPhase'
-import UpdatesPhase from '../../../database/types/UpdatesPhase'
-import TeamMember from '../../../database/types/TeamMember'
-import {DataLoaderWorker} from '../../graphql'
 import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
+import getRethink from '../../../database/rethinkDriver'
+import CheckInPhase from '../../../database/types/CheckInPhase'
+import CheckInStage from '../../../database/types/CheckInStage'
+import TeamMember from '../../../database/types/TeamMember'
+import UpdatesPhase from '../../../database/types/UpdatesPhase'
+import UpdatesStage from '../../../database/types/UpdatesStage'
+import {DataLoaderWorker} from '../../graphql'
+import createMeetingMembers from './createMeetingMembers'
 
 /*
  * NewMeetings have a predefined set of stages, we need to add the new team member manually
@@ -14,8 +14,10 @@ import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
 
 const setInPhase = (phase: CheckInPhase | UpdatesPhase, newStage: CheckInStage | UpdatesStage) => {
   const firstStage = phase.stages[0]
+  const isPhaseComplete = phase.stages.every((stage) => stage.isComplete)
   newStage.isNavigable = firstStage.isNavigable
   newStage.isNavigableByFacilitator = firstStage.isNavigableByFacilitator
+  newStage.isComplete = isPhaseComplete
   phase.stages.push(newStage)
 }
 

--- a/packages/server/graphql/mutations/startNewMeeting.ts
+++ b/packages/server/graphql/mutations/startNewMeeting.ts
@@ -7,6 +7,9 @@ import {
 import getRethink from '../../database/rethinkDriver'
 import GenericMeetingPhase from '../../database/types/GenericMeetingPhase'
 import Meeting from '../../database/types/Meeting'
+import MeetingAction from '../../database/types/MeetingAction'
+import MeetingRetrospective from '../../database/types/MeetingRetrospective'
+import MeetingSettingsRetrospective from '../../database/types/MeetingSettingsRetrospective'
 import Organization from '../../database/types/Organization'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
@@ -17,9 +20,6 @@ import StartNewMeetingPayload from '../types/StartNewMeetingPayload'
 import createMeetingMembers from './helpers/createMeetingMembers'
 import createNewMeetingPhases from './helpers/createNewMeetingPhases'
 import {startSlackMeeting} from './helpers/notifySlack'
-import MeetingRetrospective from '../../database/types/MeetingRetrospective'
-import MeetingAction from '../../database/types/MeetingAction'
-import MeetingSettingsRetrospective from '../../database/types/MeetingSettingsRetrospective'
 
 export default {
   type: new GraphQLNonNull(StartNewMeetingPayload),
@@ -104,8 +104,9 @@ export default {
 
     // Disallow accidental starts (2 meetings within 2 seconds)
     const newActiveMeetings = await dataLoader.get('activeMeetingsByTeamId').load(teamId)
-    const otherActiveMeeting = newActiveMeetings.find(({createdAt, id, meetingType}) => {
-      if (id == meeting.id) return false
+    const otherActiveMeeting = newActiveMeetings.find((activeMeeting) => {
+      const {createdAt, id} = activeMeeting
+      if (id === meeting.id || activeMeeting.meetingType !== meetingType) return false
       return meetingType === EMeetingTypeEnum.action || createdAt > Date.now() - DUPLICATE_THRESHOLD
     })
     if (otherActiveMeeting) {

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -1,24 +1,24 @@
 import {
   GraphQLEnumType,
   GraphQLFloat,
+  GraphQLID,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLID
+  GraphQLObjectType
 } from 'graphql'
-import NewMeeting, {newMeetingFields} from './NewMeeting'
-import RetroReflectionGroup from './RetroReflectionGroup'
-import {resolveForSU} from '../resolvers'
-import RetrospectiveMeetingSettings from './RetrospectiveMeetingSettings'
+import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
 import {RETROSPECTIVE} from 'parabol-client/utils/constants'
-import Task from './Task'
-import {getUserId} from '../../utils/authorization'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
-import RetrospectiveMeetingMember from './RetrospectiveMeetingMember'
+import {getUserId} from '../../utils/authorization'
 import filterTasksByMeeting from '../../utils/filterTasksByMeeting'
 import {GQLContext} from '../graphql'
-import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
+import {resolveForSU} from '../resolvers'
+import NewMeeting, {newMeetingFields} from './NewMeeting'
+import RetroReflectionGroup from './RetroReflectionGroup'
+import RetrospectiveMeetingMember from './RetrospectiveMeetingMember'
+import RetrospectiveMeetingSettings from './RetrospectiveMeetingSettings'
+import Task from './Task'
 
 const ReflectionGroupSortEnum = new GraphQLEnumType({
   name: 'ReflectionGroupSortEnum',
@@ -106,9 +106,10 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
           )
           if (!discussPhase) return reflectionGroups
           const {stages} = discussPhase
-          return stages.map((stage) =>
-            reflectionGroups.find((group) => group.id === stage.reflectionGroupId)
-          )
+          // boolean filter in case the meeting was terminated & there are no groups made yet
+          return stages
+            .map((stage) => reflectionGroups.find((group) => group.id === stage.reflectionGroupId))
+            .filter(Boolean)
         }
         reflectionGroups.sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : 1))
         return reflectionGroups


### PR DESCRIPTION
Wouldn't ya know it, I go to fix 1 thing & find 3 other bugs.

The bottom bar didn't respond sometimes. This was caused because there was an invisible snackbar on top of half the bar. This happened because `onTransitionEnd`, which removed the snackbar, doesn't fire unless the tab is active

If a meeting was killed, an empty email would get sent. This was caused because we order reflectionGroups by the order that they're in for discussion items. since there are no discussion items, reflectionGroups would be null instead of []. Curious typescript didn't flag this one.

The active meetings "current phase" label would sometimes say check-in even when the meeting was much further along. This was caused by a new team member joining the meeting. their check-in stage was initialized with `isComplete == false`, and therefore the meeting state would be the first incomplete stage. Now, if a phase is complete, that incoming stage is complete, too.

If you have a check-in meeting in progress & try start a retro it says meeting already started. that's wrong, so now it works. 

TEST
- [ ] start a retro, navigate to another tab in the browser. ctrl+c the server, restart the server, navigate back to the meeting, see the "Offline" snack is gone disappear (fix #3775)
- [ ] Add 1 reflection, then end the meeting, the email gets sent correctly (fix #3719)
- [ ] start a meeting with a check-in round, go to the reflect phase, go back to dash, click the active meetings, see the current phase is reflect
- [ ] in another tab, have a new person join the team & meeting. go to the active meetings, the current phase is still reflect (in the past it would have regressed to check-in)
- [ ] start an action meeting, then start a retro meeting a couple seconds later. it works (in the past, it wouldn't)
