### PR TITLE
Fixes fatal client-side bugs found in sentry

### DIFF
--- a/packages/client/components/Facilitator.tsx
+++ b/packages/client/components/Facilitator.tsx
@@ -99,7 +99,8 @@ const Facilitator = (props: Props) => {
   const {meeting} = props
   const {endedAt, facilitatorUserId, facilitator} = meeting
   const {user, picture, preferredName} = facilitator
-  const {isConnected} = user
+  // https://sentry.io/share/issue/efef01c3e7934ab981ed5c80ef2d64c8/
+  const isConnected = user?.isConnected ?? false
   const {togglePortal, menuProps, menuPortal, originRef, portalStatus} = useMenu<HTMLDivElement>(
     MenuPosition.UPPER_RIGHT,
     {

--- a/packages/client/mutations/RemoveReflectionMutation.ts
+++ b/packages/client/mutations/RemoveReflectionMutation.ts
@@ -48,7 +48,8 @@ const removeReflectionAndEmptyGroup = (
   if (!reflectionGroup) return
   safeRemoveNodeFromArray(reflectionId, reflectionGroup, 'reflections')
   const reflections = reflectionGroup.getLinkedRecords('reflections')
-  if (reflections.length === 0) {
+  // https://sentry.io/share/issue/c8712aae0e6544a1ac0acd3be8d38ae8/
+  if (!reflections || reflections.length === 0) {
     handleRemoveReflectionGroups(reflectionGroupId, meetingId, store)
   }
 }


### PR DESCRIPTION
In sentry, we found 3 fatal client side bugs that are rooted in objects not existing in the client cache where they are guaranteed to exist. This leads me to believe the bug is in Relay, likely as a race condition in how it garbage collects. It is possible that the Relay team has fixed this bug in a newer version (even if they didn't know they fixed it or it wasn't in the changelog).

For this reason, we should up the priority of bumping the relay version. There will be breaking changes & we'll likely have to re-fork it again with our fixes that won't get accepted to their master branch.

@nickoferrall 

