### PR TITLE
Fix Query Renderer so that it gets reflection groups of current run rather than previous run

### DIFF
--- a/packages/client/components/DemoSummary.tsx
+++ b/packages/client/components/DemoSummary.tsx
@@ -2,19 +2,25 @@ import useCanonical from '~/hooks/useCanonical'
 import React, {useEffect} from 'react'
 import NewMeetingSummaryRoot from '../modules/summary/components/NewMeetingSummaryRoot'
 import AtmosphereProvider from './AtmosphereProvider/AtmosphereProvider'
-import LocalAtmosphere from '~/modules/demo/LocalAtmosphere'
 import {MutableRecordSource} from 'relay-runtime/lib/store/RelayStoreTypes'
 
 const getLocalAtmosphere = () => {
   return import(/* webpackChunkName: 'LocalAtmosphere' */ '~/modules/demo/LocalAtmosphere')
 }
 
+async function clearLocalAtmosphere() {
+  const LocalAtmosphere = await getLocalAtmosphere()
+    .then((mod) => mod.default)
+    .catch()
+  const atmosphere = new LocalAtmosphere().getStore().getSource() as MutableRecordSource
+  atmosphere.clear()
+}
+
 const DemoSummary = () => {
   useCanonical('retrospective-demo-summary')
   useEffect(() => {
     return () => {
-      const localAtmosphere = new LocalAtmosphere().getStore().getSource() as MutableRecordSource
-      localAtmosphere.clear()
+      clearLocalAtmosphere()
       window.localStorage.removeItem('retroDemo')
     }
   }, [])

--- a/packages/client/components/DemoSummary.tsx
+++ b/packages/client/components/DemoSummary.tsx
@@ -2,6 +2,8 @@ import useCanonical from '~/hooks/useCanonical'
 import React, {useEffect} from 'react'
 import NewMeetingSummaryRoot from '../modules/summary/components/NewMeetingSummaryRoot'
 import AtmosphereProvider from './AtmosphereProvider/AtmosphereProvider'
+import LocalAtmosphere from '~/modules/demo/LocalAtmosphere'
+import {MutableRecordSource} from 'relay-runtime/lib/store/RelayStoreTypes'
 
 const getLocalAtmosphere = () => {
   return import(/* webpackChunkName: 'LocalAtmosphere' */ '~/modules/demo/LocalAtmosphere')
@@ -11,6 +13,8 @@ const DemoSummary = () => {
   useCanonical('retrospective-demo-summary')
   useEffect(() => {
     return () => {
+      const localAtmosphere = new LocalAtmosphere().getStore().getSource() as MutableRecordSource
+      localAtmosphere.clear()
       window.localStorage.removeItem('retroDemo')
     }
   }, [])

--- a/packages/client/modules/summary/components/NewMeetingSummaryRoot.tsx
+++ b/packages/client/modules/summary/components/NewMeetingSummaryRoot.tsx
@@ -29,7 +29,7 @@ const NewMeetingSummaryRoot = ({atmosphere, match}: Props) => {
       query={query}
       variables={{meetingId}}
       render={renderQuery(NewMeetingSummary, {props: {urlAction}, size: LoaderSize.WHOLE_PAGE})}
-      fetchPolicy={'store-or-network' as any}
+      fetchPolicy={'network-only' as any}
     />
   )
 }

--- a/packages/client/modules/summary/components/NewMeetingSummaryRoot.tsx
+++ b/packages/client/modules/summary/components/NewMeetingSummaryRoot.tsx
@@ -29,7 +29,7 @@ const NewMeetingSummaryRoot = ({atmosphere, match}: Props) => {
       query={query}
       variables={{meetingId}}
       render={renderQuery(NewMeetingSummary, {props: {urlAction}, size: LoaderSize.WHOLE_PAGE})}
-      fetchPolicy={'network-only' as any}
+      fetchPolicy={'store-or-network' as any}
     />
   )
 }


### PR DESCRIPTION
This PR aims to fix the following issue: #3950 

It does this by changing the fetch policy of the QueryRenderer in NewMeetingSummaryRoot from store-and-network to network-only. This causes the query to render from the network data it gets rather than what is found inside the store. This fixes the issue of previously stored reflection groups showing up in the meeting summary for the demo.

Steps to Reproduce:
- [ ] Started server (either in dev or prod mode)
- [ ] Go to the demo located at: http://localhost:3000/retrospective-demo/
- [ ] Run through the demo and pick an arbitrary number of reflection groups to create and vote on (for example, 1 or 2)
- [ ] See the created and voted reflection groups in the meeting summary of the demo
- [ ] Run through the demo again, this time picking a different number of reflection groups (6 or 7)
- [ ] See that the meeting summary of the demo shows the right reflections, rather than the old ones