### PR TITLE
Added tab access for due date

### DIFF
--- a/packages/client/components/DueDateToggle.tsx
+++ b/packages/client/components/DueDateToggle.tsx
@@ -140,6 +140,7 @@ const DueDateToggle = (props: Props) => {
     <>
       <Toggle
         cardIsActive={!dueDate && cardIsActive}
+        tabIndex={0}
         dueDate={!!dueDate}
         isPastDue={isPastDue}
         isDueSoon={isDueSoon}


### PR DESCRIPTION
This PR attempts to resolve issue #2194.

Users can:

* Tab to the due date toggle

* Use the keyboard to open (enter) and close the menu (escape)
