### PR TITLE
bump mediasoup-client package to ^3.6.21

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -76,7 +76,7 @@
     "json2csv": "^4.2.1",
     "jwt-decode": "^2.1.0",
     "linkify-it": "^2.0.3",
-    "mediasoup-client": "^3.6.12",
+    "mediasoup-client": "^3.6.21",
     "micro-memoize": "^2.0.3",
     "mousetrap": "^1.6.3",
     "ms": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4520,6 +4520,11 @@ awaitqueue@^2.1.1, awaitqueue@^2.2.3:
   resolved "https://registry.yarnpkg.com/awaitqueue/-/awaitqueue-2.2.3.tgz#cf97176cea8e9b39fccac7c4952deb9fba4d21c5"
   integrity sha512-vKY8hHHt1FT05UBxaTKWoA8+A3APnyzcOO1UBY5wQ7ENzXCFi3Yy4wSKsqrO0ncDD/5CI6IZDN1nVZQKziWIqg==
 
+awaitqueue@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/awaitqueue/-/awaitqueue-2.3.3.tgz#35e6568970fcac3de1644a2c28abc1074045b570"
+  integrity sha512-RbzQg6VtPUtyErm55iuQLTrBJ2uihy5BKBOEkyBwv67xm5Fn2o/j+Bz+a5BmfSoe2oZ5dcz9Z3fExS8pL+LLhw==
+
 awesome-typescript-loader@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-5.2.1.tgz#a41daf7847515f4925cdbaa3075d61f289e913fc"
@@ -5154,15 +5159,15 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
+
 bowser@^2.5.3:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.9.0.tgz#3bed854233b419b9a7422d9ee3e85504373821c9"
   integrity sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA==
-
-bowser@^2.9.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.10.0.tgz#be3736f161c4bb8b10958027ab99465d2a811198"
-  integrity sha512-OCsqTQboTEWWsUjcp5jLSw2ZHsBiv2C105iFs61bOT0Hnwi9p7/uuXdd7mu8RYcarREfdjNN+8LitmEHATsLYg==
 
 boxen@^1.2.1:
   version "1.3.0"
@@ -7044,6 +7049,13 @@ debug@^3.0, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6
   dependencies:
     ms "^2.1.1"
 
+debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -8127,7 +8139,7 @@ events@^3.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
   integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
 
-events@^3.1.0:
+events@^3.1.0, events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
   integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
@@ -12365,20 +12377,20 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-mediasoup-client@^3.6.12:
-  version "3.6.12"
-  resolved "https://registry.yarnpkg.com/mediasoup-client/-/mediasoup-client-3.6.12.tgz#3a865b69f6d1c93f33c4d03fc935d85b2be9edc5"
-  integrity sha512-smpXv4foIEgnt7PZtVrppJIswVJrGnExg3kS2WsHb48ByG+KCiLAaYDYoECUlwpxUxupps164u+ZTEs1gmiF2w==
+mediasoup-client@^3.6.21:
+  version "3.6.21"
+  resolved "https://registry.yarnpkg.com/mediasoup-client/-/mediasoup-client-3.6.21.tgz#7b1c96676c3cad5fd6c9300ccb985ba023d2a52b"
+  integrity sha512-uzJsWPhfRAF1TFnkcrgNE66nyyD3odaXxNCsYGDKDjILLnjSU++eaebRtmFz2dPaq8XEfcWmsXNP9kyx4CEFnQ==
   dependencies:
     "@types/debug" "^4.1.5"
     "@types/events" "^3.0.0"
-    awaitqueue "^2.2.3"
-    bowser "^2.9.0"
-    debug "^4.1.1"
-    events "^3.1.0"
+    awaitqueue "^2.3.3"
+    bowser "^2.11.0"
+    debug "^4.2.0"
+    events "^3.2.0"
     h264-profile-level-id "^1.0.1"
     sdp-transform "^2.14.0"
-    supports-color "^7.1.0"
+    supports-color "^7.2.0"
 
 mediasoup@^3.6.21:
   version "3.6.21"
@@ -12847,7 +12859,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==


### PR DESCRIPTION
Resolves #4290 

This one isn't practical to fully reproduce and test. But after fetching the latest patch of mediasoup-client, `https://github.com/ParabolInc/parabol/blob/mediasoup-edge/node_modules/mediasoup-client/lib/handlers/Chrome74.js#L4` should not have any rest parameter syntax in it. This syntax was tripping up edge 18 even though the code wasn't being executed, because the browser wasn't able to parse the syntax when it loaded javascripts. This update brings in a patch that fixes the issue by targeting an older ES version in mediasoup-client's tsconfig file.

**AC**
- [ ] After running `yarn && yarn dev`, search for `...` in `https://github.com/ParabolInc/parabol/blob/mediasoup-edge/node_modules/mediasoup-client/lib/handlers/Chrome74.js#L4` . No results should appear.
