### PR TITLE
Made a mutation for private schema enableSAMLForDomain

### DIFF
--- a/packages/server/graphql/intranetSchema/intranetSchema.ts
+++ b/packages/server/graphql/intranetSchema/intranetSchema.ts
@@ -14,6 +14,7 @@ import endOldMeetings from './mutations/endOldMeetings'
 import flagConversionModal from './mutations/flagConversionModal'
 import flagOverLimit from './mutations/flagOverLimit'
 import loginSAML from './mutations/loginSAML'
+import enableSAMLForDomain from './mutations/enableSAMLForDomain'
 import profileCPU from './mutations/profileCPU'
 import runScheduledJobs from './mutations/runScheduledJobs'
 import sendBatchNotificationEmails from './mutations/sendBatchNotificationEmails'
@@ -64,6 +65,7 @@ const mutation = new GraphQLObjectType<any, GQLContext, any>({
     flagConversionModal,
     flagOverLimit,
     loginSAML,
+    enableSAMLForDomain,
     runScheduledJobs,
     sendBatchNotificationEmails,
     sendUpcomingInvoiceEmails,

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -1,0 +1,36 @@
+import {GraphQLNonNull, GraphQLString, GraphQLBoolean} from 'graphql'
+import getRethink from '../../../database/rethinkDriver'
+
+const enableSAMLForDomain = {
+  type: new GraphQLNonNull(GraphQLBoolean),
+  description: 'Enable SAML for domain',
+  args: {
+    url: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    domain: {
+      type: GraphQLNonNull(GraphQLString),
+    },
+    metadata: {
+      type: GraphQLNonNull(GraphQLString),
+    },
+    cert: {
+      type: GraphQLNonNull(GraphQLString),
+    }
+  },
+  async resolve(_source, {url, domain, metadata, cert}) {
+    const r = await getRethink()
+    const normalizedDomain = domain.toLowerCase()
+    await r
+      .table('SAML')
+      .insert({
+        domain: normalizedDomain,
+        url: url,
+        metadata: metadata,
+        cert: cert
+      })
+      .run()
+  }
+}
+
+export default enableSAMLForDomain

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -30,6 +30,8 @@ const enableSAMLForDomain = {
         cert: cert
       })
       .run()
+
+    return true
   }
 }
 

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -6,28 +6,25 @@ const enableSAMLForDomain = {
   description: 'Enable SAML for domain',
   args: {
     url: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNull(GraphQLString)
     },
     domain: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLNonNull(GraphQLString)
     },
     metadata: {
-      type: GraphQLNonNull(GraphQLString),
-    },
-    cert: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLNonNull(GraphQLString)
     }
   },
-  async resolve(_source, {url, domain, metadata, cert}) {
+  async resolve(_source, {url, domain, metadata}) {
     const r = await getRethink()
     const normalizedDomain = domain.toLowerCase()
+    const normalizedUrl = url.toLowerCase()
     await r
       .table('SAML')
       .insert({
         domain: normalizedDomain,
-        url: url,
-        metadata: metadata,
-        cert: cert
+        url: normalizedUrl,
+        metadata: metadata
       })
       .run()
 


### PR DESCRIPTION
This PR resolves issue #3951 

It adds a private schema enableSAMLForDomain.ts, and creates a graphql mutation for it, which adds a record to the SAML table with domain, url, metadata and cert fields.