### PR TITLE
Update OrgBillingView when CC is updated/added

### DIFF
--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
@@ -14,6 +14,8 @@ import StripeClientManager, {StripeError} from '../../../../utils/StripeClientMa
 import CreditCardErrorLine from './CreditCardErrorLine'
 import {CreditCardModalActionType} from './CreditCardModal'
 import CreditCardPricingLine from './CreditCardPricingLine'
+import {createRefetchContainer} from 'react-relay'
+import graphql from 'babel-plugin-relay/macro'
 
 const Form = styled('form')({
   borderRadius: 2,
@@ -75,10 +77,11 @@ interface Props {
   orgId: string
   onSuccess?: () => void
   onLater?: (e: React.FormEvent) => void
+  invoiceListRefetch?: (refetchVariables: {}) => void
 }
 
 const CreditCardForm = (props: Props) => {
-  const {activeUserCount, actionType, onSuccess, onLater, orgId} = props
+  const {activeUserCount, actionType, onSuccess, onLater, orgId, invoiceListRefetch} = props
   const atmosphere = useAtmosphere()
   const isStripeLoaded = useScript('https://js.stripe.com/v2/')
   const [stripeClientManager] = useState(() => new StripeClientManager())
@@ -144,11 +147,23 @@ const CreditCardForm = (props: Props) => {
     const handleCompleted = (data) => {
       const [mutationName] = Object.keys(data)
       const {error} = data[mutationName]
+      console.log(data[mutationName])
       onCompleted()
       if (error) {
         handleError(error.message, error.message)
         return
       }
+
+      const refetchVariables = {
+        orgId: orgId,
+        first: 3
+      }
+
+      if (invoiceListRefetch) {
+        console.log('WE ARE REFETCHING')
+        invoiceListRefetch(refetchVariables)
+      }
+
       if (onSuccess) {
         onSuccess()
       }

--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
@@ -75,11 +75,10 @@ interface Props {
   orgId: string
   onSuccess?: () => void
   onLater?: (e: React.FormEvent) => void
-  invoiceListRefetch?: (refetchVariables: {}) => void
 }
 
 const CreditCardForm = (props: Props) => {
-  const {activeUserCount, actionType, onSuccess, onLater, orgId, invoiceListRefetch} = props
+  const {activeUserCount, actionType, onSuccess, onLater, orgId} = props
   const atmosphere = useAtmosphere()
   const isStripeLoaded = useScript('https://js.stripe.com/v2/')
   const [stripeClientManager] = useState(() => new StripeClientManager())
@@ -152,14 +151,6 @@ const CreditCardForm = (props: Props) => {
       }
 
       if (onSuccess) {
-        const refetchVariables = {
-          orgId: orgId,
-          first: 3
-        }
-
-        if (invoiceListRefetch) {
-          invoiceListRefetch(refetchVariables)
-        }
         onSuccess()
       }
     }

--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
@@ -14,8 +14,6 @@ import StripeClientManager, {StripeError} from '../../../../utils/StripeClientMa
 import CreditCardErrorLine from './CreditCardErrorLine'
 import {CreditCardModalActionType} from './CreditCardModal'
 import CreditCardPricingLine from './CreditCardPricingLine'
-import {createRefetchContainer} from 'react-relay'
-import graphql from 'babel-plugin-relay/macro'
 
 const Form = styled('form')({
   borderRadius: 2,
@@ -147,7 +145,6 @@ const CreditCardForm = (props: Props) => {
     const handleCompleted = (data) => {
       const [mutationName] = Object.keys(data)
       const {error} = data[mutationName]
-      console.log(data[mutationName])
       onCompleted()
       if (error) {
         handleError(error.message, error.message)
@@ -160,7 +157,6 @@ const CreditCardForm = (props: Props) => {
       }
 
       if (invoiceListRefetch) {
-        console.log('WE ARE REFETCHING')
         invoiceListRefetch(refetchVariables)
       }
 

--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardForm.tsx
@@ -151,16 +151,15 @@ const CreditCardForm = (props: Props) => {
         return
       }
 
-      const refetchVariables = {
-        orgId: orgId,
-        first: 3
-      }
-
-      if (invoiceListRefetch) {
-        invoiceListRefetch(refetchVariables)
-      }
-
       if (onSuccess) {
+        const refetchVariables = {
+          orgId: orgId,
+          first: 3
+        }
+
+        if (invoiceListRefetch) {
+          invoiceListRefetch(refetchVariables)
+        }
         onSuccess()
       }
     }

--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardModal.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardModal.tsx
@@ -31,20 +31,21 @@ interface Props {
   closePortal: () => void
   orgId: string
   meetingId?: string
+  invoiceListRefetch?: (refetchVariables: {}) => void
 }
 
 type Status = 'success' | 'later' | 'init'
 
 const CreditCardModal = (props: Props) => {
-  const {actionType, activeUserCount, closePortal, orgId, meetingId} = props
+  const {actionType, activeUserCount, closePortal, orgId, meetingId, invoiceListRefetch} = props
   const [status, setStatus] = useState<Status>('init')
   const atmosphere = useAtmosphere()
   const onSuccess =
     actionType === 'update'
       ? closePortal
       : () => {
-          setStatus('success')
-        }
+        setStatus('success')
+      }
   const onLater = (e: React.FormEvent) => {
     e.preventDefault()
     setStatus('later')
@@ -70,6 +71,7 @@ const CreditCardModal = (props: Props) => {
       </DialogTitle>
       <CreditCardReassurance actionType={actionType} />
       <CreditCardForm
+        invoiceListRefetch={invoiceListRefetch}
         actionType={actionType}
         activeUserCount={activeUserCount}
         orgId={orgId}

--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardModal.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardModal.tsx
@@ -31,21 +31,22 @@ interface Props {
   closePortal: () => void
   orgId: string
   meetingId?: string
-  invoiceListRefetch?: (refetchVariables: {}) => void
+  onUpgrade?: () => void
 }
 
 type Status = 'success' | 'later' | 'init'
 
 const CreditCardModal = (props: Props) => {
-  const {actionType, activeUserCount, closePortal, orgId, meetingId, invoiceListRefetch} = props
+  const {actionType, activeUserCount, closePortal, orgId, meetingId, onUpgrade} = props
   const [status, setStatus] = useState<Status>('init')
   const atmosphere = useAtmosphere()
   const onSuccess =
     actionType === 'update'
       ? closePortal
       : () => {
-        setStatus('success')
-      }
+          onUpgrade?.()
+          setStatus('success')
+        }
   const onLater = (e: React.FormEvent) => {
     e.preventDefault()
     setStatus('later')
@@ -71,7 +72,6 @@ const CreditCardModal = (props: Props) => {
       </DialogTitle>
       <CreditCardReassurance actionType={actionType} />
       <CreditCardForm
-        invoiceListRefetch={invoiceListRefetch}
         actionType={actionType}
         activeUserCount={activeUserCount}
         orgId={orgId}

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
@@ -19,10 +19,7 @@ const OrgBilling = (props: Props) => {
   return (
     <div>
       <OrgBillingUpgrade organization={organization} invoiceListRefetch={relay && relay.refetch} />
-      <OrgBillingCreditCardInfo
-        organization={organization}
-        invoiceListRefetch={relay && relay.refetch}
-      />
+      <OrgBillingCreditCardInfo organization={organization} />
       <OrgBillingInvoices viewer={viewer} />
       <OrgBillingDangerZone organization={organization} />
     </div>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {createRefetchContainer} from 'react-relay'
+import {createRefetchContainer, RelayRefetchProp} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import {OrgBilling_viewer} from '../../../../__generated__/OrgBilling_viewer.graphql'
 import {OrgBilling_organization} from '../../../../__generated__/OrgBilling_organization.graphql'
@@ -11,9 +11,7 @@ import OrgBillingUpgrade from './OrgBillingUpgrade'
 interface Props {
   viewer: OrgBilling_viewer
   organization: OrgBilling_organization
-  relay: {
-    refetch?: (refetchVariables: {}) => void
-  }
+  relay: RelayRefetchProp
 }
 
 const OrgBilling = (props: Props) => {
@@ -21,33 +19,38 @@ const OrgBilling = (props: Props) => {
   return (
     <div>
       <OrgBillingUpgrade organization={organization} invoiceListRefetch={relay && relay.refetch} />
-      <OrgBillingCreditCardInfo organization={organization} invoiceListRefetch={relay && relay.refetch} />
+      <OrgBillingCreditCardInfo
+        organization={organization}
+        invoiceListRefetch={relay && relay.refetch}
+      />
       <OrgBillingInvoices viewer={viewer} />
       <OrgBillingDangerZone organization={organization} />
     </div>
   )
 }
 
-export default createRefetchContainer(OrgBilling, {
-  viewer: graphql`
-    fragment OrgBilling_viewer on User {
-      ...OrgBillingInvoices_viewer
-    }
-  `,
-  organization: graphql`
-    fragment OrgBilling_organization on Organization {
-      ...OrgBillingCreditCardInfo_organization
-      ...OrgBillingUpgrade_organization
-      ...OrgBillingDangerZone_organization
-      id
-    }
-  `,
-},
-  graphql`
-      query OrgBillingQuery($first: Int!, $after: DateTime, $orgId: ID!) {
-        viewer {
-          ...OrgBillingInvoices_viewer
-        }
+export default createRefetchContainer(
+  OrgBilling,
+  {
+    viewer: graphql`
+      fragment OrgBilling_viewer on User {
+        ...OrgBillingInvoices_viewer
       }
-`
+    `,
+    organization: graphql`
+      fragment OrgBilling_organization on Organization {
+        ...OrgBillingCreditCardInfo_organization
+        ...OrgBillingUpgrade_organization
+        ...OrgBillingDangerZone_organization
+        id
+      }
+    `
+  },
+  graphql`
+    query OrgBillingQuery($first: Int!, $after: DateTime, $orgId: ID!) {
+      viewer {
+        ...OrgBillingInvoices_viewer
+      }
+    }
+  `
 )

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {createRefetchContainer} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import {OrgBilling_viewer} from '../../../../__generated__/OrgBilling_viewer.graphql'
 import {OrgBilling_organization} from '../../../../__generated__/OrgBilling_organization.graphql'
@@ -11,21 +11,24 @@ import OrgBillingUpgrade from './OrgBillingUpgrade'
 interface Props {
   viewer: OrgBilling_viewer
   organization: OrgBilling_organization
+  relay: {
+    refetch?: (refetchVariables: {}) => void
+  }
 }
 
 const OrgBilling = (props: Props) => {
-  const {organization, viewer} = props
+  const {organization, viewer, relay} = props
   return (
     <div>
-      <OrgBillingUpgrade organization={organization} />
-      <OrgBillingCreditCardInfo organization={organization} />
+      <OrgBillingUpgrade organization={organization} invoiceListRefetch={relay && relay.refetch} />
+      <OrgBillingCreditCardInfo organization={organization} invoiceListRefetch={relay && relay.refetch} />
       <OrgBillingInvoices viewer={viewer} />
       <OrgBillingDangerZone organization={organization} />
     </div>
   )
 }
 
-export default createFragmentContainer(OrgBilling, {
+export default createRefetchContainer(OrgBilling, {
   viewer: graphql`
     fragment OrgBilling_viewer on User {
       ...OrgBillingInvoices_viewer
@@ -38,5 +41,13 @@ export default createFragmentContainer(OrgBilling, {
       ...OrgBillingDangerZone_organization
       id
     }
-  `
-})
+  `,
+},
+  graphql`
+      query OrgBillingQuery($first: Int!, $after: DateTime, $orgId: ID!) {
+        viewer {
+          ...OrgBillingInvoices_viewer
+        }
+      }
+`
+)

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingCreditCardInfo.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingCreditCardInfo.tsx
@@ -64,14 +64,12 @@ const CreditCardModal = lazyPreload(() =>
 
 interface Props {
   organization: OrgBillingCreditCardInfo_organization
-  invoiceListRefetch?: (refetchVariables: {}) => void
 }
 
 const OrgBillingCreditCardInfo = (props: Props) => {
-  const {organization, invoiceListRefetch} = props
+  const {organization} = props
   const {creditCard, id: orgId, orgUserCount} = organization
   const {modalPortal, closePortal, togglePortal} = useModal()
-  const onUpgrade = () => invoiceListRefetch?.({orgId, first: 3})
   if (!creditCard) return null
   const {activeUserCount} = orgUserCount
   const {brand, last4, expiry} = creditCard
@@ -101,7 +99,6 @@ const OrgBillingCreditCardInfo = (props: Props) => {
           <CreditCardModal
             activeUserCount={activeUserCount}
             orgId={orgId}
-            onUpgrade={onUpgrade}
             actionType={'update'}
             closePortal={closePortal}
           />

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingCreditCardInfo.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingCreditCardInfo.tsx
@@ -64,10 +64,11 @@ const CreditCardModal = lazyPreload(() =>
 
 interface Props {
   organization: OrgBillingCreditCardInfo_organization
+  invoiceListRefetch?: (refetchVariables: {}) => void
 }
 
 const OrgBillingCreditCardInfo = (props: Props) => {
-  const {organization} = props
+  const {organization, invoiceListRefetch} = props
   const {creditCard, id: orgId, orgUserCount} = organization
   const {modalPortal, closePortal, togglePortal} = useModal()
   if (!creditCard) return null
@@ -99,6 +100,7 @@ const OrgBillingCreditCardInfo = (props: Props) => {
           <CreditCardModal
             activeUserCount={activeUserCount}
             orgId={orgId}
+            invoiceListRefetch={invoiceListRefetch}
             actionType={'update'}
             closePortal={closePortal}
           />

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingCreditCardInfo.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingCreditCardInfo.tsx
@@ -71,6 +71,7 @@ const OrgBillingCreditCardInfo = (props: Props) => {
   const {organization, invoiceListRefetch} = props
   const {creditCard, id: orgId, orgUserCount} = organization
   const {modalPortal, closePortal, togglePortal} = useModal()
+  const onUpgrade = () => invoiceListRefetch?.({orgId, first: 3})
   if (!creditCard) return null
   const {activeUserCount} = orgUserCount
   const {brand, last4, expiry} = creditCard
@@ -100,7 +101,7 @@ const OrgBillingCreditCardInfo = (props: Props) => {
           <CreditCardModal
             activeUserCount={activeUserCount}
             orgId={orgId}
-            invoiceListRefetch={invoiceListRefetch}
+            onUpgrade={onUpgrade}
             actionType={'update'}
             closePortal={closePortal}
           />

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingUpgrade.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingUpgrade.tsx
@@ -39,10 +39,11 @@ const StyledPrimaryButton = styled(PrimaryButton)({
 
 interface Props {
   organization: OrgBillingUpgrade_organization
+  invoiceListRefetch?: (refetchVariables: {}) => void
 }
 
 const OrgBillingUpgrade = (props: Props) => {
-  const {organization} = props
+  const {organization, invoiceListRefetch} = props
   const {id: orgId, tier, orgUserCount} = organization
   const {activeUserCount} = orgUserCount
   const {togglePortal, closePortal, modalPortal} = useModal()
@@ -50,6 +51,7 @@ const OrgBillingUpgrade = (props: Props) => {
     <>
       {modalPortal(
         <CreditCardModal
+          invoiceListRefetch={invoiceListRefetch}
           actionType={'upgrade'}
           closePortal={closePortal}
           orgId={orgId}

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingUpgrade.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingUpgrade.tsx
@@ -47,11 +47,12 @@ const OrgBillingUpgrade = (props: Props) => {
   const {id: orgId, tier, orgUserCount} = organization
   const {activeUserCount} = orgUserCount
   const {togglePortal, closePortal, modalPortal} = useModal()
+  const onUpgrade = () => invoiceListRefetch?.({orgId, first: 3})
   return (
     <>
       {modalPortal(
         <CreditCardModal
-          invoiceListRefetch={invoiceListRefetch}
+          onUpgrade={onUpgrade}
           actionType={'upgrade'}
           closePortal={closePortal}
           orgId={orgId}


### PR DESCRIPTION
This PR aims to resolved issue #3281.

It does this by turning the createFragmentContainer in OrgBilling.tsx into a createRefetchContainer, refetching the viewer query found in OrgBillingRoot.tsx when CC info is successfully updated/added to the page.

Users can:
- [ ] Run Server locally
- [ ] Go to organization billing page
- [ ] Add CC info
- [ ] See invoices component in billing view when upgraded modal is closed.