### PR TITLE
Add CLI to create new mutations

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dev": "node scripts/dev.js",
     "lint": "lerna run --parallel lint",
     "test": "start-server-and-test start http://localhost:3000 cypress",
+    "newMutation": "yarn sucrase-node scripts/codeshift/newMutation.ts",
     "cypress": "yarn workspace parabol-cypress start",
     "typecheck": "lerna run --parallel typecheck",
     "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "husky": "^3.0.1",
     "jscodeshift": "^0.7.0",
     "lerna": "^3.19.0",
+    "minimist": "^1.2.5",
     "prettier": "^1.19.1",
     "relay-compiler": "^8.0.0",
     "relay-config": "^8.0.0",

--- a/scripts/codeshift/baseClientMutation.ts
+++ b/scripts/codeshift/baseClientMutation.ts
@@ -1,0 +1,42 @@
+import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
+import {StandardMutation} from '../types/relayMutations'
+import {PASCAL_MUTATIONMutation as TPASCAL_MUTATIONMutation} from '../__generated__/PASCAL_MUTATIONMutation.graphql'
+
+graphql`
+  fragment PASCAL_MUTATIONMutation_meeting on PASCAL_MUTATIONSuccess {
+    <<ADD FIELDS>>
+  }
+`
+
+const mutation = graphql`
+  mutation PASCAL_MUTATIONMutation() {
+    MUTATION_NAME() {
+      ... on ErrorPayload {
+        error {
+          message
+        }
+      }
+      ...PASCAL_MUTATIONMutation_meeting @relay(mask: false)
+    }
+  }
+`
+
+const PASCAL_MUTATIONMutation: StandardMutation<TPASCAL_MUTATIONMutation> = (
+  atmosphere,
+  variables,
+  {onError, onCompleted}
+) => {
+  return commitMutation<TPASCAL_MUTATIONMutation>(atmosphere, {
+    mutation,
+    variables,
+    optimisticUpdater: (store) => {
+      const {} = variables
+
+    },
+    onCompleted,
+    onError
+  })
+}
+
+export default PASCAL_MUTATIONMutation

--- a/scripts/codeshift/baseClientMutation.ts
+++ b/scripts/codeshift/baseClientMutation.ts
@@ -5,7 +5,7 @@ import {PASCAL_MUTATIONMutation as TPASCAL_MUTATIONMutation} from '../__generate
 
 graphql`
   fragment PASCAL_MUTATIONMutation_meeting on PASCAL_MUTATIONSuccess {
-    <<ADD FIELDS>>
+
   }
 `
 

--- a/scripts/codeshift/baseMutation.ts
+++ b/scripts/codeshift/baseMutation.ts
@@ -1,0 +1,35 @@
+import {GraphQLNonNull} from 'graphql'
+import getRethink from '../../database/rethinkDriver'
+import {getUserId} from '../../utils/authorization'
+import publish from '../../utils/publish'
+import {GQLContext} from '../graphql'
+
+const MUTATION_NAME = {
+  type: 'TYPE',
+  description: ``,
+  args: {
+  },
+  resolve: async (
+    _source,
+    {},
+    {authToken, dataLoader, socketId: mutatorId}: GQLContext
+  ) => {
+    const r = await getRethink()
+    const viewerId = getUserId(authToken)
+    const now = new Date()
+    const operationId = dataLoader.share()
+    const subOptions = {mutatorId, operationId}
+
+    //AUTH
+
+
+    // VALIDATION
+
+
+    // RESOLUTION
+    const data = {}
+    return data
+  }
+}
+
+export default MUTATION_NAME

--- a/scripts/codeshift/basePayload.ts
+++ b/scripts/codeshift/basePayload.ts
@@ -1,0 +1,17 @@
+import {GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import {GQLContext} from '../graphql'
+import makeMutationPayload from './makeMutationPayload'
+
+export const SUCCESS_PAYLOAD = new GraphQLObjectType<any, GQLContext>({
+  name: 'SUCCESS_PAYLOAD',
+  fields: () => ({
+
+  })
+})
+
+const MUTATION_PAYLOAD = makeMutationPayload(
+  'MUTATION_PAYLOAD',
+  SUCCESS_PAYLOAD
+)
+
+export default MUTATION_PAYLOAD

--- a/scripts/codeshift/codeshiftExplicitGql.ts
+++ b/scripts/codeshift/codeshiftExplicitGql.ts
@@ -26,7 +26,8 @@ const transform: Transform = (fileInfo, api, options) => {
   })
   return root.toSource({
     objectCurlySpacing: false,
-    quote: 'single'
+    quote: 'single',
+    reuseWhitespace: false
   })
 }
 

