### PR TITLE
Fix for duplicate pins

### DIFF
--- a/packages/server/graphql/mutations/endNewMeeting.ts
+++ b/packages/server/graphql/mutations/endNewMeeting.ts
@@ -104,7 +104,7 @@ const getPinnedAgendaItems = async (teamId: string) => {
     .run()
 }
 
-const clonePinnedAgendaItem = async (pinnedAgendaItems: AgendaItem[]) => {
+const clonePinnedAgendaItems = async (pinnedAgendaItems: AgendaItem[]) => {
   const r = await getRethink()
   const formattedPinnedAgendaItems = pinnedAgendaItems.map((agendaItem) => {
     const agendaItemId = `${agendaItem.teamId}::${shortid.generate()}`
@@ -169,6 +169,10 @@ const removeEmptyTasks = async (teamId: string, meetingId: string) => {
 }
 
 const finishActionMeeting = async (meeting: MeetingAction, dataLoader: DataLoaderWorker) => {
+  /* If isKill, no agenda items were processed so clear none of them.
+   * Similarly, don't clone pins. the original ones will show up again.
+   */
+
   const {id: meetingId, teamId, phases} = meeting
   const r = await getRethink()
   const [meetingMembers, tasks, doneTasks] = await Promise.all([
@@ -193,10 +197,12 @@ const finishActionMeeting = async (meeting: MeetingAction, dataLoader: DataLoade
   ])
   const userIds = meetingMembers.map(({userId}) => userId)
   const meetingPhase = getMeetingPhase(phases)
+  const pinnedAgendaItems = await getPinnedAgendaItems(teamId)
   const isKill = getIsKill(MeetingTypeEnum.action, meetingPhase)
   await Promise.all([
     isKill ? undefined : archiveTasksForDB(doneTasks, meetingId),
     isKill ? undefined : clearAgendaItems(teamId),
+    isKill ? undefined : clonePinnedAgendaItems(pinnedAgendaItems),
     updateTaskSortOrders(userIds, tasks),
     r
       .table('NewMeeting')
@@ -345,10 +351,7 @@ export default {
     const presentMemberUserIds = presentMembers.map(({userId}) => userId)
     endSlackMeeting(meetingId, teamId, dataLoader).catch(console.log)
 
-    const pinnedAgendaItems = await getPinnedAgendaItems(teamId)
     const result = await finishMeetingType(completedMeeting, dataLoader)
-
-    clonePinnedAgendaItem(pinnedAgendaItems)
 
     await shuffleCheckInOrder(teamId)
     const updatedTaskIds = (result && result.updatedTaskIds) || []


### PR DESCRIPTION
Resolves #3967

### Acceptance criteria
- [x] A team has floating pinned agenda items. Ending a retro meeting on the same team does not propagate/duplicate the existing pins.
- [x] During a check-in meeting, there exists pinned agenda items. If the meeting is terminated early (before getting to any agenda items), the pinned agenda items should not have duplicate occurrences.