### PR TITLE
Fix for long URL and lightened up the grey

### DIFF
--- a/packages/client/components/BottomControlBarReady.tsx
+++ b/packages/client/components/BottomControlBarReady.tsx
@@ -35,6 +35,7 @@ const CheckIcon = styled(Icon)<{progress: number; isNext: boolean; isViewerReady
     fontSize: 24,
     fontWeight: 600,
     height: 24,
+    opacity: isNext ? 1 : isViewerReady ? 1 : 0.5,
     transformOrigin: '0 0',
     // 20px to 16 = 0.75
     transform: progress > 0 ? `scale(0.75)translate(4px, 4px)` : undefined,

--- a/packages/client/components/BottomNavControl.tsx
+++ b/packages/client/components/BottomNavControl.tsx
@@ -2,25 +2,35 @@ import styled from '@emotion/styled'
 import {TransitionStatus} from '~/hooks/useTransition'
 import {BezierCurve} from '~/types/constEnums'
 import FlatButton, {FlatButtonProps} from './FlatButton'
+import {PALETTE} from '../styles/paletteV2'
 
 interface Props extends FlatButtonProps {
   confirming?: boolean
+  disabled?: boolean
   status: TransitionStatus
+  waiting?: boolean
 }
 
-const BottomNavControl = styled(FlatButton)<Props>(({status, confirming}) => ({
-  border: 0,
-  borderRadius: 0,
-  minHeight: 56,
-  width: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : 90,
-  opacity: confirming
-    ? 0.5
-    : status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
-    ? 0
-    : 1,
-  padding: 0,
-  transformOrigin: 'center bottom',
-  transition: `all 300ms ${BezierCurve.DECELERATE}`
-}))
+const BottomNavControl = styled(FlatButton)<Props>((props) => {
+  const {confirming, disabled, status, waiting} = props
+  const visuallyDisabled = disabled || waiting
+  return {
+    border: 0,
+    borderRadius: 0,
+    minHeight: 56,
+    width: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : 90,
+    opacity: confirming
+      ? 0.5
+      : status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
+      ? 0
+      : 1,
+    padding: 0,
+    transformOrigin: 'center bottom',
+    transition: `all 300ms ${BezierCurve.DECELERATE}`,
+    ':hover,:focus,:active': {
+      backgroundColor: !visuallyDisabled ? PALETTE.BACKGROUND_MAIN_LIGHTENED : undefined
+    }
+  }
+})
 
 export default BottomNavControl

--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -29,7 +29,7 @@ const BodyCol = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   paddingBottom: 8,
-  width: 'calc(100% - 54px)'
+  width: 'calc(100% - 56px)'
 })
 
 const EditorWrapper = styled('div')({

--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -29,7 +29,11 @@ const BodyCol = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   paddingBottom: 8,
-  width: '100%'
+  width: 'calc(100% - 54px)'
+})
+
+const EditorWrapper = styled('div')({
+  paddingRight: 16
 })
 
 interface Props {
@@ -136,17 +140,19 @@ const ThreadedCommentBase = (props: Props) => {
           onReply={onReply}
         />
         {isActive && (
-          <CommentEditor
-            dataCy={`${dataCy}`}
-            editorRef={editorRef}
-            teamId={teamId}
-            editorState={editorState}
-            setEditorState={setEditorState}
-            onBlur={onSubmit}
-            onSubmit={onSubmit}
-            readOnly={!isEditing}
-            placeholder={'Edit your comment'}
-          />
+          <EditorWrapper>
+            <CommentEditor
+              dataCy={`${dataCy}`}
+              editorRef={editorRef}
+              teamId={teamId}
+              editorState={editorState}
+              setEditorState={setEditorState}
+              onBlur={onSubmit}
+              onSubmit={onSubmit}
+              readOnly={!isEditing}
+              placeholder={'Edit your comment'}
+            />
+          </EditorWrapper>
         )}
         {isActive && (
           <ThreadedCommentFooter


### PR DESCRIPTION
Fixes for issues #3936 and #4046 

### Updates
- Adjusted the width and added a wrapper so that long links don't cause problems
- Lightened the hover grey for the bottom nav control. The ready button text currently changes from grey to green. I imagine that we don't want to lighten the grey text on a white background so I've lightened the hover colour so that there's more of a contrast between the button, text and the thread. 

I think this helps but it doesn't necessarily make it super obvious that the user has clicked "Ready". Perhaps a green background with white text would be clearer?

Also, it may be difficult to test this branch until this installation error is resolved: #4077 