### PR TITLE
Fixes for bottom bar cover and floating snackbar

### DIFF
--- a/packages/client/components/ActionMeetingAgendaItems.tsx
+++ b/packages/client/components/ActionMeetingAgendaItems.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import {ActionMeetingAgendaItems_meeting} from '~/__generated__/ActionMeetingAgendaItems_meeting.graphql'
 import EditorHelpModalContainer from '../containers/EditorHelpModalContainer/EditorHelpModalContainer'
@@ -56,14 +56,16 @@ const ActionMeetingAgendaItems = (props: Props) => {
   const {showSidebar, team, id: meetingId, endedAt, localStage} = meeting
   const {agendaItems} = team
   const {agendaItemId} = localStage
+  const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
+  const meetingContentRef = useRef<HTMLDivElement>(null)
   const agendaItem = agendaItems.find((item) => item.id === agendaItemId!)
   // optimistic updater could remove the agenda item
   if (!agendaItem) return null
   const {content, teamMember} = agendaItem
   const {picture, preferredName} = teamMember
-  const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
+
   return (
-    <MeetingContent>
+    <MeetingContent ref={meetingContentRef}>
       <MeetingHeaderAndPhase hideBottomBar={!!endedAt}>
         <MeetingTopBar
           avatarGroup={avatarGroup}
@@ -81,7 +83,11 @@ const ActionMeetingAgendaItems = (props: Props) => {
           </AgendaVerbatim>
           <StyledCopy>{`${preferredName}, what do you need?`}</StyledCopy>
           <ThreadColumn isDesktop={isDesktop}>
-            <DiscussionThreadRoot meetingId={meetingId} threadSourceId={agendaItemId!} />
+            <DiscussionThreadRoot
+              meetingContentRef={meetingContentRef}
+              meetingId={meetingId}
+              threadSourceId={agendaItemId!}
+            />
           </ThreadColumn>
           <EditorHelpModalContainer />
         </PhaseWrapper>

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useRef} from 'react'
+import React, {useRef, RefObject} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import {useCoverable} from '~/hooks/useControlBarCovers'
 import {Breakpoint, DiscussionThreadEnum, MeetingControlBarEnum} from '~/types/constEnums'
@@ -26,11 +26,14 @@ const Wrapper = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
 }))
 
 interface Props {
+  meetingContentRef: RefObject<HTMLDivElement>
   viewer: DiscussionThread_viewer
 }
 
 const DiscussionThread = (props: Props) => {
-  const {viewer} = props
+  console.log('DiscussionThread -> props', props)
+  const {meetingContentRef, viewer} = props
+
   const meeting = viewer.meeting!
   const {endedAt, replyingToCommentId, threadSource} = meeting
   const {thread} = threadSource!
@@ -44,7 +47,8 @@ const DiscussionThread = (props: Props) => {
   const listRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<HTMLTextAreaElement>(null)
   const ref = useRef<HTMLDivElement>(null)
-  const isExpanded = useCoverable('threads', ref, MeetingControlBarEnum.HEIGHT) || !!endedAt
+  const isExpanded =
+    useCoverable('threads', ref, MeetingControlBarEnum.HEIGHT, meetingContentRef) || !!endedAt
 
   return (
     <Wrapper isExpanded={isExpanded} ref={ref}>

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -31,7 +31,6 @@ interface Props {
 }
 
 const DiscussionThread = (props: Props) => {
-  console.log('DiscussionThread -> props', props)
   const {meetingContentRef, viewer} = props
 
   const meeting = viewer.meeting!

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -16,11 +16,13 @@ const Wrapper = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
   boxShadow: Elevation.DISCUSSION_THREAD,
   display: 'flex',
   flexDirection: 'column',
-  height: '100%',
+  // height: '100%',
+  height: 72,
   overflow: 'hidden',
   width: 'calc(100% - 16px)',
+  border: '2px solid green',
   [makeMinWidthMediaQuery(Breakpoint.SIDEBAR_LEFT)]: {
-    height: isExpanded ? '100%' : `calc(100% - ${MeetingControlBarEnum.HEIGHT}px)`,
+    // height: isExpanded ? '100%' : `calc(100% - ${MeetingControlBarEnum.HEIGHT}px)`,
     width: DiscussionThreadEnum.WIDTH
   }
 }))
@@ -34,6 +36,7 @@ const DiscussionThread = (props: Props) => {
   const meeting = viewer.meeting!
   const {endedAt, replyingToCommentId, threadSource} = meeting
   const {thread} = threadSource!
+
   const threadSourceId = threadSource!.id!
   const edges = thread?.edges ?? [] // should never happen, but Terry reported it in demo. likely relay error
   const threadables = edges.map(({node}) => node)
@@ -44,6 +47,10 @@ const DiscussionThread = (props: Props) => {
   const editorRef = useRef<HTMLTextAreaElement>(null)
   const ref = useRef<HTMLDivElement>(null)
   const isExpanded = useCoverable('threads', ref, MeetingControlBarEnum.HEIGHT) || !!endedAt
+
+  // const myFunc = () => useCoverable('threads', ref, MeetingControlBarEnum.HEIGHT) || !!endedAt
+
+  console.log('DiscussionThread -> isExpanded', isExpanded)
   return (
     <Wrapper isExpanded={isExpanded} ref={ref}>
       <DiscussionThreadList

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -16,13 +16,11 @@ const Wrapper = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
   boxShadow: Elevation.DISCUSSION_THREAD,
   display: 'flex',
   flexDirection: 'column',
-  // height: '100%',
-  height: 72,
+  height: '100%',
   overflow: 'hidden',
   width: 'calc(100% - 16px)',
-  border: '2px solid green',
   [makeMinWidthMediaQuery(Breakpoint.SIDEBAR_LEFT)]: {
-    // height: isExpanded ? '100%' : `calc(100% - ${MeetingControlBarEnum.HEIGHT}px)`,
+    height: isExpanded ? '100%' : `calc(100% - ${MeetingControlBarEnum.HEIGHT}px)`,
     width: DiscussionThreadEnum.WIDTH
   }
 }))
@@ -48,9 +46,6 @@ const DiscussionThread = (props: Props) => {
   const ref = useRef<HTMLDivElement>(null)
   const isExpanded = useCoverable('threads', ref, MeetingControlBarEnum.HEIGHT) || !!endedAt
 
-  // const myFunc = () => useCoverable('threads', ref, MeetingControlBarEnum.HEIGHT) || !!endedAt
-
-  console.log('DiscussionThread -> isExpanded', isExpanded)
   return (
     <Wrapper isExpanded={isExpanded} ref={ref}>
       <DiscussionThreadList

--- a/packages/client/components/DiscussionThreadRoot.tsx
+++ b/packages/client/components/DiscussionThreadRoot.tsx
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {RefObject} from 'react'
 import {QueryRenderer} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import renderQuery from '../utils/relay/renderQuery'
@@ -15,19 +15,20 @@ const query = graphql`
 
 interface Props {
   meetingId: string
+  meetingContentRef: RefObject<HTMLDivElement>
   threadSourceId: string
 }
 
 const DiscussionThreadRoot = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {meetingId, threadSourceId} = props
+  const {meetingContentRef, meetingId, threadSourceId} = props
   return (
     <QueryRenderer
       environment={atmosphere}
       query={query}
       variables={{meetingId, threadSourceId}}
       fetchPolicy={'store-or-network' as any}
-      render={renderQuery(DiscussionThread)}
+      render={renderQuery(DiscussionThread, {props: {meetingContentRef}})}
     />
   )
 }

--- a/packages/client/components/RetroDiscussPhase.tsx
+++ b/packages/client/components/RetroDiscussPhase.tsx
@@ -196,7 +196,11 @@ const RetroDiscussPhase = (props: Props) => {
                 </ColumnInner>
               </ReflectionColumn>
               <ThreadColumn isDesktop={isDesktop}>
-                <DiscussionThreadRoot meetingId={meetingId} threadSourceId={reflectionGroupId!} />
+                <DiscussionThreadRoot
+                  meetingContentRef={phaseRef}
+                  meetingId={meetingId}
+                  threadSourceId={reflectionGroupId!}
+                />
               </ThreadColumn>
             </ColumnsContainer>
           </DiscussPhaseWrapper>

--- a/packages/client/hooks/useControlBarCovers.ts
+++ b/packages/client/hooks/useControlBarCovers.ts
@@ -39,7 +39,7 @@ export const useCoverable = (
   id: string,
   ref: RefObject<HTMLDivElement>,
   height: number,
-  meetingContentRef?: any
+  parentRef?: RefObject<HTMLDivElement>
 ) => {
   const updateCoverables = () => {
     console.log('Resize!')
@@ -66,7 +66,7 @@ export const useCoverable = (
     coverables[id] = coverable
   }
 
-  useResizeObserver(meetingContentRef, updateCoverables)
+  useResizeObserver(updateCoverables, parentRef)
 
   useEffect(() => {
     updateCoverables()

--- a/packages/client/hooks/useControlBarCovers.ts
+++ b/packages/client/hooks/useControlBarCovers.ts
@@ -1,5 +1,6 @@
 import {RefObject, useEffect} from 'react'
 import {BezierCurve, Breakpoint} from '~/types/constEnums'
+import useResizeObserver from './useResizeObserver'
 
 interface ControlBarCoverable {
   id: string
@@ -34,8 +35,15 @@ const ensureCovering = (
   coverable.isExpanded = willBeExpanded
 }
 
-export const useCoverable = (id: string, ref: RefObject<HTMLDivElement>, height: number) => {
+export const useCoverable = (
+  id: string,
+  ref: RefObject<HTMLDivElement>,
+  height: number,
+  meetingContentRef?: any
+) => {
   const updateCoverables = () => {
+    console.log('Resize!')
+
     const el = ref.current
     if (!el) return
     if (window.innerWidth < Breakpoint.SINGLE_REFLECTION_COLUMN) return
@@ -58,7 +66,7 @@ export const useCoverable = (id: string, ref: RefObject<HTMLDivElement>, height:
     coverables[id] = coverable
   }
 
-  window.addEventListener('resize', () => updateCoverables())
+  useResizeObserver(meetingContentRef, updateCoverables)
 
   useEffect(() => {
     updateCoverables()

--- a/packages/client/hooks/useControlBarCovers.ts
+++ b/packages/client/hooks/useControlBarCovers.ts
@@ -1,4 +1,4 @@
-import {RefObject, useCallback, useEffect} from 'react'
+import {RefObject, useEffect} from 'react'
 import {BezierCurve, Breakpoint} from '~/types/constEnums'
 
 interface ControlBarCoverable {
@@ -35,14 +35,13 @@ const ensureCovering = (
 }
 
 export const useCoverable = (id: string, ref: RefObject<HTMLDivElement>, height: number) => {
-  const memoizedCallback = useCallback(() => {
+  const updateCoverables = () => {
     const el = ref.current
     if (!el) return
     if (window.innerWidth < Breakpoint.SINGLE_REFLECTION_COLUMN) return
     const bbox = el.getBoundingClientRect()
     const {left, right} = bbox
     const oldCoverable = coverables[id]
-    console.log('useCoverable -> oldCoverable', oldCoverable)
     const BUFFER = 8
     const coverable = {
       id,
@@ -52,23 +51,22 @@ export const useCoverable = (id: string, ref: RefObject<HTMLDivElement>, height:
       right: right + BUFFER,
       isExpanded: oldCoverable?.isExpanded ?? false
     }
-    console.log('useCoverable -> coverable', coverable)
     if (covering.el) {
       cacheCoveringBBox()
       ensureCovering(coverable, covering.left, covering.right)
     }
     coverables[id] = coverable
-  }, [])
+  }
+
+  window.addEventListener('resize', () => updateCoverables())
 
   useEffect(() => {
-    memoizedCallback()
+    updateCoverables()
     return () => {
       const oldCoverable = coverables[id]
       ;(oldCoverable as any).el = null
     }
   }, [])
-
-  window.addEventListener('resize', () => memoizedCallback())
 
   return coverables[id]?.isExpanded ?? false
 }

--- a/packages/client/hooks/useControlBarCovers.ts
+++ b/packages/client/hooks/useControlBarCovers.ts
@@ -42,8 +42,6 @@ export const useCoverable = (
   parentRef?: RefObject<HTMLDivElement>
 ) => {
   const updateCoverables = () => {
-    console.log('Resize!')
-
     const el = ref.current
     if (!el) return
     if (window.innerWidth < Breakpoint.SINGLE_REFLECTION_COLUMN) return

--- a/packages/client/hooks/useCoords.ts
+++ b/packages/client/hooks/useCoords.ts
@@ -205,7 +205,7 @@ const useCoords = <
     options.portalStatus
   ])
 
-  useResizeObserver(targetRef.current, () => {
+  useResizeObserver(targetRef, () => {
     const targetBBox = targetRef.current?.getBoundingClientRect()
     const originBBox = originRef.current?.getBoundingClientRect()
     if (targetBBox && originBBox) {

--- a/packages/client/hooks/useCoords.ts
+++ b/packages/client/hooks/useCoords.ts
@@ -205,14 +205,14 @@ const useCoords = <
     options.portalStatus
   ])
 
-  useResizeObserver(targetRef, () => {
+  useResizeObserver(() => {
     const targetBBox = targetRef.current?.getBoundingClientRect()
     const originBBox = originRef.current?.getBoundingClientRect()
     if (targetBBox && originBBox) {
       const coordState = getNextCoords(targetBBox, originBBox, preferredMenuPosition)
       setCoords(coordState)
     }
-  })
+  }, targetRef)
 
   useWindowResize(coordsRef, targetRef.current, setCoords)
   const {coords, menuPosition} = coordsRef.current

--- a/packages/client/hooks/useResizeObserver.ts
+++ b/packages/client/hooks/useResizeObserver.ts
@@ -10,7 +10,10 @@ declare global {
 
 const ResizeObserver = window.ResizeObserver || (ResizeObserverPolyfill as {new (): ResizeObserver})
 
-const useResizeObserver = (ref: RefObject, cb: ResizeObserverCallback) => {
+const useResizeObserver = (
+  cb: ResizeObserverCallback,
+  ref?: RefObject<HTMLDivElement | HTMLElement>
+) => {
   const eventCb = useEventCallback(cb)
   useEffect(() => {
     if (!ref || !ref.current) return

--- a/packages/client/hooks/useResizeObserver.ts
+++ b/packages/client/hooks/useResizeObserver.ts
@@ -1,4 +1,4 @@
-import {useEffect} from 'react'
+import {useEffect, RefObject} from 'react'
 import ResizeObserverPolyfill from 'resize-observer-polyfill'
 import useEventCallback from './useEventCallback'
 
@@ -10,16 +10,16 @@ declare global {
 
 const ResizeObserver = window.ResizeObserver || (ResizeObserverPolyfill as {new (): ResizeObserver})
 
-const useResizeObserver = (el: HTMLElement | null, cb: ResizeObserverCallback) => {
+const useResizeObserver = (ref: RefObject, cb: ResizeObserverCallback) => {
   const eventCb = useEventCallback(cb)
   useEffect(() => {
-    if (!el) return
+    if (!ref || !ref.current) return
     const resizeObserver = new ResizeObserver(eventCb)
-    resizeObserver.observe(el)
+    resizeObserver.observe(ref.current)
     return () => {
       resizeObserver.disconnect()
     }
-  }, [el, eventCb])
+  }, [ref, eventCb])
 }
 
 export default useResizeObserver

--- a/packages/client/hooks/useSnackbarPad.ts
+++ b/packages/client/hooks/useSnackbarPad.ts
@@ -8,6 +8,7 @@ const useSnackbarPad = (ref: RefObject<HTMLElement>) => {
   const el = ref.current
   useEffect(() => {
     const bbox = getBBox(el)
+    // put a max on bbox.top
     const snackbarOffset = bbox ? window.innerHeight - bbox.top : 48
     commitLocalUpdate(atmosphere, (store) => {
       const viewer = store.getRoot().getLinkedRecord('viewer')!

--- a/packages/client/hooks/useSnackbarPad.ts
+++ b/packages/client/hooks/useSnackbarPad.ts
@@ -9,7 +9,8 @@ const useSnackbarPad = (ref: RefObject<HTMLElement>) => {
   useEffect(() => {
     const bbox = getBBox(el)
     // put a max on bbox.top
-    const snackbarOffset = bbox ? window.innerHeight - bbox.top : 48
+    const snackbarOffset = bbox ? Math.max(window.innerHeight - bbox.top, 96) : 48
+
     commitLocalUpdate(atmosphere, (store) => {
       const viewer = store.getRoot().getLinkedRecord('viewer')!
       viewer.setValue(snackbarOffset, 'snackbarOffset')


### PR DESCRIPTION
Fixes for issues #3959 and #3934 

- Resizing the window/meeting content now causes the discussion thread to account for the position of the bottom bar
- Unable to reproduce the floating snackbar bug but have added a `Math.max` which should hopefully catch it

### Test

- [ ] Resize the window in a check-in and retro meeting and check whether the discussion thread position adjusts for the bottom bar
- [ ] Click the burger button and slide the bottom bar. Check whether the discussion thread position adjusts 