### PR TITLE
Poker Estimate Phase: Card Deck

### DIFF
--- a/packages/client/components/EstimatePhaseArea.tsx
+++ b/packages/client/components/EstimatePhaseArea.tsx
@@ -4,6 +4,7 @@ import {PALETTE} from '~/styles/paletteV2'
 import SwipeableViews from 'react-swipeable-views'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import {Breakpoint} from '~/types/constEnums'
+import PokerCardDeck from './PokerCardDeck'
 
 const EstimateArea = styled('div')({
   display: 'flex',
@@ -67,6 +68,7 @@ const EstimatePhaseArea = () => {
           return <StepperDot key={idx} isActive={idx === activeIdx} />
         })}
       </StepperDots>
+      <PokerCardDeck />
       <SwipeableViews
         containerStyle={containerStyle}
         enableMouseEvents
@@ -79,6 +81,7 @@ const EstimatePhaseArea = () => {
           <SwipableEstimateItem key={idx} />
         ))}
       </SwipeableViews>
+
     </EstimateArea>
   )
 }

--- a/packages/client/components/PokerCard.tsx
+++ b/packages/client/components/PokerCard.tsx
@@ -6,7 +6,7 @@ import {BezierCurve, PokerCards} from '../types/constEnums'
 import getColorLuminance from '../utils/getColorLuminance'
 import getBezierTimePercentGivenDistancePercent from '../utils/getBezierTimePercentGivenDistancePercent'
 
-const COLLAPSED_X = window.innerWidth - PokerCards.WIDTH - 16
+const getCollapsedX = () => window.innerWidth - PokerCards.WIDTH - 16
 const COLLAPSE_DUR = 1000
 const EASE = BezierCurve.DECELERATE
 
@@ -24,7 +24,7 @@ const getXPos = (idx: number, isCollapsed: boolean, cardRef: RefObject<HTMLDivEl
   const x = cardRef.current?.getBoundingClientRect().x ?? null
   const STEP_VAL = -PokerCards.OVERLAP
   if (!isCollapsed || x === null) return STEP_VAL * idx
-  const delta = COLLAPSED_X - x
+  const delta = getCollapsedX() - x
   return delta + (STEP_VAL * idx)
 }
 
