### PR TITLE
A round of UI polish

### DIFF
--- a/packages/client/components/DiscussPhaseReflectionGrid.tsx
+++ b/packages/client/components/DiscussPhaseReflectionGrid.tsx
@@ -12,6 +12,7 @@ import ReflectionCard from './ReflectionCard/ReflectionCard'
 const GridWrapper = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
   height: isExpanded ? '100%' : `calc(100% - ${MeetingControlBarEnum.HEIGHT + 16}px)`,
   overflow: 'auto',
+  padding: '8px 16px 0',
   marginBottom: 16
 }))
 

--- a/packages/client/components/ReflectionCard/AddReactjiButton.tsx
+++ b/packages/client/components/ReflectionCard/AddReactjiButton.tsx
@@ -12,8 +12,8 @@ const Button = styled(PlainButton)({
   height: 24,
   lineHeight: '24px',
   opacity: 0.5,
-  padding: '2px 0 4px',
-  width: 28,
+  padding: '3px 0',
+  width: 24,
   ':hover, :focus': {
     opacity: 1
   }

--- a/packages/client/components/RetroDiscussPhase.tsx
+++ b/packages/client/components/RetroDiscussPhase.tsx
@@ -128,7 +128,7 @@ const ColumnInner = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
   display: isDesktop ? undefined : 'flex',
   justifyContent: 'center',
   height: '100%',
-  padding: isDesktop ? '8px 16px 16px' : undefined,
+  padding: isDesktop ? '0 0 16px' : undefined,
   paddingBottom: isDesktop ? undefined : 8,
   width: '100%'
 }))
@@ -187,12 +187,12 @@ const RetroDiscussPhase = (props: Props) => {
                   {isDesktop ? (
                     <DiscussPhaseReflectionGrid meeting={meeting} />
                   ) : (
-                      <ReflectionGroup
-                        meeting={meeting}
-                        phaseRef={phaseRef}
-                        reflectionGroup={reflectionGroup}
-                      />
-                    )}
+                    <ReflectionGroup
+                      meeting={meeting}
+                      phaseRef={phaseRef}
+                      reflectionGroup={reflectionGroup}
+                    />
+                  )}
                 </ColumnInner>
               </ReflectionColumn>
               <ThreadColumn isDesktop={isDesktop}>

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -19,7 +19,7 @@ const HeaderActions = styled('div')<{isViewerComment: boolean}>(({isViewerCommen
 
 const AddReactji = styled(AddReactjiButton)({
   display: 'flex',
-  padding: 0
+  marginRight: 4
 })
 
 interface Props {

--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
@@ -84,7 +84,7 @@ const NewCheckInQuestion = (props: Props) => {
   }
   const {viewerId} = atmosphere
   const isFacilitating = facilitatorUserId === viewerId
-  const tip = 'Tap to customize the Icebreaker.'
+  const tip = 'Tap to customize the Icebreaker'
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLButtonElement>(
     MenuPosition.UPPER_CENTER,

--- a/packages/client/modules/teamDashboard/components/AgendaInput/AgendaInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaInput/AgendaInput.tsx
@@ -72,7 +72,6 @@ const StyledIcon = styled(Icon)({
   color: PALETTE.TEXT_BLUE,
   display: 'block',
   left: 16,
-  opacity: 0.7,
   pointerEvents: 'none',
   position: 'absolute',
   top: 9

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummaryHeader.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummaryHeader.tsx
@@ -64,12 +64,12 @@ const SummaryHeader = (props: Props) => {
         </tr>
         <tr>
           <td align='center' style={teamNameLabel}>
-            {teamName}
+            {meetingName}
           </td>
         </tr>
         <tr>
           <td align='center' style={dateLabel}>
-            {isDemo ? meetingDate : `${meetingName} • ${meetingDate}`}
+            {isDemo ? meetingDate : `${teamName} • ${meetingDate}`}
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
I’ve been saving up a batch of patch fixes to correct design intent (styling, alignment, hierarchy, etc.):
### Verify changes
- [x] Fixes color usage of the agenda input `add` icon
- [x] Yanks punctuation on the impertiatve tooltip copy when editing the Icebreaker
- [x] Swaps meeting and team names in the header of the meeting summary for correct document hierarchy
- [x] Fixes the reaction button alignment in thread comments
- [x] Fixes clipping of reflection card box-shadow in the Discuss phase