### PR TITLE
New meeting view updates

### DIFF
--- a/packages/client/components/DropdownToggleV2.tsx
+++ b/packages/client/components/DropdownToggleV2.tsx
@@ -5,11 +5,11 @@ import useMenu from '../hooks/useMenu'
 import {PALETTE} from '../styles/paletteV2'
 import {ICON_SIZE} from '../styles/typographyV2'
 
-const DropdownIcon = styled(Icon)({
+const DropdownIcon = styled(Icon)<{hasCustomIcon: boolean}>(({hasCustomIcon}) => ({
   color: PALETTE.TEXT_MAIN,
-  padding: 12,
-  fontSize: ICON_SIZE.MD24
-})
+  padding: hasCustomIcon ? 15 : 12,
+  fontSize: hasCustomIcon ? ICON_SIZE.MD18 : ICON_SIZE.MD24
+}))
 
 const DropdownBlock = styled('div')<{disabled: boolean | undefined}>(({disabled}) => ({
   background: '#fff',
@@ -27,13 +27,14 @@ const DropdownBlock = styled('div')<{disabled: boolean | undefined}>(({disabled}
 interface Props {
   className?: string
   disabled?: boolean
+  icon?: string
   onClick: ReturnType<typeof useMenu>['togglePortal']
   onMouseEnter?: () => void
   children: ReactNode
 }
 
 const DropdownToggleV2 = forwardRef((props: Props, ref: Ref<HTMLDivElement>) => {
-  const {className, children, onClick, onMouseEnter, disabled} = props
+  const {className, children, icon, onClick, onMouseEnter, disabled} = props
   return (
     <DropdownBlock
       className={className}
@@ -43,7 +44,7 @@ const DropdownToggleV2 = forwardRef((props: Props, ref: Ref<HTMLDivElement>) => 
       onClick={disabled ? undefined : onClick}
     >
       {children}
-      {!disabled && <DropdownIcon>expand_more</DropdownIcon>}
+      {!disabled && <DropdownIcon hasCustomIcon={Boolean(icon)}>{icon || 'expand_more'}</DropdownIcon>}
     </DropdownBlock>
   )
 })

--- a/packages/client/components/DropdownToggleV2.tsx
+++ b/packages/client/components/DropdownToggleV2.tsx
@@ -13,11 +13,11 @@ const DropdownIcon = styled(Icon)<{hasCustomIcon: boolean}>(({hasCustomIcon}) =>
 
 const DropdownBlock = styled('div')<{disabled: boolean | undefined}>(({disabled}) => ({
   background: '#fff',
-  border: `2px solid ${PALETTE.BORDER_DROPDOWN}`,
+  border: `1px solid ${PALETTE.BORDER_DROPDOWN}`,
   borderRadius: '4px',
   cursor: disabled ? 'not-allowed' : 'pointer',
   display: 'flex',
-  fontSize: 16,
+  fontSize: 14,
   lineHeight: '24px',
   fontWeight: 600,
   userSelect: 'none',

--- a/packages/client/components/ExpansionPanelSummary.tsx
+++ b/packages/client/components/ExpansionPanelSummary.tsx
@@ -16,7 +16,10 @@ const Label = styled('div')({
   display: 'flex',
   fontSize: 14,
   fontWeight: 600,
-  justifyContent: 'center'
+  justifyContent: 'center',
+  ':hover': {
+    color: PALETTE.LINK_BLUE_HOVER
+  }
 })
 
 interface Props {

--- a/packages/client/components/ExpansionPanelSummary.tsx
+++ b/packages/client/components/ExpansionPanelSummary.tsx
@@ -5,7 +5,7 @@ import {PALETTE} from '../styles/paletteV2'
 import {ICON_SIZE} from '../styles/typographyV2'
 
 const DropdownIcon = styled(Icon)({
-  padding: 12,
+  padding: '8px 0 8px 4px',
   fontSize: ICON_SIZE.MD24
 })
 
@@ -14,6 +14,7 @@ const Label = styled('div')({
   color: PALETTE.LINK_BLUE,
   cursor: 'pointer',
   display: 'flex',
+  fontSize: 14,
   fontWeight: 600,
   justifyContent: 'center'
 })
@@ -29,7 +30,7 @@ const ExpansionPanelSummary = (props: Props) => {
   return (
     <Label onClick={onClick}>
       {label}
-      <DropdownIcon>{isExpanded ? 'expand_less' : 'expand_more'}</DropdownIcon>
+      <DropdownIcon>{isExpanded ? 'unfold_less' : 'unfold_more'}</DropdownIcon>
     </Label>
   )
 }

--- a/packages/client/components/MenuToggleV2Text.tsx
+++ b/packages/client/components/MenuToggleV2Text.tsx
@@ -11,10 +11,9 @@ const MenuToggleInner = styled('div')({
   minWidth: 0
 })
 
-const GroupIcon = styled(Icon)({
+const MenuToggleIcon = styled(Icon)({
   color: PALETTE.TEXT_GRAY,
-  paddingLeft: 12,
-  paddingRight: 12
+  padding: '0 16px'
 })
 
 const MenuToggleLabel = styled('div')({
@@ -32,7 +31,7 @@ const MenuToggleV2Text = forwardRef((props: Props, ref: any) => {
   const {icon, label} = props
   return (
     <MenuToggleInner ref={ref}>
-      <GroupIcon>{icon}</GroupIcon>
+      <MenuToggleIcon>{icon}</MenuToggleIcon>
       <MenuToggleLabel>{label}</MenuToggleLabel>
     </MenuToggleInner>
   )

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -18,6 +18,7 @@ import NewMeetingIllustration from './NewMeetingIllustration'
 import NewMeetingMeetingSelector from './NewMeetingMeetingSelector'
 import NewMeetingSettings from './NewMeetingSettings'
 import NewMeetingTeamPicker from './NewMeetingTeamPicker'
+import {Elevation} from '../styles/elevation'
 
 interface Props {
   retry(): void
@@ -37,11 +38,16 @@ const TeamAndSettings = styled('div')<{isDesktop}>(({isDesktop}) => ({
   display: 'flex',
   flexDirection: 'column',
   gridArea: 'settings',
-  paddingTop: isDesktop ? 32 : undefined,
+  marginTop: isDesktop ? 32 : undefined,
   [MEDIA_QUERY_VERTICAL_CENTERING]: {
     minHeight: isDesktop ? undefined : 166
   }
 }))
+
+const TeamAndSettingsInner = styled('div')({
+  borderRadius: '4px',
+  boxShadow: Elevation.Z1,
+})
 
 const NewMeetingBlock = styled('div')<{innerWidth: number; isDesktop: boolean}>(
   {
@@ -143,8 +149,10 @@ const NewMeeting = (props: Props) => {
         </IllustrationAndSelector>
         <NewMeetingHowTo meetingType={meetingType} />
         <TeamAndSettings isDesktop={isDesktop}>
-          <NewMeetingTeamPicker selectedTeam={selectedTeam} teams={teams} />
-          <NewMeetingSettings selectedTeam={selectedTeam} meetingType={meetingType} />
+          <TeamAndSettingsInner>
+            <NewMeetingTeamPicker selectedTeam={selectedTeam} teams={teams} />
+            <NewMeetingSettings selectedTeam={selectedTeam} meetingType={meetingType} />
+          </TeamAndSettingsInner>
         </TeamAndSettings>
         <NewMeetingActions team={selectedTeam} meetingType={meetingType} />
       </NewMeetingInner>

--- a/packages/client/components/NewMeetingDropdown.tsx
+++ b/packages/client/components/NewMeetingDropdown.tsx
@@ -4,6 +4,7 @@ import DropdownToggleV2 from './DropdownToggleV2'
 import MenuToggleV2Text from './MenuToggleV2Text'
 import styled from '@emotion/styled'
 import {NewMeeting} from '../types/constEnums'
+import {PALETTE} from '~/styles/paletteV2'
 
 interface Props {
   className?: string
@@ -16,7 +17,11 @@ interface Props {
 }
 
 const Dropdown = styled(DropdownToggleV2)({
-  width: NewMeeting.CONTROLS_WIDTH
+  backgroundColor: '#fff',
+  width: NewMeeting.CONTROLS_WIDTH,
+  ':hover': {
+    backgroundColor: PALETTE.BACKGROUND_MAIN_LIGHTENED
+  }
 })
 
 const NewMeetingDropdown = forwardRef((props: Props, ref: any) => {

--- a/packages/client/components/NewMeetingDropdown.tsx
+++ b/packages/client/components/NewMeetingDropdown.tsx
@@ -8,6 +8,7 @@ import {NewMeeting} from '../types/constEnums'
 interface Props {
   className?: string
   icon: string
+  dropdownIcon?: string
   label: string
   disabled?: boolean
   onClick: ReturnType<typeof useMenu>['togglePortal']
@@ -19,10 +20,11 @@ const Dropdown = styled(DropdownToggleV2)({
 })
 
 const NewMeetingDropdown = forwardRef((props: Props, ref: any) => {
-  const {className, icon, label, disabled, onClick, onMouseEnter} = props
+  const {className, icon, dropdownIcon, label, disabled, onClick, onMouseEnter} = props
   return (
     <Dropdown
       className={className}
+      icon={dropdownIcon}
       onMouseEnter={onMouseEnter}
       onClick={onClick}
       disabled={disabled}

--- a/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
@@ -17,12 +17,12 @@ const ButtonRow = styled(PlainButton)({
   alignItems: 'center',
   display: 'flex',
   paddingTop: 12,
-  paddingLeft: 12,
+  paddingLeft: 14,
   width: NewMeeting.CONTROLS_WIDTH
 })
 
 const Label = styled('div')({
-  color: PALETTE.TEXT_GRAY,
+  color: PALETTE.TEXT_MAIN,
   cursor: 'pointer',
   fontSize: 14,
   fontWeight: 600,
@@ -31,13 +31,14 @@ const Label = styled('div')({
   userSelect: 'none'
 })
 
-const StyledCheckbox = styled(Checkbox)({
+const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
+  color: active ? PALETTE.LINK_BLUE : PALETTE.TEXT_MAIN,
   fontSize: ICON_SIZE.MD24,
-  marginRight: 8,
+  marginRight: 4,
   textAlign: 'center',
   userSelect: 'none',
   width: ICON_SIZE.MD24
-})
+}))
 
 interface Props {
   settings: NewMeetingSettingsToggleCheckIn_settings

--- a/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
@@ -16,9 +16,15 @@ import PlainButton from './PlainButton/PlainButton'
 const ButtonRow = styled(PlainButton)({
   alignItems: 'center',
   display: 'flex',
-  paddingTop: 12,
-  paddingLeft: 14,
-  width: NewMeeting.CONTROLS_WIDTH
+  padding: '12px 12px 12px 16px',
+  width: NewMeeting.CONTROLS_WIDTH,
+  background: '#fff',
+  border: `1px solid ${PALETTE.BORDER_DROPDOWN}`,
+  borderTop: 0,
+  borderRadius: '0 0 4px 4px',
+  ':hover': {
+    backgroundColor: PALETTE.BACKGROUND_MAIN_LIGHTENED
+  }
 })
 
 const Label = styled('div')({
@@ -27,14 +33,14 @@ const Label = styled('div')({
   fontSize: 14,
   fontWeight: 600,
   minWidth: 160,
-  padding: '8px 0 8px 8px',
-  userSelect: 'none'
+  lineHeight: '24px',
+  userSelect: 'none',
 })
 
 const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
   color: active ? PALETTE.LINK_BLUE : PALETTE.TEXT_MAIN,
   fontSize: ICON_SIZE.MD24,
-  marginRight: 4,
+  marginRight: 16,
   textAlign: 'center',
   userSelect: 'none',
   width: ICON_SIZE.MD24

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -8,6 +8,7 @@ import useRouter from '../hooks/useRouter'
 import {NewMeetingTeamPicker_teams} from '~/__generated__/NewMeetingTeamPicker_teams.graphql'
 import {NewMeetingTeamPicker_selectedTeam} from '~/__generated__/NewMeetingTeamPicker_selectedTeam.graphql'
 import NewMeetingDropdown from './NewMeetingDropdown'
+import styled from '@emotion/styled'
 
 const SelectTeamDropdown = lazyPreload(() =>
   import(
@@ -20,6 +21,10 @@ interface Props {
   selectedTeam: NewMeetingTeamPicker_selectedTeam
   teams: NewMeetingTeamPicker_teams
 }
+
+const Dropdown = styled(NewMeetingDropdown)({
+  borderRadius: '4px 4px 0 0'
+})
 
 const NewMeetingTeamPicker = (props: Props) => {
   const {selectedTeam, teams} = props
@@ -36,7 +41,7 @@ const NewMeetingTeamPicker = (props: Props) => {
   }
   return (
     <>
-      <NewMeetingDropdown
+      <Dropdown
         icon={'group'}
         label={name}
         onClick={togglePortal}

--- a/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
@@ -19,7 +19,8 @@ const ReflectTemplateModal = lazyPreload(() =>
 )
 
 const Dropdown = styled(NewMeetingDropdown)({
-  marginTop: 16
+  borderWidth: '0 1px 1px',
+  borderRadius: 0
 })
 
 const RetroTemplatePicker = (props: Props) => {

--- a/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
@@ -31,6 +31,7 @@ const RetroTemplatePicker = (props: Props) => {
     <>
       <Dropdown
         icon={'question_answer'}
+        dropdownIcon={'edit'}
         label={templateName}
         onClick={togglePortal}
         onMouseEnter={ReflectTemplateModal.preload}


### PR DESCRIPTION
Fixes part of #4237 the other ideas will be on the backlog or iceboxed

### Tests
- [x] At the mobile breakpoint, the ‘How to Run’ used the proper `unfold_less` or `unfold_more` icon for consistency
- [x] The template control has the pencil icon (`edit`) instead of the dropdown icon for consistency
- [x] Icebreaker has a blue checkbox to distinguish from the decorative label icons on the left of the controls
- [x] The settings controls are unified in a single panel
- [x] All controls work (how to run, team selector, template selector, icebreaker toggle)

![Screen Shot 2020-10-13 at 18 09 07](https://user-images.githubusercontent.com/307286/95925353-3835f500-0d7f-11eb-8ca3-b7ef54f6f888.png)
