### PR TITLE
Email updates

### DIFF
--- a/packages/server/email/components/Header/Header.tsx
+++ b/packages/server/email/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import emailDir from '../../emailDir'
 import {emailTableBase} from '../../styles'
+import makeAppLink from '../../../utils/makeAppLink'
 
 const imageStyle = {
   border: '0px',
@@ -12,20 +13,29 @@ const cellStyle = {
   padding: '32px 0px'
 }
 
+const linkStyle = {
+  display: 'block',
+  textDecoration: 'none'
+}
+
+const dashUrl = makeAppLink('me')
+
 const Header = () => {
   return (
     <table style={emailTableBase} width='100%'>
       <tbody>
         <tr>
           <td align='left' style={cellStyle}>
-            <img
-              crossOrigin=''
-              alt='Parabol, Inc. Logo'
-              height={40}
-              src={`${emailDir}email-header-branding-color@3x.png`}
-              style={imageStyle}
-              width={192}
-            />
+            <a style={linkStyle} href={dashUrl}>
+              <img
+                crossOrigin=''
+                alt='Parabol, Inc. Logo'
+                height={40}
+                src={`${emailDir}email-header-branding-color@3x.png`}
+                style={imageStyle}
+                width={192}
+              />
+            </a>
           </td>
         </tr>
       </tbody>

--- a/packages/server/email/components/MeetingSummaryEmailRootSSR.tsx
+++ b/packages/server/email/components/MeetingSummaryEmailRootSSR.tsx
@@ -25,6 +25,12 @@ interface Props {
   meetingId: string
 }
 
+export const meetingSummaryUrlParams = {
+  utm_source: 'summary email',
+  utm_medium: 'email',
+  utm_campaign: 'after-meeting'
+}
+
 const MeetingSummaryEmailRootSSR = (props: Props) => {
   const {environment, meetingId} = props
   return (
@@ -40,12 +46,7 @@ const MeetingSummaryEmailRootSSR = (props: Props) => {
         if (!newMeeting) return null
         const {team} = newMeeting
         const {id: teamId} = team
-        const params = {
-          utm_source: 'summary email',
-          utm_medium: 'email',
-          utm_campaign: 'after-meeting'
-        }
-        const options = {params}
+        const options = {params: meetingSummaryUrlParams}
         const referrerUrl = makeAppLink(`new-summary/${meetingId}`, options)
         const meetingUrl = makeAppLink(`meet/${meetingId}`, options)
         const teamDashUrl = makeAppLink(`team/${teamId}`, options)

--- a/packages/server/email/components/NotificationSummary/NotificationSummaryEmail.tsx
+++ b/packages/server/email/components/NotificationSummary/NotificationSummaryEmail.tsx
@@ -29,29 +29,22 @@ export default function NotificationSummaryEmail() {
       <EmailBlock innerMaxWidth={innerMaxWidth}>
         <Header />
         <p style={copyStyle}>
-          {'Hi '}%recipient.name%{','}
+          {'Hi '}%recipient.name%{' -'}
         </p>
         <p style={copyStyle}>
           {'A friendly nudge, in case you missed it:'}
-          <b>
-            {'you’ve been mentioned in '}
+          <span style={{fontWeight: 600}}>
+            {'you have '}
             %recipient.numNotifications%
-            {' task(s)'}
-          </b>
-          {'in the past day — '}
+            {' unread notification(s)'}
+          </span>
+          {' — '}
           <a style={linkStyle} href={dashUrl}>
-            {'see what’s new and what your team needs'}
+            {'see what your team needs'}
           </a>
           {'.'}
         </p>
-        <p style={copyStyle}>
-          {'You have received '}
-          <span style={{fontWeight: 600}}>
-            %recipient.numNotifications%{' new notification(s)'}
-          </span>
-          {' in the last day.'}
-        </p>
-        <Button url={dashUrl}>{'See Notifications'}</Button>
+        <Button url={dashUrl}>{'Open Parabol'}</Button>
         <EmptySpace height={24} />
         <p style={copyStyle}>
           {'You can also see '}
@@ -61,7 +54,7 @@ export default function NotificationSummaryEmail() {
           {'.'}
         </p>
         <p style={copyStyle}>
-          {'And if you ever need anything from us, don’t hesitate to reach out at '}
+          {'If you need anything from us, don’t hesitate to reach out at '}
           <a style={linkStyle} href='mailto:love@parabol.co'>
             {'love@parabol.co'}
           </a>
@@ -70,7 +63,7 @@ export default function NotificationSummaryEmail() {
         <p style={copyStyle}>
           {'Have fun & do great work,'}
           <br />
-          {'-'}
+          {'- '}
           <a style={linkStyle} href='https://www.parabol.co/team'>
             {'Parabol Team'}
           </a>

--- a/packages/server/email/components/NotificationSummary/NotificationSummaryEmail.tsx
+++ b/packages/server/email/components/NotificationSummary/NotificationSummaryEmail.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import makeAppLink from '../../../utils/makeAppLink'
-import {emailCopyStyle, emailLinkStyle, emailProductTeamSignature} from '../../styles'
+import {emailCopyStyle, emailLinkStyle} from '../../styles'
 import Button from '../Button'
 import EmailBlock from '../EmailBlock/EmailBlock'
 import EmailFooter from '../EmailFooter/EmailFooter'
@@ -20,7 +20,8 @@ const linkStyle = {
   ...emailLinkStyle
 }
 
-const notificationPageUrl = makeAppLink('me')
+const dashUrl = makeAppLink('me')
+const tasksUrl = makeAppLink('me/tasks')
 
 export default function NotificationSummaryEmail() {
   return (
@@ -31,32 +32,47 @@ export default function NotificationSummaryEmail() {
           {'Hi '}%recipient.name%{','}
         </p>
         <p style={copyStyle}>
+          {'A friendly nudge, in case you missed it:'}
+          <b>
+            {'you’ve been mentioned in '}
+            %recipient.numNotifications%
+            {' task(s)'}
+          </b>
+          {'in the past day — '}
+          <a style={linkStyle} href={dashUrl}>
+            {'see what’s new and what your team needs'}
+          </a>
+          {'.'}
+        </p>
+        <p style={copyStyle}>
           {'You have received '}
           <span style={{fontWeight: 600}}>
             %recipient.numNotifications%{' new notification(s)'}
           </span>
           {' in the last day.'}
         </p>
-        <Button url={notificationPageUrl}>{'See My Notifications'}</Button>
+        <Button url={dashUrl}>{'See Notifications'}</Button>
         <EmptySpace height={24} />
-        <p style={copyStyle}>{'This is just a friendly, automated nudge!'}</p>
-        <p style={copyStyle}>{'Your teammates need you!'}</p>
-        <p style={copyStyle}>{emailProductTeamSignature}</p>
         <p style={copyStyle}>
-          <b>{'P.S. We want to hear from you:'}</b>
+          {'You can also see '}
+          <a style={linkStyle} href={tasksUrl}>
+            {'everything on your plate in the Tasks view'}
+          </a>
+          {'.'}
         </p>
         <p style={copyStyle}>
-          {'Email us at '}
+          {'And if you ever need anything from us, don’t hesitate to reach out at '}
           <a style={linkStyle} href='mailto:love@parabol.co'>
             {'love@parabol.co'}
           </a>
-          {' with any feedback or questions you may have about our software.'}
+          {'.'}
         </p>
         <p style={copyStyle}>
-          {'Or, schedule a video chat with our product team: '}
+          {'Have fun & do great work,'}
           <br />
-          <a style={linkStyle} href='https://calendly.com/parabol/product/'>
-            {'https://calendly.com/parabol/product/'}
+          {'-'}
+          <a style={linkStyle} href='https://www.parabol.co/team'>
+            {'Parabol Team'}
           </a>
         </p>
         <EmptySpace height={16} />

--- a/packages/server/email/components/NotificationSummary/index.tsx
+++ b/packages/server/email/components/NotificationSummary/index.tsx
@@ -25,7 +25,7 @@ If you ever need anything from us, don’t hesitate to reach out at love@parabol
 
 export default (props) => {
   const subject = `Your team needs you: %recipient.numNotifications% notification(s) 👀`
-  const previewText = 'You’ve been tagged in some tasks — see what people need'
+  const previewText = 'You have unread notifications — see what your team needs'
   return {
     subject,
     body: textOnlySummary(),

--- a/packages/server/email/components/NotificationSummary/index.tsx
+++ b/packages/server/email/components/NotificationSummary/index.tsx
@@ -1,5 +1,4 @@
 import Oy from 'oy-vey'
-import makeDateString from 'parabol-client/utils/makeDateString'
 import React from 'react'
 import makeAppLink from '../../../utils/makeAppLink'
 import NotificationSummaryEmail from './NotificationSummaryEmail'
@@ -11,30 +10,28 @@ import NotificationSummaryEmail from './NotificationSummaryEmail'
  */
 
 const textOnlySummary = () => {
-  const notificationPageUrl = makeAppLink('me')
+  const dashUrl = makeAppLink('me')
   return `Hi there, %recipient.name%!
 
-You have received %recipient.numNotifications% new notification(s) in the last day.
+You’ve received %recipient.numNotifications% new notification(s) in the last day.
 
-View them on Parabol here: ${notificationPageUrl}
+View them on Parabol here: ${dashUrl}
+
+If you ever need anything from us, don’t hesitate to reach out at love@parabol.co.
 
 - The Product Team at Parabol
-
-P.S. Help us make our software better!
-Email us at love@parabol.co and tell us the good, the bad, and the Ugly!
-Or better yet, pick a time on our calendar for a video chat with our core product team: https://calendly.com/parabol/
 `
 }
 
 export default (props) => {
-  const {date} = props
-  const subject = `Parabol notifications for ${makeDateString(date)}`
+  const subject = `Your team needs you: %recipient.numNotifications% notification(s) 👀`
+  const previewText = 'You’ve been tagged in some tasks — see what people need'
   return {
     subject,
     body: textOnlySummary(),
     html: Oy.renderTemplate(<NotificationSummaryEmail {...props} />, {
       title: subject,
-      previewText: subject
+      previewText
     })
   }
 }

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
@@ -8,6 +8,8 @@ import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 import EmailBorderBottom from './EmailBorderBottom'
 import RetroTopic from './RetroTopic'
+import makeAppLink from 'parabol-server/utils/makeAppLink'
+import {meetingSummaryUrlParams} from 'parabol-server/email/components/MeetingSummaryEmailRootSSR'
 
 const sectionHeading = {
   color: PALETTE.TEXT_MAIN,
@@ -21,14 +23,12 @@ interface Props {
   isDemo: boolean
   isEmail: boolean
   meeting: RetroTopics_meeting
-  meetingUrl: string
 }
 
 const RetroTopics = (props: Props) => {
-  const {isDemo, isEmail, meeting, meetingUrl} = props
+  const {isDemo, isEmail, meeting} = props
   const {id: meetingId, reflectionGroups} = meeting
   if (!reflectionGroups) return null
-  const toPart = isEmail ? meetingUrl : `/meet/${meetingId}`
   return (
     <>
       <tr>
@@ -36,15 +36,21 @@ const RetroTopics = (props: Props) => {
           {plural(reflectionGroups.length, RETRO_TOPIC_LABEL)}
         </td>
       </tr>
-      {reflectionGroups.map((topic, idx) => (
-        <RetroTopic
-          key={topic.id}
-          isDemo={isDemo}
-          isEmail={isEmail}
-          topic={topic}
-          to={`${toPart}/discuss/${idx + 1}`}
-        />
-      ))}
+      {reflectionGroups.map((topic, idx) => {
+        const topicUrlPath = `meet/${meetingId}/discuss/${idx + 1}`
+        const topicUrl = isEmail
+          ? makeAppLink(topicUrlPath, {params: meetingSummaryUrlParams})
+          : `/${topicUrlPath}`
+        return (
+          <RetroTopic
+            key={topic.id}
+            isDemo={isDemo}
+            isEmail={isEmail}
+            topic={topic}
+            to={topicUrl}
+          />
+        )
+      })}
       <EmailBorderBottom />
     </>
   )

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -57,12 +57,7 @@ const SummarySheet = (props: Props) => {
         <CreateAccountSection isDemo={isDemo} />
         <MeetingMembersWithTasks meeting={meeting} />
         <MeetingMembersWithoutTasks meeting={meeting} />
-        <RetroTopics
-          isDemo={isDemo}
-          isEmail={referrer === 'email'}
-          meeting={meeting}
-          meetingUrl={meetingUrl}
-        />
+        <RetroTopics isDemo={isDemo} isEmail={referrer === 'email'} meeting={meeting} />
         {meetingType === ACTION && (
           <SummaryEmailScheduleCalendar
             isDemo={isDemo}


### PR DESCRIPTION
- Fixes #3712
- Fixes #3779 

### Tests
#### Notification summary email
- [ ] Trigger the notification summary, the email has updated copy
- [ ] Bonus points: the email has granular information about task assignment and mentions by team the user is on

#### Retro summary email
- [ ] Vote on 3 topics in a retro
- [ ] In the summary email, when tapping on a topic the URL takes you to that exact topic/stage
- [ ] Bonus points: we remove the query params, leaving a clean URL, once Google Analytics has captured the data