### PR TITLE
support nested formdata pieces

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -57,7 +57,7 @@
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "^10.0.27",
     "@mattkrick/fast-rtc-swarm": "^0.4.1",
-    "@mattkrick/graphql-trebuchet-client": "^1.0.0",
+    "@mattkrick/graphql-trebuchet-client": "^1.0.2",
     "@mattkrick/sanitize-svg": "0.2.1",
     "@mattkrick/trebuchet-client": "^2.0.0",
     "@sentry/browser": "^5.8.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.0.3",
     "@mattkrick/fast-rtc-swarm": "^0.4.0",
-    "@mattkrick/graphql-trebuchet-client": "^0.2.0",
+    "@mattkrick/graphql-trebuchet-client": "^1.0.2",
     "@types/analytics-node": "^3.1.3",
     "@types/dotenv": "^6.1.1",
     "@types/graphql": "^14.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,15 +2134,10 @@
     eventemitter3 "^3.1.0"
     tslib "^1.9.3"
 
-"@mattkrick/graphql-trebuchet-client@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@mattkrick/graphql-trebuchet-client/-/graphql-trebuchet-client-0.2.0.tgz#d50603b97900bfeb87d97ea0cad1ea0104b34773"
-  integrity sha512-8l5LfOp6TwKbtxG2/yySl1Q9czdH3395J9lPWjW4VR2ZKaAPuJuCVnHh0PQEXuhBrFW4Qmq0Z503cqreiBiDWQ==
-
-"@mattkrick/graphql-trebuchet-client@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@mattkrick/graphql-trebuchet-client/-/graphql-trebuchet-client-1.0.1.tgz#59750cdcc88d777267394a95293443f4919d9fde"
-  integrity sha512-9r0LjFWPefUHXN+lX2fAgcPMi1NbdsnXPJCL+fJdhZ1Jeo3F+La6KF2S+bo0bMBNsHowqSaeuTv2arSi0DDHJQ==
+"@mattkrick/graphql-trebuchet-client@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@mattkrick/graphql-trebuchet-client/-/graphql-trebuchet-client-1.0.2.tgz#9ef56ca05ed6e3f6785348ae67c70f23c2d5cce0"
+  integrity sha512-XexI4g+4U6LuaNNdOhpuD1PewHXmvvcKcs61pZFD2HZTSUT4h807WyZiKIONpqHb/egjPqtB8khldAex76d1uQ==
 
 "@mattkrick/sanitize-svg@0.2.1", "@mattkrick/sanitize-svg@^0.2.1":
   version "0.2.1"


### PR DESCRIPTION
this PR adds a convention to convert nested objects into a file FormData schema.
Nested fields are store as dot separated values (e.g. `{query, 'payload.uploadables.file': File}`)

@tiffanyhan this cleans up a few of the rough edges for file uploads from the client. after migrating to the new uWS we can use this same convention to reconstruct the object on the server