### PR TITLE
New Meeting Notifications - Active Meetings

### DIFF
--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -38,17 +38,15 @@ interface Props {
 }
 
 const NewMeetingActionsCurrentMeetings = (props: Props) => {
-  const {meetingType, team} = props
+  const {team} = props
   const isDesktop = useBreakpoint(Breakpoint.NEW_MEETING_GRID)
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu<HTMLButtonElement>(
     MenuPosition.LOWER_RIGHT,
     {isDropdown: true}
   )
   const {activeMeetings} = team
-  const activeMeetingsOfType = activeMeetings.filter(
-    (meeting) => meeting.meetingType === meetingType
-  )
-  const meetingCount = activeMeetingsOfType.length
+
+  const meetingCount = activeMeetings.length
   const label = `${meetingCount} Active ${plural(meetingCount, 'Meeting')}`
   if (meetingCount === 0 && !isDesktop) return null
   return (
@@ -62,7 +60,7 @@ const NewMeetingActionsCurrentMeetings = (props: Props) => {
         <ForumIcon>forum</ForumIcon>
         {label}
       </CurrentButton>
-      {menuPortal(<SelectMeetingDropdown menuProps={menuProps} meetings={activeMeetingsOfType!} />)}
+      {menuPortal(<SelectMeetingDropdown menuProps={menuProps} meetings={activeMeetings!} />)}
     </>
   )
 }

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -14,6 +14,7 @@ import {MeetingTypeEnum} from '../types/graphql'
 import FlatButton from './FlatButton'
 import Icon from './Icon'
 import SelectMeetingDropdown from './SelectMeetingDropdown'
+import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 
 const CurrentButton = styled(FlatButton)<{hasMeetings: boolean}>(({hasMeetings}) => ({
   color: PALETTE.BACKGROUND_PINK,
@@ -46,6 +47,8 @@ const NewMeetingActionsCurrentMeetings = (props: Props) => {
   )
   const {activeMeetings} = team
 
+  useSnacksForNewMeetings(activeMeetings)
+
   const meetingCount = activeMeetings.length
   const label = `${meetingCount} Active ${plural(meetingCount, 'Meeting')}`
   if (meetingCount === 0 && !isDesktop) return null
@@ -72,6 +75,17 @@ export default createFragmentContainer(NewMeetingActionsCurrentMeetings, {
       activeMeetings {
         ...SelectMeetingDropdown_meetings
         meetingType
+        id
+        createdAt
+        facilitator {
+          id
+          preferredName
+        }
+        meetingType
+        name
+        team {
+          name
+        }
       }
     }
   `


### PR DESCRIPTION
This PR attempts to address issue #3761. It does this by removing the check for meetingType when looking up all the active meetings in a team. 

Steps to check functionality:
- [ ] Create two or more users and add them to a single team
- [ ] Navigate all of them to the meeting lobby
- [ ] Have one user start a meeting (either a check-in or a retro)
- [ ] Check that the active meetings list becomes visible and gets updated for the other users
- [ ] Check that snackbar shows up in meeting lobby when another user starts meeting