### PR TITLE
Implements Archived Checkbox Filter for Task View

### DIFF
--- a/packages/client/clientSchema.graphql
+++ b/packages/client/clientSchema.graphql
@@ -22,6 +22,7 @@ extend type RetrospectiveMeeting {
 
 extend type Team {
   teamMemberFilter: TeamMember
+  showArchivedTasksCheckbox: Boolean!
 }
 
 extend type User {

--- a/packages/client/components/Dashboard/DashSectionControls.js
+++ b/packages/client/components/Dashboard/DashSectionControls.js
@@ -4,7 +4,7 @@ const DashSectionControls = styled('div')({
   alignItems: 'center',
   display: 'flex',
   flex: 1,
-  justifyContent: 'space-between',
+  justifyContent: 'flex-start',
   overflow: 'auto',
   maxWidth: '100%',
   width: '100%'

--- a/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
@@ -180,6 +180,9 @@ export default createFragmentContainer(AgendaAndTasks, {
         teamId: id
         teamName: name
         showArchivedTasksCheckbox
+        teamMemberFilter {
+          id
+        }
         ...AgendaListAndInput_team
         ...TeamTasksHeaderContainer_team
       }

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -11,7 +11,6 @@ import {PALETTE} from '../../../../styles/paletteV2'
 import {MathEnum, NavSidebar} from '../../../../types/constEnums'
 import {AreaEnum} from '../../../../types/graphql'
 import getRallyLink from '../../../userDashboard/helpers/getRallyLink'
-import TeamArchiveHeader from '../TeamArchiveHeader/TeamArchiveHeader'
 
 const CARD_WIDTH = 256 + 32 // account for box model and horizontal padding
 const GRID_PADDING = 16
@@ -34,16 +33,6 @@ const Root = styled('div')({
   flexDirection: 'column',
   // hide the window scrollbar, the cardGrid scrollbar will mimic the window scrollbar
   overflow: 'hidden',
-  width: '100%'
-})
-
-const Header = styled('div')({
-  padding: `0 0 0 20px`
-})
-
-const Border = styled('div')({
-  borderTop: `.0625rem solid ${PALETTE.BORDER_LIGHTER}`,
-  height: 1,
   width: '100%'
 })
 
@@ -86,7 +75,7 @@ interface Props {
 }
 
 const TeamArchive = (props: Props) => {
-  const {viewer, relay, team, teamId} = props
+  const {viewer, relay, team} = props
   const {hasMore, isLoading, loadMore} = relay
   const {teamName} = team
   const {archivedTasks} = viewer
@@ -197,10 +186,6 @@ const TeamArchive = (props: Props) => {
 
   return (
     <Root>
-      <Header>
-        <TeamArchiveHeader teamId={teamId} />
-        <Border />
-      </Header>
       <Body>
         {edges.length ? (
           <CardGrid>

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -73,7 +73,6 @@ const LinkSpan = styled('div')({
 interface Props {
   relay: RelayPaginationProp
   viewer: TeamArchive_viewer
-  teamId: string
   team: TeamArchive_team
 }
 
@@ -294,7 +293,6 @@ export default createPaginationContainer(
     team: graphql`
       fragment TeamArchive_team on Team {
         teamName: name
-        orgId
         teamMemberFilter {
           id
         }

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -8,7 +8,7 @@ import {TeamArchive_viewer} from '~/__generated__/TeamArchive_viewer.graphql'
 import NullableTask from '../../../../components/NullableTask/NullableTask'
 import useDocumentTitle from '../../../../hooks/useDocumentTitle'
 import {PALETTE} from '../../../../styles/paletteV2'
-import {MathEnum, NavSidebar} from '../../../../types/constEnums'
+import {MathEnum, Layout} from '../../../../types/constEnums'
 import {AreaEnum} from '../../../../types/graphql'
 import getRallyLink from '../../../userDashboard/helpers/getRallyLink'
 import toTeamMemberId from '~/utils/relay/toTeamMemberId'
@@ -20,8 +20,8 @@ const GRID_PADDING = 16
 
 const getColumnCount = () => {
   if (typeof window === 'undefined') return 4
-  const {innerWidth} = window
-  return Math.floor((innerWidth - NavSidebar.WIDTH - GRID_PADDING) / CARD_WIDTH)
+
+  return Math.floor((Layout.TASK_COLUMNS_MAX_WIDTH - GRID_PADDING) / CARD_WIDTH)
 }
 
 const getGridIndex = (index: number, columnCount: number) => {
@@ -42,9 +42,14 @@ const Root = styled('div')({
 const Body = styled('div')({
   display: 'flex',
   flex: 1,
+  height: '100%',
+  margin: '0 auto',
   flexDirection: 'column',
   justifyContent: 'flex-start',
-  paddingLeft: '12',
+  maxWidth: Layout.TASK_COLUMNS_MAX_WIDTH,
+  overflow: 'auto',
+  padding: `0 10px`,
+  width: '100%',
   position: 'relative'
 })
 const CardGrid = styled('div')({
@@ -52,8 +57,7 @@ const CardGrid = styled('div')({
   display: 'flex',
   // grow to the largest height possible
   flex: 1,
-  outline: 0,
-  width: '100%'
+  outline: 0
 })
 
 const EmptyMsg = styled('div')({

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -186,7 +186,7 @@ const TeamArchive = (props: Props) => {
             // put styles here because aphrodite is async
             <div
               key={`cardBlockFor${task.id}`}
-              style={{...style, width: CARD_WIDTH, padding: '1rem 0.5rem 0'}}
+              style={{...style, width: CARD_WIDTH, padding: '1rem 0.5rem'}}
             >
               <NullableTask
                 dataCy={`archive-task`}

--- a/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
@@ -17,10 +17,6 @@ const TeamSettings = lazy(() =>
     /* webpackChunkName: 'TeamSettingsWrapper' */ '../../components/TeamSettingsWrapper/TeamSettingsWrapper'
   )
 )
-const ArchivedTasks = lazy(() =>
-  import(/* webpackChunkName: 'TeamArchiveRoot' */ '../TeamArchive/TeamArchiveRoot')
-)
-
 interface Props {
   teamId: string
   viewer: TeamContainer_viewer
@@ -58,10 +54,6 @@ const TeamContainer = (props: Props) => {
             {/* TODO: replace match.path with a relative when the time comes: https://github.com/ReactTraining/react-router/pull/4539 */}
             <Route exact path={match.path} component={AgendaTasks} />
             <Route path={`${match.path}/settings`} component={TeamSettings} />
-            <Route
-              path={`${match.path}/archive`}
-              render={(p) => <ArchivedTasks {...p} team={team} />}
-            />
           </Switch>
         </Suspense>
       </Team>
@@ -74,7 +66,6 @@ export default createFragmentContainer(TeamContainer, {
     fragment TeamContainer_viewer on User {
       team(teamId: $teamId) {
         ...Team_team
-        ...TeamArchive_team
       }
     }
   `

--- a/packages/client/modules/teamDashboard/containers/TeamArchive/TeamArchiveRoot.tsx
+++ b/packages/client/modules/teamDashboard/containers/TeamArchive/TeamArchiveRoot.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import graphql from 'babel-plugin-relay/macro'
-import {RouteComponentProps} from 'react-router'
 import {QueryRenderer} from 'react-relay'
 import TeamArchive from '../../components/TeamArchive/TeamArchive'
 import {LoaderSize} from '../../../../types/constEnums'
@@ -15,16 +14,13 @@ const query = graphql`
   }
 `
 
-interface Props extends RouteComponentProps<{teamId: string}> {
+interface Props {
+  teamId: string
   team: any
 }
 
-const TeamArchiveRoot = ({match, team}: Props) => {
+const TeamArchiveRoot = ({teamId, team}: Props) => {
   const atmosphere = useAtmosphere()
-  const {
-    params: {teamId}
-  } = match
-  const {viewerId} = atmosphere
   return (
     <QueryRenderer
       environment={atmosphere}
@@ -32,7 +28,7 @@ const TeamArchiveRoot = ({match, team}: Props) => {
       variables={{teamId, first: 40}}
       fetchPolicy={'store-or-network' as any}
       render={renderQuery(TeamArchive, {
-        props: {teamId, team, userId: viewerId},
+        props: {team},
         size: LoaderSize.PANEL
       })}
     />

--- a/packages/client/modules/teamDashboard/containers/TeamTasksHeader/TeamTasksHeaderContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/TeamTasksHeader/TeamTasksHeaderContainer.tsx
@@ -6,6 +6,7 @@ import {TeamTasksHeaderContainer_team} from '~/__generated__/TeamTasksHeaderCont
 import {TeamTasksHeaderContainer_viewer} from '~/__generated__/TeamTasksHeaderContainer_viewer.graphql'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import TeamTasksHeader from '../../components/TeamTasksHeader/TeamTasksHeader'
+import setArchivedTasksCheckbox from '~/utils/relay/setArchivedTasksCheckbox'
 
 interface Props {
   team: TeamTasksHeaderContainer_team
@@ -18,6 +19,9 @@ const TeamTasksHeaderContainer = (props: Props) => {
   const atmosphere = useAtmosphere()
   useEffect(() => {
     filterTeamMember(atmosphere, teamId, null)
+  }, [teamId])
+  useEffect(() => {
+    setArchivedTasksCheckbox(atmosphere, teamId, false)
   }, [teamId])
 
   return <TeamTasksHeader team={team} viewer={viewer} />

--- a/packages/client/utils/relay/setArchivedTasksCheckbox.ts
+++ b/packages/client/utils/relay/setArchivedTasksCheckbox.ts
@@ -1,0 +1,17 @@
+import {commitLocalUpdate} from 'react-relay'
+import {ITeam} from '../../types/graphql'
+import Atmosphere from '../../Atmosphere'
+
+const setArchivedTasksCheckbox = (
+  atmosphere: Atmosphere,
+  teamId: string,
+  showArchivedTasksCheckbox: boolean
+) => {
+  commitLocalUpdate(atmosphere, (store) => {
+    const team = store.get<ITeam>(teamId)
+    if (!team) return
+    team.setValue(showArchivedTasksCheckbox, 'showArchivedTasksCheckbox')
+  })
+}
+
+export default setArchivedTasksCheckbox

--- a/packages/server/graphql/queries/archivedTasks.ts
+++ b/packages/server/graphql/queries/archivedTasks.ts
@@ -6,7 +6,7 @@ import GraphQLISO8601Type from '../types/GraphQLISO8601Type'
 import {TaskConnection} from '../types/Task'
 
 export default {
-  type: TaskConnection,
+  type: new GraphQLNonNull(TaskConnection),
   args: {
     first: {
       type: GraphQLInt

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -27,6 +27,7 @@
   "files": [
     "types/modules.d.ts",
     "email/components/SummaryEmail/MeetingSummaryEmail/MeetingSummaryEmail.tsx",
+    "graphql/queries/archivedTasks.ts",
     "server.ts"
   ],
 }


### PR DESCRIPTION
Implements #3935 .

Tests:
- [ ] When Archived checkbox is ticked, then the kanban view turns into the archive tasks view
- [ ] the team & user filters should still be active
- [ ] search bar is applicable to the archived view as well
- [ ] the pagination query should include the team & user so when they scroll, we only fetch relevant tasks