### PR TITLE
Add Redis Cache for User table

### DIFF
--- a/packages/server/billing/helpers/generateInvoice.ts
+++ b/packages/server/billing/helpers/generateInvoice.ts
@@ -1,22 +1,23 @@
-import getRethink from '../../database/rethinkDriver'
-import {fromEpochSeconds} from '../../utils/epochTime'
-import shortid from 'shortid'
-import Stripe from 'stripe'
-import Invoice from '../../database/types/Invoice'
+import {InvoiceItemType} from 'parabol-client/types/constEnums'
 import {
   InvoiceLineItemEnum,
   InvoiceStatusEnum,
   OrgUserRole,
   TierEnum
 } from 'parabol-client/types/graphql'
-import InvoiceLineItemDetail from '../../database/types/InvoiceLineItemDetail'
-import QuantityChangeLineItem from '../../database/types/QuantityChangeLineItem'
-import InvoiceLineItemOtherAdjustments from '../../database/types/InvoiceLineItemOtherAdjustments'
-import {InvoiceItemType} from 'parabol-client/types/constEnums'
-import StripeManager from '../../utils/StripeManager'
-import NextPeriodCharges from '../../database/types/NextPeriodCharges'
+import shortid from 'shortid'
+import Stripe from 'stripe'
+import getRethink from '../../database/rethinkDriver'
 import Coupon from '../../database/types/Coupon'
+import Invoice from '../../database/types/Invoice'
+import InvoiceLineItemDetail from '../../database/types/InvoiceLineItemDetail'
+import InvoiceLineItemOtherAdjustments from '../../database/types/InvoiceLineItemOtherAdjustments'
+import NextPeriodCharges from '../../database/types/NextPeriodCharges'
 import Organization from '../../database/types/Organization'
