### PR TITLE
Poker jira front-end

### DIFF
--- a/packages/client/clientSchema.graphql
+++ b/packages/client/clientSchema.graphql
@@ -16,6 +16,7 @@ extend type PokerMeeting {
   localPhase: NewMeetingPhase!
   localStage: NewMeetingStage!
   showSidebar: Boolean!
+  jiraSearchQuery: String
 }
 
 extend type RetrospectiveMeeting {
@@ -82,5 +83,9 @@ extend type UpdatesStage {
 }
 
 extend type AgendaItemsStage {
+  localScheduledEndTime: String
+}
+
+extend type EstimateStage {
   localScheduledEndTime: String
 }

--- a/packages/client/components/Checkbox.tsx
+++ b/packages/client/components/Checkbox.tsx
@@ -4,7 +4,7 @@ import {PALETTE} from '../styles/paletteV2'
 import Icon from './Icon'
 
 interface Props {
-  active: boolean
+  active: boolean | null
   className?: string
   disabled?: boolean
   onClick?: (e: React.MouseEvent) => void
@@ -20,7 +20,7 @@ const StyledIcon = styled(Icon)<{disabled: boolean | undefined}>(({disabled}) =>
 
 const Checkbox = (props: Props) => {
   const {active, className, disabled, onClick} = props
-  const icon = active ? 'check_box' : 'check_box_outline_blank'
+  const icon = active ? 'check_box' : active === false ? 'check_box_outline_blank' : 'indeterminate_check_box'
   return (
     <StyledIcon className={className} disabled={disabled} onClick={disabled ? undefined : onClick}>
       {icon}

--- a/packages/client/components/JiraIssueLink.tsx
+++ b/packages/client/components/JiraIssueLink.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {PALETTE} from '../styles/paletteV2'
+import {Card} from '../types/constEnums'
+
+const StyledLink = styled('a')({
+  color: PALETTE.TEXT_MAIN,
+  display: 'block',
+  fontSize: Card.FONT_SIZE,
+  lineHeight: '1.25rem',
+  padding: `0 ${Card.PADDING}`,
+  textDecoration: 'underline',
+  '&:hover,:focus': {
+    textDecoration: 'underline'
+  }
+})
+
+interface Props {
+  className?: string
+  dataCy?: string
+  cloudName: string
+  issueKey: string
+  projectKey: string
+}
+
+const JiraIssueLink = (props: Props) => {
+  const {dataCy, className, cloudName, issueKey, projectKey} = props
+  const href =
+    cloudName === 'jira-demo'
+      ? 'https://www.parabol.co/features/integrations'
+      : `https://${cloudName}.atlassian.net/browse/${issueKey}`
+  return (
+    <StyledLink
+      className={className}
+      data-cy={`${dataCy}-jira-issue-link`}
+      href={href}
+      rel='noopener noreferrer'
+      target='_blank'
+      title={`Jira Issue #${issueKey} on ${projectKey}`}
+    >
+      {`Issue #${issueKey}`}
+    </StyledLink>
+  )
+}
+
+export default JiraIssueLink

--- a/packages/client/components/JiraScopingNoResults.tsx
+++ b/packages/client/components/JiraScopingNoResults.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {PALETTE} from '../styles/paletteV2'
+import Icon from './Icon'
+
+const Message = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px dashed ${PALETTE.BORDER_GRAY}`,
+  borderRadius: 4,
+  color: PALETTE.TEXT_GRAY,
+  fontSize: 14,
+  fontStyle: 'italic',
+  lineHeight: '32px',
+  margin: '64px auto auto',
+  padding: '8px 16px'
+})
+
+const Info = styled(Icon)({
+  paddingRight: 16
+})
+
+const JiraScopingNoResults = () => {
+  return (
+    <Message>
+      <Info>info</Info>
+      No issues match that query
+    </Message>
+  )
+}
+
+export default JiraScopingNoResults

--- a/packages/client/components/JiraScopingSearchBar.tsx
+++ b/packages/client/components/JiraScopingSearchBar.tsx
@@ -1,0 +1,38 @@
+import graphql from 'babel-plugin-relay/macro'
+import {createFragmentContainer} from 'react-relay'
+import {JiraScopingSearchBar_meeting} from '../__generated__/JiraScopingSearchBar_meeting.graphql'
+import JiraScopingSearchHistoryToggle from './JiraScopingSearchHistoryToggle'
+import JiraScopingSearchInput from './JiraScopingSearchInput'
+import JiraScopingSearchFilterToggle from './JiraScopingSearchFilterToggle'
+import React from 'react'
+import styled from '@emotion/styled'
+
+const SearchBar = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  padding: 16
+})
+interface Props {
+  meeting: JiraScopingSearchBar_meeting
+}
+
+const JiraScopingSearchBar = (props: Props) => {
+  const {meeting} = props
+  return (
+    <SearchBar>
+      <JiraScopingSearchHistoryToggle meeting={meeting} />
+      <JiraScopingSearchInput meeting={meeting} />
+      <JiraScopingSearchFilterToggle meeting={meeting} />
+    </SearchBar>
+  )
+}
+
+export default createFragmentContainer(JiraScopingSearchBar, {
+  meeting: graphql`
+    fragment JiraScopingSearchBar_meeting on PokerMeeting {
+      ...JiraScopingSearchHistoryToggle_meeting
+      ...JiraScopingSearchInput_meeting
+      ...JiraScopingSearchFilterToggle_meeting
+    }
+  `
+})

--- a/packages/client/components/JiraScopingSearchFilterToggle.tsx
+++ b/packages/client/components/JiraScopingSearchFilterToggle.tsx
@@ -16,8 +16,8 @@ interface Props {
   meeting: JiraScopingSearchFilterToggle_meeting
 }
 
-const JiraScopingSearchFilterToggle = (props: Props) => {
-  const {meeting} = props
+const JiraScopingSearchFilterToggle = (_props: Props) => {
+  // const {meeting} = props
   return (
     <PlainButton>
       <FilterIcon>filter_list</FilterIcon>

--- a/packages/client/components/JiraScopingSearchFilterToggle.tsx
+++ b/packages/client/components/JiraScopingSearchFilterToggle.tsx
@@ -1,0 +1,40 @@
+import graphql from 'babel-plugin-relay/macro'
+import {createFragmentContainer} from 'react-relay'
+import {JiraScopingSearchFilterToggle_meeting} from '../__generated__/JiraScopingSearchFilterToggle_meeting.graphql'
+import React from 'react'
+import styled from '@emotion/styled'
+import Icon from './Icon'
+import {PALETTE} from '../styles/paletteV2'
+import {ICON_SIZE} from '../styles/typographyV2'
+import PlainButton from './PlainButton/PlainButton'
+
+const FilterIcon = styled(Icon)({
+  color: PALETTE.TEXT_GRAY,
+  fontSize: ICON_SIZE.MD24
+})
+interface Props {
+  meeting: JiraScopingSearchFilterToggle_meeting
+}
+
+const JiraScopingSearchFilterToggle = (props: Props) => {
+  const {meeting} = props
+  return (
+    <PlainButton>
+      <FilterIcon>filter_list</FilterIcon>
+    </PlainButton>
+  )
+}
+
+export default createFragmentContainer(JiraScopingSearchFilterToggle, {
+  meeting: graphql`
+    fragment JiraScopingSearchFilterToggle_meeting on PokerMeeting {
+      viewerMeetingMember {
+        teamMember {
+          atlassianAuth {
+            isActive
+          }
+        }
+      }
+    }
+  `
+})

--- a/packages/client/components/JiraScopingSearchHistoryToggle.tsx
+++ b/packages/client/components/JiraScopingSearchHistoryToggle.tsx
@@ -1,0 +1,54 @@
+import graphql from 'babel-plugin-relay/macro'
+import {createFragmentContainer} from 'react-relay'
+import {JiraScopingSearchHistoryToggle_meeting} from '../__generated__/JiraScopingSearchHistoryToggle_meeting.graphql'
+import React from 'react'
+import Icon from './Icon'
+import {PALETTE} from '../styles/paletteV2'
+import {ICON_SIZE} from '../styles/typographyV2'
+import styled from '@emotion/styled'
+import PlainButton from './PlainButton/PlainButton'
+
+const SearchIcon = styled(Icon)({
+  color: PALETTE.TEXT_GRAY,
+  fontSize: ICON_SIZE.MD24
+})
+
+const DropdownIcon = styled(Icon)({
+  color: PALETTE.TEXT_MAIN,
+  fontSize: ICON_SIZE.MD18,
+  marginLeft: -8
+})
+
+const Toggle = styled(PlainButton)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingRight: 8
+})
+interface Props {
+  meeting: JiraScopingSearchHistoryToggle_meeting
+}
+
+const JiraScopingSearchHistoryToggle = (props: Props) => {
+  const {meeting} = props
+  return (
+    <Toggle>
+      <SearchIcon>search</SearchIcon>
+      <DropdownIcon>expand_more</DropdownIcon>
+    </Toggle>
+  )
+}
+
+export default createFragmentContainer(JiraScopingSearchHistoryToggle, {
+  meeting: graphql`
+    fragment JiraScopingSearchHistoryToggle_meeting on PokerMeeting {
+      viewerMeetingMember {
+        teamMember {
+          atlassianAuth {
+            isActive
+          }
+        }
+      }
+    }
+  `
+})

--- a/packages/client/components/JiraScopingSearchHistoryToggle.tsx
+++ b/packages/client/components/JiraScopingSearchHistoryToggle.tsx
@@ -29,8 +29,8 @@ interface Props {
   meeting: JiraScopingSearchHistoryToggle_meeting
 }
 
-const JiraScopingSearchHistoryToggle = (props: Props) => {
-  const {meeting} = props
+const JiraScopingSearchHistoryToggle = (_props: Props) => {
+  // const {meeting} = props
   return (
     <Toggle>
       <SearchIcon>search</SearchIcon>

--- a/packages/client/components/JiraScopingSearchInput.tsx
+++ b/packages/client/components/JiraScopingSearchInput.tsx
@@ -1,0 +1,74 @@
+import graphql from 'babel-plugin-relay/macro'
+import {createFragmentContainer, commitLocalUpdate} from 'react-relay'
+import {JiraScopingSearchInput_meeting} from '../__generated__/JiraScopingSearchInput_meeting.graphql'
+import React from 'react'
+import styled from '@emotion/styled'
+import {PALETTE} from '../styles/paletteV2'
+import Icon from './Icon'
+import Atmosphere from '../Atmosphere'
+import useAtmosphere from '../hooks/useAtmosphere'
+
+const SearchInput = styled('input')({
+  appearance: 'none',
+  border: '1px solid transparent',
+  color: PALETTE.TEXT_MAIN,
+  fontSize: 16,
+  margin: 0,
+  outline: 0,
+  backgroundColor: 'transparent',
+  width: '100%'
+})
+
+const Wrapper = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  flex: 1
+})
+
+const ClearSearchIcon = styled(Icon)<{isEmpty: boolean}>(({isEmpty}) => ({
+  color: PALETTE.TEXT_GRAY,
+  cursor: 'pointer',
+  padding: 12,
+  visibility: isEmpty ? 'hidden' : undefined
+}))
+
+const setSearch = (atmosphere: Atmosphere, meetingId: string, value: string) => {
+  commitLocalUpdate(atmosphere, (store) => {
+    const meeting = store.get(meetingId)
+    console.log('meet', meeting)
+    if (!meeting) return
+    meeting.setValue(value, 'jiraSearchQuery')
+  })
+}
+
+interface Props {
+  meeting: JiraScopingSearchInput_meeting
+}
+
+const JiraScopingSearchInput = (props: Props) => {
+  const {meeting} = props
+  const {id: meetingId, jiraSearchQuery} = meeting
+  const isEmpty = !jiraSearchQuery
+  const atmosphere = useAtmosphere()
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearch(atmosphere, meetingId, e.target.value)
+  }
+  const clearSearch = () => {
+    setSearch(atmosphere, meetingId, '')
+  }
+  return (
+    <Wrapper>
+      <SearchInput value={jiraSearchQuery || ''} placeholder={'Search issues on Jira'} onChange={onChange} />
+      <ClearSearchIcon isEmpty={isEmpty} onClick={clearSearch}>close</ClearSearchIcon>
+    </Wrapper>
+  )
+}
+
+export default createFragmentContainer(JiraScopingSearchInput, {
+  meeting: graphql`
+    fragment JiraScopingSearchInput_meeting on PokerMeeting {
+      id
+      jiraSearchQuery
+    }
+  `
+})

--- a/packages/client/components/JiraScopingSearchResultItem.tsx
+++ b/packages/client/components/JiraScopingSearchResultItem.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import Checkbox from './Checkbox'
+import JiraIssueLink from './JiraIssueLink'
+import {PALETTE} from '../styles/paletteV2'
+
+const Item = styled('div')({
+  display: 'flex',
+  paddingLeft: 16,
+  paddingTop: 8,
+  paddingBottom: 8
+})
+
+const Issue = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  paddingLeft: 16,
+})
+
+const Title = styled('div')({
+
+})
+
+const Link = styled(JiraIssueLink)({
+  paddingLeft: 0,
+  fontSize: 12,
+  textDecoration: 'none',
+  color: PALETTE.LINK_BLUE
+})
+
+interface Props {
+  isSelected: boolean
+  title: string
+  issueKey: string
+  cloudName: string
+  projectKey: string
+}
+
+const JiraScopingSearchResultItem = (props: Props) => {
+  const {cloudName, isSelected, title, issueKey, projectKey} = props
+  return (
+    <Item>
+      <Checkbox active={isSelected} onClick={() => console.log('click')} />
+      <Issue>
+        <Title>{title}</Title>
+        <Link issueKey={issueKey} cloudName={cloudName} projectKey={projectKey} />
+      </Issue>
+    </Item>
+  )
+}
+
+export default JiraScopingSearchResultItem

--- a/packages/client/components/JiraScopingSearchResults.tsx
+++ b/packages/client/components/JiraScopingSearchResults.tsx
@@ -1,0 +1,23 @@
+import graphql from 'babel-plugin-relay/macro'
+import {createFragmentContainer} from 'react-relay'
+import {JiraScopingSearchResults_meeting} from '../__generated__/JiraScopingSearchResults_meeting.graphql'
+import JiraScopingSearchBar from './JiraScopingSearchBar'
+import React from 'react'
+interface Props {
+  meeting: JiraScopingSearchResults_meeting
+}
+
+const JiraScopingSearchResults = (props: Props) => {
+  const {meeting} = props
+  return (
+    <div>RESULTS</div>
+  )
+}
+
+export default createFragmentContainer(JiraScopingSearchResults, {
+  meeting: graphql`
+    fragment JiraScopingSearchResults_meeting on PokerMeeting {
+      id
+    }
+  `
+})

--- a/packages/client/components/JiraScopingSearchResults.tsx
+++ b/packages/client/components/JiraScopingSearchResults.tsx
@@ -1,16 +1,45 @@
 import graphql from 'babel-plugin-relay/macro'
-import {createFragmentContainer} from 'react-relay'
-import {JiraScopingSearchResults_meeting} from '../__generated__/JiraScopingSearchResults_meeting.graphql'
-import JiraScopingSearchBar from './JiraScopingSearchBar'
 import React from 'react'
+import {createFragmentContainer} from 'react-relay'
+import MockScopingList from '../modules/meeting/components/MockScopingList'
+import {JiraScopingSearchResults_meeting} from '../__generated__/JiraScopingSearchResults_meeting.graphql'
+import JiraScopingNoResults from './JiraScopingNoResults'
+import JiraScopingSearchResultItem from './JiraScopingSearchResultItem'
+import JiraScopingSelectAllIssues from './JiraScopingSelectAllIssues'
+
 interface Props {
   meeting: JiraScopingSearchResults_meeting
 }
 
-const JiraScopingSearchResults = (props: Props) => {
-  const {meeting} = props
+const JiraScopingSearchResults = (_props: Props) => {
+  // const {meeting} = props
+  const loading = false
+  if (loading) {
+    return (
+      <MockScopingList />
+    )
+  }
+
+  const results = [{
+    isSelected: true,
+    title: 'Jira Issue 1',
+    issueKey: 'KEYFOO',
+    projectKey: 'PROJ_FOO',
+    cloudName: 'CLOUDFOOD',
+  }]
+
+  if (results.length === 0) {
+    return <JiraScopingNoResults />
+  }
+
   return (
-    <div>RESULTS</div>
+    <>
+      <JiraScopingSelectAllIssues selected={false} issueCount={results.length} />
+      {results.map((result) => {
+        return <JiraScopingSearchResultItem {...result} />
+      })}
+    </>
+
   )
 }
 

--- a/packages/client/components/JiraScopingSelectAllIssues.tsx
+++ b/packages/client/components/JiraScopingSelectAllIssues.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import Checkbox from './Checkbox'
+
+const Item = styled('div')({
+  display: 'flex',
+  paddingLeft: 16
+})
+
+const Title = styled('div')({
+  paddingLeft: 16,
+  paddingBottom: 16,
+  fontWeight: 600
+})
+interface Props {
+  issueCount: number
+  selected: boolean | null
+}
+
+const JiraScopingSelectAllIssues = (props: Props) => {
+  const {selected, issueCount} = props
+  if (issueCount < 2) return null
+  return (
+    <Item>
+      <Checkbox active={selected} onClick={() => console.log('click')} />
+      <Title>{`Select all ${issueCount} issues`}</Title>
+    </Item>
+  )
+}
+
+export default JiraScopingSelectAllIssues

--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -7,6 +7,7 @@ import {ScopePhaseArea_meeting} from '~/__generated__/ScopePhaseArea_meeting.gra
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV2'
 import Icon from './Icon'
+import JiraSVG from './JiraSVG'
 import ScopePhaseAreaAddJira from './ScopePhaseAreaAddJira'
 import Tab from './Tab/Tab'
 import Tabs from './Tabs/Tabs'
@@ -36,13 +37,13 @@ const FullTab = styled(Tab)({
 })
 
 const TabIcon = styled(Icon)({
-  marginRight: 4
 })
 
 const TabLabel = styled('div')({
   display: 'flex',
   justifyContent: 'center',
-  alignItems: 'center'
+  alignItems: 'center',
+  whiteSpace: 'pre-wrap',
 })
 
 const TabContents = styled('div')({
@@ -75,7 +76,7 @@ const ScopePhaseArea = (props: Props) => {
         <FullTab
           label={
             <TabLabel>
-              <TabIcon>{'add'}</TabIcon> Jira Project
+              <JiraSVG />  Jira
             </TabLabel>
           }
           onClick={gotoAddJira}
@@ -83,7 +84,7 @@ const ScopePhaseArea = (props: Props) => {
         <FullTab
           label={
             <TabLabel>
-              <TabIcon>{'public'}</TabIcon> Parabol
+              <TabIcon>{'public'}</TabIcon>  Parabol
             </TabLabel>
           }
           onClick={gotoParabol}

--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -8,7 +8,7 @@ import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV2'
 import Icon from './Icon'
 import JiraSVG from './JiraSVG'
-import ScopePhaseAreaAddJira from './ScopePhaseAreaAddJira'
+import ScopePhaseAreaJira from './ScopePhaseAreaJira'
 import Tab from './Tab/Tab'
 import Tabs from './Tabs/Tabs'
 
@@ -43,6 +43,7 @@ const TabLabel = styled('div')({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  minWidth: 80,
   whiteSpace: 'pre-wrap',
 })
 
@@ -98,7 +99,7 @@ const ScopePhaseArea = (props: Props) => {
         style={innerStyle}
       >
         <TabContents>
-          <ScopePhaseAreaAddJira gotoParabol={gotoParabol} meeting={meeting} />
+          <ScopePhaseAreaJira gotoParabol={gotoParabol} meeting={meeting} />
         </TabContents>
         <TabContents>
         </TabContents>
@@ -118,7 +119,7 @@ export default createFragmentContainer(ScopePhaseArea, {
     fragment ScopePhaseArea_meeting on PokerMeeting {
       ...StageTimerDisplay_meeting
       ...StageTimerControl_meeting
-      ...ScopePhaseAreaAddJira_meeting
+      ...ScopePhaseAreaJira_meeting
       endedAt
       localPhase {
         ...ScopePhaseArea_phase @relay(mask: false)

--- a/packages/client/components/ScopePhaseAreaAddJira.tsx
+++ b/packages/client/components/ScopePhaseAreaAddJira.tsx
@@ -62,13 +62,11 @@ const ScopePhaseAreaAddJira = (props: Props) => {
 export default createFragmentContainer(ScopePhaseAreaAddJira, {
   meeting: graphql`
     fragment ScopePhaseAreaAddJira_meeting on PokerMeeting {
-      id
       teamId
       viewerMeetingMember {
         teamMember {
           atlassianAuth {
             isActive
-            accessToken
           }
         }
       }

--- a/packages/client/components/ScopePhaseAreaJira.tsx
+++ b/packages/client/components/ScopePhaseAreaJira.tsx
@@ -1,0 +1,37 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {createFragmentContainer} from 'react-relay'
+import {ScopePhaseAreaJira_meeting} from '../__generated__/ScopePhaseAreaJira_meeting.graphql'
+import ScopePhaseAreaAddJira from './ScopePhaseAreaAddJira'
+import ScopePhaseAreaJiraScoping from './ScopePhaseAreaJiraScoping'
+
+interface Props {
+  gotoParabol: () => void
+  meeting: ScopePhaseAreaJira_meeting
+}
+
+const ScopePhaseAreaJira = (props: Props) => {
+  const {gotoParabol, meeting} = props
+  const {viewerMeetingMember} = meeting
+  const {teamMember} = viewerMeetingMember
+  const {atlassianAuth} = teamMember
+  const hasAuth = atlassianAuth?.isActive ?? false
+  if (!hasAuth) return <ScopePhaseAreaAddJira gotoParabol={gotoParabol} meeting={meeting} />
+  return <ScopePhaseAreaJiraScoping meeting={meeting} />
+}
+
+export default createFragmentContainer(ScopePhaseAreaJira, {
+  meeting: graphql`
+    fragment ScopePhaseAreaJira_meeting on PokerMeeting {
+      ...ScopePhaseAreaAddJira_meeting
+      ...ScopePhaseAreaJiraScoping_meeting
+      viewerMeetingMember {
+        teamMember {
+          atlassianAuth {
+            isActive
+          }
+        }
+      }
+    }
+  `
+})

--- a/packages/client/components/ScopePhaseAreaJiraScoping.tsx
+++ b/packages/client/components/ScopePhaseAreaJiraScoping.tsx
@@ -1,0 +1,35 @@
+import graphql from 'babel-plugin-relay/macro'
+import {createFragmentContainer} from 'react-relay'
+import {ScopePhaseAreaJiraScoping_meeting} from '../__generated__/ScopePhaseAreaJiraScoping_meeting.graphql'
+import JiraScopingSearchBar from './JiraScopingSearchBar'
+import JiraScopingSearchResults from './JiraScopingSearchResults'
+import React from 'react'
+interface Props {
+  meeting: ScopePhaseAreaJiraScoping_meeting
+}
+
+const ScopePhaseAreaJiraScoping = (props: Props) => {
+  const {meeting} = props
+  return (
+    <>
+      <JiraScopingSearchBar meeting={meeting} />
+      <JiraScopingSearchResults meeting={meeting} />
+    </>
+  )
+}
+
+export default createFragmentContainer(ScopePhaseAreaJiraScoping, {
+  meeting: graphql`
+    fragment ScopePhaseAreaJiraScoping_meeting on PokerMeeting {
+      ...JiraScopingSearchBar_meeting
+      ...JiraScopingSearchResults_meeting
+      viewerMeetingMember {
+        teamMember {
+          atlassianAuth {
+            isActive
+          }
+        }
+      }
+    }
+  `
+})

--- a/packages/client/components/SuggestedIntegrationGitHubMenuItem.tsx
+++ b/packages/client/components/SuggestedIntegrationGitHubMenuItem.tsx
@@ -1,29 +1,22 @@
-import {SuggestedIntegrationGitHubMenuItem_suggestedIntegration} from '../__generated__/SuggestedIntegrationGitHubMenuItem_suggestedIntegration.graphql'
+import graphql from 'babel-plugin-relay/macro'
 import React, {forwardRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
-import graphql from 'babel-plugin-relay/macro'
+import {SuggestedIntegrationGitHubMenuItem_suggestedIntegration} from '../__generated__/SuggestedIntegrationGitHubMenuItem_suggestedIntegration.graphql'
 import GitHubSVG from './GitHubSVG'
 import MenuItem from './MenuItem'
 import MenuItemLabel from './MenuItemLabel'
 import SuggestedIntegrationMenuItemAvatar from './SuggestedIntegrationMenuItemAvatar'
-import useAtmosphere from '../hooks/useAtmosphere'
-import CreateGitHubIssueMutation from '../mutations/CreateGitHubIssueMutation'
-import {WithMutationProps} from '../utils/relay/withMutationProps'
 import TypeAheadLabel from './TypeAheadLabel'
 
 interface Props {
   suggestedIntegration: SuggestedIntegrationGitHubMenuItem_suggestedIntegration
-  taskId: string
-  submitMutation: WithMutationProps['submitMutation']
-  onError: WithMutationProps['onError']
-  onCompleted: WithMutationProps['onCompleted']
+  onClick: () => void
   query: string
 }
 
 const SuggestedIntegrationGitHubMenuItem = forwardRef((props: Props, ref: any) => {
-  const {query, suggestedIntegration, taskId, submitMutation, onError, onCompleted} = props
+  const {query, suggestedIntegration, onClick} = props
   const {nameWithOwner} = suggestedIntegration
-  const atmosphere = useAtmosphere()
   return (
     <MenuItem
       ref={ref}
@@ -35,11 +28,7 @@ const SuggestedIntegrationGitHubMenuItem = forwardRef((props: Props, ref: any) =
           <TypeAheadLabel query={query} label={nameWithOwner} />
         </MenuItemLabel>
       }
-      onClick={() => {
-        const variables = {nameWithOwner, taskId}
-        submitMutation()
-        CreateGitHubIssueMutation(atmosphere, variables, {onError, onCompleted})
-      }}
+      onClick={onClick}
     />
   )
 })

--- a/packages/client/components/SuggestedIntegrationJiraMenuItem.tsx
+++ b/packages/client/components/SuggestedIntegrationJiraMenuItem.tsx
@@ -1,29 +1,22 @@
-import {SuggestedIntegrationJiraMenuItem_suggestedIntegration} from '../__generated__/SuggestedIntegrationJiraMenuItem_suggestedIntegration.graphql'
+import graphql from 'babel-plugin-relay/macro'
 import React, {forwardRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
-import graphql from 'babel-plugin-relay/macro'
+import {SuggestedIntegrationJiraMenuItem_suggestedIntegration} from '../__generated__/SuggestedIntegrationJiraMenuItem_suggestedIntegration.graphql'
 import JiraSVG from './JiraSVG'
 import MenuItem from './MenuItem'
 import MenuItemLabel from './MenuItemLabel'
 import SuggestedIntegrationMenuItemAvatar from './SuggestedIntegrationMenuItemAvatar'
 import TypeAheadLabel from './TypeAheadLabel'
-import useAtmosphere from '../hooks/useAtmosphere'
-import CreateJiraIssueMutation from '../mutations/CreateJiraIssueMutation'
-import {WithMutationProps} from '../utils/relay/withMutationProps'
 
 interface Props {
   suggestedIntegration: SuggestedIntegrationJiraMenuItem_suggestedIntegration
-  taskId: string
-  submitMutation: WithMutationProps['submitMutation']
-  onError: WithMutationProps['onError']
-  onCompleted: WithMutationProps['onCompleted']
+  onClick: () => void
   query: string
 }
 
 const SuggestedIntegrationJiraMenuItem = forwardRef((props: Props, ref: any) => {
-  const {suggestedIntegration, taskId, submitMutation, onError, onCompleted, query} = props
-  const {cloudId, projectKey, projectName} = suggestedIntegration
-  const atmosphere = useAtmosphere()
+  const {suggestedIntegration, onClick, query} = props
+  const {projectName} = suggestedIntegration
   return (
     <MenuItem
       ref={ref}
@@ -35,11 +28,7 @@ const SuggestedIntegrationJiraMenuItem = forwardRef((props: Props, ref: any) => 
           <TypeAheadLabel query={query} label={projectName} />
         </MenuItemLabel>
       }
-      onClick={() => {
-        const variables = {cloudId, projectKey, taskId}
-        submitMutation()
-        CreateJiraIssueMutation(atmosphere, variables, {onError, onCompleted})
-      }}
+      onClick={onClick}
     />
   )
 })
@@ -47,8 +36,6 @@ const SuggestedIntegrationJiraMenuItem = forwardRef((props: Props, ref: any) => 
 export default createFragmentContainer(SuggestedIntegrationJiraMenuItem, {
   suggestedIntegration: graphql`
     fragment SuggestedIntegrationJiraMenuItem_suggestedIntegration on SuggestedIntegrationJira {
-      cloudId
-      projectKey
       projectName
     }
   `

--- a/packages/client/components/TaskIntegrationLink.tsx
+++ b/packages/client/components/TaskIntegrationLink.tsx
@@ -1,11 +1,13 @@
-import {TaskIntegrationLink_integration} from '../__generated__/TaskIntegrationLink_integration.graphql'
-import React from 'react'
 import styled from '@emotion/styled'
-import {createFragmentContainer} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {createFragmentContainer} from 'react-relay'
 import {PALETTE} from '../styles/paletteV2'
 import {Card} from '../types/constEnums'
 import {TaskServiceEnum} from '../types/graphql'
+import {TaskIntegrationLinkIntegrationJira} from '../__generated__/TaskIntegrationLinkIntegrationJira.graphql'
+import {TaskIntegrationLink_integration} from '../__generated__/TaskIntegrationLink_integration.graphql'
+import JiraIssueLink from './JiraIssueLink'
 
 const StyledLink = styled('a')({
   color: PALETTE.TEXT_MAIN,
@@ -29,22 +31,8 @@ const TaskIntegrationLink = (props: Props) => {
   if (!integration) return null
   const {service} = integration
   if (service === TaskServiceEnum.jira) {
-    const {issueKey, projectKey, cloudName} = integration
-    const href =
-      cloudName === 'jira-demo'
-        ? 'https://www.parabol.co/features/integrations'
-        : `https://${cloudName}.atlassian.net/browse/${issueKey}`
-    return (
-      <StyledLink
-        data-cy={`${dataCy}-jira-issue-link`}
-        href={href}
-        rel='noopener noreferrer'
-        target='_blank'
-        title={`Jira Issue #${issueKey} on ${projectKey}`}
-      >
-        {`Issue #${issueKey}`}
-      </StyledLink>
-    )
+    const {issueKey, projectKey, cloudName} = integration as unknown as TaskIntegrationLinkIntegrationJira
+    return <JiraIssueLink dataCy={`${dataCy}-jira-issue-link`} issueKey={issueKey} projectKey={projectKey} cloudName={cloudName} />
   } else if (service === TaskServiceEnum.github) {
     const {nameWithOwner, issueNumber} = integration
     const href =

--- a/packages/client/hooks/useAllIntegrations.ts
+++ b/packages/client/hooks/useAllIntegrations.ts
@@ -1,15 +1,15 @@
-import {useAllIntegrationsQueryResponse} from '../__generated__/useAllIntegrationsQuery.graphql'
-import {useEffect, useMemo, useRef, useState} from 'react'
 import graphql from 'babel-plugin-relay/macro'
-import Atmosphere from '../Atmosphere'
-import useFilteredItems from './useFilteredItems'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {fetchQuery} from 'relay-runtime'
+import Atmosphere from '../Atmosphere'
+import {useAllIntegrationsQueryResponse} from '../__generated__/useAllIntegrationsQuery.graphql'
+import useFilteredItems from './useFilteredItems'
 
 const gqlQuery = graphql`
   query useAllIntegrationsQuery($teamId: ID!, $userId: ID!) {
     viewer {
-      userOnTeam(userId: $userId) {
-        allAvailableIntegrations(teamId: $teamId) {
+      teamMember(userId: $userId, teamId: $teamId) {
+        allAvailableIntegrations {
           ...TaskFooterIntegrateMenuListItem @relay(mask: false)
         }
       }
@@ -37,14 +37,14 @@ const useAllIntegrations = (
         teamId,
         userId
       })) as useAllIntegrationsQueryResponse
-      if (!viewer || !viewer.userOnTeam) {
+      if (!viewer || !viewer.teamMember) {
         if (isMountedRef.current) {
           setStatus('error')
         }
         return
       }
-      const userOnTeam = viewer.userOnTeam
-      const {allAvailableIntegrations} = userOnTeam
+      const {teamMember} = viewer
+      const {allAvailableIntegrations} = teamMember
       if (isMountedRef.current) {
         setFetchedItems(allAvailableIntegrations)
         setStatus('loaded')

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -79,7 +79,7 @@ interface DemoEvents {
 }
 
 interface GQLDemoEmitter {
-  new (): StrictEventEmitter<EventEmitter, DemoEvents>
+  new(): StrictEventEmitter<EventEmitter, DemoEvents>
 }
 
 const makeReflectionGroupThread = () => ({
@@ -123,7 +123,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
   getUnlockedStages(stageIds: string[]) {
     const unlockedStages = [] as INewMeetingStage[]
     this.db.newMeeting.phases!.forEach((phase) => {
-      ;(phase.stages as any).forEach((stage) => {
+      ; (phase.stages as any).forEach((stage) => {
         if (stageIds.includes(stage.id)) {
           unlockedStages.push(stage)
         }
@@ -220,7 +220,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
       return {
         viewer: {
           ...this.db.users[0],
-          team: this.db.team
+          teamMember: this.db.teamMembers[0]
         }
       }
     },
@@ -560,10 +560,10 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
       const remainingReflections = this.db.reflections.filter((reflection) => reflection.isActive)
       const unlockedStageIds = remainingReflections.length
         ? unlockAllStagesForPhase(
-            this.db.newMeeting.phases as any,
-            NewMeetingPhaseTypeEnum.group,
-            true
-          )
+          this.db.newMeeting.phases as any,
+          NewMeetingPhaseTypeEnum.group,
+          true
+        )
         : []
 
       const unlockedStages = this.getUnlockedStages(unlockedStageIds)

--- a/packages/client/modules/meeting/components/MockScopingList.tsx
+++ b/packages/client/modules/meeting/components/MockScopingList.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import MockScopingTask from './MockScopingTask'
+
+const MockScopingList = () => {
+  return (
+    <>
+      {Array.from(Array(6).keys()).map((idx) => {
+        return <MockScopingTask idx={idx} />
+      })}
+    </>
+  )
+}
+
+export default MockScopingList

--- a/packages/client/modules/meeting/components/MockScopingTask.tsx
+++ b/packages/client/modules/meeting/components/MockScopingTask.tsx
@@ -1,0 +1,48 @@
+import {keyframes} from '@emotion/core'
+import styled from '@emotion/styled'
+import React from 'react'
+import {PALETTE} from '~/styles/paletteV2'
+import Icon from '../../../components/Icon'
+export const skeletonShine = keyframes`
+  0% {
+    background-position: -80px;
+  }
+  40%, 100% {
+    background-position: 400px;
+  }
+`
+
+
+const Checkbox = styled(Icon)({
+  cursor: 'default'
+})
+const MockTemplateItemBody = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  padding: '10px 16px'
+})
+
+const MockTemplateItemTitle = styled('div')<{delay: number}>(({delay}) => ({
+  animation: `${skeletonShine.toString()} 2400ms infinite linear ${delay}ms`,
+  height: 16,
+  borderRadius: '20px',
+  backgroundImage: `linear-gradient(90deg, ${PALETTE.TEXT_LIGHT_DARK} 0px, ${PALETTE.TEXT_LIGHT} 40px, ${PALETTE.TEXT_LIGHT_DARK} 80px)`,
+  backgroundSize: 600,
+  marginLeft: 8,
+  width: 320
+}))
+
+interface Props {
+  idx: number
+}
+const MockScopingTask = (props: Props) => {
+  const {idx} = props
+  return (
+    <MockTemplateItemBody>
+      <Checkbox>check_box_outline_blank</Checkbox>
+      <MockTemplateItemTitle delay={idx * 20} />
+    </MockTemplateItemBody>
+  )
+}
+
+export default MockScopingTask

--- a/packages/client/modules/teamDashboard/components/ProviderRow/AtlassianProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/AtlassianProviderRow.tsx
@@ -14,9 +14,7 @@ import ProviderActions from '../../../../components/ProviderActions'
 import ProviderCard from '../../../../components/ProviderCard'
 import RowInfo from '../../../../components/Row/RowInfo'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
-import withAtmosphere, {
-  WithAtmosphereProps
-} from '../../../../decorators/withAtmosphere/withAtmosphere'
+import withAtmosphere, {WithAtmosphereProps} from '../../../../decorators/withAtmosphere/withAtmosphere'
 import useAtlassianSites from '../../../../hooks/useAtlassianSites'
 import useBreakpoint from '../../../../hooks/useBreakpoint'
 import {MenuPosition} from '../../../../hooks/useCoords'
@@ -120,8 +118,8 @@ const AtlassianProviderRow = (props: Props) => {
     onCompleted
   } = props
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
-  const {atlassianAuth} = viewer
-  const accessToken = (atlassianAuth && atlassianAuth.accessToken) || undefined
+  const {teamMember} = viewer
+  const accessToken = teamMember?.atlassianAuth?.accessToken ?? undefined
   useFreshToken(accessToken, retry)
 
   const openOAuth = () => {
@@ -180,8 +178,8 @@ const AtlassianProviderRow = (props: Props) => {
 }
 
 graphql`
-  fragment AtlassianProviderRowViewer on User {
-    atlassianAuth(teamId: $teamId) {
+  fragment AtlassianProviderRowTeamMember on TeamMember {
+    atlassianAuth {
       accessToken
     }
   }
@@ -192,7 +190,9 @@ export default createFragmentContainer(
   {
     viewer: graphql`
       fragment AtlassianProviderRow_viewer on User {
-        ...AtlassianProviderRowViewer @relay(mask: false)
+        teamMember(teamId: $teamId) {
+          ...AtlassianProviderRowTeamMember @relay(mask: false)
+        }
       }
     `
   }

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitHubProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitHubProviderRow.tsx
@@ -1,30 +1,28 @@
-import {GitHubProviderRow_viewer} from '../../../../__generated__/GitHubProviderRow_viewer.graphql'
-import React from 'react'
 import styled from '@emotion/styled'
-import {createFragmentContainer} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {createFragmentContainer} from 'react-relay'
 import {RouteComponentProps, withRouter} from 'react-router-dom'
 import FlatButton from '../../../../components/FlatButton'
 import GitHubConfigMenu from '../../../../components/GitHubConfigMenu'
 import GitHubProviderLogo from '../../../../components/GitHubProviderLogo'
 import GitHubSVG from '../../../../components/GitHubSVG'
 import Icon from '../../../../components/Icon'
-import ProviderCard from '../../../../components/ProviderCard'
 import ProviderActions from '../../../../components/ProviderActions'
+import ProviderCard from '../../../../components/ProviderCard'
 import RowInfo from '../../../../components/Row/RowInfo'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
-import withAtmosphere, {
-  WithAtmosphereProps
-} from '../../../../decorators/withAtmosphere/withAtmosphere'
+import withAtmosphere, {WithAtmosphereProps} from '../../../../decorators/withAtmosphere/withAtmosphere'
+import useBreakpoint from '../../../../hooks/useBreakpoint'
 import {MenuPosition} from '../../../../hooks/useCoords'
 import useMenu from '../../../../hooks/useMenu'
+import {MenuMutationProps} from '../../../../hooks/useMutationProps'
 import {PALETTE} from '../../../../styles/paletteV2'
 import {ICON_SIZE} from '../../../../styles/typographyV2'
 import {Breakpoint, Providers} from '../../../../types/constEnums'
-import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
-import {MenuMutationProps} from '../../../../hooks/useMutationProps'
 import GitHubClientManager from '../../../../utils/GitHubClientManager'
-import useBreakpoint from '../../../../hooks/useBreakpoint'
+import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
+import {GitHubProviderRow_viewer} from '../../../../__generated__/GitHubProviderRow_viewer.graphql'
 
 const StyledButton = styled(FlatButton)({
   borderColor: PALETTE.BORDER_LIGHT,
@@ -79,8 +77,9 @@ const ProviderName = styled('div')({
 const GitHubProviderRow = (props: Props) => {
   const {atmosphere, viewer, teamId, submitting, submitMutation, onError, onCompleted} = props
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
-  const {githubAuth} = viewer
-  const accessToken = (githubAuth && githubAuth.accessToken) || undefined
+  const {teamMember} = viewer
+  const githubAuth = teamMember?.githubAuth
+  const accessToken = githubAuth?.accessToken ?? undefined
   const openOAuth = () => {
     GitHubClientManager.openOAuth(atmosphere, teamId, mutationProps)
   }
@@ -118,8 +117,8 @@ const GitHubProviderRow = (props: Props) => {
 }
 
 graphql`
-  fragment GitHubProviderRowViewer on User {
-    githubAuth(teamId: $teamId) {
+  fragment GitHubProviderRowTeamMember on TeamMember {
+    githubAuth {
       accessToken
       login
     }
@@ -131,7 +130,9 @@ export default createFragmentContainer(
   {
     viewer: graphql`
       fragment GitHubProviderRow_viewer on User {
-        ...GitHubProviderRowViewer @relay(mask: false)
+        teamMember(teamId: $teamId) {
+          ...GitHubProviderRowTeamMember @relay(mask: false)
+        }
       }
     `
   }

--- a/packages/client/mutations/AddAtlassianAuthMutation.ts
+++ b/packages/client/mutations/AddAtlassianAuthMutation.ts
@@ -1,14 +1,14 @@
-import {AddAtlassianAuthMutation as TAddAtlassianAuthMutation} from '../__generated__/AddAtlassianAuthMutation.graphql'
-import {commitMutation} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
 import {Disposable} from 'relay-runtime'
 import {IAddAtlassianAuthOnMutationArguments} from '../types/graphql'
 import {LocalHandlers} from '../types/relayMutations'
+import {AddAtlassianAuthMutation as TAddAtlassianAuthMutation} from '../__generated__/AddAtlassianAuthMutation.graphql'
 
 graphql`
   fragment AddAtlassianAuthMutation_team on AddAtlassianAuthPayload {
-    user {
-      ...AtlassianProviderRow_viewer
+    teamMember {
+      ...AtlassianProviderRowTeamMember
       ...TaskFooterIntegrateMenuViewerAtlassianAuth
       # after adding, check for new integrations (populates the menu)
       ...TaskFooterIntegrateMenuViewerSuggestedIntegrations

--- a/packages/client/mutations/AddGitHubAuthMutation.ts
+++ b/packages/client/mutations/AddGitHubAuthMutation.ts
@@ -1,14 +1,14 @@
-import {AddGitHubAuthMutation as TAddGitHubAuthMutation} from '../__generated__/AddGitHubAuthMutation.graphql'
-import {commitMutation} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
 import {Disposable} from 'relay-runtime'
 import {IAddGitHubAuthOnMutationArguments} from '../types/graphql'
 import {LocalHandlers} from '../types/relayMutations'
+import {AddGitHubAuthMutation as TAddGitHubAuthMutation} from '../__generated__/AddGitHubAuthMutation.graphql'
 
 graphql`
   fragment AddGitHubAuthMutation_team on AddGitHubAuthPayload {
-    user {
-      ...GitHubProviderRow_viewer
+    teamMember {
+      ...GitHubProviderRowTeamMember
       ...TaskFooterIntegrateMenuViewerGitHubAuth
       # after adding, check for new integrations (populates the menu)
       ...TaskFooterIntegrateMenuViewerSuggestedIntegrations

--- a/packages/client/mutations/RemoveAtlassianAuthMutation.ts
+++ b/packages/client/mutations/RemoveAtlassianAuthMutation.ts
@@ -1,15 +1,15 @@
-import {RemoveAtlassianAuthMutation as TRemoveAtlassianAuthMutation} from '../__generated__/RemoveAtlassianAuthMutation.graphql'
-import {commitMutation} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
 import {Disposable} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
 import {IRemoveAtlassianAuthOnMutationArguments} from '../types/graphql'
 import {LocalHandlers} from '../types/relayMutations'
+import {RemoveAtlassianAuthMutation as TRemoveAtlassianAuthMutation} from '../__generated__/RemoveAtlassianAuthMutation.graphql'
 
 graphql`
   fragment RemoveAtlassianAuthMutation_team on RemoveAtlassianAuthPayload {
-    user {
-      ...AtlassianProviderRowViewer @relay(mask: false)
+    teamMember {
+      ...AtlassianProviderRowTeamMember @relay(mask: false)
     }
   }
 `

--- a/packages/client/mutations/RemoveGitHubAuthMutation.ts
+++ b/packages/client/mutations/RemoveGitHubAuthMutation.ts
@@ -1,15 +1,15 @@
-import {RemoveGitHubAuthMutation as TRemoveGitHubAuthMutation} from '../__generated__/RemoveGitHubAuthMutation.graphql'
-import {commitMutation} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
 import {Disposable} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
 import {IRemoveGitHubAuthOnMutationArguments} from '../types/graphql'
 import {LocalHandlers} from '../types/relayMutations'
+import {RemoveGitHubAuthMutation as TRemoveGitHubAuthMutation} from '../__generated__/RemoveGitHubAuthMutation.graphql'
 
 graphql`
   fragment RemoveGitHubAuthMutation_team on RemoveGitHubAuthPayload {
-    user {
-      ...GitHubProviderRowViewer @relay(mask: false)
+    teamMember {
+      ...GitHubProviderRowTeamMember @relay(mask: false)
     }
   }
 `

--- a/packages/client/subscriptions/TeamSubscription.ts
+++ b/packages/client/subscriptions/TeamSubscription.ts
@@ -33,6 +33,7 @@ const subscription = graphql`
     teamSubscription {
       __typename
       ...AcceptTeamInvitationMutation_team @relay(mask: false)
+      ...AddAtlassianAuthMutation_team @relay(mask: false)
       ...AddReflectTemplateMutation_team @relay(mask: false)
       ...AddReflectTemplatePromptMutation_team @relay(mask: false)
       ...AddTeamMutation_team @relay(mask: false)

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -72,18 +72,8 @@ export interface IUser {
    * The userId provided by us
    */
   id: string;
-
-  /**
-   * All the integrations that the user could possibly use
-   */
-  allAvailableIntegrations: Array<SuggestedIntegration>;
   archivedTasks: ITaskConnection | null;
   archivedTasksCount: number | null;
-
-  /**
-   * The auth for the user. access token is null if not viewer. Use isActive to check for presence
-   */
-  atlassianAuth: IAtlassianAuth | null;
 
   /**
    * The assumed company this organizaiton belongs to
@@ -109,11 +99,6 @@ export interface IUser {
    * Any super power given to the user via a super user
    */
   featureFlags: IUserFeatureFlags;
-
-  /**
-   * The auth for the user. access token is null if not viewer. Use isActive to check for presence
-   */
-  githubAuth: IGitHubAuth | null;
 
   /**
    * An array of objects with information about the user's identities.
@@ -262,11 +247,6 @@ export interface IUser {
    * a string with message stating that the user is over the free tier limit, else null
    */
   overLimitCopy: string | null;
-
-  /**
-   * The integrations that the user would probably like to use
-   */
-  suggestedIntegrations: ISuggestedIntegrationQueryPayload;
   tasks: ITaskConnection;
 
   /**
@@ -306,13 +286,6 @@ export interface IUser {
   userOnTeam: IUser | null;
 }
 
-export interface IAllAvailableIntegrationsOnUserArguments {
-  /**
-   * a teamId to use as a filter for the access tokens
-   */
-  teamId: string;
-}
-
 export interface IArchivedTasksOnUserArguments {
   first?: number | null;
 
@@ -330,20 +303,6 @@ export interface IArchivedTasksOnUserArguments {
 export interface IArchivedTasksCountOnUserArguments {
   /**
    * The unique team ID
-   */
-  teamId: string;
-}
-
-export interface IAtlassianAuthOnUserArguments {
-  /**
-   * The teamId for the atlassian auth token
-   */
-  teamId: string;
-}
-
-export interface IGithubAuthOnUserArguments {
-  /**
-   * The teamId for the auth object
    */
   teamId: string;
 }
@@ -421,13 +380,6 @@ export interface IOrganizationUserOnUserArguments {
   orgId: string;
 }
 
-export interface ISuggestedIntegrationsOnUserArguments {
-  /**
-   * a teamId to use as a filter to provide more accurate suggestions
-   */
-  teamId: string;
-}
-
 export interface ITasksOnUserArguments {
   /**
    * the number of tasks to return
@@ -480,6 +432,11 @@ export interface ITeamMemberOnUserArguments {
    * The team the user is on
    */
   teamId: string;
+
+  /**
+   * If null, defaults to the team member for this user. Else, will grab the team member. Returns null if not on team.
+   */
+  userId?: string | null;
 }
 
 export interface IUserOnTeamOnUserArguments {
@@ -487,24 +444,6 @@ export interface IUserOnTeamOnUserArguments {
    * The other user
    */
   userId: string;
-}
-
-export type SuggestedIntegration =
-  | ISuggestedIntegrationGitHub
-  | ISuggestedIntegrationJira;
-
-export interface ISuggestedIntegration {
-  __typename: 'SuggestedIntegration';
-  id: string;
-  service: TaskServiceEnum;
-}
-
-/**
- * The list of services for task integrations
- */
-export const enum TaskServiceEnum {
-  github = 'github',
-  jira = 'jira'
 }
 
 /**
@@ -965,9 +904,24 @@ export interface ITeamMember {
   id: string;
 
   /**
+   * All the integrations that the user could possibly use
+   */
+  allAvailableIntegrations: Array<SuggestedIntegration>;
+
+  /**
+   * The auth for the user. access token is null if not viewer. Use isActive to check for presence
+   */
+  atlassianAuth: IAtlassianAuth | null;
+
+  /**
    * The datetime the team member was created
    */
   createdAt: any;
+
+  /**
+   * The auth for the user. access token is null if not viewer. Use isActive to check for presence
+   */
+  githubAuth: IGitHubAuth | null;
 
   /**
    * true if the user is a part of the team, false if they no longer are
@@ -1020,6 +974,11 @@ export interface ITeamMember {
   slackNotifications: Array<ISlackNotification>;
 
   /**
+   * The integrations that the user would probably like to use
+   */
+  suggestedIntegrations: ISuggestedIntegrationQueryPayload;
+
+  /**
    * Tasks owned by the team member
    */
   tasks: ITaskConnection | null;
@@ -1056,6 +1015,128 @@ export interface ITasksOnTeamMemberArguments {
    * the datetime cursor
    */
   after?: any | null;
+}
+
+export type SuggestedIntegration =
+  | ISuggestedIntegrationGitHub
+  | ISuggestedIntegrationJira;
+
+export interface ISuggestedIntegration {
+  __typename: 'SuggestedIntegration';
+  id: string;
+  service: TaskServiceEnum;
+}
+
+/**
+ * The list of services for task integrations
+ */
+export const enum TaskServiceEnum {
+  github = 'github',
+  jira = 'jira'
+}
+
+/**
+ * OAuth token for a team member
+ */
+export interface IAtlassianAuth {
+  __typename: 'AtlassianAuth';
+
+  /**
+   * shortid
+   */
+  id: string;
+
+  /**
+   * true if the auth is valid, else false
+   */
+  isActive: boolean;
+
+  /**
+   * The access token to atlassian, useful for 1 hour. null if no access token available
+   */
+  accessToken: string | null;
+
+  /**
+   * *The atlassian account ID
+   */
+  accountId: string;
+
+  /**
+   * The atlassian cloud IDs that the user has granted
+   */
+  cloudIds: Array<string>;
+
+  /**
+   * The timestamp the provider was created
+   */
+  createdAt: any;
+
+  /**
+   * The refresh token to atlassian to receive a new 1-hour accessToken, always null since server secret is required
+   */
+  refreshToken: string | null;
+
+  /**
+   * *The team that the token is linked to
+   */
+  teamId: string;
+
+  /**
+   * The timestamp the token was updated at
+   */
+  updatedAt: any;
+
+  /**
+   * The user that the access token is attached to
+   */
+  userId: string;
+}
+
+/**
+ * OAuth token for a team member
+ */
+export interface IGitHubAuth {
+  __typename: 'GitHubAuth';
+
+  /**
+   * shortid
+   */
+  id: string;
+
+  /**
+   * true if an access token exists, else false
+   */
+  isActive: boolean;
+
+  /**
+   * The access token to github. good forever
+   */
+  accessToken: string | null;
+
+  /**
+   * *The GitHub login used for queries
+   */
+  login: string;
+
+  /**
+   * The timestamp the provider was created
+   */
+  createdAt: any;
+
+  /**
+   * *The team that the token is linked to
+   */
+  teamId: string;
+
+  /**
+   * The timestamp the token was updated at
+   */
+  updatedAt: any;
+
+  /**
+   * The user that the access token is attached to
+   */
+  userId: string;
 }
 
 /**
@@ -1220,6 +1301,38 @@ export const enum SlackNotificationEventTypeEnum {
    * notification that concerns a single member on the team
    */
   member = 'member'
+}
+
+/**
+ * The details associated with a task integrated with GitHub
+ */
+export interface ISuggestedIntegrationQueryPayload {
+  __typename: 'SuggestedIntegrationQueryPayload';
+  error: IStandardMutationError | null;
+
+  /**
+   * true if the items returned are a subset of all the possible integration, else false (all possible integrations)
+   */
+  hasMore: boolean | null;
+
+  /**
+   * All the integrations that are likely to be integrated
+   */
+  items: Array<SuggestedIntegration> | null;
+}
+
+export interface IStandardMutationError {
+  __typename: 'StandardMutationError';
+
+  /**
+   * The title of the error
+   */
+  title: string | null;
+
+  /**
+   * The full error
+   */
+  message: string;
 }
 
 /**
@@ -2230,63 +2343,6 @@ export const enum TaskStatusEnum {
 }
 
 /**
- * OAuth token for a team member
- */
-export interface IAtlassianAuth {
-  __typename: 'AtlassianAuth';
-
-  /**
-   * shortid
-   */
-  id: string;
-
-  /**
-   * true if the auth is valid, else false
-   */
-  isActive: boolean;
-
-  /**
-   * The access token to atlassian, useful for 1 hour. null if no access token available
-   */
-  accessToken: string | null;
-
-  /**
-   * *The atlassian account ID
-   */
-  accountId: string;
-
-  /**
-   * The atlassian cloud IDs that the user has granted
-   */
-  cloudIds: Array<string>;
-
-  /**
-   * The timestamp the provider was created
-   */
-  createdAt: any;
-
-  /**
-   * The refresh token to atlassian to receive a new 1-hour accessToken, always null since server secret is required
-   */
-  refreshToken: string | null;
-
-  /**
-   * *The team that the token is linked to
-   */
-  teamId: string;
-
-  /**
-   * The timestamp the token was updated at
-   */
-  updatedAt: any;
-
-  /**
-   * The user that the access token is attached to
-   */
-  userId: string;
-}
-
-/**
  * The user account profile
  */
 export interface IUserFeatureFlags {
@@ -2306,53 +2362,6 @@ export interface IUserFeatureFlags {
    * true if jira is allowed
    */
   poker: boolean;
-}
-
-/**
- * OAuth token for a team member
- */
-export interface IGitHubAuth {
-  __typename: 'GitHubAuth';
-
-  /**
-   * shortid
-   */
-  id: string;
-
-  /**
-   * true if an access token exists, else false
-   */
-  isActive: boolean;
-
-  /**
-   * The access token to github. good forever
-   */
-  accessToken: string | null;
-
-  /**
-   * *The GitHub login used for queries
-   */
-  login: string;
-
-  /**
-   * The timestamp the provider was created
-   */
-  createdAt: any;
-
-  /**
-   * *The team that the token is linked to
-   */
-  teamId: string;
-
-  /**
-   * The timestamp the token was updated at
-   */
-  updatedAt: any;
-
-  /**
-   * The user that the access token is attached to
-   */
-  userId: string;
 }
 
 /**
@@ -2954,38 +2963,6 @@ export const enum NotificationEnum {
   TEAM_ARCHIVED = 'TEAM_ARCHIVED',
   TASK_INVOLVES = 'TASK_INVOLVES',
   MEETING_STAGE_TIME_LIMIT_END = 'MEETING_STAGE_TIME_LIMIT_END'
-}
-
-/**
- * The details associated with a task integrated with GitHub
- */
-export interface ISuggestedIntegrationQueryPayload {
-  __typename: 'SuggestedIntegrationQueryPayload';
-  error: IStandardMutationError | null;
-
-  /**
-   * true if the items returned are a subset of all the possible integration, else false (all possible integrations)
-   */
-  hasMore: boolean | null;
-
-  /**
-   * All the integrations that are likely to be integrated
-   */
-  items: Array<SuggestedIntegration> | null;
-}
-
-export interface IStandardMutationError {
-  __typename: 'StandardMutationError';
-
-  /**
-   * The title of the error
-   */
-  title: string | null;
-
-  /**
-   * The full error
-   */
-  message: string;
 }
 
 /**
@@ -4638,6 +4615,12 @@ export interface IAddAtlassianAuthPayload {
    * The newly created auth
    */
   atlassianAuth: IAtlassianAuth | null;
+  teamId: string | null;
+
+  /**
+   * The team member with the updated atlassianAuth
+   */
+  teamMember: ITeamMember | null;
 
   /**
    * The user with updated atlassianAuth
@@ -5487,6 +5470,11 @@ export interface IAddGitHubAuthPayload {
    * The newly created auth
    */
   githubAuth: IGitHubAuth | null;
+
+  /**
+   * The team member with the updated auth
+   */
+  teamMember: ITeamMember | null;
 
   /**
    * The user with updated githubAuth
@@ -6864,6 +6852,11 @@ export interface IRemoveAtlassianAuthPayload {
   teamId: string | null;
 
   /**
+   * The team member with the updated auth
+   */
+  teamMember: ITeamMember | null;
+
+  /**
    * The user with updated atlassianAuth
    */
   user: IUser | null;
@@ -6878,6 +6871,11 @@ export interface IRemoveGitHubAuthPayload {
    */
   authId: string | null;
   teamId: string | null;
+
+  /**
+   * The team member with the updated auth
+   */
+  teamMember: ITeamMember | null;
 
   /**
    * The user with updated githubAuth

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -12,7 +12,7 @@ import normalizeRethinkDbResults from './normalizeRethinkDbResults'
 import ProxiedCache from './ProxiedCache'
 import RethinkDataLoader from './RethinkDataLoader'
 
-type AccessTokenKey = {teamId: string; userId: string}
+type TeamUserKey = {teamId: string; userId: string}
 export interface JiraRemoteProjectKey {
   accessToken: string
   cloudId: string
@@ -192,7 +192,7 @@ export const userTasks = (parent: RethinkDataLoader) => {
 
 export const freshAtlassianAccessToken = (parent: RethinkDataLoader) => {
   const userAuthLoader = parent.get('atlassianAuthByUserId')
-  return new DataLoader<AccessTokenKey, string, string>(
+  return new DataLoader<TeamUserKey, string, string>(
     async (keys) => {
       return promiseAllPartial(
         keys.map(async ({userId, teamId}) => {

--- a/packages/server/graphql/mutations/addAtlassianAuth.ts
+++ b/packages/server/graphql/mutations/addAtlassianAuth.ts
@@ -91,7 +91,7 @@ export default {
         service: 'Atlassian'
       }
     })
-    const data = {atlassianAuthId}
+    const data = {atlassianAuthId, teamId, userId: viewerId}
     publish(SubscriptionChannel.TEAM, teamId, 'AddAtlassianAuthPayload', data, subOptions)
     return data
   }

--- a/packages/server/graphql/queries/allAvailableIntegrations.ts
+++ b/packages/server/graphql/queries/allAvailableIntegrations.ts
@@ -1,24 +1,13 @@
-import {GraphQLID, GraphQLList, GraphQLNonNull} from 'graphql'
-import {GQLContext} from '../graphql'
-import fetchAllIntegrations from './helpers/fetchAllIntegrations'
-import SuggestedIntegration from '../types/SuggestedIntegration'
+import {GraphQLList, GraphQLNonNull} from 'graphql'
 import {getUserId} from '../../utils/authorization'
-import {ISuggestedIntegrationsOnUserArguments, IUser} from 'parabol-client/types/graphql'
+import {GQLContext} from '../graphql'
+import SuggestedIntegration from '../types/SuggestedIntegration'
+import fetchAllIntegrations from './helpers/fetchAllIntegrations'
 
 export default {
   description: 'All the integrations that the user could possibly use',
   type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(SuggestedIntegration))),
-  args: {
-    teamId: {
-      type: new GraphQLNonNull(GraphQLID),
-      description: 'a teamId to use as a filter for the access tokens'
-    }
-  },
-  resolve: async (
-    {id: userId}: IUser,
-    {teamId}: ISuggestedIntegrationsOnUserArguments,
-    {authToken, dataLoader}: GQLContext
-  ) => {
+  resolve: async ({teamId, userId}, _args, {authToken, dataLoader}: GQLContext) => {
     const viewerId = getUserId(authToken)
 
     // AUTH

--- a/packages/server/graphql/queries/suggestedIntegrations.ts
+++ b/packages/server/graphql/queries/suggestedIntegrations.ts
@@ -1,6 +1,9 @@
-import {GraphQLID, GraphQLNonNull} from 'graphql'
+import {GraphQLNonNull} from 'graphql'
 import ms from 'ms'
+import {getUserId} from '../../utils/authorization'
+import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
+import SuggestedIntegrationQueryPayload from '../types/SuggestedIntegrationQueryPayload'
 import fetchAllIntegrations from './helpers/fetchAllIntegrations'
 import {
   getPermsByTaskService,
@@ -8,25 +11,11 @@ import {
   IntegrationByUserId,
   useOnlyUserIntegrations
 } from './helpers/suggestedIntegrationHelpers'
-import SuggestedIntegrationQueryPayload from '../types/SuggestedIntegrationQueryPayload'
-import {getUserId} from '../../utils/authorization'
-import standardError from '../../utils/standardError'
-import {ISuggestedIntegrationsOnUserArguments, IUser} from 'parabol-client/types/graphql'
 
 export default {
   description: 'The integrations that the user would probably like to use',
   type: new GraphQLNonNull(SuggestedIntegrationQueryPayload),
-  args: {
-    teamId: {
-      type: new GraphQLNonNull(GraphQLID),
-      description: 'a teamId to use as a filter to provide more accurate suggestions'
-    }
-  },
-  resolve: async (
-    {id: userId}: IUser,
-    {teamId}: ISuggestedIntegrationsOnUserArguments,
-    {authToken, dataLoader}: GQLContext
-  ) => {
+  resolve: async ({teamId, userId}, _args, {authToken, dataLoader}: GQLContext) => {
     const viewerId = getUserId(authToken)
 
     // AUTH

--- a/packages/server/graphql/types/AddAtlassianAuthPayload.ts
+++ b/packages/server/graphql/types/AddAtlassianAuthPayload.ts
@@ -1,9 +1,10 @@
-import {GraphQLObjectType} from 'graphql'
-import StandardMutationError from './StandardMutationError'
-import {getUserId} from '../../utils/authorization'
-import AtlassianAuth from './AtlassianAuth'
-import User from './User'
+import {GraphQLID, GraphQLObjectType} from 'graphql'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import {GQLContext} from '../graphql'
+import AtlassianAuth from './AtlassianAuth'
+import StandardMutationError from './StandardMutationError'
+import TeamMember from './TeamMember'
+import User from './User'
 
 const AddAtlassianAuthPayload = new GraphQLObjectType<any, GQLContext>({
   name: 'AddAtlassianAuthPayload',
@@ -18,12 +19,22 @@ const AddAtlassianAuthPayload = new GraphQLObjectType<any, GQLContext>({
         return dataLoader.get('atlassianAuths').load(atlassianAuthId)
       }
     },
+    teamId: {
+      type: GraphQLID
+    },
+    teamMember: {
+      type: TeamMember,
+      description: 'The team member with the updated atlassianAuth',
+      resolve: ({teamId, userId}, _args, {dataLoader}) => {
+        const teamMemberId = toTeamMemberId(teamId, userId)
+        return dataLoader.get('teamMembers').load(teamMemberId)
+      }
+    },
     user: {
       type: User,
       description: 'The user with updated atlassianAuth',
-      resolve: (_source, _args, {authToken, dataLoader}) => {
-        const viewerId = getUserId(authToken)
-        return dataLoader.get('users').load(viewerId)
+      resolve: ({userId}, _args, {dataLoader}) => {
+        return dataLoader.get('users').load(userId)
       }
     }
   })

--- a/packages/server/graphql/types/AddGitHubAuthPayload.ts
+++ b/packages/server/graphql/types/AddGitHubAuthPayload.ts
@@ -1,10 +1,12 @@
 import {GraphQLObjectType} from 'graphql'
-import getRethink from '../../database/rethinkDriver'
-import StandardMutationError from './StandardMutationError'
 import {GITHUB} from 'parabol-client/utils/constants'
-import GitHubAuth from './GitHubAuth'
-import User from './User'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
+import getRethink from '../../database/rethinkDriver'
 import {GQLContext} from '../graphql'
+import GitHubAuth from './GitHubAuth'
+import StandardMutationError from './StandardMutationError'
+import TeamMember from './TeamMember'
+import User from './User'
 
 const AddGitHubAuthPayload = new GraphQLObjectType<any, GQLContext>({
   name: 'AddGitHubAuthPayload',
@@ -24,6 +26,14 @@ const AddGitHubAuthPayload = new GraphQLObjectType<any, GQLContext>({
           .nth(0)
           .default(null)
           .run()
+      }
+    },
+    teamMember: {
+      type: TeamMember,
+      description: 'The team member with the updated auth',
+      resolve: ({teamId, userId}, _args, {dataLoader}) => {
+        const teamMemberId = toTeamMemberId(teamId, userId)
+        return dataLoader.get('teamMembers').load(teamMemberId)
       }
     },
     user: {

--- a/packages/server/graphql/types/RemoveAtlassianAuthPayload.ts
+++ b/packages/server/graphql/types/RemoveAtlassianAuthPayload.ts
@@ -1,7 +1,9 @@
 import {GraphQLID, GraphQLObjectType} from 'graphql'
-import StandardMutationError from './StandardMutationError'
-import User from './User'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import {GQLContext} from '../graphql'
+import StandardMutationError from './StandardMutationError'
+import TeamMember from './TeamMember'
+import User from './User'
 
 const RemoveAtlassianAuthPayload = new GraphQLObjectType<any, GQLContext>({
   name: 'RemoveAtlassianAuthPayload',
@@ -15,6 +17,14 @@ const RemoveAtlassianAuthPayload = new GraphQLObjectType<any, GQLContext>({
     },
     teamId: {
       type: GraphQLID
+    },
+    teamMember: {
+      type: TeamMember,
+      description: 'The team member with the updated auth',
+      resolve: ({teamId, userId}, _args, {dataLoader}) => {
+        const teamMemberId = toTeamMemberId(teamId, userId)
+        return dataLoader.get('teamMembers').load(teamMemberId)
+      }
     },
     user: {
       type: User,

--- a/packages/server/graphql/types/RemoveGitHubAuthPayload.ts
+++ b/packages/server/graphql/types/RemoveGitHubAuthPayload.ts
@@ -1,7 +1,9 @@
 import {GraphQLID, GraphQLObjectType} from 'graphql'
-import StandardMutationError from './StandardMutationError'
-import User from './User'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import {GQLContext} from '../graphql'
+import StandardMutationError from './StandardMutationError'
+import TeamMember from './TeamMember'
+import User from './User'
 
 const RemoveGitHubAuthPayload = new GraphQLObjectType<any, GQLContext>({
   name: 'RemoveGitHubAuthPayload',
@@ -15,6 +17,14 @@ const RemoveGitHubAuthPayload = new GraphQLObjectType<any, GQLContext>({
     },
     teamId: {
       type: GraphQLID
+    },
+    teamMember: {
+      type: TeamMember,
+      description: 'The team member with the updated auth',
+      resolve: ({teamId, userId}, _args, {dataLoader}) => {
+        const teamMemberId = toTeamMemberId(teamId, userId)
+        return dataLoader.get('teamMembers').load(teamMemberId)
+      }
     },
     user: {
       type: User,

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -7,7 +7,7 @@ import {
   GraphQLObjectType,
   GraphQLString
 } from 'graphql'
-import {GITHUB} from 'parabol-client/utils/constants'
+import {TierEnum as TierEnumType} from 'parabol-client/types/graphql'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import {OrgUserRole} from '../../../client/types/graphql'
 import getRethink from '../../database/rethinkDriver'
@@ -20,11 +20,8 @@ import {GQLContext} from '../graphql'
 import invoiceDetails from '../queries/invoiceDetails'
 import invoices from '../queries/invoices'
 import organization from '../queries/organization'
-import suggestedIntegrations from '../queries/suggestedIntegrations'
-import AtlassianAuth from './AtlassianAuth'
 import AuthIdentity from './AuthIdentity'
 import Company from './Company'
-import GitHubAuth from './GitHubAuth'
 import GraphQLEmailType from './GraphQLEmailType'
 import GraphQLISO8601Type from './GraphQLISO8601Type'
 import GraphQLURLType from './GraphQLURLType'
@@ -37,7 +34,6 @@ import Team from './Team'
 import TeamInvitationPayload from './TeamInvitationPayload'
 import TeamMember from './TeamMember'
 import TierEnum from './TierEnum'
-import {TierEnum as TierEnumType} from 'parabol-client/types/graphql'
 import {TimelineEventConnection} from './TimelineEvent'
 import UserFeatureFlags from './UserFeatureFlags'
 
@@ -49,25 +45,8 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
       type: new GraphQLNonNull(GraphQLID),
       description: 'The userId provided by us'
     },
-    allAvailableIntegrations: require('../queries/allAvailableIntegrations').default,
     archivedTasks: require('../queries/archivedTasks').default,
     archivedTasksCount: require('../queries/archivedTasksCount').default,
-    atlassianAuth: {
-      type: AtlassianAuth,
-      description:
-        'The auth for the user. access token is null if not viewer. Use isActive to check for presence',
-      args: {
-        teamId: {
-          type: new GraphQLNonNull(GraphQLID),
-          description: 'The teamId for the atlassian auth token'
-        }
-      },
-      resolve: async ({id: userId}, {teamId}, {authToken, dataLoader}) => {
-        if (!isTeamMember(authToken, teamId)) return null
-        const auths = await dataLoader.get('atlassianAuthByUserId').load(userId)
-        return auths.find((auth) => auth.teamId === teamId)
-      }
-    },
     company: {
       type: Company,
       description: 'The assumed company this organizaiton belongs to',
@@ -99,28 +78,6 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
           flagObj[flag] = true
         })
         return flagObj
-      }
-    },
-    githubAuth: {
-      type: GitHubAuth,
-      description:
-        'The auth for the user. access token is null if not viewer. Use isActive to check for presence',
-      args: {
-        teamId: {
-          type: new GraphQLNonNull(GraphQLID),
-          description: 'The teamId for the auth object'
-        }
-      },
-      resolve: async ({id: userId}, {teamId}, {authToken}) => {
-        if (!isTeamMember(authToken, teamId)) return null
-        const r = await getRethink()
-        return r
-          .table('Provider')
-          .getAll(teamId, {index: 'teamId'})
-          .filter({service: GITHUB, isActive: true, userId})
-          .nth(0)
-          .default(null)
-          .run()
       }
     },
     identities: {
@@ -410,7 +367,6 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
         return source.overLimitCopy
       }
     },
-    suggestedIntegrations,
     tasks: require('../queries/tasks').default,
     team: require('../queries/team').default,
     teamInvitation: {
@@ -466,15 +422,20 @@ const User = new GraphQLObjectType<any, GQLContext, any>({
         teamId: {
           type: new GraphQLNonNull(GraphQLID),
           description: 'The team the user is on'
+        },
+        userId: {
+          type: GraphQLID,
+          description:
+            'If null, defaults to the team member for this user. Else, will grab the team member. Returns null if not on team.'
         }
       },
-      resolve: (_source, {teamId}, {authToken, dataLoader}) => {
-        const viewerId = getUserId(authToken)
+      resolve: ({id}, {teamId, userId}, {authToken, dataLoader}) => {
         if (!isTeamMember(authToken, teamId)) {
-          standardError(new Error('Team not found'), {userId: viewerId})
+          const viewerId = getUserId(authToken)
+          standardError(new Error('Not on team'), {userId: viewerId})
           return null
         }
-        const teamMemberId = toTeamMemberId(teamId, viewerId)
+        const teamMemberId = toTeamMemberId(teamId, userId || id)
         return dataLoader.get('teamMembers').load(teamMemberId)
       }
     },

--- a/packages/server/tsconfig.eslint.json
+++ b/packages/server/tsconfig.eslint.json
@@ -3,6 +3,7 @@
   "include": [
     "database/types/*",
     "database/migrations/*",
+    "graphql/queries",
     "email/**/*",
     "segmentFns/*",
     "utils/*"


### PR DESCRIPTION
This wires up the front end of the Jira Integration issue #4004. 
This involved a large-ish refactor of the integration auth from the `User` to the `TeamMember`.
This is because when fetching a meeting, the `teamId` is indeterminate because the teamId is not part of the route.
To avoid a 2nd round trip, we put the auth on `TeamMember` object.
This allows us to write graphql like `meetingMember { teamMember { atlassianAuth { accessToken } } }`.
Instead of: `User { atlassianAuth(teamId) { accessToken} }`, which would require a `teamId`.
Lesson learned: when deciding where an entity lives in the graphql schema, pick the place where it'll have the fewest args.

AC:
- [ ] When the viewer clicks "Import stories from Jira" it opens an Atlassian OAuth window
- [ ] After successful OAuth, the button the button is replaced with a list of issues that is populated based on the search query
- [ ] JiraScopingSearchResults has some hardcoded variables. if loading is set to true, you see some mock items
- [ ] if results has 0 lengrth, you see a message saying no results
- [ ] if results is length 2, you see a select all
- [ ] if results is length 1 (default) you see a single item & no select all
- [ ] typing is a search query on the search input makes an X appear
- [ ] clicking the x on the search query input clears the input


Regression tests:
- [ ] can push a task to jira on the team kanban
- [ ] can push a task to github on the team kanban