### PR TITLE
add-new-route

### DIFF
--- a/packages/server/selfHostedHandler.ts
+++ b/packages/server/selfHostedHandler.ts
@@ -1,0 +1,36 @@
+import fs from 'fs'
+import mime from 'mime-types'
+import path from 'path'
+import {HttpRequest, HttpResponse} from 'uWebSockets.js'
+import pipeStreamOverResponse from './pipeStreamOverResponse'
+
+const getProjectRoot = () => {
+  let cd = __dirname
+  while (cd !== '/') {
+    if (fs.existsSync(path.join(cd, 'yarn.lock'))) return cd
+    cd = path.join(cd, '..')
+  }
+  return cd
+}
+
+const PROJECT_ROOT = getProjectRoot()
+
+const selfHostedHandler = async (res: HttpResponse, req: HttpRequest) => {
+  const url = req.getUrl()
+  let stats: fs.Stats
+  try {
+    stats = fs.statSync(path.join(PROJECT_ROOT, url))
+  } catch (e) {
+    res.writeStatus('404').end()
+    return
+  }
+  const {size} = stats
+  const ext = path.extname(url).slice(1)
+  const contentType = mime.types[ext]
+
+  res.writeHeader('content-type', contentType)
+  const readStream = fs.createReadStream(url)
+  pipeStreamOverResponse(res, readStream, size)
+}
+
+export default selfHostedHandler

--- a/packages/server/server.dev.ts
+++ b/packages/server/server.dev.ts
@@ -27,6 +27,7 @@ uws
   .get('/email/createics', (...args) => require('./ICSHandler').default(...args))
   .get('/sse', (...args) => require('./sse/SSEConnectionHandler').default(...args))
   .get('/sse-ping', (...args) => require('./sse/SSEPingHandler').default(...args))
+  .get('/self-hosted', (...args) => require('./selfHostedHandler').default(...args))
   .post('/stripe', (...args) => require('./billing/stripeWebhookHandler').default(...args))
   .post('/webhooks/github', (...args) =>
     require('./integrations/githubWebhookHandler').default(...args)

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -12,6 +12,7 @@ import './initSentry'
 import githubWebhookHandler from './integrations/githubWebhookHandler'
 import listenHandler from './listenHandler'
 import PWAHandler from './PWAHandler'
+import selfHostedHandler from './selfHostedHandler'
 import handleClose from './socketHandlers/handleClose'
 import handleMessage from './socketHandlers/handleMessage'
 import handleOpen from './socketHandlers/handleOpen'
@@ -31,6 +32,7 @@ uws
   .get('/email/createics', ICSHandler)
   .get('/sse', SSEConnectionHandler)
   .get('/sse-ping', SSEPingHandler)
+  .get('/self-hosted', selfHostedHandler)
   .post('/stripe', stripeWebhookHandler)
   .post('/webhooks/github', githubWebhookHandler)
   .post('/webhooks/graphql', webhookGraphQLHandler)


### PR DESCRIPTION
@tiffanyhan here's how i'd handle that case of self-hosted content.
the static server has a lot of sharp edges to prevent folks from doing rude things.
if the customer is gonna be self-hosted, we don't really have to worry about that.

basically, we store everything that they upload in `/self-hosted`.
Then, when they want to retrieve that, we look in `/self-hosted`
If we don't find it, we send em a 404.
If we do, we pipe it to them (this has a slight overhead vs. sending the whole thing at once, but means it can support ver large files, if the need shall arise)

note: untested!