### PR TITLE
Fix the bug where TeamCreation timeline events were missing

### DIFF
--- a/packages/server/database/migrations/20200715162900-backfillIsActiveForCreatedTeamTimelineEvent.ts
+++ b/packages/server/database/migrations/20200715162900-backfillIsActiveForCreatedTeamTimelineEvent.ts
@@ -1,0 +1,19 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
+  try {
+    await r
+      .table('TimelineEvent')
+      .filter((event) => event.hasFields('isActive').not())
+      .update({
+        isActive: true
+      })
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function() {
+  // noop
+}

--- a/packages/server/database/types/TimelineEventCreatedTeam.ts
+++ b/packages/server/database/types/TimelineEventCreatedTeam.ts
@@ -1,0 +1,22 @@
+import TimelineEvent from './TimelineEvent'
+import {TimelineEventEnum} from 'parabol-client/types/graphql'
+
+interface Input {
+  id?: string
+  createdAt?: Date
+  interactionCount?: number
+  seenCount?: number
+  userId: string
+  teamId: string
+  orgId: string
+}
+export default class TimelineEventCreatedTeam extends TimelineEvent {
+  teamId: string
+  orgId: string
+  constructor(input: Input) {
+    super({...input, type: TimelineEventEnum.createdTeam})
+    const {teamId, orgId} = input
+    this.teamId = teamId
+    this.orgId = orgId
+  }
+}

--- a/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
+++ b/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
@@ -1,13 +1,12 @@
 import {InvoiceItemType} from 'parabol-client/types/constEnums'
-import shortid from 'shortid'
 import adjustUserCount from '../../../billing/helpers/adjustUserCount'
 import getRethink from '../../../database/rethinkDriver'
 import MeetingSettingsAction from '../../../database/types/MeetingSettingsAction'
 import MeetingSettingsRetrospective from '../../../database/types/MeetingSettingsRetrospective'
 import Team from '../../../database/types/Team'
+import TimelineEventCreatedTeam from '../../../database/types/TimelineEventCreatedTeam'
 import addTeamIdToTMS from '../../../safeMutations/addTeamIdToTMS'
 import insertNewTeamMember from '../../../safeMutations/insertNewTeamMember'
-import {CREATED_TEAM} from '../../types/TimelineEventTypeEnum'
 import makeRetroTemplates from './makeRetroTemplates'
 
 interface ValidNewTeam {
@@ -32,6 +31,12 @@ export default async function createTeamAndLeader(userId: string, newTeam: Valid
     new MeetingSettingsRetrospective({teamId, selectedTemplateId: templates[0].id}),
     new MeetingSettingsAction({teamId})
   ]
+  const timelineEvent = new TimelineEventCreatedTeam({
+    createdAt: new Date(Date.now() + 5),
+    userId,
+    teamId,
+    orgId
+  })
 
   const [organizationUser] = await Promise.all([
     r
@@ -65,18 +70,7 @@ export default async function createTeamAndLeader(userId: string, newTeam: Valid
     insertNewTeamMember(userId, teamId),
     r
       .table('TimelineEvent')
-      .insert({
-        id: shortid.generate(),
-        // + 5 to make sure it comes after parabol joined event
-        createdAt: new Date(Date.now() + 5),
-        interactionCount: 0,
-        seenCount: 0,
-        type: CREATED_TEAM,
-        userId,
-        teamId,
-        orgId,
-        isActive: true
-      })
+      .insert(timelineEvent)
       .run(),
     addTeamIdToTMS(userId, teamId)
   ])

--- a/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
+++ b/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
@@ -74,7 +74,8 @@ export default async function createTeamAndLeader(userId: string, newTeam: Valid
         type: CREATED_TEAM,
         userId,
         teamId,
-        orgId
+        orgId,
+        isActive: true
       })
       .run(),
     addTeamIdToTMS(userId, teamId)


### PR DESCRIPTION
We only load [active](https://github.com/ParabolInc/parabol/blob/61b799f2469c2b347f63bf01c623e91ad0fe8d3f/packages/server/graphql/types/User.ts#L256) timeline events for a user. This bug was introduced by omitting the `isActive` field when writing the `TeamCreation` timeline event **directly** to the database.