### PR TITLE
Check-in agenda state

### DIFF
--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -17,6 +17,7 @@ import UpdateAgendaItemMutation from '../../../../mutations/UpdateAgendaItemMuta
 import pinIcon from '../../../../styles/theme/images/icons/pin.svg'
 import unpinIcon from '../../../../styles/theme/images/icons/unpin.svg'
 import {ICON_SIZE} from '../../../../styles/typographyV2'
+import {NewMeetingPhaseTypeEnum} from '~/types/graphql'
 
 const AgendaItemStyles = styled('div')({
   position: 'relative',
@@ -69,11 +70,14 @@ const getItemProps = (
     isComplete: false,
     isUnsyncedFacilitatorStage: false
   }
-
   if (!meeting) return fallback
-  const {facilitatorUserId, facilitatorStageId, localStage, localPhase} = meeting
+  const {facilitatorUserId, facilitatorStageId, localStage, localPhase, phases} = meeting
+  const agendaItemsPhase = phases!.find(
+    (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.agendaitems
+  )!
   const localStageId = (localStage && localStage.id) || ''
-  const {stages} = localPhase
+  const {phaseType} = localPhase
+  const {stages} = phaseType === NewMeetingPhaseTypeEnum.agendaitems ? localPhase : agendaItemsPhase
   if (!stages) return fallback
   const agendaItemStage = stages.find((stage) => stage.agendaItem?.id === agendaItemId)
   if (!agendaItemStage) return fallback
@@ -203,6 +207,23 @@ graphql`
     }
   }
 `
+
+graphql`
+  fragment AgendaItemAllMeetingPhases on NewMeetingPhase {
+    ... on AgendaItemsPhase {
+      stages {
+        id
+        agendaItem {
+          id
+        }
+        isComplete
+        isNavigable
+        isNavigableByFacilitator
+      }
+    }
+  }
+`
+
 export default createFragmentContainer(AgendaItem, {
   agendaItem: graphql`
     fragment AgendaItem_agendaItem on AgendaItem {
@@ -220,7 +241,12 @@ export default createFragmentContainer(AgendaItem, {
       endedAt
       facilitatorStageId
       facilitatorUserId
+      phases {
+        phaseType
+        ...AgendaItemAllMeetingPhases @relay(mask: false)
+      }
       localPhase {
+        phaseType
         ...AgendaItemPhase @relay(mask: false)
       }
       localStage {

--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -72,7 +72,7 @@ const getItemProps = (
   }
   if (!meeting) return fallback
   const {facilitatorUserId, facilitatorStageId, localStage, localPhase, phases} = meeting
-  const agendaItemsPhase = phases!.find(
+  const agendaItemsPhase = phases.find(
     (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.agendaitems
   )!
   const localStageId = (localStage && localStage.id) || ''
@@ -208,22 +208,6 @@ graphql`
   }
 `
 
-graphql`
-  fragment AgendaItemAllMeetingPhases on NewMeetingPhase {
-    ... on AgendaItemsPhase {
-      stages {
-        id
-        agendaItem {
-          id
-        }
-        isComplete
-        isNavigable
-        isNavigableByFacilitator
-      }
-    }
-  }
-`
-
 export default createFragmentContainer(AgendaItem, {
   agendaItem: graphql`
     fragment AgendaItem_agendaItem on AgendaItem {
@@ -243,7 +227,7 @@ export default createFragmentContainer(AgendaItem, {
       facilitatorUserId
       phases {
         phaseType
-        ...AgendaItemAllMeetingPhases @relay(mask: false)
+        ...AgendaItemPhase @relay(mask: false)
       }
       localPhase {
         phaseType


### PR DESCRIPTION
This PR attempts to solve the following issue: #4240 

If there are no stages present on the current phase, the onClick handler in AgendaItem gets returned with a undefined value, and the completion status gets set to false. Because the other phases do not have stages, when the user is on any other phase, clicking on agenda items becomes disabled and the items themselves are not shown as complete. In order to access the agenda items, you must click on Team Agenda first.

This PR fixes this issue by doing the following:
* adds phases variable to keep track of all phases in meeting, as well as the stages for agendaitems
* uses the stages from the agendaitems phase whenever the current phase is not agendaitems

Users can:

*   add new agenda item at Last Call, and navigate to it
*   see correct agenda item completion state
