### PR TITLE
exclude timeline events from uninteresting teams

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/backupOrganization.ts
+++ b/packages/server/graphql/intranetSchema/mutations/backupOrganization.ts
@@ -268,6 +268,7 @@ const backupOrganization = {
             timelineEvent: (r
               .table('TimelineEvent')
               .filter((row) => r(userIds).contains(row('userId'))) as any)
+              .filter((row) => r.branch(row('teamId'), r(teamIds).contains(row('teamId')), true))
               .coerceTo('array')
               .do((items) =>
                 r


### PR DESCRIPTION
fixes bug where the export would include timeline events for teams that were not a part of the requested organization