### PR TITLE
Make enableSAMLForDomain an upsert

### DIFF
--- a/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
+++ b/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
@@ -1,16 +1,23 @@
 import {R} from 'rethinkdb-ts'
 export const up = async function(r: R) {
   try {
+    const updatedSaml = await r
+      .table('SAML')
+      .map((row) => {
+        return {
+          id: row('domain'),
+          domain: row('domain'),
+          url: row('url'),
+          metadata: row('metadata')
+        }
+      })
+      .run()
+
     await r
       .table('SAML')
-      .update((row) => ({
-        id: row('domain')
-      }))
+      .insert(updatedSaml, {conflict: 'replace'})
       .run()
-  } catch (e) {
-    console.log(e)
-  }
-  try {
+
     await r
       .table('SAML')
       .filter((row) => row('id').ne(row('domain')))
@@ -21,6 +28,24 @@ export const up = async function(r: R) {
   }
 }
 
-export const down = async function() {
-  // noop
+export const down = async function(r: R) {
+  try {
+    const updatedSaml = await r
+      .table('SAML')
+      .map((row) => {
+        return {
+          domain: row('domain'),
+          url: row('url'),
+          metadata: row('metadata')
+        }
+      })
+      .run()
+
+    await r
+      .table('SAML')
+      .insert(updatedSaml)
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
 }

--- a/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
+++ b/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
@@ -1,7 +1,7 @@
 import {R} from 'rethinkdb-ts'
 export const up = async function(r: R) {
   try {
-    const updatedSaml = await r
+    const samlWithId = await r
       .table('SAML')
       .map((row) => {
         return {
@@ -15,7 +15,7 @@ export const up = async function(r: R) {
 
     await r
       .table('SAML')
-      .insert(updatedSaml, {conflict: 'replace'})
+      .insert(samlWithId, {conflict: 'replace'})
       .run()
 
     await r
@@ -30,7 +30,7 @@ export const up = async function(r: R) {
 
 export const down = async function(r: R) {
   try {
-    const updatedSaml = await r
+    const samlWithoutId = await r
       .table('SAML')
       .map((row) => {
         return {
@@ -43,7 +43,7 @@ export const down = async function(r: R) {
 
     await r
       .table('SAML')
-      .insert(updatedSaml)
+      .insert(samlWithoutId)
       .run()
   } catch (e) {
     console.log(e)

--- a/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
+++ b/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
@@ -1,0 +1,26 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
+  try {
+    await r
+      .table('SAML')
+      .update((row) => ({
+        id: row('domain')
+      }))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+  try {
+    await r
+      .table('SAML')
+      .filter((row) => row('id').eq(row('domain')))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function() {
+  // noop
+}

--- a/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
+++ b/packages/server/database/migrations/20200828161500-samlDomainAsId.ts
@@ -1,5 +1,4 @@
 import {R} from 'rethinkdb-ts'
-
 export const up = async function(r: R) {
   try {
     await r
@@ -14,7 +13,8 @@ export const up = async function(r: R) {
   try {
     await r
       .table('SAML')
-      .filter((row) => row('id').eq(row('domain')))
+      .filter((row) => row('id').ne(row('domain')))
+      .delete()
       .run()
   } catch (e) {
     console.log(e)

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -21,32 +21,17 @@ const enableSAMLForDomain = {
     const normalizedDomain = domain.toLowerCase()
     const normalizedUrl = url.toLowerCase()
 
-    const samlId = await r
+    await r
       .table('SAML')
-      .getAll(normalizedDomain, {index: 'domain'})
-      .nth(0)('id')
-      .default(null)
+      .insert(
+        {
+          id: normalizedDomain,
+          url: normalizedUrl,
+          metadata: metadata
+        },
+        {conflict: 'replace'}
+      )
       .run()
-
-    if (samlId) {
-      await r
-        .table('SAML')
-        .get(samlId)
-        .update({
-          url: normalizedUrl,
-          metadata: metadata
-        })
-        .run()
-    } else {
-      await r
-        .table('SAML')
-        .insert({
-          domain: normalizedDomain,
-          url: normalizedUrl,
-          metadata: metadata
-        })
-        .run()
-    }
 
     return true
   }

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -25,6 +25,7 @@ const enableSAMLForDomain = {
       .insert(
         {
           id: normalizedDomain,
+          domain: normalizedDomain,
           url: normalizedUrl,
           metadata: metadata
         },

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -1,4 +1,4 @@
-import {GraphQLBoolean, GraphQLNonNull, GraphQLString} from 'graphql'
+import {GraphQLNonNull, GraphQLString, GraphQLBoolean} from 'graphql'
 import getRethink from '../../../database/rethinkDriver'
 
 const enableSAMLForDomain = {

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -1,4 +1,5 @@
-import {GraphQLNonNull, GraphQLString, GraphQLBoolean} from 'graphql'
+import {GraphQLBoolean, GraphQLNonNull, GraphQLString} from 'graphql'
+
 import getRethink from '../../../database/rethinkDriver'
 
 const enableSAMLForDomain = {
@@ -20,15 +21,17 @@ const enableSAMLForDomain = {
     const normalizedDomain = domain.toLowerCase()
     const normalizedUrl = url.toLowerCase()
 
-    const samlDomainExists = (await r
+    const samlId = await r
       .table('SAML')
       .getAll(normalizedDomain, {index: 'domain'})
-      .count()
-      .run()) as number
+      .nth(0)('id')
+      .default(null)
+      .run()
 
-    if (samlDomainExists) {
+    if (samlId) {
       await r
         .table('SAML')
+        .get(samlId)
         .update({
           url: normalizedUrl,
           metadata: metadata

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -1,5 +1,4 @@
 import {GraphQLBoolean, GraphQLNonNull, GraphQLString} from 'graphql'
-
 import getRethink from '../../../database/rethinkDriver'
 
 const enableSAMLForDomain = {

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -19,14 +19,31 @@ const enableSAMLForDomain = {
     const r = await getRethink()
     const normalizedDomain = domain.toLowerCase()
     const normalizedUrl = url.toLowerCase()
-    await r
+
+    const samlDomainExists = (await r
       .table('SAML')
-      .insert({
-        domain: normalizedDomain,
-        url: normalizedUrl,
-        metadata: metadata
-      })
-      .run()
+      .getAll(normalizedDomain, {index: 'domain'})
+      .count()
+      .run()) as number
+
+    if (samlDomainExists) {
+      await r
+        .table('SAML')
+        .update({
+          url: normalizedUrl,
+          metadata: metadata
+        })
+        .run()
+    } else {
+      await r
+        .table('SAML')
+        .insert({
+          domain: normalizedDomain,
+          url: normalizedUrl,
+          metadata: metadata
+        })
+        .run()
+    }
 
     return true
   }


### PR DESCRIPTION
Issue #4031 

This PR converts make `enableSAMLForDomain` to an upsert instead of an insert for a domain.

