### PR TITLE
persist user rol, rol on SSO

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,39 @@
-version: '3.7'
+version: "3.7"
 
 services:
   db:
     image: rethinkdb:latest
     ports:
-      - '8080:8080'
-      - '29015:29015'
-      - '28015:28015'
+      - "8080:8080"
+      - "29015:29015"
+      - "28015:28015"
+    volumes:
+      - rethink-data:/data
+    networks:
+      - parabol-network
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - parabol-network
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile.prod
+      target: prod
+    env_file: .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - redis
+    networks:
+      - parabol-network
+networks:
+  parabol-network:
+volumes:
+  redis-data: {}
+  rethink-data: {}

--- a/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
+++ b/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
@@ -69,7 +69,10 @@ const loginSAML = {
     const {isInvited} = relayState
     const {extract} = loginResponse
     const {attributes, nameID: name} = extract
-    const email = attributes.email.toLowerCase()
+    const email = attributes.email?.toLowerCase()
+    if (!email) {
+      return {error: {message: 'Email attribute was not included in SAML response'}}
+    }
     const ssoDomain = getSSODomainFromEmail(email)
     if (ssoDomain !== normalizedDomain) {
       // don't blindly trust the IdP
@@ -84,7 +87,7 @@ const loginSAML = {
       .run()
     if (user) {
       return {
-        authToken: encodeAuthToken(new AuthToken({sub: user.id, tms: user.tms}))
+        authToken: encodeAuthToken(new AuthToken({sub: user.id, tms: user.tms, rol: user.rol}))
       }
     }
 

--- a/packages/server/graphql/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/mutations/acceptTeamInvitation.ts
@@ -91,7 +91,7 @@ export default {
         invitationNotificationIds
       }
 
-      const encodedAuthToken = encodeAuthToken(new AuthToken({tms, sub: viewerId}))
+      const encodedAuthToken = encodeAuthToken(new AuthToken({tms, sub: viewerId, rol: authToken.rol}))
 
       // Send the new team member a welcome & a new token
       publish(SubscriptionChannel.NOTIFICATION, viewerId, 'AuthTokenPayload', {tms})

--- a/packages/server/graphql/mutations/addOrg.ts
+++ b/packages/server/graphql/mutations/addOrg.ts
@@ -90,7 +90,7 @@ export default {
 
       return {
         ...data,
-        authToken: encodeAuthToken(new AuthToken({tms, sub: viewerId}))
+        authToken: encodeAuthToken(new AuthToken({tms, sub: viewerId, rol: authToken.rol}))
       }
     }
   )

--- a/packages/server/graphql/mutations/addTeam.ts
+++ b/packages/server/graphql/mutations/addTeam.ts
@@ -109,7 +109,7 @@ export default {
 
       return {
         ...data,
-        authToken: encodeAuthToken(new AuthToken({tms, sub: viewerId}))
+        authToken: encodeAuthToken(new AuthToken({tms, sub: viewerId, rol: authToken.rol}))
       }
     }
   )

--- a/packages/server/graphql/mutations/verifyEmail.ts
+++ b/packages/server/graphql/mutations/verifyEmail.ts
@@ -51,11 +51,11 @@ export default {
       .run()) as User
 
     if (user) {
-      const {id: userId, identities, tms} = user
+      const {id: userId, identities, rol, tms} = user
       const localIdentity = identities.find(
         (identity) => identity.type === AuthIdentityTypeEnum.LOCAL
       ) as AuthIdentityLocal
-      context.authToken = new AuthToken({sub: userId, tms})
+      context.authToken = new AuthToken({sub: userId, tms, rol})
       const authToken = encodeAuthToken(context.authToken)
       if (!localIdentity.isEmailVerified) {
         // mutative


### PR DESCRIPTION
This includes 3 fixes:
- If a SAML user logs in without the email attribute in the SAML response, it includes a good error message
- a SAML user may now be a superuser
- the superuser flag persists across token changes so you don't have to occasionally logout/login to get back to graphiql

@tianrunhe mind taking a look to make sure i'm not accidentally giving random folks super powers?