### PR TITLE
Timeline displays newly created meeting

### DIFF
--- a/packages/client/components/MyDashboardTimelineRoot.tsx
+++ b/packages/client/components/MyDashboardTimelineRoot.tsx
@@ -23,7 +23,7 @@ const MyDashboardTimelineRoot = ({atmosphere}: Props) => {
       environment={atmosphere}
       variables={{first: 10}}
       query={query}
-      fetchPolicy={'store-or-network' as any}
+      fetchPolicy={'store-and-network' as any}
       render={renderQuery(MyDashboardTimeline, {size: LoaderSize.PANEL})}
     />
   )


### PR DESCRIPTION
Issue #3682

I imagine that we need to update the subscription in `endNewMeeting` to resolve this issue. I've looked into this but haven't found a solution yet - still learning about Relay and Subscriptions.

However, updating the fetch policy does result in the newly created meeting being displayed on the timeline. Using `store-and-network` ensures that the network request is always sent. This will result in unnecessary requests but as we're just grabbing the first 10 results, it wouldn't be very expensive. 

We could also keep the fetch policy as `store-or-network` but [mark the data as stale](https://relay.dev/docs/en/experimental/a-guided-tour-of-relay#staleness-of-data) with `invalidateStore()`.

Updating the subscription is most likely the answer but I just thought I'd share this in case it's helpful.