### PR TITLE
fix connect presence logic

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/connectSocket.ts
+++ b/packages/server/graphql/intranetSchema/mutations/connectSocket.ts
@@ -35,8 +35,9 @@ export default {
         .append(socketId)
     })
     await db.write('User', userId, reqlUpdater)
-
-    const {inactive, connectedSockets, tms} = user
+    const {inactive, tms} = user
+    const connectedSockets = user.connectedSockets || []
+    connectedSockets.push(socketId)
 
     // no need to wait for this, it's just for billing
     if (inactive) {
@@ -49,7 +50,7 @@ export default {
       // TODO: re-identify
     }
 
-    if (connectedSockets.length === 0) {
+    if (connectedSockets.length === 1) {
       const operationId = dataLoader.share()
       const subOptions = {mutatorId: socketId, operationId}
       const listeningUserIds = (await r


### PR DESCRIPTION
@nickoferrall found a good bug where the presence was broken.
this fixes #4143 

TEST
- [x] open up 2 browsers, 1 per user (1 regular, 1 incognito)
- [x] in a 2nd terminal run `yarn postdeploy` to wipe the `connectedSockets` array
- [x] go to a team dash in browser 1, see that user 1 is online & user 2 is offline
- [x] login as user 2, user 1 sees user 2 logged in now
- [x] exit browser 2. user 1 sees user 2 is now offline