### PR TITLE
Disabled editing and due date selection for archived cards

### DIFF
--- a/packages/client/components/DueDateToggle.tsx
+++ b/packages/client/components/DueDateToggle.tsx
@@ -99,7 +99,7 @@ interface Props {
   cardIsActive: boolean
   task: DueDateToggle_task
   useTaskChild: UseTaskChild
-  disabled?: boolean
+  isArchived?: boolean
 }
 
 const formatDueDate = (dueDate) => {
@@ -130,7 +130,7 @@ const DueDatePicker = lazyPreload(() =>
 )
 
 const DueDateToggle = (props: Props) => {
-  const {cardIsActive, task, useTaskChild, disabled} = props
+  const {cardIsActive, task, useTaskChild, isArchived} = props
   const {dueDate} = task
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu(MenuPosition.UPPER_RIGHT)
   const {tooltipPortal, openTooltip, closeTooltip, originRef: tipRef} = useTooltip<HTMLDivElement>(
@@ -139,7 +139,7 @@ const DueDateToggle = (props: Props) => {
   const {title, isPastDue, isDueSoon} = getDateInfo(dueDate)
   return (
     <>
-      {!disabled && <Toggle
+      {!isArchived && <Toggle
         cardIsActive={!dueDate && cardIsActive}
         dueDate={!!dueDate}
         isPastDue={isPastDue}

--- a/packages/client/components/DueDateToggle.tsx
+++ b/packages/client/components/DueDateToggle.tsx
@@ -99,6 +99,7 @@ interface Props {
   cardIsActive: boolean
   task: DueDateToggle_task
   useTaskChild: UseTaskChild
+  disabled?: boolean
 }
 
 const formatDueDate = (dueDate) => {
@@ -129,7 +130,7 @@ const DueDatePicker = lazyPreload(() =>
 )
 
 const DueDateToggle = (props: Props) => {
-  const {cardIsActive, task, useTaskChild} = props
+  const {cardIsActive, task, useTaskChild, disabled} = props
   const {dueDate} = task
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu(MenuPosition.UPPER_RIGHT)
   const {tooltipPortal, openTooltip, closeTooltip, originRef: tipRef} = useTooltip<HTMLDivElement>(
@@ -138,7 +139,7 @@ const DueDateToggle = (props: Props) => {
   const {title, isPastDue, isDueSoon} = getDateInfo(dueDate)
   return (
     <>
-      <Toggle
+      {!disabled && <Toggle
         cardIsActive={!dueDate && cardIsActive}
         dueDate={!!dueDate}
         isPastDue={isPastDue}
@@ -156,7 +157,7 @@ const DueDateToggle = (props: Props) => {
           access_time
         </DueDateIcon>
         {dueDate && <DateString>{formatDueDate(dueDate)}</DateString>}
-      </Toggle>
+      </Toggle>}
       {tooltipPortal(<div>{title}</div>)}
       {menuPortal(<DueDatePicker menuProps={menuProps} task={task} useTaskChild={useTaskChild} />)}
     </>

--- a/packages/client/components/EditingStatus/EditingStatus.tsx
+++ b/packages/client/components/EditingStatus/EditingStatus.tsx
@@ -36,11 +36,11 @@ interface Props {
   isTaskHovered: boolean
   task: EditingStatus_task
   useTaskChild: UseTaskChild
-  disabled?: boolean
+  isArchived?: boolean
 }
 
 const EditingStatus = (props: Props) => {
-  const {children, isTaskHovered, task, useTaskChild, disabled} = props
+  const {children, isTaskHovered, task, useTaskChild, isArchived} = props
   const {createdAt, updatedAt, editors} = task
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
@@ -70,7 +70,7 @@ const EditingStatus = (props: Props) => {
         >
           <EditingStatusText
             editors={otherEditors}
-            disabled={disabled}
+            isArchived={isArchived}
             isEditing={isEditing}
             timestamp={timestamp}
             timestampType={timestampType}
@@ -80,7 +80,7 @@ const EditingStatus = (props: Props) => {
       </div>
       <DueDateToggle
         cardIsActive={isEditing || isTaskHovered}
-        disabled={disabled}
+        isArchived={isArchived}
         task={task}
         useTaskChild={useTaskChild}
       />

--- a/packages/client/components/EditingStatus/EditingStatus.tsx
+++ b/packages/client/components/EditingStatus/EditingStatus.tsx
@@ -36,10 +36,11 @@ interface Props {
   isTaskHovered: boolean
   task: EditingStatus_task
   useTaskChild: UseTaskChild
+  disabled?: boolean
 }
 
 const EditingStatus = (props: Props) => {
-  const {children, isTaskHovered, task, useTaskChild} = props
+  const {children, isTaskHovered, task, useTaskChild, disabled} = props
   const {createdAt, updatedAt, editors} = task
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
@@ -69,6 +70,7 @@ const EditingStatus = (props: Props) => {
         >
           <EditingStatusText
             editors={otherEditors}
+            disabled={disabled}
             isEditing={isEditing}
             timestamp={timestamp}
             timestampType={timestampType}
@@ -78,6 +80,7 @@ const EditingStatus = (props: Props) => {
       </div>
       <DueDateToggle
         cardIsActive={isEditing || isTaskHovered}
+        disabled={disabled}
         task={task}
         useTaskChild={useTaskChild}
       />

--- a/packages/client/components/EditingStatus/EditingStatusText.tsx
+++ b/packages/client/components/EditingStatus/EditingStatusText.tsx
@@ -9,7 +9,7 @@ interface Props {
   isEditing: boolean
   timestamp: string
   timestampType: TimestampType
-  disabled?: boolean
+  isArchived?: boolean
 }
 
 const useTimeFrom = (timestamp: string) => {
@@ -30,10 +30,10 @@ const useTimeFrom = (timestamp: string) => {
 }
 
 const EditingStatusText = (props: Props) => {
-  const {editors, isEditing, timestamp, timestampType, disabled} = props
+  const {editors, isEditing, timestamp, timestampType, isArchived} = props
   const timestampLabel = timestampType === 'createdAt' ? 'Created ' : 'Updated '
   const timeFrom = useTimeFrom(timestamp)
-  if (disabled) {
+  if (isArchived) {
     return <span>{`${timestampLabel}${timeFrom}`}</span>
   }
   if (editors.length === 0) {

--- a/packages/client/components/EditingStatus/EditingStatusText.tsx
+++ b/packages/client/components/EditingStatus/EditingStatusText.tsx
@@ -9,6 +9,7 @@ interface Props {
   isEditing: boolean
   timestamp: string
   timestampType: TimestampType
+  disabled?: boolean
 }
 
 const useTimeFrom = (timestamp: string) => {
@@ -29,9 +30,12 @@ const useTimeFrom = (timestamp: string) => {
 }
 
 const EditingStatusText = (props: Props) => {
-  const {editors, isEditing, timestamp, timestampType} = props
+  const {editors, isEditing, timestamp, timestampType, disabled} = props
   const timestampLabel = timestampType === 'createdAt' ? 'Created ' : 'Updated '
   const timeFrom = useTimeFrom(timestamp)
+  if (disabled) {
+    return <span>{`${timestampLabel}${timeFrom}`}</span>
+  }
   if (editors.length === 0) {
     if (isEditing) {
       return (

--- a/packages/client/components/NullableTask/NullableTask.tsx
+++ b/packages/client/components/NullableTask/NullableTask.tsx
@@ -17,10 +17,11 @@ interface Props {
   measure?: () => void
   task: NullableTask_task
   dataCy: string
+  disabled?: boolean
 }
 
 const NullableTask = (props: Props) => {
-  const {area, className, isAgenda, task, isDraggingOver, dataCy} = props
+  const {area, className, isAgenda, task, isDraggingOver, dataCy, disabled} = props
   const {content, createdBy, createdByUser} = task
   const {preferredName} = createdByUser
   const contentState = useMemo(() => {
@@ -51,6 +52,7 @@ const NullableTask = (props: Props) => {
   return showOutcome ? (
     <OutcomeCardContainer
       dataCy={`${dataCy}`}
+      disabled={disabled}
       area={area}
       className={className}
       contentState={contentState}
@@ -59,8 +61,8 @@ const NullableTask = (props: Props) => {
       task={task}
     />
   ) : (
-    <NullCard className={className} preferredName={preferredName} />
-  )
+      <NullCard className={className} preferredName={preferredName} />
+    )
 }
 
 export default createFragmentContainer(NullableTask, {

--- a/packages/client/components/NullableTask/NullableTask.tsx
+++ b/packages/client/components/NullableTask/NullableTask.tsx
@@ -17,11 +17,10 @@ interface Props {
   measure?: () => void
   task: NullableTask_task
   dataCy: string
-  disabled?: boolean
 }
 
 const NullableTask = (props: Props) => {
-  const {area, className, isAgenda, task, isDraggingOver, dataCy, disabled} = props
+  const {area, className, isAgenda, task, isDraggingOver, dataCy} = props
   const {content, createdBy, createdByUser} = task
   const {preferredName} = createdByUser
   const contentState = useMemo(() => {
@@ -52,7 +51,6 @@ const NullableTask = (props: Props) => {
   return showOutcome ? (
     <OutcomeCardContainer
       dataCy={`${dataCy}`}
-      disabled={disabled}
       area={area}
       className={className}
       contentState={contentState}

--- a/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
@@ -60,7 +60,6 @@ interface Props {
   setEditorState: (newEditorState: EditorState) => void
   useTaskChild: UseTaskChild
   dataCy: string
-  disabled?: boolean
 }
 
 const OutcomeCard = memo((props: Props) => {
@@ -76,7 +75,6 @@ const OutcomeCard = memo((props: Props) => {
     setEditorState,
     useTaskChild,
     dataCy,
-    disabled
   } = props
   const isPrivate = isTaskPrivate(task.tags)
   const isArchived = isTaskArchived(task.tags)
@@ -98,7 +96,7 @@ const OutcomeCard = memo((props: Props) => {
     >
       <TaskWatermark service={service} />
       <ContentBlock>
-        <EditingStatus isTaskHovered={isTaskHovered} disabled={disabled} task={task} useTaskChild={useTaskChild}>
+        <EditingStatus isTaskHovered={isTaskHovered} isArchived={isArchived} task={task} useTaskChild={useTaskChild}>
           <StatusIndicatorBlock data-cy={`${dataCy}-status`} title={statusIndicatorTitle}>
             <OutcomeCardStatusIndicator status={isDraggingOver || status} />
             {isPrivate && <OutcomeCardStatusIndicator status='private' />}

--- a/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
@@ -34,10 +34,10 @@ const RootCard = styled('div')<{
   boxShadow: isDragging
     ? Elevation.CARD_DRAGGING
     : isTaskFocused
-    ? cardFocusShadow
-    : isTaskHovered
-    ? cardHoverShadow
-    : cardShadow
+      ? cardFocusShadow
+      : isTaskHovered
+        ? cardHoverShadow
+        : cardShadow
 }))
 
 const ContentBlock = styled('div')({
@@ -60,6 +60,7 @@ interface Props {
   setEditorState: (newEditorState: EditorState) => void
   useTaskChild: UseTaskChild
   dataCy: string
+  disabled?: boolean
 }
 
 const OutcomeCard = memo((props: Props) => {
@@ -74,7 +75,8 @@ const OutcomeCard = memo((props: Props) => {
     task,
     setEditorState,
     useTaskChild,
-    dataCy
+    dataCy,
+    disabled
   } = props
   const isPrivate = isTaskPrivate(task.tags)
   const isArchived = isTaskArchived(task.tags)
@@ -87,7 +89,7 @@ const OutcomeCard = memo((props: Props) => {
   const archivedTitle = ', set as #archived'
   const statusIndicatorTitle = `${statusTitle}${isPrivate ? privateTitle : ''}${
     isArchived ? archivedTitle : ''
-  }`
+    }`
   return (
     <RootCard
       isTaskHovered={isTaskHovered}
@@ -96,7 +98,7 @@ const OutcomeCard = memo((props: Props) => {
     >
       <TaskWatermark service={service} />
       <ContentBlock>
-        <EditingStatus isTaskHovered={isTaskHovered} task={task} useTaskChild={useTaskChild}>
+        <EditingStatus isTaskHovered={isTaskHovered} disabled={disabled} task={task} useTaskChild={useTaskChild}>
           <StatusIndicatorBlock data-cy={`${dataCy}-status`} title={statusIndicatorTitle}>
             <OutcomeCardStatusIndicator status={isDraggingOver || status} />
             {isPrivate && <OutcomeCardStatusIndicator status='private' />}

--- a/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
+++ b/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
@@ -29,10 +29,11 @@ interface Props {
   isDraggingOver: TaskStatusEnum | undefined
   task: OutcomeCardContainer_task
   dataCy: string
+  disabled?: boolean
 }
 
 const OutcomeCardContainer = memo((props: Props) => {
-  const {contentState, className, isDraggingOver, task, area, isAgenda, dataCy} = props
+  const {contentState, className, isDraggingOver, task, area, isAgenda, dataCy, disabled} = props
   const {id: taskId, team} = task
   const {id: teamId} = team
   const atmosphere = useAtmosphere()
@@ -110,6 +111,7 @@ const OutcomeCardContainer = memo((props: Props) => {
     >
       <OutcomeCard
         dataCy={`${dataCy}-card`}
+        disabled={disabled}
         area={area}
         editorRef={editorRef}
         editorState={editorStateRef.current}

--- a/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
+++ b/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
@@ -29,11 +29,10 @@ interface Props {
   isDraggingOver: TaskStatusEnum | undefined
   task: OutcomeCardContainer_task
   dataCy: string
-  disabled?: boolean
 }
 
 const OutcomeCardContainer = memo((props: Props) => {
-  const {contentState, className, isDraggingOver, task, area, isAgenda, dataCy, disabled} = props
+  const {contentState, className, isDraggingOver, task, area, isAgenda, dataCy} = props
   const {id: taskId, team} = task
   const {id: teamId} = team
   const atmosphere = useAtmosphere()
@@ -111,7 +110,6 @@ const OutcomeCardContainer = memo((props: Props) => {
     >
       <OutcomeCard
         dataCy={`${dataCy}-card`}
-        disabled={disabled}
         area={area}
         editorRef={editorRef}
         editorState={editorStateRef.current}

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -175,6 +175,7 @@ const TeamArchive = (props: Props) => {
             >
               <NullableTask
                 dataCy={`archive-task`}
+                disabled={true}
                 key={key}
                 area={AreaEnum.teamDash}
                 measure={measure}
@@ -244,15 +245,15 @@ const TeamArchive = (props: Props) => {
             </InfiniteLoader>
           </CardGrid>
         ) : (
-          <EmptyMsg>
-            <span>
-              {'🤓'}
-              {' Hi there! There are zero archived tasks. '}
-              {'Nothing to see here. How about a fun rally video? '}
-              <LinkSpan>{getRallyLink()}!</LinkSpan>
-            </span>
-          </EmptyMsg>
-        )}
+            <EmptyMsg>
+              <span>
+                {'🤓'}
+                {' Hi there! There are zero archived tasks. '}
+                {'Nothing to see here. How about a fun rally video? '}
+                <LinkSpan>{getRallyLink()}!</LinkSpan>
+              </span>
+            </EmptyMsg>
+          )}
       </Body>
     </Root>
   )

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -175,7 +175,6 @@ const TeamArchive = (props: Props) => {
             >
               <NullableTask
                 dataCy={`archive-task`}
-                disabled={true}
                 key={key}
                 area={AreaEnum.teamDash}
                 measure={measure}


### PR DESCRIPTION
This PR aims to solve issue #2219: 
It adds disable option to TeamArchive outcome cards so that editing and date selection can be disabled.

To test:
- [ ] Start server
- [ ] Log in to parabol instance with user
- [ ] Go to team section and check archived cards
- [ ] See that the due date button is missing and that clicking on card does not change editing status