### PR TITLE
fix source maps to enable debugging with breakpoints in vscode

### DIFF
--- a/scripts/webpack/dev.servers.config.js
+++ b/scripts/webpack/dev.servers.config.js
@@ -14,7 +14,7 @@ const DOTENV = path.join(PROJECT_ROOT, 'scripts', 'webpack', 'utils', 'dotenv.js
 module.exports = {
   stats: 'minimal',
   watch: true,
-  devtool: 'eval',
+  devtool: 'eval-source-map',
   mode: 'development',
   node: {
     __dirname: false


### PR DESCRIPTION
Resolves #3958.

This PR changes the webpack configuration for the dev server so that source maps are created with deterministic line number references from target to source. This change enables developers working on Parabol to use the VSCode debugger tool to debug their local server with breakpoints.

### Acceptance Criteria
- [x] Developer can debug the server locally using breakpoints in VS Code
~~Developer can debug staging server in VS Code through SSH tunneling~~ (don't need now)
- [x] Documentation for how to setup the process are in Notion