### PR TITLE
upgrade uws

### DIFF
--- a/packages/server/graphql/httpGraphQLHandler.ts
+++ b/packages/server/graphql/httpGraphQLHandler.ts
@@ -68,7 +68,7 @@ const httpGraphQLHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRe
   const contentType = req.getHeader('content-type')
   const connectionId = req.getHeader('x-correlation-id')
   const authToken = getReqAuth(req)
-  const ip = uwsGetIP(res, req)
+  const ip = uwsGetIP(res)
   if (contentType.startsWith('application/json')) {
     const body = await parseBody(res)
     if (!body) {

--- a/packages/server/graphql/intranetGraphQLHandler.ts
+++ b/packages/server/graphql/intranetGraphQLHandler.ts
@@ -14,7 +14,7 @@ interface IntranetPayload {
 }
 const intranetHttpGraphQLHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
   const authToken = getReqAuth(req)
-  const ip = uwsGetIP(res, req)
+  const ip = uwsGetIP(res)
   if (!isAuthenticated(authToken) || !isSuperUser(authToken)) {
     res.writeStatus('401').end()
     return

--- a/packages/server/graphql/mutations/addTeam.ts
+++ b/packages/server/graphql/mutations/addTeam.ts
@@ -28,7 +28,6 @@ export default {
   },
   resolve: rateLimit({perMinute: 4, perHour: 20})(
     async (_source, args, {authToken, dataLoader, socketId: mutatorId}) => {
-      console.log({_source})
       const operationId = dataLoader.share()
       const subOptions = {mutatorId, operationId}
       const r = await getRethink()

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -133,7 +133,7 @@
     "string-similarity": "^3.0.0",
     "stripe": "^4.24.0",
     "tslib": "^1.11.1",
-    "uWebSockets.js": "uNetworking/uWebSockets.js#v17.6.0",
+    "uWebSockets.js": "uNetworking/uWebSockets.js#v18.8.0",
     "webpack-hot-client": "https://github.com/mattkrick/webpack-hot-client/tarball/2e0b804700ba886f17bd9c5e2e60ec03b58aecdb"
   },
   "jest": {

--- a/packages/server/server.dev.ts
+++ b/packages/server/server.dev.ts
@@ -43,6 +43,7 @@ uws
     compression: SHARED_COMPRESSOR,
     idleTimeout: 0,
     maxPayloadLength: 5 * 2 ** 20,
+    upgrade: (...args) => require('./socketHandlers/handleUpgrade').default(...args),
     open: (...args) => require('./socketHandlers/handleOpen').default(...args),
     message: (...args) => require('./socketHandlers/handleMessage').default(...args),
     // today, we don't send folks enough data to worry about backpressure
@@ -70,6 +71,7 @@ if (module.hot) {
     './graphql/httpGraphQLHandler',
     './graphql/intranetGraphQLHandler',
     './createSSR',
+    './socketHandlers/handleUpgrade',
     './socketHandlers/handleMessage',
     './socketHandlers/handleClose',
     './socketHandlers/handleOpen'

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -15,6 +15,7 @@ import PWAHandler from './PWAHandler'
 import handleClose from './socketHandlers/handleClose'
 import handleMessage from './socketHandlers/handleMessage'
 import handleOpen from './socketHandlers/handleOpen'
+import handleUpgrade from './socketHandlers/handleUpgrade'
 import SSEConnectionHandler from './sse/SSEConnectionHandler'
 import SSEPingHandler from './sse/SSEPingHandler'
 import staticFileHandler from './staticFileHandler'
@@ -41,6 +42,7 @@ uws
     compression: SHARED_COMPRESSOR,
     idleTimeout: 0,
     maxPayloadLength: 5 * 2 ** 20,
+    upgrade: handleUpgrade,
     open: handleOpen,
     message: handleMessage,
     // today, we don't send folks enough data to worry about backpressure

--- a/packages/server/socketHandlers/handleOpen.ts
+++ b/packages/server/socketHandlers/handleOpen.ts
@@ -1,65 +1,18 @@
-import {TrebuchetCloseReason} from 'parabol-client/types/constEnums'
-import {HttpRequest, WebSocket} from 'uWebSockets.js'
+import {WebSocket, WebSocketBehavior} from 'uWebSockets.js'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 import keepAlive from '../socketHelpers/keepAlive'
 import sendEncodedMessage from '../socketHelpers/sendEncodedMessage'
-import {isAuthenticated} from '../utils/authorization'
-import checkBlacklistJWT from '../utils/checkBlacklistJWT'
-import getQueryToken from '../utils/getQueryToken'
-import sendToSentry from '../utils/sendToSentry'
-import uwsGetIP from '../utils/uwsGetIP'
 import handleConnect from './handleConnect'
 
 const APP_VERSION = process.env.npm_package_version
 
-const authorize = async (connectionContext: ConnectionContext<WebSocket>) => {
-  const {authToken, socket} = connectionContext
-  const {sub: userId, iat} = authToken
-  // ALL async calls must come after the message listener, or we'll skip out on messages (e.g. resub after server restart)
-  const isBlacklistedJWT = await checkBlacklistJWT(userId, iat)
-  if (isBlacklistedJWT) {
-    if (!socket.done) {
-      socket.end(1011, TrebuchetCloseReason.EXPIRED_SESSION)
-    }
-    return
-  }
+const handleOpen: WebSocketBehavior['open'] = async (socket: WebSocket) => {
+  const {authToken, ip} = socket
+  const connectionContext = socket.connectionContext = new ConnectionContext(socket, authToken, ip)
+  // messages will start coming in before handleConnect completes & sit in the readyQueue
   const nextAuthToken = await handleConnect(connectionContext)
   sendEncodedMessage(socket, {version: APP_VERSION, authToken: nextAuthToken})
   keepAlive(connectionContext)
-}
-
-const handleOpen = (socket: WebSocket, req: HttpRequest) => {
-  try {
-    const protocol = req.getHeader('sec-websocket-protocol')
-    if (protocol !== 'trebuchet-ws') {
-      // protocol error
-      sendToSentry(new Error(`WebSocket error: invalid protocol: ${protocol}`))
-      socket.end(1002)
-      return
-    }
-
-    const authToken = getQueryToken(req)
-    if (!isAuthenticated(authToken)) {
-      const clientIp = req.getHeader('x-forwarded-for')
-      const badAuthToken = getQueryToken(req, true)
-      const {sub, exp} = badAuthToken
-      // internal error (bad auth)
-      sendToSentry(new Error(`WebSocket error: not authenticated`), {
-        userId: sub,
-        ip: clientIp,
-        tags: {exp: new Date(exp * 1000).toJSON()},
-        sampleRate: 0.01
-      })
-      socket.end(1011)
-      return
-    }
-    const ip = uwsGetIP(socket, req)
-    socket.connectionContext = new ConnectionContext(socket, authToken, ip)
-    // keep async stuff separate so the message handler gets set up fast
-    authorize(socket.connectionContext).catch()
-  } catch (e) {
-    sendToSentry(e)
-  }
 }
 
 export default handleOpen

--- a/packages/server/socketHandlers/handleUpgrade.ts
+++ b/packages/server/socketHandlers/handleUpgrade.ts
@@ -1,0 +1,42 @@
+import {WebSocketBehavior} from 'uWebSockets.js'
+import {TrebuchetCloseReason} from '../../client/types/constEnums'
+import {isAuthenticated} from '../utils/authorization'
+import checkBlacklistJWT from '../utils/checkBlacklistJWT'
+import getQueryToken from '../utils/getQueryToken'
+import sendToSentry from '../utils/sendToSentry'
+import uwsGetIP from '../utils/uwsGetIP'
+
+
+const handleUpgrade: WebSocketBehavior['upgrade'] = async (res, req, context) => {
+  const aborted = {done: false}
+  const protocol = req.getHeader('sec-websocket-protocol')
+  if (protocol !== 'trebuchet-ws') {
+    sendToSentry(new Error(`WebSocket error: invalid protocol: ${protocol}`))
+    // WS Error 1002 is roughly HTTP 412 Precondition Failed because we can't support the req header
+    res.writeStatus('412').end()
+    return
+  }
+  const authToken = getQueryToken(req)
+  if (!isAuthenticated(authToken)) {
+    res.writeStatus('401').end()
+    return
+  }
+  res.onAborted(() => {
+    aborted.done = true
+  })
+
+  const key = req.getHeader('sec-websocket-key')
+  const extensions = req.getHeader('sec-websocket-extensions')
+  const {sub: userId, iat} = authToken
+  // ALL async calls must come after the message listener, or we'll skip out on messages (e.g. resub after server restart)
+  const isBlacklistedJWT = await checkBlacklistJWT(userId, iat)
+  if (aborted.done) return
+  if (isBlacklistedJWT) {
+    res.writeStatus('401').end(TrebuchetCloseReason.EXPIRED_SESSION)
+    return
+  }
+  const ip = uwsGetIP(res)
+  res.upgrade({ip, authToken}, key, protocol, extensions, context)
+}
+
+export default handleUpgrade

--- a/packages/server/sse/SSEConnectionHandler.ts
+++ b/packages/server/sse/SSEConnectionHandler.ts
@@ -18,7 +18,7 @@ const APP_VERSION = process.env.npm_package_version
 
 const SSEConnectionHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
   const authToken = getQueryToken(req)
-  const connectionContext = new ConnectionContext(res, authToken, uwsGetIP(res, req))
+  const connectionContext = new ConnectionContext(res, authToken, uwsGetIP(res))
   res.onAborted(() => {
     handleDisconnect(connectionContext)
   })

--- a/packages/server/utils/makeSentryRequest.ts
+++ b/packages/server/utils/makeSentryRequest.ts
@@ -5,7 +5,7 @@ import {HttpResponse, HttpRequest} from 'uWebSockets.js'
 
 const makeSentryRequest = (res: HttpResponse, req: HttpRequest) => {
   return {
-    ip: uwsGetIP(res, req),
+    ip: uwsGetIP(res),
     method: req.getMethod().toUpperCase(),
     url: req.getUrl(),
     header: uwsGetHeaders(req),

--- a/packages/server/utils/uwsGetIP.ts
+++ b/packages/server/utils/uwsGetIP.ts
@@ -1,10 +1,8 @@
-import {HttpResponse, WebSocket, HttpRequest} from 'uWebSockets.js'
+import {HttpResponse} from 'uWebSockets.js'
 
-const uwsGetIP = (res: HttpResponse | WebSocket, req: HttpRequest) => {
-  const clientIp = req.getHeader('x-forwarded-for')
-  if (clientIp) return clientIp
-  const ipBuffer = Buffer.from(res.getRemoteAddress())
-  return ipBuffer.byteLength === 16 ? ipBuffer.toString('hex') : ipBuffer.join('.')
+const uwsGetIP = (res: HttpResponse) => {
+  // nginx will always returned the proxied address in the header, locally, we just grab the remote address
+  return Buffer.from(res.getProxiedRemoteAddressAsText()).toString() || Buffer.from(res.getRemoteAddressAsText()).toString()
 }
 
 export default uwsGetIP

--- a/yarn.lock
+++ b/yarn.lock
@@ -18068,9 +18068,9 @@ typescript@^4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
   integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
-uWebSockets.js@uNetworking/uWebSockets.js#v17.6.0:
-  version "17.6.0"
-  resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/a24c50180536c1edbc112ba63cda7d07df1b4a93"
+uWebSockets.js@uNetworking/uWebSockets.js#v18.8.0:
+  version "18.8.0"
+  resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/55540c25d74dca5d018db44174c3a558032da10e"
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
to handle multipart form data, we need to upgrade uWS.
There are a few breaking changes:
- uWS v18 no longer passes the `request` into the open handler. instead, it introduces an upgrade handler. Once auth has been performed in the upgrade handler, we can pass in the authToken & IP address to the open handler.
- it added a native way to get proxied IP addresses that always returns IPv6, so we use that instead. we'll need to verify this in prod to make sure we don't rate limit folks unfairly