--- a/scripts/codeshift/newMutation.ts
+++ b/scripts/codeshift/newMutation.ts
@@ -148,7 +148,7 @@ const addToClientSubscription = (mutationName: string, subscription?: string) =>
   const subStr = fs.readFileSync(subPath, 'utf-8')
   const typename = '__typename'
   const nextStr = subStr.replace(typename, typename + '\n' + fragment)
-  console.log(nextStr)
+  fs.writeFileSync(subPath, nextStr)
 }
 const newMutation = () => {
   const argv = parseArgs(process.argv.slice(2), {

--- a/scripts/codeshift/newMutation.ts
+++ b/scripts/codeshift/newMutation.ts
@@ -1,0 +1,177 @@
+import {comprehensionExpression} from 'jscodeshift'
+
+const parseArgs = require('minimist')
+const fs = require('fs')
+const path = require('path')
+import j from 'jscodeshift/src/core'
+const tsParser = require('jscodeshift/parser/ts')
+
+const PROJECT_ROOT = path.join(__dirname, '../../')
+
+const createServerMutation = (mutationName: string, subscription?: string) => {
+  const MUTATIONS_ROOT = path.join(PROJECT_ROOT, 'packages', 'server', 'graphql', 'mutations')
+  const mutationPath = path.join(MUTATIONS_ROOT, `${mutationName}.ts`)
+
+  if (fs.existsSync(mutationPath)) {
+    console.log('mutation already exists! aborting...')
+    // return
+  }
+
+  const baseMutation = fs.readFileSync(path.join(PROJECT_ROOT, 'scripts/codeshift', 'baseMutation.ts'), 'utf-8')
+  const ast = j(baseMutation, {parser: tsParser()})
+  // rename mutation
+  ast.findVariableDeclarators('MUTATION_NAME').renameTo(mutationName)
+  // rename export
+  ast.find(j.ExportDefaultDeclaration).forEach((path) => {
+    path.value.declaration.name = mutationName
+  })
+
+  // add payload import statement
+  const payloadName = mutationName[0].toUpperCase() + mutationName.slice(1) + 'Payload'
+  ast.find(j.ImportDeclaration).at(-1)
+    .insertBefore(`import ${payloadName} from '../types/${payloadName}'`)
+    .insertBefore(`import {SubscriptionChannel} from 'parabol-client/types/constEnums'`)
+
+  // add payload as type
+  ast.find(j.StringLiteral, {value: 'TYPE'}).replaceWith(`GraphQLNonNull(${payloadName})`)
+  // add the publisher
+  if (subscription) {
+    const channel = `SubscriptionChannel.${subscription.toUpperCase()}`
+    const variable = subscription.toLowerCase() + 'Id'
+    const success = payloadName.replace('Payload', 'Success')
+    ast.find(j.ReturnStatement)
+      // .insertBefore(`const data = {${variable}}`)
+      .insertBefore(`publish(${channel}, ${variable}, '${success}', data, subOptions)`)
+    ast.findVariableDeclarators('data').replaceWith(`data = {${variable}}`)
+  }
+
+  const res = ast.toSource({
+    objectCurlySpacing: false,
+    quote: 'single'
+  })
+
+
+  fs.writeFileSync(mutationPath, res)
+}
+
+const createServerMutationPayload = (mutationName: string) => {
+  const payloadName = mutationName[0].toUpperCase() + mutationName.slice(1) + 'Payload'
+  const success = payloadName.replace('Payload', 'Success')
+  // simple string replacement
+  const basePayload = fs.readFileSync(path.join(PROJECT_ROOT, 'scripts/codeshift', 'basePayload.ts'), 'utf-8')
+  const nextPayload = basePayload.replace(/MUTATION_PAYLOAD/g, payloadName).replace(/SUCCESS_PAYLOAD/g, success)
+  const TYPES_ROOT = path.join(PROJECT_ROOT, 'packages', 'server', 'graphql', 'types')
+  const payloadPath = path.join(TYPES_ROOT, `${payloadName}.ts`)
+  fs.writeFileSync(payloadPath, nextPayload)
+}
+
+const addToRootMutation = (mutationName: string) => {
+  const rootMutationPath = path.join(PROJECT_ROOT, 'packages', 'server', 'graphql', 'rootMutation.ts')
+  const rootMutation = fs.readFileSync(rootMutationPath, 'utf-8')
+  const ast = j(rootMutation, {parser: tsParser()})
+  const alreadyImported = ast.find(j.ImportDeclaration, {
+    specifiers: [{
+      local: {
+        name: mutationName
+      }
+    }]
+  }).length > 0
+  if (alreadyImported) {
+    console.log('Already imported into rootMutation')
+    return
+  }
+
+  ast.find(j.ImportDeclaration).at(-1)
+    .insertBefore(`import ${mutationName} from './mutations/${mutationName}'`)
+
+  const objectPath = ast.find(j.ObjectExpression).at(1).get()
+  const entry = j.objectProperty.from({key: j.identifier(mutationName), value: j.identifier(mutationName), shorthand: true})
+  objectPath.value.properties.push(entry)
+
+  const res = ast.toSource({
+    objectCurlySpacing: false,
+    quote: 'single'
+  })
+  fs.writeFileSync(rootMutationPath, res)
+}
+
+const addToRootSubscription = (mutationName: string, subscription?: string) => {
+  if (!subscription) return
+  const fileName = subscription[0].toUpperCase() + subscription.slice(1) + 'SubscriptionPayload.ts'
+  const subPath = path.join(PROJECT_ROOT, 'packages', 'server', 'graphql', 'types', fileName)
+  const sub = fs.readFileSync(subPath, 'utf-8')
+  const payloadName = mutationName[0].toUpperCase() + mutationName.slice(1) + 'Payload'
+  const successName = payloadName.replace('Payload', 'Success')
+  const ast = j(sub, {parser: tsParser()})
+  const alreadyImported = ast.find(j.ImportDeclaration, {
+    specifiers: [{
+      local: {
+        name: successName
+      }
+    }]
+  }).length > 0
+  if (alreadyImported) {
+    console.log('Already imported into rootMutation')
+    return
+  }
+  // add import
+  ast.find(j.ImportDeclaration).at(-1)
+    .insertBefore(`import {${successName}} from './${payloadName}'`)
+
+  const payloadArr = ast.find(j.ArrayExpression).get()
+  payloadArr.value.elements.push(j.identifier(successName))
+  const res = ast.toSource({
+    objectCurlySpacing: false,
+    quote: 'single'
+  })
+  fs.writeFileSync(subPath, res)
+}
+
+const createClientMutation = (mutationName: string) => {
+  const pascalMutation = mutationName[0].toUpperCase() + mutationName.slice(1)
+  const fileName = pascalMutation + 'Mutation.ts'
+  const mutationPath = path.join(PROJECT_ROOT, 'packages/client/mutations', fileName)
+
+  const basePath = path.join(PROJECT_ROOT, 'scripts/codeshift', 'baseClientMutation.ts')
+  const baseStr = fs.readFileSync(basePath, 'utf-8')
+  const nextStr = baseStr.replace(/PASCAL_MUTATION/g, pascalMutation).replace(/MUTATION_NAME/g, mutationName)
+  fs.writeFileSync(mutationPath, nextStr)
+}
+
+const addToClientSubscription = (mutationName: string, subscription?: string) => {
+  if (!subscription) return
+  const lowerSubscription = subscription.toLowerCase()
+  const fileName = subscription[0].toLowerCase() + subscription.slice(1) + 'Subscription.ts'
+  const subPath = path.join(PROJECT_ROOT, 'packages/client/subscriptions', fileName)
+  const pascalMutation = mutationName[0].toUpperCase() + mutationName.slice(1) + 'Mutation'
+  const fragment = `      ...${pascalMutation}_${lowerSubscription} @relay(mask: false)`
+  const subStr = fs.readFileSync(subPath, 'utf-8')
+  const typename = '__typename'
+  const nextStr = subStr.replace(typename, typename + '\n' + fragment)
+  console.log(nextStr)
+}
+const newMutation = () => {
+  const argv = parseArgs(process.argv.slice(2), {
+    alias: {
+      s: 'subscription',
+      f: 'field'
+    }
+  })
+
+  const rawMutationName = argv._[0]
+  if (!rawMutationName) {
+    console.log('Please provide a mutation name as the first argument')
+    return
+  }
+  const mutationName = rawMutationName[0].toLowerCase() + rawMutationName.slice(1)
+  const subscription = argv.subscription
+  createServerMutation(mutationName, subscription)
+  createServerMutationPayload(mutationName)
+
+  addToRootSubscription(mutationName, subscription)
+  addToRootMutation(mutationName)
+
+  createClientMutation(mutationName)
+  addToClientSubscription(mutationName, subscription)
+}
+newMutation()


### PR DESCRIPTION
fixes #3960

creating a new mutation isn't hard, but there's a lot of ugly boilerplate.
we should get paid to solve hard problems, not do mindless junk.
So, I made a CLI to generate the boilerplate.
we've got about 10 mutations to develop for the next sprint, so this should help.

How to use:
- call the CLI: e.g. `yarn newMutation addSmilesToFriends --subscription team`

How it works:
- this will generate a mutation called `addSmilesToFriends` and connect it to the Team subscription
- if this mutation is going to be hooked up to a subscription, you can add that with a `--subscription` (or `-s`) flag
- it will generate a mutation file on the client & server
- it will generate a mutation payload file on the server
- it will update the rootMutation & rootSubscription on the server
- it will update the client subscription with the mutation fragment

@tianrunhe @tiffanyhan @nickoferrall let me know if this is useful!