### PR TITLE
Fix demo timeline event bug

### DIFF
--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -1403,6 +1403,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         isKill: !currentStage,
         removedTaskIds: [],
         removedSuggestedActionId: null,
+        timelineEvent: null,
         updatedTasks: this.db.tasks,
         __typename: 'EndNewMeetingPayload'
       }

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -397,17 +397,21 @@ const initDB = (botScript) => {
     user: users[idx]
   }))
   users.forEach((user, idx) => {
-    ; (user as any).teamMember = teamMembers[idx]
+    ;(user as any).teamMember = teamMembers[idx]
   })
   const org = initDemoOrg()
   const newMeeting = initNewMeeting(org, teamMembers, meetingMembers)
   const team = initDemoTeam(org, teamMembers, newMeeting)
   teamMembers.forEach((teamMember) => {
-    ; (teamMember as any).team = team
+    ;(teamMember as any).team = team
   })
   team.meetingSettings.team = team as any
+  newMeeting.commentCount = 0
+  newMeeting.reflectionCount = 0
+  newMeeting.taskCount = 0
   newMeeting.team = team as any
   newMeeting.teamId = team.id
+  newMeeting.topicCount = 0
   newMeeting.settings = team.meetingSettings as any
   return {
     meetingMembers,

--- a/packages/client/mutations/handlers/handleAddTimelineEvent.ts
+++ b/packages/client/mutations/handlers/handleAddTimelineEvent.ts
@@ -6,7 +6,7 @@ const handleAddTimelineEvent = (
   store: RecordSourceSelectorProxy
 ) => {
   const viewer = store.getRoot().getLinkedRecord('viewer')
-  if (!viewer) return
+  if (!viewer || !meeting || !timelineEvent) return
   timelineEvent.setLinkedRecord(meeting, 'meeting')
   const timelineConnection = ConnectionHandler.getConnection(viewer, 'TimelineFeedList_timeline')
   if (timelineConnection) {


### PR DESCRIPTION
Bug fix following #4179.

The retro demo was crashing when the meeting ended as the demo wasn't handling timeline events. 

### Test

- [ ] Go to `/retrospective-demo`, complete the demo and end the meeting without it crashing