### PR TITLE
Update README.md to include -i option on "yarn dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ git clone https://github.com/ParabolInc/parabol.git
 $ cd parabol
 $ cp .env.example .env # Add your own vars here
 $ rethinkdb & redis-server & # Or if you prefer docker: $ docker-compose up -d db
-$ yarn && yarn dev
+$ yarn && yarn dev -i # -i is only needed the first time you clone the repo
 ```
 
 Build for production and start application:


### PR DESCRIPTION
When people first cloned the repo, they need to run ``yarn dev -i`` to properly get the DB setup and migration ready. After it's done one time, they don't need to include the ``-i`` option anymore to make it fast.