### PR TITLE
fixes #3712 notif summary email copy

### DIFF
--- a/packages/server/email/components/Header/Header.tsx
+++ b/packages/server/email/components/Header/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import emailDir from '../../emailDir'
 import {emailTableBase} from '../../styles'
+import makeAppLink from '../../../utils/makeAppLink'
 
 const imageStyle = {
   border: '0px',
@@ -12,20 +13,29 @@ const cellStyle = {
   padding: '32px 0px'
 }
 
+const linkStyle = {
+  display: 'block',
+  textDecoration: 'none'
+}
+
+const dashUrl = makeAppLink('me')
+
 const Header = () => {
   return (
     <table style={emailTableBase} width='100%'>
       <tbody>
         <tr>
           <td align='left' style={cellStyle}>
-            <img
-              crossOrigin=''
-              alt='Parabol, Inc. Logo'
-              height={40}
-              src={`${emailDir}email-header-branding-color@3x.png`}
-              style={imageStyle}
-              width={192}
-            />
+            <a style={linkStyle} href={dashUrl}>
+              <img
+                crossOrigin=''
+                alt='Parabol, Inc. Logo'
+                height={40}
+                src={`${emailDir}email-header-branding-color@3x.png`}
+                style={imageStyle}
+                width={192}
+              />
+            </a>
           </td>
         </tr>
       </tbody>

--- a/packages/server/email/components/NotificationSummaryEmail.tsx
+++ b/packages/server/email/components/NotificationSummaryEmail.tsx
@@ -1,8 +1,9 @@
 import plural from 'parabol-client/utils/plural'
+import {ContactInfo, ExternalLinks} from 'parabol-client/types/constEnums'
 import PropTypes from 'prop-types'
 import React from 'react'
 import makeAppLink from '../../utils/makeAppLink'
-import {emailCopyStyle, emailLinkStyle, emailProductTeamSignature} from '../styles'
+import {emailCopyStyle, emailLinkStyle} from '../styles'
 import Button from './Button'
 import EmailBlock from './EmailBlock/EmailBlock'
 import EmailFooter from './EmailFooter/EmailFooter'
@@ -21,7 +22,7 @@ const linkStyle = {
   ...emailLinkStyle
 }
 
-const notificationPageUrl = makeAppLink('me/tasks')
+const tasksUrl = makeAppLink('me/tasks')
 
 export interface NotificationSummaryProps {
   preferredName: string
@@ -33,34 +34,29 @@ export default function NotificationSummaryEmail(props: NotificationSummaryProps
     <Layout maxWidth={544}>
       <EmailBlock innerMaxWidth={innerMaxWidth}>
         <Header />
-        <p style={copyStyle}>{`Hi ${preferredName},`}</p>
+        <p style={copyStyle}>{`Hi ${preferredName} -`}</p>
         <p style={copyStyle}>
-          {'You have received '}
+          {'You have '}
           <span style={{fontWeight: 600}}>
             {`${notificationCount} new ${plural(notificationCount, 'notification')}`}
           </span>
-          {' in the last day.'}
+          {' — see what’s changed with your teams.'}
         </p>
-        <Button url={notificationPageUrl}>{'See My Notifications'}</Button>
+        <Button url={tasksUrl}>{'See My Dashboard'}</Button>
         <EmptySpace height={24} />
-        <p style={copyStyle}>{'This is just a friendly, automated nudge!'}</p>
-        <p style={copyStyle}>{'Your teammates need you!'}</p>
-        <p style={copyStyle}>{emailProductTeamSignature}</p>
         <p style={copyStyle}>
-          <b>{'P.S. We want to hear from you:'}</b>
-        </p>
-        <p style={copyStyle}>
-          {'Email us at '}
-          <a style={linkStyle} href='mailto:love@parabol.co'>
-            {'love@parabol.co'}
+          {'If you need anything from us, don’t hesitate to reach out at '}
+          <a style={linkStyle} href={`mailto:${ContactInfo.EMAIL_LOVE}`}>
+            {ContactInfo.EMAIL_LOVE}
           </a>
-          {' with any feedback or questions you may have about our software.'}
+          {'.'}
         </p>
         <p style={copyStyle}>
-          {'Or, schedule a video chat with our product team: '}
+          {'Have fun & do great work,'}
           <br />
-          <a style={linkStyle} href='https://calendly.com/parabol/product/'>
-            {'https://calendly.com/parabol/product/'}
+          {'- '}
+          <a style={linkStyle} href={ExternalLinks.TEAM}>
+            {'Parabol Team'}
           </a>
         </p>
         <EmptySpace height={16} />

--- a/packages/server/email/components/notificationSummaryCreator.tsx
+++ b/packages/server/email/components/notificationSummaryCreator.tsx
@@ -8,12 +8,12 @@ import NotificationSummaryEmail, {NotificationSummaryProps} from './Notification
 const textOnlySummary = (props: NotificationSummaryProps) => {
   const {preferredName, notificationCount} = props
   const taskUrl = makeAppLink('me/tasks')
-  return `Hi ${preferredName}-
+  return `Hi ${preferredName} -
 
-A friendly nudge, in case you missed it: you have ${notificationCount} unread ${plural(
+You have ${notificationCount} new ${plural(
     notificationCount,
     'notification'
-  )} — see what your team needs.
+  )} — see what’s changed with your teams.
 
 You can see everything on your plate in the Tasks view: ${taskUrl}
 
@@ -27,10 +27,10 @@ ${ExternalLinks.TEAM}
 
 const notificationSummaryCreator = (props: NotificationSummaryProps) => {
   const {notificationCount} = props
-  const subject = `Your team needs you: ${notificationCount} unread ${plural(
+  const subject = `You have ${notificationCount} new ${plural(
     notificationCount,
     'notification'
-  )}👀`
+  )} 👀`
   return {
     subject,
     body: textOnlySummary(props),


### PR DESCRIPTION
Fixes #3712 

### Tests
- [ ] go to `/email` and see an updated email — verify that the copy looks good and the links work (logo, button, email, team page)