### PR TITLE
remove trailing slash from intranet graphql url

### DIFF
--- a/packages/client/modules/admin/containers/Graphql/GraphqlContainer.tsx
+++ b/packages/client/modules/admin/containers/Graphql/GraphqlContainer.tsx
@@ -30,7 +30,7 @@ const GraphqlContainer = () => {
     window.localStorage.setItem(LocalStorageKey.GRAPHIQL_SCHEMA, value)
   }
   const fetcher = async ({query, variables}) => {
-    const url = `${window.location.origin}/intranet-graphql/`
+    const url = `${window.location.origin}/intranet-graphql`
     const res = await fetch(url, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
**AC:**

- [x] Go to `/admin/graphql` and verify doing any query works