+import QuantityChangeLineItem from '../../database/types/QuantityChangeLineItem'
+import db from '../../db'
+import {fromEpochSeconds} from '../../utils/epochTime'
+import StripeManager from '../../utils/StripeManager'
 
 interface InvoicesByStartTime {
   [start: string]: {
@@ -73,12 +74,7 @@ interface DetailedLineItemDict {
 }
 
 const getEmailLookup = async (userIds: string[]) => {
-  const r = await getRethink()
-  const usersAndEmails = (await r
-    .table('User')
-    .getAll(r.args(userIds), {index: 'id'})
-    .pluck('id', 'email')
-    .run()) as {id: string; email: string}[]
+  const usersAndEmails = await db.readMany('User', userIds)
   return usersAndEmails.reduce((dict, doc) => {
     dict[doc.id] = doc.email
     return dict

--- a/packages/server/database/migrations/20200610125717-cleanUsers.ts
+++ b/packages/server/database/migrations/20200610125717-cleanUsers.ts
@@ -1,0 +1,25 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
+  try {
+    await r
+      .table('User')
+      .replace((row) =>
+        row.without(
+          'welcomeSentAt',
+          'cacheExpiresAt',
+          'cachedAt',
+          'emailVerified',
+          'name',
+          'nickname'
+        )
+      )
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function() {
+  // noop
+}

--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -42,7 +42,7 @@ import Team from './types/Team'
 import TimelineEvent from './types/TimelineEvent'
 import User from './types/User'
 
-export type RethinkTypes = {
+export type RethinkSchema = {
   AgendaItem: {
     type: AgendaItem
     index: 'teamId' | 'meetingId'
@@ -101,13 +101,13 @@ export type RethinkTypes = {
   }
   Notification: {
     type:
-    | NotificationTaskInvolves
-    | NotificationTeamArchived
-    | NotificationMeetingStageTimeLimitEnd
-    | NotificationPaymentRejected
-    | NotificationKickedOut
-    | NotificationPromoteToBillingLeader
-    | NotificationTeamInvitation
+      | NotificationTaskInvolves
+      | NotificationTeamArchived
+      | NotificationMeetingStageTimeLimitEnd
+      | NotificationPaymentRejected
+      | NotificationKickedOut
+      | NotificationPromoteToBillingLeader
+      | NotificationTeamInvitation
     index: 'userId'
   }
   Organization: {
@@ -202,7 +202,11 @@ export type RethinkTypes = {
   }
 }
 
-type ParabolR = R<RethinkTypes>
+export type DBType = {
+  [P in keyof RethinkSchema]: RethinkSchema[P]['type']
+}
+
+type ParabolR = R<RethinkSchema>
 
 const config = getRethinkConfig()
 let isLoading = false

--- a/packages/server/database/types/User.ts
+++ b/packages/server/database/types/User.ts
@@ -7,7 +7,6 @@ interface Input {
   id?: string
   preferredName: string
   email: string
-  emailVerified?: boolean
   featureFlags?: string[]
   lastSeenAt?: Date
   lastSeenAtURL?: string
@@ -29,7 +28,6 @@ export default class User {
   connectedSockets: string[]
   preferredName: string
   email: string
-  emailVerified: boolean
   featureFlags: string[]
   lastSeenAt: Date | null
   lastSeenAtURL: string | null
@@ -55,7 +53,6 @@ export default class User {
       createdAt,
       picture,
       updatedAt,
-      emailVerified,
       featureFlags,
       lastSeenAt,
       lastSeenAtURL,
@@ -80,7 +77,6 @@ export default class User {
     this.createdAt = createdAt || now
     this.picture = picture || `${AVATAR_BUCKET}/${avatarName}.png`
     this.updatedAt = updatedAt || now
-    this.emailVerified = emailVerified || false
     this.featureFlags = featureFlags || []
     this.identities = identities || []
     this.inactive = inactive || false

--- a/packages/server/dataloader/LoaderMakerPrimary.ts
+++ b/packages/server/dataloader/LoaderMakerPrimary.ts
@@ -1,5 +1,5 @@
-import {RethinkTypes} from '../database/rethinkDriver'
+import {DBType} from '../database/rethinkDriver'
 
-export default class LoaderMakerPrimary<T extends keyof RethinkTypes> {
+export default class LoaderMakerPrimary<T extends keyof DBType> {
   constructor(public table: T) {}
 }

--- a/packages/server/dataloader/LocalCache.ts
+++ b/packages/server/dataloader/LocalCache.ts
@@ -38,7 +38,7 @@ export default class LocalCache {
       cacheHits[i]()
     }
   }
-  private async dispatchBatch() {
+  private dispatchBatch = async () => {
     this.hasReadDispatched = true
     // grab a reference to them now because after await is called they may be overwritten when a new batch is created
     const {keys, callbacks, cacheHits} = this
@@ -97,6 +97,7 @@ export default class LocalCache {
       this.primeLocal(key, doc)
     })
     this.redisCache.prime(table, docs)
+    return this
   }
   async read<T extends keyof RethinkTypes>(table: T, id: string) {
     const key = `${table}:${id}`

--- a/packages/server/dataloader/LocalCache.ts
+++ b/packages/server/dataloader/LocalCache.ts
@@ -80,8 +80,11 @@ export default class LocalCache {
     this.hasWriteDispatched = true
     const {writes} = this
     const results = await this.redisCache.write(writes)
-    writes.forEach(({resolve}, idx) => {
-      resolve(results[idx])
+    writes.forEach(({resolve, table, id}, idx) => {
+      const key = `${table}:${id}`
+      const result = results[idx]
+      this.primeLocal(key, result)
+      resolve(result)
     })
   }
   async clear<T extends keyof RethinkTypes>(table: T, id: string) {

--- a/packages/server/dataloader/LocalCache.ts
+++ b/packages/server/dataloader/LocalCache.ts
@@ -1,7 +1,6 @@
-import ms from 'ms'
 import {DBType} from '../database/rethinkDriver'
 import RedisCache from './RedisCache'
-import {Doc, RWrite, Updater} from './RethinkDBCache'
+import {RWrite, Updater} from './RethinkDBCache'
 
 const resolvedPromise = Promise.resolve()
 
@@ -23,10 +22,11 @@ export default class LocalCache<T extends keyof DBType> {
     resolve: (payload: any) => void
     updater: Updater<DBType[T]>
   }[]
-  private ttl = ms('1h')
+  private ttl: number
   private redisCache = new RedisCache()
   // private redisCache = new RedisCache(this.clearLocal)
-  constructor() {
+  constructor(ttl: number) {
+    this.ttl = ttl
     setInterval(this.gc, this.ttl).unref()
   }
 
@@ -80,7 +80,7 @@ export default class LocalCache<T extends keyof DBType> {
     delete this.cacheMap[key]
     return this
   }
-  private primeLocal(key: string, doc: Doc) {
+  private primeLocal(key: string, doc: DBType[keyof DBType]) {
     this.cacheMap[key] = {
       ts: Date.now(),
       promise: Promise.resolve(doc)

--- a/packages/server/dataloader/LocalCache.ts
+++ b/packages/server/dataloader/LocalCache.ts
@@ -1,0 +1,173 @@
+import ms from 'ms'
+import {RethinkTypes} from '../database/rethinkDriver'
+import RedisCache from './RedisCache'
+import {Doc, RType, RWrite, Updater} from './RethinkDBCache'
+
+const resolvedPromise = Promise.resolve()
+
+// every original read has 1 key, 1 callback and 1 entry in the cacheMap
+// every duplicate request has 1 cacheHit that, when called, resolves to the original promise in the cacheMap
+export default class LocalCache {
+  private cacheMap = {} as {[key: string]: {ts: number; promise: Promise<any>}}
+  private hasReadDispatched = true
+  private hasWriteDispatched = true
+  private keys = [] as string[]
+  private callbacks = [] as {resolve: (payload: any) => void; reject: (err: any) => void}[]
+  private cacheHits = [] as (() => void)[]
+  private writes = [] as (RWrite<any> & {resolve: (payload: any) => void})[]
+  private ttl = ms('1h')
+  private redisCache = new RedisCache()
+  constructor() {
+    setInterval(this.gc, this.ttl).unref()
+  }
+
+  private gc = () => {
+    const keys = Object.keys(this.cacheMap)
+    const oldestValidTS = Date.now() - this.ttl
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      const {ts} = this.cacheMap[key]
+      if (ts < oldestValidTS) {
+        delete this.cacheMap[key]
+      }
+    }
+  }
+  private resolveCacheHits(cacheHits: (() => void)[]) {
+    // cacheHits are possibly from the previous batch, hence the param
+    for (let i = 0; i < cacheHits.length; i++) {
+      cacheHits[i]()
+    }
+  }
+  private async dispatchBatch() {
+    this.hasReadDispatched = true
+    // grab a reference to them now because after await is called they may be overwritten when a new batch is created
+    const {keys, callbacks, cacheHits} = this
+    if (keys.length === 0) {
+      this.resolveCacheHits(cacheHits)
+      return
+    }
+    try {
+      const values = await this.redisCache.read(keys)
+      this.resolveCacheHits(cacheHits)
+      for (let i = 0; i < callbacks.length; i++) {
+        const {resolve, reject} = callbacks[i]
+        const value = values[i]
+        const handle = value instanceof Error ? reject : resolve
+        handle(value)
+      }
+    } catch (e) {
+      this.resolveCacheHits(cacheHits)
+      for (let i = 0; i < callbacks.length; i++) {
+        this.clearLocal(keys[i])
+        const {reject} = callbacks[i]
+        reject(e)
+      }
+    }
+  }
+
+  private clearLocal(key: string) {
+    delete this.cacheMap[key]
+    return this
+  }
+  private primeLocal(key: string, doc: Doc) {
+    this.cacheMap[key] = {
+      ts: Date.now(),
+      promise: Promise.resolve(doc)
+    }
+  }
+
+  private dispatchWrite = async () => {
+    this.hasWriteDispatched = true
+    const {writes} = this
+    const results = await this.redisCache.write(writes)
+    writes.forEach(({resolve}, idx) => {
+      resolve(results[idx])
+    })
+  }
+  async clear<T extends keyof RethinkTypes>(table: T, id: string) {
+    const key = `${table}:${id}`
+    this.clearLocal(key)
+    await this.redisCache.clear(key)
+    return this
+  }
+
+  async prime<T extends keyof RethinkTypes>(table: T, docs: RType<T>[]) {
+    docs.forEach((doc) => {
+      const key = `${table}:${doc.id}`
+      this.primeLocal(key, doc)
+    })
+    this.redisCache.prime(table, docs)
+  }
+  async read<T extends keyof RethinkTypes>(table: T, id: string) {
+    const key = `${table}:${id}`
+    if (this.hasReadDispatched) {
+      this.hasReadDispatched = false
+      this.keys = []
+      this.callbacks = []
+      this.cacheHits = []
+      resolvedPromise.then(() => {
+        process.nextTick(this.dispatchBatch)
+      })
+    }
+    const cachedRecord = this.cacheMap[key]
+    if (cachedRecord) {
+      cachedRecord.ts = Date.now()
+      return new Promise<RType<T>>((resolve) => {
+        this.cacheHits.push(() => {
+          resolve(cachedRecord.promise)
+        })
+      })
+    }
+    this.keys.push(key)
+    const promise = new Promise<RType<T>>((resolve, reject) => {
+      this.callbacks.push({resolve, reject})
+    })
+    this.cacheMap[key] = {ts: Date.now(), promise}
+    return promise
+  }
+
+  async readMany<T extends keyof RethinkTypes>(table: T, ids: string[]) {
+    const loadPromises = [] as Promise<RType<T>>[]
+    for (let i = 0; i < ids.length; i++) {
+      loadPromises.push(this.read(table, ids[i]).catch((error) => error))
+    }
+    return Promise.all(loadPromises)
+  }
+  async write<T extends keyof RethinkTypes, P extends RType<T>>(
+    table: T,
+    id: string,
+    updater: Updater<P>
+  ) {
+    if (this.hasWriteDispatched) {
+      this.hasWriteDispatched = false
+      this.writes = [] as (RWrite<P> & {resolve: (payload: any) => void})[]
+      resolvedPromise.then(() => {
+        process.nextTick(this.dispatchWrite)
+      })
+    }
+    return new Promise<P>((resolve) => {
+      this.writes.push({id, table, updater, resolve})
+    })
+  }
+
+  async writeMany<T extends keyof RethinkTypes, P extends RType<T>>(
+    table: T,
+    ids: string[],
+    updater: Updater<P>
+  ) {
+    return Promise.all(ids.map((id) => this.write(table, id, updater)))
+  }
+
+  // currently doesn't support updater functions
+  async writeTable<T extends keyof RethinkTypes, P extends Partial<RType<T>>>(
+    table: T,
+    updater: P
+  ) {
+    Object.keys(this.cacheMap).forEach((key) => {
+      if (!key.startsWith(`${table}:`)) return
+      const doc = this.cacheMap[key]
+      Object.assign(doc, updater)
+    })
+    await this.redisCache.writeTable(table, updater)
+  }
+}

--- a/packages/server/dataloader/ProxiedCache.ts
+++ b/packages/server/dataloader/ProxiedCache.ts
@@ -1,8 +1,8 @@
 import DataLoader from 'dataloader'
-import {RethinkTypes} from '../database/rethinkDriver'
+import {DBType} from '../database/rethinkDriver'
 import db from '../db'
 
-export default class ProxiedCache<T extends keyof RethinkTypes> implements DataLoader<string, T> {
+export default class ProxiedCache<T extends keyof DBType> implements DataLoader<string, T> {
   table: T
   constructor(table: T) {
     this.table = table

--- a/packages/server/dataloader/ProxiedCache.ts
+++ b/packages/server/dataloader/ProxiedCache.ts
@@ -1,0 +1,31 @@
+import DataLoader from 'dataloader'
+import {RethinkTypes} from '../database/rethinkDriver'
+import db from '../db'
+
+export default class ProxiedCache<T extends keyof RethinkTypes> implements DataLoader<string, T> {
+  table: T
+  constructor(table: T) {
+    this.table = table
+  }
+
+  load(id: string) {
+    return db.read(this.table, id)
+  }
+  loadMany(ids: string[]) {
+    return db.readMany(this.table, ids)
+  }
+
+  clear(id: string) {
+    // this is actually async, but we don't await so it looks like a DataLoader
+    db.clear(this.table, id)
+    return this
+  }
+  clearAll() {
+    // noop, need to implement in LocalCache
+    return this
+  }
+  prime(_id: string, doc: any) {
+    db.prime(this.table, [doc])
+    return this
+  }
+}

--- a/packages/server/dataloader/RedisCache.ts
+++ b/packages/server/dataloader/RedisCache.ts
@@ -72,11 +72,11 @@ export default class RedisCache<T extends keyof DBType> {
   write = async (writes: RWrite<T>[]) => {
     const results = await this.rethinkDBCache.write(writes)
     const redisWrites = [] as string[][]
-    results.map((result, idx) => {
+    results.forEach((result, idx) => {
+      // result will be null if the underlying document is not found
       if (!result) return
       const write = writes[idx]
-      const {table} = write
-      const {id} = result
+      const {table, id} = write
       const key = `${table}:${id}`
       redisWrites.push(msetpx(key, result))
     })

--- a/packages/server/dataloader/RedisCache.ts
+++ b/packages/server/dataloader/RedisCache.ts
@@ -44,8 +44,9 @@ export default class RedisCache {
     const redisWrites = [] as string[][]
     results.map((result, idx) => {
       if (!result) return
-      const table = writes[idx]
-      const id = result
+      const write = writes[idx]
+      const {table} = write
+      const {id} = result
       const key = `${table}:${id}`
       redisWrites.push(msetpx(key, result))
     })

--- a/packages/server/dataloader/RedisCache.ts
+++ b/packages/server/dataloader/RedisCache.ts
@@ -1,0 +1,91 @@
+import ms from 'ms'
+import {RethinkTypes} from '../database/rethinkDriver'
+import getRedis from '../utils/getRedis'
+import RethinkDBCache, {Doc, RType, RWrite} from './RethinkDBCache'
+
+const TTL = ms('3h')
+
+const msetpx = (key: string, value: object) => {
+  return ['set', key, JSON.stringify(value), 'PX', TTL] as string[]
+}
+
+export default class RedisCache {
+  rethinkDBCache = new RethinkDBCache()
+  read = async (keys: string[]) => {
+    const redis = getRedis()
+    const cachedDocs = await redis.mget(...keys)
+    const missingKeys = [] as string[]
+    const parsedDocs = [] as {id: string}[]
+    for (let i = 0; i < cachedDocs.length; i++) {
+      const cachedDoc = cachedDocs[i]
+      if (cachedDoc === null) {
+        missingKeys.push(keys[i])
+      } else {
+        parsedDocs.push(JSON.parse(cachedDoc))
+      }
+    }
+    if (missingKeys.length === 0) return parsedDocs
+    const docsByKey = await this.rethinkDBCache.read(missingKeys)
+    const writes = [] as string[][]
+    Object.keys(docsByKey).forEach((key) => {
+      writes.push(msetpx(key, docsByKey[key]))
+    })
+    // don't wait for redis to populate the local cache
+    redis.multi(writes).exec()
+    return keys.map((key, idx) => {
+      const cachedDoc = cachedDocs[idx]
+      if (cachedDoc) return JSON.parse(cachedDoc)
+      return docsByKey[key]
+    })
+  }
+
+  write = async <T extends keyof RethinkTypes>(writes: RWrite<T>[]) => {
+    const results = await this.rethinkDBCache.write(writes)
+    const redisWrites = [] as string[][]
+    results.map((result, idx) => {
+      if (!result) return
+      const table = writes[idx]
+      const id = result
+      const key = `${table}:${id}`
+      redisWrites.push(msetpx(key, result))
+    })
+    const redis = getRedis()
+    // awaiting redis isn't strictly required, can get speedboost by removing the wait
+    await redis.multi(redisWrites).exec()
+    return results
+  }
+
+  clear = async (key: string) => {
+    const redis = getRedis()
+    return redis.del(key)
+  }
+  prime = async <T extends keyof RethinkTypes>(table: T, docs: Doc[]) => {
+    const redis = getRedis()
+    const writes = docs.map((doc) => {
+      return msetpx(`${table}:${doc.id}`, doc)
+    })
+    await redis.multi(writes).exec()
+  }
+  writeTable = async <T extends keyof RethinkTypes>(table: T, updater: Partial<RType<T>>) => {
+    // inefficient to not update rethink & redis in parallel, but writeTable is uncommon
+    await this.rethinkDBCache.writeTable(table, updater)
+    return new Promise((resolve) => {
+      const redis = getRedis()
+      const stream = redis.scanStream({match: `${table}:*`, count: 100})
+      stream.on('data', async (keys) => {
+        stream.pause()
+        const userStrs = await redis.mget(...keys)
+        const writes = userStrs.map((userStr, idx) => {
+          const user = JSON.parse(userStr!)
+          Object.assign(user, updater)
+          return msetpx(keys[idx], user)
+        })
+        await redis.multi(writes).exec()
+        stream.resume()
+      })
+      stream.on('end', () => {
+        resolve()
+      })
+    })
+  }
+}

--- a/packages/server/dataloader/RedisCache.ts
+++ b/packages/server/dataloader/RedisCache.ts
@@ -1,19 +1,49 @@
+import Redis from 'ioredis'
 import ms from 'ms'
-import {RethinkTypes} from '../database/rethinkDriver'
-import getRedis from '../utils/getRedis'
-import RethinkDBCache, {Doc, RType, RWrite} from './RethinkDBCache'
+import {DBType} from '../database/rethinkDriver'
+import RethinkDBCache, {Doc, RWrite} from './RethinkDBCache'
 
 const TTL = ms('3h')
 
 const msetpx = (key: string, value: object) => {
   return ['set', key, JSON.stringify(value), 'PX', TTL] as string[]
 }
+// type ClearLocal = (key: string) => void
 
-export default class RedisCache {
+export default class RedisCache<T extends keyof DBType> {
   rethinkDBCache = new RethinkDBCache()
-  read = async (keys: string[]) => {
-    const redis = getRedis()
-    const cachedDocs = await redis.mget(...keys)
+  redis = new Redis(process.env.REDIS_URL)
+  // remote invalidation is stuck on upgrading to Redis v6 in prod
+  // invalidator = new Redis(process.env.REDIS_URL)
+  cachedTypes = new Set<string>()
+  invalidatorClientId!: string
+  // constructor(clearLocal: ClearLocal) {
+  //   this.initializeInvalidator(clearLocal)
+  // }
+  // private async initializeInvalidator(clearLocal: ClearLocal) {
+  //   this.invalidator.subscribe('__redis__:invalidate')
+  //   this.invalidator.on('message', (_channel, key) => {
+  //     clearLocal(key)
+  //   })
+  //   this.invalidatorClientId = await this.redis.client('id')
+  // }
+  // private trackInvalidations(fetches: {table: T}[]) {
+  //   // This O(N) operation could be O(1), but that requires updating the prefixes as we cache more things
+  //   // the risk of an invalid cache hit isn't worth it
+  //   for (let i = 0; i < fetches.length; i++) {
+  //     const {table} = fetches[i]
+  //     if (!this.cachedTypes.has(table)) {
+  //       this.cachedTypes.add(table)
+  //       // whenever any key starts with the ${table} prefix gets set, send an invalidation message to the invalidator
+  //       // noloop is used to exclude sending the message to the client that called set
+  //       this.redis.client('TRACKING', 'ON', 'REDIRECT', this.invalidatorClientId, 'BCAST', 'NOLOOP', 'PREFIX', table)
+  //     }
+  //   }
+  // }
+  read = async (fetches: {table: T; id: string}[]) => {
+    // this.trackInvalidations(fetches)
+    const keys = fetches.map(({table, id}) => `${table}:${id}`)
+    const cachedDocs = await this.redis.mget(...keys)
     const missingKeys = [] as string[]
     const parsedDocs = [] as {id: string}[]
     for (let i = 0; i < cachedDocs.length; i++) {
@@ -31,7 +61,7 @@ export default class RedisCache {
       writes.push(msetpx(key, docsByKey[key]))
     })
     // don't wait for redis to populate the local cache
-    redis.multi(writes).exec()
+    this.redis.multi(writes).exec()
     return keys.map((key, idx) => {
       const cachedDoc = cachedDocs[idx]
       if (cachedDoc) return JSON.parse(cachedDoc)
@@ -39,7 +69,7 @@ export default class RedisCache {
     })
   }
 
-  write = async <T extends keyof RethinkTypes>(writes: RWrite<T>[]) => {
+  write = async (writes: RWrite<T>[]) => {
     const results = await this.rethinkDBCache.write(writes)
     const redisWrites = [] as string[][]
     results.map((result, idx) => {
@@ -50,38 +80,34 @@ export default class RedisCache {
       const key = `${table}:${id}`
       redisWrites.push(msetpx(key, result))
     })
-    const redis = getRedis()
     // awaiting redis isn't strictly required, can get speedboost by removing the wait
-    await redis.multi(redisWrites).exec()
+    await this.redis.multi(redisWrites).exec()
     return results
   }
 
   clear = async (key: string) => {
-    const redis = getRedis()
-    return redis.del(key)
+    return this.redis.del(key)
   }
-  prime = async <T extends keyof RethinkTypes>(table: T, docs: Doc[]) => {
-    const redis = getRedis()
+  prime = async (table: T, docs: Doc[]) => {
     const writes = docs.map((doc) => {
       return msetpx(`${table}:${doc.id}`, doc)
     })
-    await redis.multi(writes).exec()
+    await this.redis.multi(writes).exec()
   }
-  writeTable = async <T extends keyof RethinkTypes>(table: T, updater: Partial<RType<T>>) => {
+  writeTable = async (table: T, updater: Partial<DBType[T]>) => {
     // inefficient to not update rethink & redis in parallel, but writeTable is uncommon
     await this.rethinkDBCache.writeTable(table, updater)
     return new Promise((resolve) => {
-      const redis = getRedis()
-      const stream = redis.scanStream({match: `${table}:*`, count: 100})
+      const stream = this.redis.scanStream({match: `${table}:*`, count: 100})
       stream.on('data', async (keys) => {
         stream.pause()
-        const userStrs = await redis.mget(...keys)
+        const userStrs = await this.redis.mget(...keys)
         const writes = userStrs.map((userStr, idx) => {
           const user = JSON.parse(userStr!)
           Object.assign(user, updater)
           return msetpx(keys[idx], user)
         })
-        await redis.multi(writes).exec()
+        await this.redis.multi(writes).exec()
         stream.resume()
       })
       stream.on('end', () => {

--- a/packages/server/dataloader/RethinkDBCache.ts
+++ b/packages/server/dataloader/RethinkDBCache.ts
@@ -1,0 +1,59 @@
+import getRethink, {RethinkTypes} from '../database/rethinkDriver'
+import {RDatum} from '../database/stricterR'
+
+export interface Doc {
+  id: string
+  [key: string]: any
+}
+export type Updater<T> = Partial<T> | ((doc: RDatum<T>) => any)
+export type RType<T extends keyof RethinkTypes> = RethinkTypes[T]['type']
+export type RWrite<T> = {id: string; table: T; updater: Updater<T>}
+export default class RethinkDBCache {
+  read = async (keys: string[]) => {
+    const r = await getRethink()
+    const idsByTable = {} as {[table: string]: string[]}
+    keys.forEach((key) => {
+      const [table, id] = key.split(':')
+      idsByTable[table] = idsByTable[table] || []
+      idsByTable[table].push(id)
+    })
+    const reqlObj = {} as {[table: string]: Doc[]}
+    Object.keys(idsByTable).forEach((table) => {
+      const ids = idsByTable[table]
+      reqlObj[table] = (r
+        .table(table as any)
+        .getAll(r.args(ids))
+        .coerceTo('array') as unknown) as Doc[]
+    })
+
+    const dbDocsByTable = await r(reqlObj).run()
+    const docsByKey = {} as {[key: string]: Doc}
+    Object.keys(dbDocsByTable).forEach((table) => {
+      const docs = dbDocsByTable[table]
+      docs.forEach((doc) => {
+        const key = `${table}:${doc.id}`
+        docsByKey[key] = doc
+      })
+    })
+    return docsByKey
+  }
+  write = async <T extends keyof RethinkTypes>(writes: RWrite<T>[]) => {
+    const r = await getRethink()
+    const reqlParts = writes.map((update) => {
+      const {table, id, updater} = update
+      return r
+        .table(table)
+        .get(id)
+        .update(updater, {returnChanges: true})('changes')(0)('new_val')
+        .default(null)
+    })
+    return r(reqlParts).run()
+  }
+  writeTable = async <T extends keyof RethinkTypes>(table: T, updater: Partial<RType<T>>) => {
+    const r = await getRethink()
+    return r
+      .table(table)
+      .update(updater)
+      .run()
+  }
+}

--- a/packages/server/dataloader/RethinkDBCache.ts
+++ b/packages/server/dataloader/RethinkDBCache.ts
@@ -47,7 +47,7 @@ export default class RethinkDBCache {
         .update(updater, {returnChanges: true})('changes')(0)('new_val')
         .default(null)
     })
-    return r(reqlParts).run()
+    return r(reqlParts).run() as Promise<RType<T>[]>
   }
   writeTable = async <T extends keyof RethinkTypes>(table: T, updater: Partial<RType<T>>) => {
     const r = await getRethink()

--- a/packages/server/dataloader/RethinkDBCache.ts
+++ b/packages/server/dataloader/RethinkDBCache.ts
@@ -40,13 +40,16 @@ export default class RethinkDBCache {
     const r = await getRethink()
     const reqlParts = writes.map((update) => {
       const {table, id, updater} = update
-      return r
-        .table(table)
-        .get(id)
-        .update(updater, {returnChanges: true})('changes')(0)('new_val')
-        .default(null)
+      return (
+        r
+          .table(table)
+          .get(id)
+          // "always" will return the document whether it has changed or not
+          .update(updater, {returnChanges: 'always'})('changes')(0)('new_val')
+          .default(null)
+      )
     })
-    return r(reqlParts).run() as Promise<DBType[T][]>
+    return r(reqlParts).run() as Promise<(DBType[T] | null)[]>
   }
   writeTable = async <T extends keyof DBType>(table: T, updater: Partial<DBType[T]>) => {
     const r = await getRethink()

--- a/packages/server/dataloader/RethinkDataLoader.ts
+++ b/packages/server/dataloader/RethinkDataLoader.ts
@@ -1,5 +1,5 @@
 import DataLoader from 'dataloader'
-import {RethinkTypes} from '../database/rethinkDriver'
+import {DBType} from '../database/rethinkDriver'
 import * as customLoaderMakers from './customLoaderMakers'
 import fkLoader from './fkLoader'
 import * as foreignLoaderMakers from './foreignLoaderMakers'
@@ -23,7 +23,7 @@ type Loaders = keyof LoaderMakers
 
 type PrimaryLoaderMakers = typeof primaryLoaderMakers
 type PrimaryLoaders = keyof PrimaryLoaderMakers
-type Unprimary<T> = T extends LoaderMakerPrimary<infer U> ? RethinkTypes[U]['type'] : never
+type Unprimary<T> = T extends LoaderMakerPrimary<infer U> ? DBType[U]['type'] : never
 type TypeFromPrimary<T extends PrimaryLoaders> = Unprimary<PrimaryLoaderMakers[T]>
 
 type ForeignLoaderMakers = typeof foreignLoaderMakers

--- a/packages/server/dataloader/RethinkDataLoader.ts
+++ b/packages/server/dataloader/RethinkDataLoader.ts
@@ -1,4 +1,5 @@
 import DataLoader from 'dataloader'
+import {RethinkTypes} from '../database/rethinkDriver'
 import * as customLoaderMakers from './customLoaderMakers'
 import fkLoader from './fkLoader'
 import * as foreignLoaderMakers from './foreignLoaderMakers'
@@ -6,7 +7,6 @@ import LoaderMakerForeign from './LoaderMakerForeign'
 import LoaderMakerPrimary from './LoaderMakerPrimary'
 import pkLoader from './pkLoader'
 import * as primaryLoaderMakers from './primaryLoaderMakers'
-import {RethinkTypes} from '../database/rethinkDriver'
 
 interface LoaderDict {
   [loaderName: string]: DataLoader<any, any>

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -9,6 +9,7 @@ import Task from '../database/types/Task'
 import {ThreadSource} from '../database/types/ThreadSource'
 import AtlassianServerManager from '../utils/AtlassianServerManager'
 import normalizeRethinkDbResults from './normalizeRethinkDbResults'
+import ProxiedCache from './ProxiedCache'
 import RethinkDataLoader from './RethinkDataLoader'
 
 type AccessTokenKey = {teamId: string; userId: string}
@@ -51,6 +52,10 @@ const threadableLoaders = [
 // export type LoaderMakerCustom<K, V, C = K> = (parent: RethinkDataLoader) => DataLoader<K, V, C>
 
 // TODO: refactor if the interface pattern is used a total of 3 times
+
+export const users = () => {
+  return new ProxiedCache('User')
+}
 
 export const commentCountByThreadId = (parent: RethinkDataLoader) => {
   return new DataLoader<string, number, string>(

--- a/packages/server/dataloader/fkLoader.ts
+++ b/packages/server/dataloader/fkLoader.ts
@@ -1,9 +1,9 @@
 import DataLoader from 'dataloader'
-import {RethinkTypes} from '../database/rethinkDriver'
+import {DBType} from '../database/rethinkDriver'
 
-const fkLoader = <T extends keyof RethinkTypes>(
-  standardLoader: DataLoader<string, RethinkTypes[T]['type']>,
-  options: DataLoader.Options<string, RethinkTypes[T]['type']>,
+const fkLoader = <T extends keyof DBType>(
+  standardLoader: DataLoader<string, DBType[T]>,
+  options: DataLoader.Options<string, DBType[T]>,
   field: string,
   fetchFn: (ids: string[]) => any[] | Promise<any[]>
 ) => {
@@ -14,7 +14,7 @@ const fkLoader = <T extends keyof RethinkTypes>(
     })
     return ids.map((id) => items.filter((item) => item[field] === id))
   }
-  return new DataLoader<string, RethinkTypes[T]['type']>(batchFn, options)
+  return new DataLoader<string, DBType[T]>(batchFn, options)
 }
 
 export default fkLoader

--- a/packages/server/dataloader/getLoaderNameByTable.ts
+++ b/packages/server/dataloader/getLoaderNameByTable.ts
@@ -1,0 +1,13 @@
+import * as primaryLoaderMakers from './primaryLoaderMakers'
+
+const loadersByTable = {}
+Object.keys(primaryLoaderMakers).forEach((loaderName) => {
+  const loader = primaryLoaderMakers[loaderName]
+  loadersByTable[loader.table] = loaderName
+})
+
+const getLoaderNameByTable = (table: string) => {
+  return loadersByTable[table]
+}
+
+export default getLoaderNameByTable

--- a/packages/server/dataloader/pkLoader.ts
+++ b/packages/server/dataloader/pkLoader.ts
@@ -1,9 +1,9 @@
 import DataLoader from 'dataloader'
-import getRethink, {RethinkTypes} from '../database/rethinkDriver'
+import getRethink, {DBType} from '../database/rethinkDriver'
 import normalizeRethinkDbResults from './normalizeRethinkDbResults'
 
-const pkLoader = <T extends keyof RethinkTypes>(
-  options: DataLoader.Options<string, RethinkTypes[T]['type']>,
+const pkLoader = <T extends keyof DBType>(
+  options: DataLoader.Options<string, DBType[T]>,
   table: T
 ) => {
   // don't pass in a a filter here because they requested a specific ID, they know what they want
@@ -13,9 +13,9 @@ const pkLoader = <T extends keyof RethinkTypes>(
       .table(table)
       .getAll(r.args(keys), {index: 'id'})
       .run()) as any
-    return normalizeRethinkDbResults<RethinkTypes[T]['type']>(keys, docs)
+    return normalizeRethinkDbResults<DBType[T]>(keys, docs)
   }
-  return new DataLoader<string, RethinkTypes[T]['type']>(batchFn, options)
+  return new DataLoader<string, DBType[T]>(batchFn, options)
 }
 
 export default pkLoader

--- a/packages/server/db.ts
+++ b/packages/server/db.ts
@@ -8,7 +8,7 @@
  * Stage 2 listens for invalidations coming from other nodes and invalidates Stage 1 when necessary (WIP, stuck on Redis v6)
  *
  * READS:
- *    Stage 1 caches the record inside a Promise. if not found, it it queries Stage 2, caches the result, and returns
+ *    Stage 1 caches the record inside a Promise. if not found, it queries Stage 2, caches the result, and returns
  *    Stage 2 gets the missing items & looks them up in redis. If not found, it queries Stage 3, caches the result, and returns
  *    Stage 3 sends a single batched query to RethinkDB containing all items not present in Stage 2
  *

--- a/packages/server/db.ts
+++ b/packages/server/db.ts
@@ -1,19 +1,19 @@
 /*
  * This is a 3-stage cache
- * Stage 1 is a local cache (Node process), which stores parsed JSON.
+ * Stage 1 is a query batcher and local cache (Node process), which stores parsed JSON.
  * Stage 2 is a remote cache (Redis), which stores the document in serialized JSON
  * Stage 3 is the DB itself (RethinkDB)
- * Stage 1 also batches read/write requests to a single microtask to reduce latency
  * Stage 1 runs a garbage collector every hour to remove docs that haven't been used in 1 hour
  * Stage 2 uses Redis's built-in TTL to expire documents after 3 hours
+ * Stage 2 listens for invalidations coming from other nodes and invalidates Stage 1 when necessary (WIP, stuck on Redis v6)
  *
  * READS:
  *    Stage 1 caches the record inside a Promise. if not found, it it queries Stage 2, caches the result, and returns
  *    Stage 2 gets the missing items & looks them up in redis. If not found, it queries Stage 3, caches the result, and returns
- *    Stage 3 Batches all missing records by table and sends a single query to RethinkDB
+ *    Stage 3 sends a single batched query to RethinkDB containing all items not present in Stage 2
  *
  * WRITES:
- *    Stage 1 updates the cached value if found, calls Stage 2, then returns when Stage 2 finishes
+ *    Stage 1 passes the write request to Stage 2updates the cached value if found, calls Stage 2, then returns when Stage 2 finishes
  *    Stage 2 queries the current value from redis. If found, updates the value in redis and calls Stage 3
  *    Stage 3 batches all updates and sends a single query to RethinkDB
  *

--- a/packages/server/db.ts
+++ b/packages/server/db.ts
@@ -1,0 +1,24 @@
+/*
+ * This is a 3-stage cache
+ * Stage 1 is a local cache (Node process), which stores parsed JSON.
+ * Stage 2 is a remote cache (Redis), which stores the document in serialized JSON
+ * Stage 3 is the DB itself (RethinkDB)
+ * Stage 1 also batches read/write requests to a single microtask to reduce latency
+ * Stage 1 runs a garbage collector every hour to remove docs that haven't been used in 1 hour
+ * Stage 2 uses Redis's built-in TTL to expire documents after 3 hours
+ *
+ * READS:
+ *    Stage 1 caches the record inside a Promise. if not found, it it queries Stage 2, caches the result, and returns
+ *    Stage 2 gets the missing items & looks them up in redis. If not found, it queries Stage 3, caches the result, and returns
+ *    Stage 3 Batches all missing records by table and sends a single query to RethinkDB
+ *
+ * WRITES:
+ *    Stage 1 updates the cached value if found, calls Stage 2, then returns when Stage 2 finishes
+ *    Stage 2 queries the current value from redis. If found, updates the value in redis and calls Stage 3
+ *    Stage 3 batches all updates and sends a single query to RethinkDB
+ */
+
+import LocalCache from './dataloader/LocalCache'
+
+const db = new LocalCache()
+export default db

--- a/packages/server/db.ts
+++ b/packages/server/db.ts
@@ -16,6 +16,10 @@
  *    Stage 1 updates the cached value if found, calls Stage 2, then returns when Stage 2 finishes
  *    Stage 2 queries the current value from redis. If found, updates the value in redis and calls Stage 3
  *    Stage 3 batches all updates and sends a single query to RethinkDB
+ *
+ * PROXIED CACHE:
+ *    The LocalCache is essentially a DataLoader that doesn't expire after the request completes
+ *    ProxiedCache maps the LocalCache to the DataLoader API so the dataloader worker can use it
  */
 
 import LocalCache from './dataloader/LocalCache'

--- a/packages/server/db.ts
+++ b/packages/server/db.ts
@@ -22,7 +22,8 @@
  *    ProxiedCache maps the LocalCache to the DataLoader API so the dataloader worker can use it
  */
 
+import ms from 'ms'
 import LocalCache from './dataloader/LocalCache'
 
-const db = new LocalCache()
+const db = new LocalCache(ms('1h'))
 export default db

--- a/packages/server/graphql/DataLoaderCache.ts
+++ b/packages/server/graphql/DataLoaderCache.ts
@@ -1,7 +1,13 @@
 import DataLoader from 'dataloader'
+import getLoaderNameByTable from '../dataloader/getLoaderNameByTable'
 
 export interface DataLoaderBase {
   get: (loaderName: any) => DataLoader<any, any>
+  loaders: {
+    [key: string]: {
+      clear(id: string): void
+    }
+  }
 }
 
 export class CacheWorker<T extends DataLoaderBase> {
@@ -21,6 +27,10 @@ export class CacheWorker<T extends DataLoaderBase> {
     return this.dataLoaderBase.get(dataLoaderName)
   }
 
+  clear = (table: string, id: string) => {
+    const loaderName = getLoaderNameByTable(table)
+    this.dataLoaderBase.loaders[loaderName]?.clear(id)
+  }
   dispose(force?: boolean) {
     const ttl = force || !this.shared ? 0 : this.cache.ttl
     clearTimeout(this.disposeId!)

--- a/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
+++ b/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
@@ -36,7 +36,10 @@ const addNewFeature = {
       url
     }
     await Promise.all([
-      r.table('NewFeature').insert(newFeature),
+      r
+        .table('NewFeature')
+        .insert(newFeature)
+        .run(),
       db.writeTable('User', {newFeatureId})
     ])
 

--- a/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
+++ b/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
@@ -1,10 +1,11 @@
 import {GraphQLNonNull, GraphQLString} from 'graphql'
+import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import shortid from 'shortid'
 import getRethink from '../../../database/rethinkDriver'
+import db from '../../../db'
 import {requireSU} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
-import shortid from 'shortid'
 import AddNewFeaturePayload from '../../types/addNewFeaturePayload'
-import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 
 const addNewFeature = {
   type: AddNewFeaturePayload,
@@ -34,12 +35,10 @@ const addNewFeature = {
       copy,
       url
     }
-    await r({
-      newFeature: r.table('NewFeature').insert(newFeature),
-      userUpdate: r.table('User').update({
-        newFeatureId
-      })
-    }).run()
+    await Promise.all([
+      r.table('NewFeature').insert(newFeature),
+      db.writeTable('User', {newFeatureId})
+    ])
 
     const onlineUserIds = await r
       .table('User')

--- a/packages/server/graphql/intranetSchema/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/intranetSchema/mutations/draftEnterpriseInvoice.ts
@@ -2,6 +2,7 @@ import {GraphQLID, GraphQLInt, GraphQLNonNull} from 'graphql'
 import {OrgUserRole, TierEnum} from 'parabol-client/types/graphql'
 import getRethink from '../../../database/rethinkDriver'
 import User from '../../../database/types/User'
+import db from '../../../db'
 import {requireSU} from '../../../utils/authorization'
 import {fromEpochSeconds} from '../../../utils/epochTime'
 import segmentIo from '../../../utils/segmentIo'
@@ -48,12 +49,8 @@ const getBillingLeaderUser = async (
     (organizationUser) => organizationUser.role === OrgUserRole.BILLING_LEADER
   )
   const billingLeaderUserIds = billingLeaders.map(({userId}) => userId)
-  return r
-    .table('User')
-    .getAll(r.args(billingLeaderUserIds))
-    .nth(0)
-    .default(null)
-    .run()
+  const billingLeaderUsers = await db.readMany('User', billingLeaderUserIds)
+  return billingLeaderUsers[0]
 }
 
 export default {

--- a/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
+++ b/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
@@ -93,7 +93,6 @@ const loginSAML = {
       id: userId,
       email,
       preferredName: name,
-      emailVerified: true,
       lastSeenAt: now,
       tier: TierEnum.enterprise
     })

--- a/packages/server/graphql/intranetSchema/queries/user.ts
+++ b/packages/server/graphql/intranetSchema/queries/user.ts
@@ -1,5 +1,6 @@
 import {GraphQLID, GraphQLString} from 'graphql'
 import getRethink from '../../../database/rethinkDriver'
+import db from '../../../db'
 import {requireSU} from '../../../utils/authorization'
 import User from '../../types/User'
 
@@ -27,11 +28,7 @@ const user = {
         .default(null)
         .run()
     }
-    return r
-      .table('User')
-      .get(userId)
-      .default(null)
-      .run()
+    return db.read('User', userId)
   }
 }
 

--- a/packages/server/graphql/mutations/createJiraIssue.ts
+++ b/packages/server/graphql/mutations/createJiraIssue.ts
@@ -4,6 +4,7 @@ import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {ICreateJiraIssueOnMutationArguments} from 'parabol-client/types/graphql'
 import getRethink from '../../database/rethinkDriver'
+import db from '../../db'
 import AtlassianServerManager from '../../utils/AtlassianServerManager'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
@@ -92,10 +93,8 @@ export default {
 
     const isViewerAllowed = viewerAuth ? viewerAuth.isActive : false
     if (!isViewerAllowed) {
-      const creatorName = await r
-        .table('User')
-        .get(viewerId)('preferredName')
-        .run()
+      const creator = await db.read('User', viewerId)
+      const creatorName = creator.preferredName
       markdown = `${markdown}\n\n_Added by ${creatorName}_`
     }
 

--- a/packages/server/graphql/mutations/deleteUser.ts
+++ b/packages/server/graphql/mutations/deleteUser.ts
@@ -1,6 +1,7 @@
 import {GraphQLID, GraphQLNonNull, GraphQLString} from 'graphql'
 import getRethink from '../../database/rethinkDriver'
 import User from '../../database/types/User'
+import db from '../../db'
 import {getUserId, isSuperUser} from '../../utils/authorization'
 import segmentIo from '../../utils/segmentIo'
 import {GQLContext} from '../graphql'
@@ -57,15 +58,11 @@ export default {
     await Promise.all(
       orgIds.map((orgId) => removeFromOrg(userIdToDelete, orgId, undefined, dataLoader))
     )
-    await r
-      .table('User')
-      .get(userIdToDelete)
-      .update({
-        isRemoved: true,
-        email: 'DELETED',
-        reasonRemoved: validReason
-      })
-      .run()
+    await db.write('User', userIdToDelete, {
+      isRemoved: true,
+      email: 'DELETED',
+      reasonRemoved: validReason
+    })
     segmentIo.track({
       userId,
       event: 'Account Removed',

--- a/packages/server/graphql/mutations/dismissNewFeature.ts
+++ b/packages/server/graphql/mutations/dismissNewFeature.ts
@@ -1,5 +1,5 @@
 import {GraphQLNonNull} from 'graphql'
-import getRethink from '../../database/rethinkDriver'
+import db from '../../db'
 import {getUserId} from '../../utils/authorization'
 import DismissNewFeaturePayload from '../types/DismissNewFeaturePayload'
 
@@ -8,19 +8,9 @@ export default {
   description: `Redeem an invitation token for a logged in user`,
   // rate limited because a notificationId subverts the expiration of the token & we don't want any brute forces for expired tokens
   resolve: async (_source, _args, {authToken}) => {
-    const r = await getRethink()
-
     // AUTH
     const viewerId = getUserId(authToken)
-
-    await r
-      .table('User')
-      .get(viewerId)
-      .update({
-        newFeatureId: null
-      })
-      .run()
-
+    await db.write('User', viewerId, {newFeatureId: null})
     return {}
   }
 }

--- a/packages/server/graphql/mutations/emailPasswordReset.ts
+++ b/packages/server/graphql/mutations/emailPasswordReset.ts
@@ -9,6 +9,7 @@ import getRethink from '../../database/rethinkDriver'
 import AuthIdentityLocal from '../../database/types/AuthIdentityLocal'
 import PasswordResetRequest from '../../database/types/PasswordResetRequest'
 import User from '../../database/types/User'
+import db from '../../db'
 import getMailManager from '../../email/getMailManager'
 import resetPasswordEmailCreator from '../../email/resetPasswordEmailCreator'
 import {GQLContext} from '../graphql'
@@ -70,11 +71,7 @@ const emailPasswordReset = {
       .insert(new PasswordResetRequest({ip, email, token: resetPasswordToken}))
       .run()
 
-    await r
-      .table('User')
-      .get(userId)
-      .update({identities})
-      .run()
+    await db.write('User', userId, {identities})
 
     const {subject, body, html} = resetPasswordEmailCreator({resetPasswordToken})
     const success = await getMailManager().sendEmail({

--- a/packages/server/graphql/mutations/helpers/handleInvitationToken.ts
+++ b/packages/server/graphql/mutations/helpers/handleInvitationToken.ts
@@ -1,8 +1,8 @@
+import db from '../../../db'
+import {DataLoaderWorker} from '../../graphql'
 import getIsMassInviteToken from './getIsMassInviteToken'
 import handleMassInviteToken from './handleMassInviteToken'
 import handleTeamInviteToken from './handleTeamInviteToken'
-import getRethink from '../../../database/rethinkDriver'
-import {DataLoaderWorker} from '../../graphql'
 
 const handleInvitationToken = async (
   invitationToken: string,
@@ -10,11 +10,7 @@ const handleInvitationToken = async (
   dataLoader: DataLoaderWorker,
   notificationId?: string
 ) => {
-  const r = await getRethink()
-  const viewer = await r
-    .table('User')
-    .get(viewerId)
-    .run()
+  const viewer = await db.read('User', viewerId)
   const {email, tms} = viewer
   const isMassInviteToken = getIsMassInviteToken(invitationToken)
   if (isMassInviteToken) return handleMassInviteToken(invitationToken, email, tms, dataLoader)

--- a/packages/server/graphql/mutations/helpers/removeFromOrg.ts
+++ b/packages/server/graphql/mutations/helpers/removeFromOrg.ts
@@ -52,7 +52,8 @@ const removeFromOrg = async (
         {removedAt: now},
         {returnChanges: true}
       )('changes')(0)('new_val')
-      .default(null) as unknown) as OrganizationUser,
+      .default(null)
+      .run() as unknown) as OrganizationUser,
     db.read('User', userId)
   ])
 

--- a/packages/server/graphql/mutations/loginWithGoogle.ts
+++ b/packages/server/graphql/mutations/loginWithGoogle.ts
@@ -4,6 +4,7 @@ import getRethink from '../../database/rethinkDriver'
 import AuthIdentityGoogle from '../../database/types/AuthIdentityGoogle'
 import AuthToken from '../../database/types/AuthToken'
 import User from '../../database/types/User'
+import db from '../../db'
 import encodeAuthToken from '../../utils/encodeAuthToken'
 import GoogleServerManager from '../../utils/GoogleServerManager'
 import standardError from '../../utils/standardError'
@@ -74,13 +75,7 @@ const loginWithGoogle = {
             id: sub
           })
           identities.push(googleIdentity) // mutative
-          await r
-            .table('User')
-            .get(viewerId)
-            .update({
-              identities
-            })
-            .run()
+          await db.write('User', viewerId, {identities})
         }
         // MUTATIVE
         context.authToken = new AuthToken({sub: viewerId, rol, tms: existingUser.tms})

--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -1,13 +1,14 @@
 import {GraphQLID, GraphQLList, GraphQLNonNull, GraphQLString} from 'graphql'
+import {InvoiceItemType} from 'parabol-client/types/constEnums'
+import {ITeam, OrgUserRole} from 'parabol-client/types/graphql'
 import adjustUserCount from '../../billing/helpers/adjustUserCount'
 import getRethink from '../../database/rethinkDriver'
+import Notification from '../../database/types/Notification'
+import Organization from '../../database/types/Organization'
+import db from '../../db'
+import safeArchiveEmptyPersonalOrganization from '../../safeMutations/safeArchiveEmptyPersonalOrganization'
 import {getUserId, isSuperUser} from '../../utils/authorization'
 import standardError from '../../utils/standardError'
-import {ITeam, OrgUserRole} from 'parabol-client/types/graphql'
-import {InvoiceItemType} from 'parabol-client/types/constEnums'
-import safeArchiveEmptyPersonalOrganization from '../../safeMutations/safeArchiveEmptyPersonalOrganization'
-import Organization from '../../database/types/Organization'
-import Notification from '../../database/types/Notification'
 
 const moveToOrg = async (teamId: string, orgId: string, authToken: any) => {
   const r = await getRethink()
@@ -97,12 +98,9 @@ const moveToOrg = async (teamId: string, orgId: string, authToken: any) => {
     })
   )
 
-  const inactiveUserIds = await r
-    .table('User')
-    .getAll(r.args(newToOrgUserIds), {index: 'id'})
-    .filter({inactive: true})('id')
-    .run()
+  const newUsers = await db.readMany('User', newToOrgUserIds)
 
+  const inactiveUserIds = newUsers.filter((user) => user.inactive).map(({id}) => id)
   inactiveUserIds.map((newInactiveUserId) => {
     return adjustUserCount(newInactiveUserId, orgId, InvoiceItemType.AUTO_PAUSE_USER)
   })

--- a/packages/server/graphql/mutations/updateUserProfile.ts
+++ b/packages/server/graphql/mutations/updateUserProfile.ts
@@ -70,7 +70,8 @@ const updateUserProfile = {
         .table('TeamMember')
         .getAll(userId, {index: 'userId'})
         .update(updates, {returnChanges: true})('changes')('new_val')
-        .default([]) as unknown) as TeamMember[],
+        .default([])
+        .run() as unknown) as TeamMember[],
       db.write('User', userId, updates)
     ])
     //

--- a/packages/server/graphql/mutations/verifyEmail.ts
+++ b/packages/server/graphql/mutations/verifyEmail.ts
@@ -5,6 +5,7 @@ import AuthIdentityLocal from '../../database/types/AuthIdentityLocal'
 import AuthToken from '../../database/types/AuthToken'
 import EmailVerification from '../../database/types/EmailVerification'
 import User from '../../database/types/User'
+import db from '../../db'
 import createNewLocalUser from '../../utils/createNewLocalUser'
 import encodeAuthToken from '../../utils/encodeAuthToken'
 import rateLimit from '../rateLimit'
@@ -59,11 +60,7 @@ export default {
       if (!localIdentity.isEmailVerified) {
         // mutative
         localIdentity.isEmailVerified = true
-        await r
-          .table('User')
-          .get(userId)
-          .update({identities, updatedAt: now})
-          .run()
+        await db.write('User', userId, {identities, updatedAt: now})
       }
       return {authToken, userId}
     }

--- a/packages/server/graphql/queries/verifiedInvitation.ts
+++ b/packages/server/graphql/queries/verifiedInvitation.ts
@@ -59,7 +59,10 @@ export default {
         teamId
       } = teamInvitation
       const [team, inviter] = await Promise.all([
-        r.table('Team').get(teamId),
+        r
+          .table('Team')
+          .get(teamId)
+          .run(),
         db.read('User', invitedBy)
       ])
       const bestMeeting = await getBestInvitationMeeting(teamId, maybeMeetingId, dataLoader)

--- a/packages/server/graphql/queries/verifiedInvitation.ts
+++ b/packages/server/graphql/queries/verifiedInvitation.ts
@@ -1,15 +1,16 @@
 import dns, {MxRecord} from 'dns'
+import promisify from 'es6-promisify'
 import {GraphQLID, GraphQLNonNull} from 'graphql'
+import {InvitationTokenError} from 'parabol-client/types/constEnums'
+import {AuthIdentityTypeEnum} from 'parabol-client/types/graphql'
+import getRethink from '../../database/rethinkDriver'
+import User from '../../database/types/User'
+import db from '../../db'
+import getBestInvitationMeeting from '../../utils/getBestInvitationMeeting'
+import getSAMLURLFromEmail from '../../utils/getSAMLURLFromEmail'
+import {GQLContext} from '../graphql'
 import rateLimit from '../rateLimit'
 import VerifiedInvitationPayload from '../types/VerifiedInvitationPayload'
-import getRethink from '../../database/rethinkDriver'
-import promisify from 'es6-promisify'
-import getSAMLURLFromEmail from '../../utils/getSAMLURLFromEmail'
-import {AuthIdentityTypeEnum, ITeam} from 'parabol-client/types/graphql'
-import User from '../../database/types/User'
-import {GQLContext} from '../graphql'
-import {InvitationTokenError} from 'parabol-client/types/constEnums'
-import getBestInvitationMeeting from '../../utils/getBestInvitationMeeting'
 
 const resolveMx = promisify(dns.resolveMx, dns)
 
@@ -57,10 +58,10 @@ export default {
         meetingId: maybeMeetingId,
         teamId
       } = teamInvitation
-      const {team, inviter} = await r({
-        team: (r.table('Team').get(teamId) as unknown) as ITeam,
-        inviter: (r.table('User').get(invitedBy) as unknown) as User
-      }).run()
+      const [team, inviter] = await Promise.all([
+        r.table('Team').get(teamId),
+        db.read('User', invitedBy)
+      ])
       const bestMeeting = await getBestInvitationMeeting(teamId, maybeMeetingId, dataLoader)
       const meetingType = bestMeeting?.meetingType ?? null
       const meetingId = bestMeeting?.id ?? null

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -23,7 +23,6 @@ import organization from '../queries/organization'
 import suggestedIntegrations from '../queries/suggestedIntegrations'
 import AtlassianAuth from './AtlassianAuth'
 import AuthIdentity from './AuthIdentity'
-import BlockedUserType from './BlockedUserType'
 import Company from './Company'
 import GitHubAuth from './GitHubAuth'
 import GraphQLEmailType from './GraphQLEmailType'
@@ -68,18 +67,6 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
         return auths.find((auth) => auth.teamId === teamId)
       }
     },
-    blockedFor: {
-      type: new GraphQLList(BlockedUserType),
-      description: 'Array of identifier + ip pairs'
-    },
-    cachedAt: {
-      type: GraphQLISO8601Type,
-      description: 'The timestamp of the user was cached'
-    },
-    cacheExpiresAt: {
-      type: GraphQLISO8601Type,
-      description: 'The timestamp when the cached user expires'
-    },
     company: {
       type: Company,
       description: 'The assumed company this organizaiton belongs to',
@@ -100,10 +87,6 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
     email: {
       type: new GraphQLNonNull(GraphQLEmailType),
       description: 'The user email'
-    },
-    emailVerified: {
-      type: GraphQLBoolean,
-      description: 'true if email is verified, false otherwise'
     },
     featureFlags: {
       type: new GraphQLNonNull(UserFeatureFlags),
@@ -205,10 +188,6 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
         return lastMetAt ? new Date(lastMetAt) : null
       }
     },
-    loginsCount: {
-      type: GraphQLInt,
-      description: 'The number of logins for this user'
-    },
     monthlyStreakMax: {
       type: GraphQLNonNull(GraphQLInt),
       description: 'The largest number of consecutive months the user has checked into a meeting',
@@ -234,14 +213,6 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
           .sort((a, b) => (a < b ? 1 : -1))
         return getMonthlyStreak(meetingDates, true)
       }
-    },
-    name: {
-      type: GraphQLString,
-      description: 'Name associated with the user'
-    },
-    nickname: {
-      type: GraphQLString,
-      description: 'Nickname associated with the user'
     },
     suggestedActions: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SuggestedAction))),
@@ -319,7 +290,7 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
     },
     preferredName: {
       type: new GraphQLNonNull(GraphQLString),
-      description: 'The application-specific name, defaults to nickname',
+      description: 'The application-specific name, defaults to email before the tld',
       resolve: ({preferredName, name}) => {
         return preferredName || name
       }

--- a/packages/server/safeMutations/acceptTeamInvitation.ts
+++ b/packages/server/safeMutations/acceptTeamInvitation.ts
@@ -9,7 +9,7 @@ import User from '../database/types/User'
 import {DataLoaderWorker} from '../graphql/graphql'
 import addTeamMemberToMeetings from '../graphql/mutations/helpers/addTeamMemberToMeetings'
 import getNewTeamLeadUserId from '../safeQueries/getNewTeamLeadUserId'
-import setUserTierForOrgId from '../utils/setUserTierForOrgId'
+import setUserTierForUserIds from '../utils/setUserTierForUserIds'
 import addTeamIdToTMS from './addTeamIdToTMS'
 import insertNewTeamMember from './insertNewTeamMember'
 
@@ -109,8 +109,7 @@ const acceptTeamInvitation = async (
     } catch (e) {
       console.log(e)
     }
-    // wildly inefficient, updating everyone on the org, but not a hot query
-    await setUserTierForOrgId(orgId)
+    await setUserTierForUserIds([userId])
   }
 
   // if a meeting is going on right now, add them

--- a/packages/server/safeMutations/addTeamIdToTMS.ts
+++ b/packages/server/safeMutations/addTeamIdToTMS.ts
@@ -1,22 +1,19 @@
 import getRethink from '../database/rethinkDriver'
+import db from '../db'
 
 const addTeamIdToTMS = async (userId, teamId) => {
   const r = await getRethink()
-  return r
-    .table('User')
-    .get(userId)
-    .update((user) => ({
-      tms: r.branch(
-        user('tms')
-          .contains(teamId)
-          .default(false),
-        user('tms'),
-        user('tms')
-          .default([])
-          .append(teamId)
-      )
-    }))
-    .run()
+  return db.write('User', userId, (user) => ({
+    tms: r.branch(
+      user('tms')
+        .contains(teamId)
+        .default(false),
+      user('tms'),
+      user('tms')
+        .default([])
+        .append(teamId)
+    )
+  }))
 }
 
 export default addTeamIdToTMS

--- a/packages/server/safeMutations/insertNewTeamMember.ts
+++ b/packages/server/safeMutations/insertNewTeamMember.ts
@@ -1,16 +1,14 @@
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import getRethink from '../database/rethinkDriver'
 import TeamMember from '../database/types/TeamMember'
+import db from '../db'
 
 const insertNewTeamMember = async (userId: string, teamId: string) => {
   const r = await getRethink()
   const now = new Date()
   const teamMemberId = toTeamMemberId(teamId, userId)
   const [user, checkInOrder, existingTeamMember] = await Promise.all([
-    r
-      .table('User')
-      .get(userId)
-      .run(),
+    db.read('User', userId),
     r
       .table('TeamMember')
       .getAll(teamId, {index: 'teamId'})

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -1,30 +1,10 @@
 import SegmentIo from 'analytics-node'
 import crypto from 'crypto'
-import getRethink from '../database/rethinkDriver'
+import db from '../db'
 import PROD from '../PROD'
 import {toEpochSeconds} from './epochTime'
-import getRedis from './getRedis'
-import sendToSentry from './sendToSentry'
 
 const {SEGMENT_WRITE_KEY, SERVER_SECRET} = process.env
-
-const getEmail = async (userId: string) => {
-  const redis = getRedis()
-  const key = `email:${userId}`
-  const email = await redis.get(key)
-  if (email) return email
-  const r = await getRethink()
-  const dbEmail = await r
-    .table('User')
-    .get(userId)('email')
-    .run()
-  if (!dbEmail) {
-    sendToSentry(new Error('Email for user not found'), {userId})
-    return ''
-  }
-  await redis.set(key, dbEmail)
-  return dbEmail
-}
 
 const segmentIo = new SegmentIo(SEGMENT_WRITE_KEY || 'x', {
   flushAt: PROD ? 20 : 1,
@@ -39,13 +19,15 @@ segmentIo.track = async (options) => {
     .update(ts)
     .digest('base64')
   const {userId, event, properties} = options
-  const email = await getEmail(options.userId as string)
+  const user = await db.read('User', options.userId)
+  const {email, tier} = user
   return (segmentIo as any)._track({
     userId,
     event,
     properties: {
       ...properties,
-      email
+      email,
+      tier
     },
     timestamp: now,
     parabolToken: parabolToken as any

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -20,14 +20,13 @@ segmentIo.track = async (options) => {
     .digest('base64')
   const {userId, event, properties} = options
   const user = await db.read('User', options.userId)
-  const {email, tier} = user
+  const {email} = user
   return (segmentIo as any)._track({
     userId,
     event,
     properties: {
       ...properties,
-      email,
-      tier
+      email
     },
     timestamp: now,
     parabolToken: parabolToken as any

--- a/packages/server/utils/setUserTierForOrgId.ts
+++ b/packages/server/utils/setUserTierForOrgId.ts
@@ -1,12 +1,14 @@
 import getRethink from '../database/rethinkDriver'
+import db from '../db'
 
 const setUserTierForOrgId = async (orgId: string) => {
   const r = await getRethink()
-  await r
+  const userIds = await r
     .table('OrganizationUser')
     .getAll(orgId, {index: 'orgId'})
     .filter({removedAt: null})('userId')
-    .coerceTo('array')
+    .run()
+  await r(userIds)
     .do((userIds) => {
       return r
         .table('User')
@@ -40,6 +42,7 @@ const setUserTierForOrgId = async (orgId: string) => {
         )
     })
     .run()
+  await Promise.all(userIds.map((userId) => db.clear('User', userId)))
 }
 
 export default setUserTierForOrgId

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -1,0 +1,50 @@
+import getRethink from '../database/rethinkDriver'
+import db from '../db'
+import segmentIo from './segmentIo'
+
+const setUserTierForUserIds = async (userIds: string[]) => {
+  const r = await getRethink()
+  await r
+    .table('User')
+    .getAll(r.args(userIds))
+    .update(
+      (user) => ({
+        tier: r
+          .table('OrganizationUser')
+          .getAll(user('id'), {index: 'userId'})
+          .filter({removedAt: null})('orgId')
+          .coerceTo('array')
+          .distinct()
+          .do((orgIds) =>
+            r
+              .table('Organization')
+              .getAll(r.args(orgIds))('tier')
+              .distinct()
+              .coerceTo('array')
+          )
+          .do((tiers) => {
+            return r.branch(
+              tiers.contains('enterprise'),
+              'enterprise',
+              tiers.contains('pro'),
+              'pro',
+              'personal'
+            )
+          })
+      }),
+      {nonAtomic: true}
+    )
+    .run()
+  await Promise.all(userIds.map((userId) => db.clear('User', userId)))
+  const users = await db.readMany('User', userIds)
+  users.forEach((user) => {
+    segmentIo.identify({
+      userId: user.id,
+      traits: {
+        highestTier: user.tier
+      }
+    })
+  })
+}
+
+export default setUserTierForUserIds

--- a/scripts/toolboxSrc/postDeploy.ts
+++ b/scripts/toolboxSrc/postDeploy.ts
@@ -1,18 +1,13 @@
 import fs from 'fs'
 import path from 'path'
 import getRethink from '../../packages/server/database/rethinkDriver'
+import db from '../../packages/server/db'
 import getProjectRoot from '../webpack/utils/getProjectRoot'
 
 const PROJECT_ROOT = getProjectRoot()
 
 const flushSocketConnections = async () => {
-  const r = await getRethink()
-  return r
-    .table('User')
-    .update({
-      connectedSockets: []
-    })
-    .run()
+  return db.writeTable('User', {connectedSockets: []})
 }
 
 const storePersistedQueries = async () => {


### PR DESCRIPTION
Today, almost every single request to the database requires looking up the User in the DB.
To minimize the hits to the DB we use a [DataLoader] (https://github.com/graphql/dataloader) inside the graphql resolvers. This reduces the number of DB hits to 1 per request, since the dataloader is disposed of after the request completes.

We can further reduce hits to the DB by caching the User in redis & busting the cache when the User is updated.

We can do better still by batching the queries together so only 1 message is sent to the DB.
We can use that same batching strategy for the cache so only 1 message is sent to redis. 
We can also cache the document in memory to avoid repeatedly hitting redis & parsing the JSON.

This PR implements this batching + 3-stage cache strategy for all reads to the User table.
calling `db.read` returns the document locally, from redis, or from the DB. 
calling `db.write` updates the document in the DB and updates the redis and local cache.

For now, this is ONLY implemented for reads to the User table when using the userId primary key.
In the future, we can reuse this strategy for foreign keys & more types

One severe limitation: this only works with a single node instance. if node1 sends a write, its cache, redis', and the DB are all updated. however, node2's local cache will now be stale. To fix, we can use Redis' new client-side-caching, but that feature is only in v6, which DO doesn't offer yet. 

TEST
- [ ] can visit My Profile, change my name, hit update, refresh, & see the name change is persisted
- [ ] other team members see the name change
- [ ] many users can make simultaneous reads/writes & everything works normally (not sure how to test, will probably need to write a script to send repeated read/writes to the server)

 