### PR TITLE
add robots.txt to nginx config

### DIFF
--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -91,7 +91,7 @@ server {
 
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
@@ -172,7 +172,7 @@ server {
   }
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -39,6 +39,10 @@ server {
 }
 {{ end }}
 
+geo $dollar {
+  default "$";
+}
+
 {{ if eq $scheme "http" }}
 server {
   listen      [{{ $.NGINX_BIND_ADDRESS_IP6 }}]:{{ $listen_port }};
@@ -91,7 +95,7 @@ server {
 
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
@@ -172,7 +176,7 @@ server {
   }
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -90,7 +90,7 @@ server {
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
-  location /robots.txt {
+  location = /robots.txt {
     add_header Content-Type text/plain;
     return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
@@ -172,7 +172,7 @@ server {
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
-  location /robots.txt {
+  location = /robots.txt {
     add_header Content-Type text/plain;
     return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -91,7 +91,7 @@ server {
 
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
@@ -172,7 +172,7 @@ server {
   }
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -90,6 +90,11 @@ server {
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
+  location = /robots.txt {
+    add_header Content-Type text/plain;
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+  }
+
   error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
   location /400-error.html {
     root {{ $.DOKKU_LIB_ROOT }}/data/nginx-vhosts/dokku-errors;
@@ -166,6 +171,11 @@ server {
     proxy_set_header X-Request-Start $msec;
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
+
+  location = /robots.txt {
+    add_header Content-Type text/plain;
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+  }
 
   error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
   location /400-error.html {

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -90,7 +90,7 @@ server {
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
-  location = /robots.txt {
+  location /robots.txt {
     add_header Content-Type text/plain;
     return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
@@ -172,7 +172,7 @@ server {
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
-  location = /robots.txt {
+  location /robots.txt {
     add_header Content-Type text/plain;
     return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -91,7 +91,7 @@ server {
 
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
@@ -172,7 +172,7 @@ server {
   }
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /\$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -39,6 +39,8 @@ server {
 }
 {{ end }}
 
+{{/* Hacky-but-necessary workaround since you can't escape $ in nginx string literals */}}
+{{/* See: https://stackoverflow.com/questions/57466554/how-do-i-escape-in-nginx-variables */}}
 geo $dollar {
   default "$";
 }

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -88,12 +88,12 @@ server {
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Request-Start $msec;
   }
-  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
   location = /robots.txt {
     add_header Content-Type text/plain;
     return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
   error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
   location /400-error.html {
@@ -170,12 +170,11 @@ server {
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Request-Start $msec;
   }
-  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
-
   location = /robots.txt {
     add_header Content-Type text/plain;
     return 200 "User-agent: *\nDisallow: /\nAllow: /$\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
+  include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
   error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 /400-error.html;
   location /400-error.html {


### PR DESCRIPTION
Resolve #4114

- [ ] Using `/robots.txt` on staging or dev (if deployed), go to this [online tester](https://technicalseo.com/tools/robots-txt/) and verify the whitelisted paths:

> /
create-account
signin
retrospective-demo
retrospective-demo/reflect
retrospective-demo/group
retrospective-demo/vote
retrospective-demo/discuss/1
retrospective-demo-summary

Note: I can't verify how good ^^this tester is, but the [official google tester](https://support.google.com/webmasters/answer/6062598?hl=en) requires extra finagling to verify that you own the app you're testing.