### PR TITLE
Segment and Check-in fixes

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -47,9 +47,18 @@ const AnalyticsPage = () => {
   /* eslint-disable */
   const {href, pathname} = location
   const pathnameRef = useRef(pathname)
+  useEffect(() => {
+    if (!window.analytics) {
+      // we dont use the segment snippet because we can guarantee no call will be made to segment before it's loaded
+      // internally, segment will call an initial page event unless parseFloat(version, 10) !== 0
+      // this knowledge comes from reading the minified analytics.js code
+      const mockSnippet = [] as any
+      mockSnippet.SNIPPET_VERSION = '4.1.0'
+      window.analytics = mockSnippet
+    }
+  }, [])
   const [isSegmentLoaded] = useScript(`https://cdn.segment.com/analytics.js/v1/${key}/analytics.min.js`, {crossOrigin: true})
   const atmosphere = useAtmosphere()
-
   useEffect(() => {
     if (!isSegmentLoaded || !window.analytics) return
     const token = window.localStorage.getItem(LocalStorageKey.APP_TOKEN_KEY)
@@ -78,6 +87,7 @@ const AnalyticsPage = () => {
       const title = document.title || ''
       // This is the magic. Ignore everything after hitting the pipe
       const [pageName] = title.split(' | ')
+      console.log('PAGE', pageName, pathname, href)
       window.analytics.page(pageName, {
         referrer: makeHref(prevPathname),
         title,

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -59,6 +59,7 @@ const AnalyticsPage = () => {
   }, [])
   const [isSegmentLoaded] = useScript(`https://cdn.segment.com/analytics.js/v1/${key}/analytics.min.js`, {crossOrigin: true})
   const atmosphere = useAtmosphere()
+
   useEffect(() => {
     if (!isSegmentLoaded || !window.analytics) return
     const token = window.localStorage.getItem(LocalStorageKey.APP_TOKEN_KEY)
@@ -87,7 +88,6 @@ const AnalyticsPage = () => {
       const title = document.title || ''
       // This is the magic. Ignore everything after hitting the pipe
       const [pageName] = title.split(' | ')
-      console.log('PAGE', pageName, pathname, href)
       window.analytics.page(pageName, {
         referrer: makeHref(prevPathname),
         title,

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -86,21 +86,6 @@ export interface IUser {
   atlassianAuth: IAtlassianAuth | null
 
   /**
-   * Array of identifier + ip pairs
-   */
-  blockedFor: Array<IBlockedUserType | null> | null
-
-  /**
-   * The timestamp of the user was cached
-   */
-  cachedAt: any | null
-
-  /**
-   * The timestamp when the cached user expires
-   */
-  cacheExpiresAt: any | null
-
-  /**
    * The assumed company this organizaiton belongs to
    */
   company: ICompany | null
@@ -119,11 +104,6 @@ export interface IUser {
    * The user email
    */
   email: any
-
-  /**
-   * true if email is verified, false otherwise
-   */
-  emailVerified: boolean | null
 
   /**
    * Any super power given to the user via a super user
@@ -179,11 +159,6 @@ export interface IUser {
   lastMetAt: any | null
 
   /**
-   * The number of logins for this user
-   */
-  loginsCount: number | null
-
-  /**
    * The largest number of consecutive months the user has checked into a meeting
    */
   monthlyStreakMax: number
@@ -192,16 +167,6 @@ export interface IUser {
    * The number of consecutive 30-day intervals that the user has checked into a meeting as of this moment
    */
   monthlyStreakCurrent: number
-
-  /**
-   * Name associated with the user
-   */
-  name: string | null
-
-  /**
-   * Nickname associated with the user
-   */
-  nickname: string | null
 
   /**
    * the most important actions for the user to perform
@@ -234,7 +199,7 @@ export interface IUser {
   picture: any
 
   /**
-   * The application-specific name, defaults to nickname
+   * The application-specific name, defaults to email before the tld
    */
   preferredName: string
 
@@ -2183,23 +2148,6 @@ export interface IAtlassianAuth {
    * The user that the access token is attached to
    */
   userId: string
-}
-
-/**
- * Identifier and IP address blocked
- */
-export interface IBlockedUserType {
-  __typename: 'BlockedUserType'
-
-  /**
-   * The identifier (usually email) of blocked user
-   */
-  identifier: string | null
-
-  /**
-   * The IP address of the blocked user
-   */
-  id: string | null
 }
 
 /**

--- a/packages/server/graphql/mutations/endNewMeeting.ts
+++ b/packages/server/graphql/mutations/endNewMeeting.ts
@@ -169,7 +169,7 @@ const removeEmptyTasks = async (teamId: string, meetingId: string) => {
 }
 
 const finishActionMeeting = async (meeting: MeetingAction, dataLoader: DataLoaderWorker) => {
-  const {id: meetingId, teamId} = meeting
+  const {id: meetingId, teamId, phases} = meeting
   const r = await getRethink()
   const [meetingMembers, tasks, doneTasks] = await Promise.all([
     dataLoader.get('meetingMembersByMeetingId').load(meetingId),
@@ -192,11 +192,12 @@ const finishActionMeeting = async (meeting: MeetingAction, dataLoader: DataLoade
       .run()
   ])
   const userIds = meetingMembers.map(({userId}) => userId)
-
+  const meetingPhase = getMeetingPhase(phases)
+  const isKill = getIsKill(MeetingTypeEnum.action, meetingPhase)
   await Promise.all([
-    archiveTasksForDB(doneTasks, meetingId),
+    isKill ? undefined : archiveTasksForDB(doneTasks, meetingId),
+    isKill ? undefined : clearAgendaItems(teamId),
     updateTaskSortOrders(userIds, tasks),
-    clearAgendaItems(teamId),
     r
       .table('NewMeeting')
       .get(meetingId)

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -44,7 +44,8 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
     },
     commentCount: {
       type: new GraphQLNonNull(GraphQLInt),
-      description: 'The number of comments generated in the meeting'
+      description: 'The number of comments generated in the meeting',
+      resolve: ({commentCount}) => commentCount || 0
     },
     maxVotesPerGroup: {
       type: GraphQLNonNull(GraphQLInt),
@@ -64,7 +65,8 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
     },
     reflectionCount: {
       type: GraphQLNonNull(GraphQLInt),
-      description: 'The number of reflections generated in the meeting'
+      description: 'The number of reflections generated in the meeting',
+      resolve: ({reflectionCount}) => reflectionCount || 0
     },
     reflectionGroup: {
       type: RetroReflectionGroup,
@@ -127,7 +129,8 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
     },
     taskCount: {
       type: new GraphQLNonNull(GraphQLInt),
-      description: 'The number of tasks generated in the meeting'
+      description: 'The number of tasks generated in the meeting',
+      resolve: ({taskCount}) => taskCount || 0
     },
     tasks: {
       type: new GraphQLNonNull(GraphQLList(GraphQLNonNull(Task))),
@@ -142,7 +145,8 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
     },
     topicCount: {
       type: GraphQLNonNull(GraphQLInt),
-      description: 'The number of topics generated in the meeting'
+      description: 'The number of topics generated in the meeting',
+      resolve: ({topicCount}) => topicCount || 0
     },
     totalVotes: {
       type: GraphQLNonNull(GraphQLInt),
@@ -169,15 +173,6 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
         return dataLoader.get('meetingMembers').load(meetingMemberId)
       }
     }
-    // reflections: {
-    //   type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(RetroReflection))),
-    //   description: 'The reflections generated during the reflect phase of the retro',
-    //   resolve: async ({id}, args, {dataLoader}) => {
-    //     const reflections = await dataLoader.get('retroReflectionsByMeetingId').load(id);
-    //     reflections.sort((a, b) => a.sortOrder < b.sortOrder ? -1 : 1);
-    //     return reflections;
-    //   }
-    // }
   })
 })
 


### PR DESCRIPTION
TEST
- [ ] enable the SEGMENT_WRITE_KEY in the .env & turn off ad blockers so segment is firing events. Hit refresh, see that only 1 `p` network request is being sent fix #3922
- [ ] End a checkin meeting before getting to the agenda item phase, note that the items stay in the done column & agenda item list is not flushed fix #3880