### PR TITLE
remove waits from tests

### DIFF
--- a/packages/cypress/cypress.json
+++ b/packages/cypress/cypress.json
@@ -7,6 +7,5 @@
   "supportFile": "support/index.js",
   "videosFolder": "videos",
   "projectId": "3wn18n",
-  "chromeWebSecurity": false,
-  "ignoreTestFiles": "demo_*"
+  "chromeWebSecurity": false
 }

--- a/packages/cypress/integration/demo_discuss.ts
+++ b/packages/cypress/integration/demo_discuss.ts
@@ -3,16 +3,22 @@ async function addTask(text) {
   cy.get('button')
     .contains('Add a Task')
     .click()
-  // retries until is editable
-  cy.get('div[contenteditable="true"]').should('have.length', 4)
-  cy.get('.DraftEditor-root')
-    .contains('.DraftEditor-root', 'Describe what')
-    .type(`${text}{enter}`)
+
+  cy.contains('.DraftEditor-root', 'Describe what')
+    .should(($e) => {
+      expect($e.find('.public-DraftEditor-content')).to.have.prop('contenteditable', 'true')
+    })
+    .type(text)
+    .type('{enter}')
+    .should('have.text', text)
 }
 
 function editTask(text: string, oldContent: string) {
   cy.contains('.DraftEditor-root', oldContent)
-    .type(`{selectall}{backspace}${text}{enter}`)
+    .type('{selectall}')
+    .type('{backspace}')
+    .type(text)
+    .type('{enter}')
     .should('have.text', text)
 }
 

--- a/packages/cypress/integration/demo_discuss.ts
+++ b/packages/cypress/integration/demo_discuss.ts
@@ -1,51 +1,19 @@
 // Adds the task in cypress and returns an index to use for editing and replying to the task
-function addTask(text) {
-  cy.get(`[data-cy=discuss-input-add]`).click()
-
-  cy.get(`[data-cy=discuss-thread-list]`)
-    .children()
-    .last()
-    .as('add-discuss-task')
-
-  return new Cypress.Promise((resolve) => {
-    cy.get('@add-discuss-task')
-      .invoke('index')
-      .then((i) => {
-        i = i - 2
-
-        cy.get(`[data-cy=thread-item-${i}-task-card-editor]`).as('card-editor')
-
-        cy.get('@card-editor').should('be.visible')
-
-        cy.wait(50)
-
-        cy.get('@card-editor').type(`${text}`)
-
-        cy.wait(50)
-
-        cy.get('@card-editor').should('have.text', `${text}`)
-
-        cy.wait(50)
-
-        cy.get('@card-editor').type('{enter}')
-
-        resolve(i)
-      })
-  })
+async function addTask(text) {
+  cy.get('button')
+    .contains('Add a Task')
+    .click()
+  // retries until is editable
+  cy.get('div[contenteditable="true"]').should('have.length', 4)
+  cy.get('.DraftEditor-root')
+    .contains('.DraftEditor-root', 'Describe what')
+    .type(`${text}{enter}`)
 }
 
-function editTask(text, idx) {
-  cy.get(`[data-cy=thread-item-${idx}-task-card-editor]`).as('edit-discuss-task')
-
-  cy.get('@edit-discuss-task')
-    .type('{selectall}')
-    .type('{backspace}')
-    .type(`${text}`)
-    .should('have.text', `${text}`)
-
-  cy.get('@edit-discuss-task').type('{enter}')
-
-  cy.get('@edit-discuss-task').should('have.text', text)
+function editTask(text: string, oldContent: string) {
+  cy.contains('.DraftEditor-root', oldContent)
+    .type(`{selectall}{backspace}${text}{enter}`)
+    .should('have.text', text)
 }
 
 function replyComment(text, idx, child) {
@@ -166,13 +134,11 @@ describe('Test Discuss page Demo', () => {
   })
 
   it('can create a new task', () => {
-    addTask('New Task created').then((result) => {
-      taskIndex = result
-    })
+    addTask('New Task created')
   })
 
   it('can edit a created task', () => {
-    editTask('Edited the task', taskIndex)
+    editTask('Edited the task', 'New Task created')
   })
 
   it('can reply to a created task', () => {

--- a/packages/cypress/support/commands.ts
+++ b/packages/cypress/support/commands.ts
@@ -71,7 +71,7 @@ const visitReflect = () => {
   cy.visit('/retrospective-demo/reflect')
   cy.get('[data-cy=start-demo-button]')
     .should('be.visible')
-    .click()
+    .click({force: true})
     .then(() => {
       cy.get('[data-cy=sidebar-toggle]').click()
     })


### PR DESCRIPTION
Goals:
- Establish pattern to remove `wait` wherever possible
- Establish pattern to create tests without modifying app code

Root cause:
- The reason the `wait` was required is because cypress was referencing an unmounted DOM node
- When the user clicks "create task", an optimistic task appears immediately so the UI feels snappy. It is then replaced by a persisted task that is editable. This is the cause for the unmount.
- Just like a human, cypress shouldn't know or care about optimistic updating or DOM nodes being unmounted. It should try to act like a human as much as possible
- So, we tell cypress to look for a task with a placeholder that is editable. The gotcha here is that _cypress only retries the last command before the assertion_. See https://docs.cypress.io/guides/core-concepts/retry-ability.html#Commands-vs-assertions.

Other notes:
The tests are really solid! Moving forward, a fun challenge would be to try and write tests without modifying the application code (e.g. injecting `data-cy`). Although it isn't always possible, this is usually preferable because it means tests are less tightly coupled to the app internals & it's closer to how a human would read the page.

For example, the `editTask` function now has a signature that accepts the `oldContent` instead of an `idx`. Try refactoring the other tests to see if it's possible to remove `taskIndex` entirely.

