### PR TITLE
Fixes for Cypress tests and getDemoEntities

### DIFF
--- a/packages/client/components/DiscussionThreadList.tsx
+++ b/packages/client/components/DiscussionThreadList.tsx
@@ -66,7 +66,7 @@ const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
     <Wrapper data-cy={`${dataCy}`} ref={ref}>
       <HeaderBlock />
       <PusherDowner />
-      {threadables.map((threadable, idx) => {
+      {threadables.map((threadable) => {
         const {id} = threadable
         return (
           <ThreadedItem

--- a/packages/client/components/DiscussionThreadList.tsx
+++ b/packages/client/components/DiscussionThreadList.tsx
@@ -70,7 +70,6 @@ const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
         const {id} = threadable
         return (
           <ThreadedItem
-            dataCy={`thread-item-${idx}`}
             key={id}
             threadable={threadable}
             meeting={meeting}

--- a/packages/client/components/ThreadedItem.tsx
+++ b/packages/client/components/ThreadedItem.tsx
@@ -11,7 +11,6 @@ interface Props {
   threadable: ThreadedItem_threadable
   meeting: ThreadedItem_meeting
   reflectionGroupId: string
-  dataCy: string
 }
 
 export type ReplyMention = {
@@ -22,13 +21,13 @@ export type ReplyMention = {
 export type SetReplyMention = (replyMention: ReplyMention) => void
 
 export const ThreadedItem = (props: Props) => {
-  const {threadable, reflectionGroupId, meeting, dataCy} = props
+  const {threadable, reflectionGroupId, meeting} = props
   const {__typename, replies} = threadable
   const [replyMention, setReplyMention] = useState<ReplyMention>(null)
   if (!replies) debugger
   const child = (
     <ThreadedRepliesList
-      dataCy={`${dataCy}-child`}
+      dataCy={`child`}
       meeting={meeting}
       replies={replies}
       reflectionGroupId={reflectionGroupId}
@@ -38,7 +37,7 @@ export const ThreadedItem = (props: Props) => {
   if (__typename === 'Task') {
     return (
       <ThreadedTaskBase
-        dataCy={`${dataCy}-task`}
+        dataCy={`task`}
         task={threadable}
         meeting={meeting}
         reflectionGroupId={reflectionGroupId}
@@ -51,7 +50,7 @@ export const ThreadedItem = (props: Props) => {
   }
   return (
     <ThreadedCommentBase
-      dataCy={`${dataCy}-comment`}
+      dataCy={`comment`}
       comment={threadable}
       meeting={meeting}
       reflectionGroupId={reflectionGroupId}

--- a/packages/client/components/ThreadedRepliesList.tsx
+++ b/packages/client/components/ThreadedRepliesList.tsx
@@ -22,11 +22,11 @@ const ThreadedRepliesList = (props: Props) => {
   if (!replies) return null
   return (
     <>
-      {replies.map((reply, idx) => {
+      {replies.map((reply) => {
         const {__typename, id} = reply
         return __typename === 'Task' ? (
           <ThreadedTaskBase
-            dataCy={`${dataCy}-task-${idx}`}
+            dataCy={`${dataCy}-task`}
             key={id}
             isReply
             task={reply}
@@ -35,16 +35,16 @@ const ThreadedRepliesList = (props: Props) => {
             setReplyMention={setReplyMention}
           />
         ) : (
-          <ThreadedCommentBase
-            dataCy={`${dataCy}-comment-${idx}`}
-            key={id}
-            isReply
-            comment={reply}
-            meeting={meeting}
-            reflectionGroupId={reflectionGroupId}
-            setReplyMention={setReplyMention}
-          />
-        )
+            <ThreadedCommentBase
+              dataCy={`${dataCy}-comment`}
+              key={id}
+              isReply
+              comment={reply}
+              meeting={meeting}
+              reflectionGroupId={reflectionGroupId}
+              setReplyMention={setReplyMention}
+            />
+          )
       })}
     </>
   )

--- a/packages/client/modules/demo/getDemoEntities.ts
+++ b/packages/client/modules/demo/getDemoEntities.ts
@@ -21,7 +21,7 @@ const demoLookup = (text) => {
 const getDemoEntities = async (text: string) => {
   if (!text || text.length <= 2) return []
   const remoteAtmosphere = new Atmosphere()
-  if (!(window as any).Cypress) {
+  if ((window as any).Cypress) {
     const lookupEntities = demoLookup(text)
     return lookupEntities || []
   }

--- a/packages/cypress/cypress.json
+++ b/packages/cypress/cypress.json
@@ -7,6 +7,5 @@
   "supportFile": "support/index.js",
   "videosFolder": "videos",
   "projectId": "3wn18n",
-  "chromeWebSecurity": false,
-  "ignoreTestFiles": "demo_*"
+  "chromeWebSecurity": false
 }

--- a/packages/cypress/support/commands.ts
+++ b/packages/cypress/support/commands.ts
@@ -97,13 +97,13 @@ const visitPhase = (phase: string, idx = '') => {
   })
   cy.get(`[data-cy=next-phase]`)
     .should('be.visible')
-    .click()
+    .dblclick()
 
   cy.url().should('be.eq', `http://localhost:3000/retrospective-demo/${phase}${idx}`)
 }
 
 // const click = ($el) => {
-// return $el.click()
+//   return $el.click()
 // }
 
 Cypress.Commands.add('visitReflect', visitReflect)


### PR DESCRIPTION
This PR does the following:
* adds a double click to demo tests to account for bottom control bar progress (will now double click to go to next phase)
* removes index checking from most discussion tests
* fixes the if statement in getDemoEntities to use lookup table when in Cypress mode