### PR TITLE
Fix a bug which prevent reflect template to be copied over

### DIFF
--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -76,7 +76,7 @@ const addReflectTemplate = {
         parentTemplateId
       })
       const prompts = await dataLoader.get('reflectPromptsByTemplateId').load(parentTemplate.id)
-      const activePrompts = prompts.filter(({isActive}) => isActive)
+      const activePrompts = prompts.filter(({removedAt}) => !removedAt)
       const newTemplatePrompts = activePrompts.map((prompt) => {
         return new RetrospectivePrompt({
           ...prompt,

--- a/packages/server/graphql/mutations/updateTemplateScope.ts
+++ b/packages/server/graphql/mutations/updateTemplateScope.ts
@@ -80,7 +80,7 @@ const updateTemplateScope = {
       })
       clonedTemplateId = clonedTemplate.id
       const prompts = await dataLoader.get('reflectPromptsByTemplateId').load(templateId)
-      const activePrompts = prompts.filter(({isActive}) => isActive)
+      const activePrompts = prompts.filter(({removedAt}) => !removedAt)
       const promptIds = activePrompts.map(({id}) => id)
       const clonedPrompts = activePrompts.map((prompt) => {
         return new RetrospectivePrompt({


### PR DESCRIPTION
This fixes #4289 .

Root cause: field `isActive` has been deprecated in favor of `removedAt`.

Tests:

*   [ ] When copying an existing template, the prompts were copied over
*   [ ] After a copied template was created, user can add new prompts at will