### PR TITLE
Bug fix for first item in menu

### DIFF
--- a/packages/client/components/Menu.tsx
+++ b/packages/client/components/Menu.tsx
@@ -157,7 +157,7 @@ const Menu = forwardRef((props: Props, ref: any) => {
         setSafeIdx(activeIdx === null ? null : activeIdx - 1)
       } else if (e.key === 'Enter' || (tabReturns && e.key === 'Tab')) {
         e.preventDefault()
-        if (activeIdx) {
+        if (activeIdx !== null) {
           const itemHandle = itemHandles.current[activeIdx]
           itemHandle?.onClick?.(e)
         }


### PR DESCRIPTION
PR for issue #4181 

### Test

- [ ] Open the emoji menu in a task card, press down and then enter to select the first option
- [ ] Open status menu on a card in the kanban, press down and then enter to select the first option