### PR TITLE
prefix /create-account rule

### DIFF
--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -97,7 +97,7 @@ server {
 
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 
@@ -178,7 +178,7 @@ server {
   }
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 


### PR DESCRIPTION
Fix #4160 

> @tiffanyhan on staging i get this:
User-agent: *
Disallow: /
Allow: /$
Allow: create-account
Allow: /signin
Allow: /retrospective-demo
should create-account have a slash prefix like the rest?