### PR TITLE
Poker drawer styles

### DIFF
--- a/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
+++ b/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
@@ -60,13 +60,17 @@ const Header = styled('div')({
   borderBottom: `1px solid ${PALETTE.BORDER_LIGHTER}`,
   display: 'flex',
   justifyContent: 'space-between',
-  padding: '6px 12px',
+  padding: '8px 8px 8px 12px',
   width: '100%'
 })
 
 const HeaderLabel = styled(LabelHeading)({
   textTransform: 'none',
   width: '100%'
+})
+
+const StyledCloseButton = styled(PlainButton)({
+  height: 24
 })
 
 interface Props {
@@ -90,9 +94,9 @@ const EstimatePhaseDiscussionDrawer = (props: Props) => {
     <Drawer isDesktop={isDesktop} isOpen={isOpen} ref={ref}>
       <Header>
         <HeaderLabel>{'Discussion'}</HeaderLabel>
-        <PlainButton onClick={onToggle}>
+        <StyledCloseButton onClick={onToggle}>
           <CancelIcon>close</CancelIcon>
-        </PlainButton>
+        </StyledCloseButton>
       </Header>
       <ThreadColumn>
         <DiscussionThreadRoot

--- a/packages/client/components/MeetingTopBar.tsx
+++ b/packages/client/components/MeetingTopBar.tsx
@@ -48,6 +48,7 @@ const PrimaryActionBlock = styled('div')({
 })
 
 const AvatarGroupBlock = styled('div')({
+  alignItems: 'center',
   display: 'flex',
   justifyContent: 'center',
   padding: '10px 0',
@@ -65,24 +66,24 @@ const StyledSidebarToggle = styled(SidebarToggle)({
   marginRight: 16
 })
 
-const StyledIcon = styled(Icon)({
-  color: '#FFFF',
-  transform: 'scaleX(-1)',
-  fontSize: ICON_SIZE.MD24,
-  [meetingAvatarMediaQueries[0]]: {
-    fontSize: ICON_SIZE.MD36
-  }
-})
-
 const badgeSize = 10
 
 const Badge = styled('div')({
-  bottom: 14,
   display: 'block',
   height: badgeSize,
-  position: 'relative',
-  right: -8,
-  width: badgeSize
+  position: 'absolute',
+  width: badgeSize,
+  right: -1,
+  top: -1,
+  zIndex: 1,
+  [meetingAvatarMediaQueries[0]]: {
+    right: 2,
+    top: 2
+  },
+  [meetingAvatarMediaQueries[1]]: {
+    right: 3,
+    top: 3
+  }
 })
 
 const BadgeDot = styled('div')<{isCommentUnread: boolean}>(({isCommentUnread}) => ({
@@ -97,7 +98,17 @@ const BadgeDot = styled('div')<{isCommentUnread: boolean}>(({isCommentUnread}) =
 const ButtonContainer = styled('div')({
   alignItems: 'center',
   alignContent: 'center',
-  display: 'flex'
+  display: 'flex',
+  height: 32,
+  marginLeft: 11,
+  position: 'relative',
+  [meetingAvatarMediaQueries[0]]: {
+    height: 48,
+    marginLeft: 10
+  },
+  [meetingAvatarMediaQueries[1]]: {
+    height: 56
+  }
 })
 
 const DiscussionButton = styled(PlainButton)({
@@ -105,9 +116,24 @@ const DiscussionButton = styled(PlainButton)({
   backgroundColor: PALETTE.TEXT_PURPLE,
   borderRadius: '50%',
   display: 'flex',
-  padding: 8,
+  padding: 7,
   [meetingAvatarMediaQueries[0]]: {
+    padding: 12
+  },
+  [meetingAvatarMediaQueries[1]]: {
     padding: 10
+  }
+})
+
+const StyledIcon = styled(Icon)({
+  color: '#FFFF',
+  transform: 'scaleX(-1)',
+  fontSize: ICON_SIZE.MD18,
+  [meetingAvatarMediaQueries[0]]: {
+    fontSize: ICON_SIZE.MD24
+  },
+  [meetingAvatarMediaQueries[1]]: {
+    fontSize: ICON_SIZE.MD36
   }
 })
 

--- a/packages/client/components/PokerActiveVoting.tsx
+++ b/packages/client/components/PokerActiveVoting.tsx
@@ -23,8 +23,8 @@ const CheckIcon = styled(Icon)({
 })
 
 const BannerWrap = styled('div')<{showTip: boolean}>(({showTip}) => ({
-  margin: 'auto',
-  padding: '8px 16px 200px', // accounts for deck of cards below the tip
+  margin: '0 auto',
+  padding: '8px 16px',
   opacity: showTip ? 1 : 0,
   transition: `opacity 200ms ${BezierCurve.DECELERATE}`
 }))

--- a/packages/client/components/PokerEstimateHeaderCardJira.tsx
+++ b/packages/client/components/PokerEstimateHeaderCardJira.tsx
@@ -15,7 +15,7 @@ import {Breakpoint} from '~/types/constEnums'
 
 const HeaderCardWrapper = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
   display: 'flex',
-  padding: isDesktop ? '4px 16px' : '4px 8px'
+  padding: isDesktop ? '0px 16px 4px' : '0px 8px 4px'
 }))
 
 const HeaderCard = styled('div')({


### PR DESCRIPTION
@nickoferrall I made a few style changes without bothering you with the details. Merge into your `poker-drawer` branch if you accept!

- [ ] The discussion button matches the avatar size (good for this iteration, I’m thinking of further normalizing these sizes in the top bar in the future)
- [ ] Refines layout of poker estimate phase
- [ ] Refines styling of poker thread header