### PR TITLE
#3870 Add thread comments to CSV export

### DIFF
--- a/packages/server/database/migrations/20200617000000-addMeetingIdIndexToAgendaItems.ts
+++ b/packages/server/database/migrations/20200617000000-addMeetingIdIndexToAgendaItems.ts
@@ -1,0 +1,23 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
+  try {
+    await r
+      .table('AgendaItem')
+      .indexCreate('meetingId')
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function(r: R) {
+  try {
+    await r
+      .table('AgendaItem')
+      .indexDrop('meetingId')
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/dataloader/foreignLoaderMakers.ts
+++ b/packages/server/dataloader/foreignLoaderMakers.ts
@@ -31,6 +31,19 @@ export const agendaItemsByTeamId = new LoaderMakerForeign(
   }
 )
 
+export const agendaItemsByMeetingId = new LoaderMakerForeign(
+  'agendaItems',
+  'meetingId',
+  async (meetingIds) => {
+    const r = await getRethink()
+    return r
+      .table('AgendaItem')
+      .getAll(r.args(meetingIds), {index: 'meetingId'})
+      .orderBy('sortOrder')
+      .run()
+  }
+)
+
 export const atlassianAuthByUserId = new LoaderMakerForeign(
   'atlassianAuths',
   'userId',

--- a/packages/server/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/server/email/components/SummaryEmail/ExportToCSV.tsx
@@ -173,7 +173,7 @@ class ExportToCSV extends Component<Props> {
       tasks.forEach((task) => {
         rows.push({
           reflectionTitle: title!,
-          author: task!.createdByUser!.preferredName,
+          author: task?.createdByUser?.preferredName ?? 'Anonymous',
           votes,
           type: 'Task',
           createdAt: task.createdAt,
@@ -185,7 +185,7 @@ class ExportToCSV extends Component<Props> {
       reflections.forEach((reflection) => {
         rows.push({
           reflectionTitle: title!,
-          author: 'anonymous',
+          author: 'Anonymous',
           votes,
           type: 'Reflection',
           createdAt: reflection.createdAt!,
@@ -198,7 +198,7 @@ class ExportToCSV extends Component<Props> {
         if (edge!.node!.__typename !== 'Comment') return
         rows.push({
           reflectionTitle: title!,
-          author: edge!.node!.createdByUser!.preferredName,
+          author: edge!.node!.createdByUser?.preferredName ?? 'Anonymous',
           votes,
           type: 'Comment',
           createdAt: edge.node.createdAt,
@@ -209,7 +209,7 @@ class ExportToCSV extends Component<Props> {
         edge.node.replies.forEach((reply) => {
           rows.push({
             reflectionTitle: title!,
-            author: reply!.createdByUser!.preferredName,
+            author: reply!.createdByUser?.preferredName ?? 'Anonymous',
             votes,
             type: 'Reply',
             createdAt: reply.createdAt,
@@ -262,7 +262,7 @@ class ExportToCSV extends Component<Props> {
       const {thread} = agendaItem
       thread.edges.forEach((edge) => {
         if (edge.node.__typename !== 'Comment') return
-        const authorName = edge!.node!.createdByUser!.preferredName
+        const authorName = edge!.node!.createdByUser?.preferredName ?? 'Anonymous'
         rows.push({
           author: authorName,
           status: userStatus[authorName],

--- a/packages/server/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/server/email/components/SummaryEmail/ExportToCSV.tsx
@@ -99,6 +99,9 @@ const query = graphql`
             tasks {
               content
               createdAt
+              createdByUser {
+                preferredName
+              }
             }
             title
             voteCount
@@ -113,6 +116,7 @@ type Meeting = NonNullable<NonNullable<ExportToCSVQuery['response']['viewer']>['
 
 interface CSVRetroRow {
   title: string
+  author: string
   votes: number
   prompt: string
   type: 'Task' | 'Reflection' | 'Comment' | 'Reply'
@@ -122,7 +126,7 @@ interface CSVRetroRow {
 }
 
 interface CSVActionRow {
-  user: string
+  author: string
   status: 'present' | 'absent'
   agendaItem: string
   type: 'Task' | 'Comment' | 'Reply'
@@ -168,6 +172,7 @@ class ExportToCSV extends Component<Props> {
       tasks.forEach((task) => {
         rows.push({
           title: title!,
+          author: task!.createdByUser!.preferredName,
           votes,
           type: 'Task',
           createdAt: task.createdAt,
@@ -179,6 +184,7 @@ class ExportToCSV extends Component<Props> {
       reflections.forEach((reflection) => {
         rows.push({
           title: title!,
+          author: 'anonymous',
           votes,
           type: 'Reflection',
           createdAt: reflection.createdAt!,
@@ -190,6 +196,7 @@ class ExportToCSV extends Component<Props> {
       thread.edges.forEach((edge) => {
         rows.push({
           title: title!,
+          author: edge!.node!.createdByUser!.preferredName,
           votes,
           type: 'Comment',
           createdAt: edge.node.createdAt,
@@ -200,6 +207,7 @@ class ExportToCSV extends Component<Props> {
         edge.node.replies.forEach((reply) => {
           rows.push({
             title: title!,
+            author: reply!.createdByUser!.preferredName,
             votes,
             type: 'Reply',
             createdAt: reply.createdAt,
@@ -223,7 +231,7 @@ class ExportToCSV extends Component<Props> {
       const {preferredName} = user
       if (tasks.length === 0) {
         rows.push({
-          user: preferredName,
+          author: preferredName,
           status,
           agendaItem: '',
           type: 'Task',
@@ -236,7 +244,7 @@ class ExportToCSV extends Component<Props> {
       tasks.forEach((task) => {
         const {content, createdAt, agendaItem} = task
         rows.push({
-          user: preferredName,
+          author: preferredName,
           status,
           agendaItem: agendaItem ? agendaItem.content : '',
           type: 'Task',
@@ -251,7 +259,7 @@ class ExportToCSV extends Component<Props> {
       thread.edges.forEach((edge) => {
         if (edge.node.__typename !== 'Comment') return
         rows.push({
-          user: edge!.node!.createdByUser!.preferredName,
+          author: edge!.node!.createdByUser!.preferredName,
           status: 'present',
           agendaItem: agendaItem ? agendaItem.content : '',
           type: 'Comment',
@@ -261,7 +269,7 @@ class ExportToCSV extends Component<Props> {
         })
         edge.node.replies.forEach((reply) => {
           rows.push({
-            user: reply!.createdByUser!.preferredName,
+            author: reply!.createdByUser!.preferredName,
             status: 'present',
             agendaItem: agendaItem ? agendaItem.content : '',
             type: 'Reply',

--- a/packages/server/graphql/types/ActionMeeting.ts
+++ b/packages/server/graphql/types/ActionMeeting.ts
@@ -76,6 +76,13 @@ const ActionMeeting = new GraphQLObjectType<IActionMeeting, GQLContext>({
         if (agendaItem.meetingId !== meetingId) return null
         return agendaItem
       }
+    },
+    agendaItems: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(AgendaItem))),
+      description: 'All of the agenda items for the meeting',
+      resolve: async ({id: meetingId}, _args, {dataLoader}) => {
+        return await dataLoader.get('agendaItemsByMeetingId').load(meetingId)
+      }
     }
   })
 })


### PR DESCRIPTION
Implements #3870 (Add thread comments to CSV export).

### Tests:

*   [ ] After a retro meeting is ended, user can export a CSV summary:
    *   [ ] For reflections, author should remain anonymous
    *   [ ] Comments and replies are also exported
    *   [ ] Replies have `replyTo` column to indicate which comment they are replied to
    *   [ ] Supports anonymous comments
    *   [ ] Supports anonymous replies 
    *   [ ] Replies to tasks are included in the output
    *   [ ] A Task that is a Reply has type Task
    *   [ ] A Task that is a Reply has the discussionThread content of the threadParentId  
*   [ ] After an action meeting is ended, user can export a CSV summary:
    *   [ ] Author status should indicate if the author has attended the meeting or not
    *   [ ] Comments and replies are also exported and should correspond to the agenda items
    *   [ ] Replies have `replyTo` column to indicate which comment they are replied to