### PR TITLE
Early end summary fix [base: share-templates]

### DIFF
--- a/packages/server/database/types/DiscussStage.ts
+++ b/packages/server/database/types/DiscussStage.ts
@@ -1,7 +1,8 @@
-import GenericMeetingStage from './GenericMeetingStage'
 import {DISCUSS} from 'parabol-client/utils/constants'
+import GenericMeetingStage from './GenericMeetingStage'
 
 export default class DiscussStage extends GenericMeetingStage {
+  reflectionGroupId?: string
   constructor(public sortOrder: number, durations: number[] | undefined) {
     super(DISCUSS, durations)
   }

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -10,6 +10,7 @@ import {
 import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
 import {RETROSPECTIVE} from 'parabol-client/utils/constants'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
+import DiscussPhase from '../../database/types/DiscussPhase'
 import {getUserId} from '../../utils/authorization'
 import filterTasksByMeeting from '../../utils/filterTasksByMeeting'
 import {GQLContext} from '../graphql'
@@ -105,13 +106,19 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
           const {phases} = meeting
           const discussPhase = phases.find(
             (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.discuss
-          )
+          ) as DiscussPhase
           if (!discussPhase) return reflectionGroups
           const {stages} = discussPhase
-          // boolean filter in case the meeting was terminated & there are no groups made yet
-          return stages
-            .map((stage) => reflectionGroups.find((group) => group.id === stage.reflectionGroupId))
-            .filter(Boolean)
+          // for early terminations the stages may not exist
+          const sortLookup = {} as {[reflectionGroupId: string]: number}
+          reflectionGroups.forEach((group) => {
+            const idx = stages.findIndex((stage) => stage.reflectionGroupId === group.id)
+            sortLookup[group.id] = idx
+          })
+          reflectionGroups.sort((a, b) => {
+            sortLookup[a.id] < sortLookup[b.id] ? -1 : 1
+          })
+          return reflectionGroups
         }
         reflectionGroups.sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : 1))
         return reflectionGroups


### PR DESCRIPTION
When a user groups things & then ends the meeting without voting, the summary doesn't show the groups.
it probably should.

fixes the issue here: https://github.com/ParabolInc/parabol/issues/3622#issuecomment-648971359
