### PR TITLE
setup config to enable client code debugging in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,121 +1,99 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch dev.js",
-            "program": "${workspaceFolder}/scripts/dev.js",
-            "args": [
-                "-d"
-            ],
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Webpack",
-            "program": "${workspaceFolder}/node_modules/.bin/webpack",
-            "args": [
-                "--config",
-                "${workspaceFolder}/scripts/webpack/prod.client.config.js"
-            ],
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "attach",
-            "name": "Attach by Process ID",
-            "processId": "${command:PickProcess}",
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug Executor",
-            "runtimeExecutable": "yarn",
-            "runtimeArgs": [
-                "debug:executor"
-            ],
-            "port": 9229,
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug Prod",
-            "runtimeExecutable": "yarn",
-            "runtimeArgs": [
-                "debug:prod"
-            ],
-            "port": 9229,
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch via Yarn",
-            "runtimeExecutable": "yarn",
-            "runtimeArgs": [
-                "debug"
-            ],
-            "port": 9229,
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug relay compiler",
-            "program": "${workspaceFolder}/node_modules/.bin/relay-compiler",
-            "args": [],
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug Babel Plugin",
-            "console": "integratedTerminal",
-            "autoAttachChildProcesses": true,
-            "program": "${workspaceFolder}/node_modules/.bin/babel",
-            "args": [
-                "--config-file=${workspaceFolder}/packages/gql-executor/babel.config.json",
-                "${workspaceFolder}/packages/gql-executor/client/utils/GitHubManager.js"
-            ],
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Debug Codeshift",
-            "console": "integratedTerminal",
-            // "autoAttachChildProcesses": true,
-            "program": "${workspaceFolder}/node_modules/.bin/jscodeshift",
-            "args": [
-                "--transform=${workspaceFolder}/scripts/codeshift/packageRefToRelative.ts",
-                "${workspaceFolder}/packages/gql-executor/"
-            ],
-            "skipFiles": [
-                "<node_internals>/**"
-            ]
-        },
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch dev.js",
+      "program": "${workspaceFolder}/scripts/dev.js",
+      "args": ["-d"],
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Webpack",
+      "program": "${workspaceFolder}/node_modules/.bin/webpack",
+      "args": ["--config", "${workspaceFolder}/scripts/webpack/prod.client.config.js"],
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "name": "Launch Chrome",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Executor",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["debug:executor"],
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Prod",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["debug:prod"],
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch via Yarn",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["debug"],
+      "port": 9229,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug relay compiler",
+      "program": "${workspaceFolder}/node_modules/.bin/relay-compiler",
+      "args": [],
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Babel Plugin",
+      "console": "integratedTerminal",
+      "autoAttachChildProcesses": true,
+      "program": "${workspaceFolder}/node_modules/.bin/babel",
+      "args": [
+        "--config-file=${workspaceFolder}/packages/gql-executor/babel.config.json",
+        "${workspaceFolder}/packages/gql-executor/client/utils/GitHubManager.js"
+      ],
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Codeshift",
+      "console": "integratedTerminal",
+      // "autoAttachChildProcesses": true,
+      "program": "${workspaceFolder}/node_modules/.bin/jscodeshift",
+      "args": [
+        "--transform=${workspaceFolder}/scripts/codeshift/packageRefToRelative.ts",
+        "${workspaceFolder}/packages/gql-executor/"
+      ],
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
 }

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -10,7 +10,7 @@ const SERVER_ROOT = path.join(PROJECT_ROOT, 'packages', 'server')
 const STATIC_ROOT = path.join(PROJECT_ROOT, 'static')
 
 module.exports = {
-  devtool: 'eval',
+  devtool: 'eval-source-map',
   mode: 'development',
   entry: {
     app: [path.join(CLIENT_ROOT, 'client.tsx')]


### PR DESCRIPTION
Resolves #3979

These changes enable developers working on Parabol to locally debug client code in VSCode via a Chrome extension.
- makes a small change to client dev webpack
- adds a vscode launch config

### Acceptance Criteria
- [x] Developer can debug the client locally using breakpoints in VS Code
- [x] Documentation for how to set it up is in Notion