### PR TITLE
sets GA clientId to Segment anonymousId

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -9,6 +9,7 @@ import {LocalStorageKey} from '~/types/constEnums'
 import safeIdentify from '~/utils/safeIdentify'
 import {AnalyticsPageQuery} from '~/__generated__/AnalyticsPageQuery.graphql'
 import useScript from '../hooks/useScript'
+import getAnonymousId from '../utils/getAnonymousId'
 import makeHref from '../utils/makeHref'
 
 const query = graphql`
@@ -92,7 +93,9 @@ const AnalyticsPage = () => {
         referrer: makeHref(prevPathname),
         title,
         path: pathname,
-        url: href
+        url: href,
+        // See: segmentIo.ts:28 for more information on the next line
+        context: {integrations: {'Google Analytics': {clientId: getAnonymousId()}}}
       })
     }, TIME_TO_RENDER_TREE)
   }, [isSegmentLoaded, pathname])

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -37,8 +37,9 @@ segmentIo.track = async (options) => {
        * be tallied as "direct" rather than acquired through a known channel (e.g.
        * "Organic Search"), making it look like all these new users just dropped out of the
        * sky.
-       * 
-       * GA requires we specify which GA User ID to update. We can do this by passing in
+       *
+       * To work around this, we specify which a UUID Segment will consistently hash
+       * between our marketing site and app domains. We do this by passing in
        * additional Segment context, as seen here:
        */
       integrations: {

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -20,10 +20,31 @@ segmentIo.track = async (options) => {
     .digest('base64')
   const {userId, event, properties} = options
   const user = await db.read('User', options.userId)
-  const {email} = user
+  const {email, segmentId} = user
   return (segmentIo as any)._track({
     userId,
     event,
+    context: {
+      /*
+       * Specify the Google Analytics ID for use with the Google Analytics integration
+       *
+       * Why do we do this? GA is a sad, old bear. Here's the story: when
+       * a user new to Parabol visits our marketing website the Segment-generated
+       * anonymousId is hashed to create the GA User ID. Before this change,
+       * we assumed sending a identify() event that would tie the new, Parabol userId to the
+       * anonymousId, but Google Analytics apparently does not support tying users together
+       * in this way. When we would looked at our data, events coming from our app would
+       * be tallied as "direct" rather than acquired through a known channel (e.g.
+       * "Organic Search"), making it look like all these new users just dropped out of the
+       * sky.
+       * 
+       * GA requires we specify which GA User ID to update. We can do this by passing in
+       * additional Segment context, as seen here:
+       */
+      integrations: {
+        'Google Analytics': {clientId: segmentId}
+      }
+    },
     properties: {
       ...properties,
       email


### PR DESCRIPTION
Closes #4116 

Should emit segment events in the form of:

```javascript
{
  // ...
  context: {
    integrations: {
      "Google Analytics": {
        clientId: '1a94b8ed-f331-4f96-bd3a-77a3723aba70'
      }
    }
  },
  // ...
}
```

### TEST

- [ ] When I load a new page on the app, I see page() events emitted Segment conforming to above spec
- [ ] When I complete a meeting, I see track() events emitted on Segment confirming to the above spec