### PR TITLE
Updated timeline task header

### DIFF
--- a/packages/client/components/TimelinePriorityTasks.tsx
+++ b/packages/client/components/TimelinePriorityTasks.tsx
@@ -29,7 +29,6 @@ const PriorityTasksHeader = styled('div')({
   fontWeight: 600,
   paddingTop: 16,
   paddingBottom: 16,
-  position: 'sticky',
   top: 0,
   zIndex: 2
 })


### PR DESCRIPTION
![sticky-task-header](https://user-images.githubusercontent.com/39854876/88405220-d50f7480-cdc6-11ea-946f-220ad48383f8.png)

Timeline task header is currently sticky. When the user scrolls down, the header moves over the task. This only happens in Chrome, not in Safari. 

Removing the `sticky` position prevents this from happening. 