@@ -33,9 +33,10 @@ const getShuffleToTopDelay = (cardRef: RefObject<HTMLDivElement>, deckRef: RefOb
   const deckX = deckRef.current?.getBoundingClientRect().x ?? null
   const cardRefX = cardRef.current?.getBoundingClientRect().x ?? null
   if (deckX === null || cardRefX === null) return 0
-  const isExpanding = cardRefX === COLLAPSED_X
+  const collapsedX = getCollapsedX()
+  const isExpanding = cardRefX === collapsedX
   const distanceToWait = isExpanding ? PokerCards.WIDTH : idx === 0 ? PokerCards.OVERLAP : cardRefX + PokerCards.WIDTH - deckX
-  const distaneTheFirstCardMustTravel = COLLAPSED_X - deckX
+  const distaneTheFirstCardMustTravel = collapsedX - deckX
   const distancePercent = (distanceToWait + 48) / distaneTheFirstCardMustTravel
   const timePercent = getBezierTimePercentGivenDistancePercent(distancePercent, EASE)
   return timePercent * COLLAPSE_DUR

--- a/packages/client/components/PokerCard.tsx
+++ b/packages/client/components/PokerCard.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import logoMarkWhite from '../styles/theme/images/brand/mark-white.svg'
+import {BezierCurve} from '../types/constEnums'
 
 
 const colorLuminance = (rawHex: string, lum: number) => {
@@ -13,24 +15,57 @@ const colorLuminance = (rawHex: string, lum: number) => {
   return rgb
 }
 
-const CardBase = styled('div')<{color: string}>(({color}) => ({
+const getYPos = (isSelected: boolean, totalCards: number, idx: number) => {
+  if (isSelected) return -48
+  const totalSteps = Math.floor(totalCards / 2)
+  const stepIdx = idx <= totalSteps ? idx : totalSteps - (idx - totalSteps)
+  const STEP_VAL = -4
+  return STEP_VAL * stepIdx
+}
+const CardBase = styled('div')<{color: string, idx: number, isSelected: boolean, totalCards: number}>(({color, idx, isSelected, totalCards}) => ({
   background: `radial-gradient(50% 50% at 50% 50%, ${color} 0%, ${colorLuminance(color, -.12)} 100%)`,
   borderRadius: 6,
+  display: 'flex',
   height: 175,
+  justifyContent: 'center',
+  position: 'relative',
+  transform: `translate(${-96 * idx}px, ${getYPos(isSelected, totalCards, idx)}px)`,
+  transition: `transform 100ms ${BezierCurve.DECELERATE}`,
   width: 125
-
 }))
 
+const UpperLeftCardValue = styled('div')({
+  color: '#fff',
+  textShadow: '0px 1px 1px rgba(0,0,0,0.05)',
+  fontSize: 20,
+  fontWeight: 600,
+  position: 'absolute',
+  top: 4,
+  left: 8
+})
+
+const Logo = styled('img')({
+  // set min & max to accomodate custom logos here
+  minWidth: 64,
+  maxWidth: 96,
+  opacity: 0.5
+
+})
 interface Props {
   card: any
+  idx: number
+  isSelected: boolean
+  onClick: () => void
+  totalCards: number
 }
 
 const PokerCard = (props: Props) => {
-  const {card} = props
-  const {color} = card
+  const {card, idx, isSelected, onClick, totalCards} = props
+  const {color, label} = card
   return (
-    <CardBase color={color}>
-
+    <CardBase color={color} idx={idx} isSelected={isSelected} totalCards={totalCards} onClick={onClick}>
+      <UpperLeftCardValue>{label}</UpperLeftCardValue>
+      <Logo src={logoMarkWhite} />
     </CardBase>
   )
 }

--- a/packages/client/components/PokerCard.tsx
+++ b/packages/client/components/PokerCard.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled'
+import React from 'react'
+
+
+const colorLuminance = (rawHex: string, lum: number) => {
+  const hex = rawHex.slice(1)
+  let rgb = "#"
+  for (let i = 0; i < 3; i++) {
+    const partial = parseInt(hex.substr(i * 2, 2), 16)
+    const color = Math.round(Math.min(Math.max(0, partial + (partial * lum)), 255)).toString(16)
+    rgb += ("00" + color).substr(color.length)
+  }
+  return rgb
+}
+
+const CardBase = styled('div')<{color: string}>(({color}) => ({
+  background: `radial-gradient(50% 50% at 50% 50%, ${color} 0%, ${colorLuminance(color, -.12)} 100%)`,
+  borderRadius: 6,
+  height: 175,
+  width: 125
+
+}))
+
+interface Props {
+  card: any
+}
+
+const PokerCard = (props: Props) => {
+  const {card} = props
+  const {color} = card
+  return (
+    <CardBase color={color}>
+
+    </CardBase>
+  )
+}
+
+export default PokerCard

--- a/packages/client/components/PokerCardDeck.tsx
+++ b/packages/client/components/PokerCardDeck.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, {useState} from 'react'
 import {PALETTE} from '../styles/paletteV2'
 import PokerCard from './PokerCard'
 
@@ -9,7 +9,7 @@ const Deck = styled('div')({
   position: 'absolute',
   bottom: -32,
   width: '100%',
-  zIndex: 999 // TODO remove
+  zIndex: 1 // TODO remove. needs to be under bottom bar but above dimension bg
 })
 interface Props {
 
@@ -23,10 +23,17 @@ const PokerCardDeck = (props: Props) => {
     {label: '3', value: 3, color: PALETTE.BACKGROUND_GREEN},
   ]
 
+  const [selectedIdx, setSelectedIdx] = useState<number>()
+  // const [isCollapsed, setIsCollapsed] = useState(false)
+
   return (
     <Deck>
-      {cards.map((card) => {
-        return <PokerCard key={card.value} card={card} />
+      {cards.map((card, idx) => {
+        const isSelected = selectedIdx === idx
+        const onClick = () => {
+          setSelectedIdx(idx)
+        }
+        return <PokerCard key={card.value} card={card} idx={idx} totalCards={cards.length} onClick={onClick} isSelected={isSelected} />
       })}
     </Deck>
   )

--- a/packages/client/components/PokerCardDeck.tsx
+++ b/packages/client/components/PokerCardDeck.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {PALETTE} from '../styles/paletteV2'
+import PokerCard from './PokerCard'
+
+const Deck = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  position: 'absolute',
+  bottom: -32,
+  width: '100%',
+  zIndex: 999 // TODO remove
+})
+interface Props {
+
+}
+
+const PokerCardDeck = (props: Props) => {
+  const {} = props
+  const cards = [
+    {label: '1', value: 1, color: PALETTE.BACKGROUND_RED},
+    {label: '2', value: 2, color: PALETTE.BACKGROUND_BLUE},
+    {label: '3', value: 3, color: PALETTE.BACKGROUND_GREEN},
+  ]
+
+  return (
+    <Deck>
+      {cards.map((card) => {
+        return <PokerCard key={card.value} card={card} />
+      })}
+    </Deck>
+  )
+}
+
+export default PokerCardDeck

--- a/packages/client/components/PokerCardDeck.tsx
+++ b/packages/client/components/PokerCardDeck.tsx
@@ -1,16 +1,20 @@
 import styled from '@emotion/styled'
-import React, {useState} from 'react'
+import React, {useRef, useState} from 'react'
+import useHotkey from '../hooks/useHotkey'
+import usePokerDeckLeft from '../hooks/usePokerDeckLeft'
 import {PALETTE} from '../styles/paletteV2'
 import PokerCard from './PokerCard'
 
-const Deck = styled('div')({
+const Deck = styled('div')<{left: number}>(({left}) => ({
   display: 'flex',
-  justifyContent: 'center',
+  left,
+  // justifyContent: 'center',
   position: 'absolute',
   bottom: -32,
   width: '100%',
   zIndex: 1 // TODO remove. needs to be under bottom bar but above dimension bg
-})
+}))
+
 interface Props {
 
 }
@@ -21,19 +25,27 @@ const PokerCardDeck = (props: Props) => {
     {label: '1', value: 1, color: PALETTE.BACKGROUND_RED},
     {label: '2', value: 2, color: PALETTE.BACKGROUND_BLUE},
     {label: '3', value: 3, color: PALETTE.BACKGROUND_GREEN},
+    {label: '4', value: 4, color: PALETTE.BACKGROUND_YELLOW},
   ]
-
-  const [selectedIdx, setSelectedIdx] = useState<number>()
-  // const [isCollapsed, setIsCollapsed] = useState(false)
+  const totalCards = cards.length
+  const [selectedIdx, setSelectedIdx] = useState<number | undefined>()
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const deckRef = useRef<HTMLDivElement>(null)
+  const toggleCollapse = () => {
+    setIsCollapsed(!isCollapsed)
+  }
+  useHotkey('c', toggleCollapse)
+  const left = usePokerDeckLeft(deckRef, totalCards)
 
   return (
-    <Deck>
+    <Deck ref={deckRef} left={left}>
       {cards.map((card, idx) => {
         const isSelected = selectedIdx === idx
         const onClick = () => {
-          setSelectedIdx(idx)
+          if (isCollapsed) return
+          setSelectedIdx(isSelected ? undefined : idx)
         }
-        return <PokerCard key={card.value} card={card} idx={idx} totalCards={cards.length} onClick={onClick} isSelected={isSelected} />
+        return <PokerCard key={card.value} card={card} idx={idx} totalCards={totalCards} onClick={onClick} isCollapsed={isCollapsed} isSelected={isSelected} deckRef={deckRef} />
       })}
     </Deck>
   )

--- a/packages/client/hooks/usePokerDeckLeft.ts
+++ b/packages/client/hooks/usePokerDeckLeft.ts
@@ -1,0 +1,15 @@
+
+import {RefObject, useLayoutEffect, useState} from 'react'
+import {PokerCards} from '../types/constEnums'
+
+const usePokerDeckLeft = (deckRef: RefObject<HTMLDivElement>, totalCards: number) => {
+  const [left, setLeft] = useState(0)
+  useLayoutEffect(() => {
+    const totalWidth = deckRef.current!.clientWidth
+    const deckWidth = PokerCards.WIDTH + (PokerCards.WIDTH - PokerCards.OVERLAP) * (totalCards - 1)
+    setLeft((totalWidth - deckWidth) / 2)
+  }, [])
+  return left
+}
+
+export default usePokerDeckLeft

--- a/packages/client/hooks/usePokerDeckLeft.ts
+++ b/packages/client/hooks/usePokerDeckLeft.ts
@@ -1,14 +1,17 @@
 
 import {RefObject, useLayoutEffect, useState} from 'react'
 import {PokerCards} from '../types/constEnums'
+import useResizeObserver from './useResizeObserver'
 
 const usePokerDeckLeft = (deckRef: RefObject<HTMLDivElement>, totalCards: number) => {
   const [left, setLeft] = useState(0)
-  useLayoutEffect(() => {
+  const adjustLeft = () => {
     const totalWidth = deckRef.current!.clientWidth
     const deckWidth = PokerCards.WIDTH + (PokerCards.WIDTH - PokerCards.OVERLAP) * (totalCards - 1)
     setLeft((totalWidth - deckWidth) / 2)
-  }, [])
+  }
+  useLayoutEffect(adjustLeft, [])
+  useResizeObserver(adjustLeft, deckRef)
   return left
 }
 

--- a/packages/client/hooks/usePokerZIndexOverride.ts
+++ b/packages/client/hooks/usePokerZIndexOverride.ts
@@ -1,0 +1,27 @@
+
+import {RefObject, useEffect} from 'react'
+
+const usePokerZIndexOverride = (delay: number, cardRef: RefObject<HTMLDivElement>, isExpanding: boolean, collapseDuration: number) => {
+  useEffect(() => {
+    if (delay === 0) return
+    const el = cardRef.current
+    if (!el) return
+    const {style} = el
+
+    if (isExpanding) {
+      style.zIndex = '1'
+      setTimeout(() => {
+        style.zIndex = ''
+      }, delay)
+    } else {
+      setTimeout(() => {
+        style.zIndex = '1'
+        setTimeout(() => {
+          style.zIndex = ''
+        }, collapseDuration)
+      }, delay)
+    }
+  }, [delay])
+}
+
+export default usePokerZIndexOverride

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -167,6 +167,12 @@ export const enum MeetingLabels {
   TIMER = 'Timer'
 }
 
+export const enum PokerCards {
+  HEIGHT = 175,
+  WIDTH = 125,
+  OVERLAP = 96
+
+}
 export const enum UserTaskViewFilterLabels {
   ALL_TEAMS = 'All Teams',
   ALL_TEAM_MEMBERS = 'All Team Members'

--- a/packages/client/utils/getBezierTimePercentGivenDistancePercent.ts
+++ b/packages/client/utils/getBezierTimePercentGivenDistancePercent.ts
@@ -1,0 +1,47 @@
+// Imagine you have an animation that takes 10 seconds
+// After 5 seconds, how much of the animation would be complete?
+// If the curve is linear, the answer is 50%
+// If the curve decelerates (ie very fast at first, then gradually slower), it'll be > 50%
+// Now, the inverse: given that the animation is 70% complete, how much time has elapsed?
+// Calculating this is hard, so instead I built a LUT and then iterate over it to find the approximation
+
+const bezierLookup = [] as {x: number, y: number}[]
+
+const getBezierTimePercentGivenDistancePercent = (threshold: number, bezierCurve: string) => {
+  if (bezierLookup.length === 0) {
+    const re = /\(([^)]+)\)/
+    const [x1, y1, x2, y2] = re
+      .exec(bezierCurve)![1]
+      .split(',')
+      .map(Number)
+    // css bezier-curves imply a start of 0,0 and end of 1,1
+    const x0 = 0
+    const y0 = 0
+    const x3 = 1
+    const y3 = 1
+
+    const cX = 3 * (x1 - x0)
+    const bX = 3 * (x2 - x1) - cX
+    const aX = x3 - x0 - cX - bX
+    const cY = 3 * (y1 - y0)
+    const bY = 3 * (y2 - y1) - cY
+    const aY = y3 - y0 - cY - bY
+
+    for (let t = 0; t < 1; t += .01) {
+      const x = aX * t ** 3 + bX * t ** 2 + (cX * t) + x0
+      const y = aY * t ** 3 + bY * t ** 2 + (cY * t) + y0
+      bezierLookup.push({x, y})
+    }
+  }
+  let x
+  for (let i = 1; i < bezierLookup.length; i++) {
+    const point = bezierLookup[i]
+    if (point.y > threshold) {
+      x = bezierLookup[i - 1].x
+      break
+    }
+  }
+  return x
+}
+
+export default getBezierTimePercentGivenDistancePercent

--- a/packages/client/utils/getColorLuminance.ts
+++ b/packages/client/utils/getColorLuminance.ts
@@ -1,0 +1,12 @@
+const getColorLuminance = (rawHex: string, lum: number) => {
+  const hex = rawHex.slice(1)
+  let rgb = "#"
+  for (let i = 0; i < 3; i++) {
+    const partial = parseInt(hex.substr(i * 2, 2), 16)
+    const color = Math.round(Math.min(Math.max(0, partial + (partial * lum)), 255)).toString(16)
+    rgb += ("00" + color).substr(color.length)
+  }
+  return rgb
+}
+
+export default getColorLuminance


### PR DESCRIPTION
fixes #4257 

TEST
- [ ] a deck of cards overlays the estimate phase dimension
- [ ] clicking a card makes it rise up
- [ ] clicking another card lowers the old one down & the new one up
- [ ] hitting "c" collapses/expands the deck 
- [ ] deck looks good with 3 cards
- [ ] deck looks good with 20 cards
- [ ] resizing the window & then collapsing still makes a stack at the bottom right of the screen
- [ ] toggling the left nav or resizing the screen keeps the cards in the center 