### PR TITLE
add summary

### DIFF
--- a/packages/client/components/TimelineEventCard.tsx
+++ b/packages/client/components/TimelineEventCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {Component, ReactNode} from 'react'
+import React, {ReactNode} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import {cardShadow} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV2'
@@ -12,7 +12,8 @@ import TimelineEventHeaderMenuToggle from './TimelineEventHeaderMenuToggle'
 
 interface Props {
   children: ReactNode
-  iconName: string
+  iconName?: string
+  IconSVG?: ReactNode
   title: ReactNode
   timelineEvent: TimelineEventCard_timelineEvent
 }
@@ -51,15 +52,6 @@ const EventIcon = styled(Icon)({
   width: 24
 })
 
-// const MenuIcon = styled(Icon)({
-//   color: PALETTE.PRIMARY_MAIN,
-//   position: 'absolute',
-//   fontSize: ICON_SIZE.MD18,
-//   top: 0,
-//   right: 0,
-//   userSelect: 'none'
-// })
-
 const HeaderText = styled('div')({
   display: 'flex',
   flexDirection: 'column',
@@ -70,28 +62,27 @@ const HeaderText = styled('div')({
   paddingTop: 2
 })
 
-class TimelineEventCard extends Component<Props> {
-  render() {
-    const {children, iconName, title, timelineEvent} = this.props
-    const {id: timelineEventId, createdAt, type} = timelineEvent
-    return (
-      <Surface>
-        <CardHeader>
-          <CardTitleBlock>
-            <EventIcon>{iconName}</EventIcon>
-            <HeaderText>
-              {title}
-              <TimelineEventDate createdAt={createdAt} />
-            </HeaderText>
-          </CardTitleBlock>
-          {type == 'retroComplete' || type == 'actionComplete' ? (
-            <TimelineEventHeaderMenuToggle timelineEventId={timelineEventId} />
-          ) : null}
-        </CardHeader>
-        {children}
-      </Surface>
-    )
-  }
+const TimelineEventCard = (props: Props) => {
+  const {children, iconName, IconSVG, title, timelineEvent} = props
+  const {id: timelineEventId, createdAt, type} = timelineEvent
+  return (
+    <Surface>
+      <CardHeader>
+        <CardTitleBlock>
+          {iconName && <EventIcon>{iconName}</EventIcon>}
+          {IconSVG}
+          <HeaderText>
+            {title}
+            <TimelineEventDate createdAt={createdAt} />
+          </HeaderText>
+        </CardTitleBlock>
+        {type == 'retroComplete' || type == 'actionComplete' ? (
+          <TimelineEventHeaderMenuToggle timelineEventId={timelineEventId} />
+        ) : null}
+      </CardHeader>
+      {children}
+    </Surface>
+  )
 }
 
 export default createFragmentContainer(TimelineEventCard, {

--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -2,8 +2,10 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import {NewMeetingPhaseTypeEnum} from '../types/graphql'
 import plural from '../utils/plural'
 import {TimelineEventPokerComplete_timelineEvent} from '../__generated__/TimelineEventPokerComplete_timelineEvent.graphql'
+import CardsSVG from './CardsSVG'
 import StyledLink from './StyledLink'
 import TimelineEventBody from './TimelineEventBody'
 import TimelineEventCard from './TimelineEventCard'
@@ -28,21 +30,30 @@ const TimelineEventPokerComplete = (props: Props) => {
     id: meetingId,
     name: meetingName,
     commentCount,
+    phases
   } = meeting
   const {name: teamName} = team
+  const estimatePhase = phases.find((phase) => phase.phaseType === NewMeetingPhaseTypeEnum.ESTIMATE)!
+  const stages = estimatePhase.stages!
+  const storyCount = new Set(stages.map(({serviceTaskId}) => serviceTaskId)).size
   return (
     <TimelineEventCard
-      iconName='style'
+      IconSVG={<CardsSVG />}
       timelineEvent={timelineEvent}
       title={
         <TimelineEventTitle>{`${meetingName} with ${teamName} Complete`}</TimelineEventTitle>
       }
     >
       <TimelineEventBody>
-        {'You added '}
+        {'You voted on '}
+        <CountItem>
+          {storyCount} {plural(storyCount, 'story', 'stories')}
+        </CountItem>
+        {' and added '}
         <CountItem>
           {commentCount} {plural(commentCount, 'comment')}
         </CountItem>
+        {'.'}
         <br />
         <Link to={`/meet/${meetingId}/estimate/1`}>See the estimates</Link>
         {' in your meeting or '}
@@ -61,6 +72,15 @@ export default createFragmentContainer(TimelineEventPokerComplete, {
         id
         commentCount
         name
+        phases {
+          phaseType
+          ... on EstimatePhase {
+            stages {
+              id
+              serviceTaskId
+            }
+          }
+        }
       }
       team {
         id

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -706,6 +706,11 @@ export interface IJiraIssue {
   commentors: Array<ICommentorDetails> | null;
 
   /**
+   * Alias for summary used by the Story interface
+   */
+  title: string;
+
+  /**
    * The ID of the jira cloud where the issue lives
    */
   cloudId: string;
@@ -775,6 +780,11 @@ export interface IStory {
    * A list of users currently commenting
    */
   commentors: Array<ICommentorDetails> | null;
+
+  /**
+   * The title, independent of the story type
+   */
+  title: string;
 }
 
 export interface IThreadOnStoryArguments {
@@ -1445,6 +1455,11 @@ export interface ITask {
    * A list of users currently commenting
    */
   commentors: Array<ICommentorDetails> | null;
+
+  /**
+   * The first block of the content
+   */
+  title: string;
 
   /**
    * The agenda item that the task was created in, if any

--- a/packages/server/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/server/email/components/SummaryEmail/ExportToCSV.tsx
@@ -9,6 +9,8 @@ import withMutationProps, {WithMutationProps} from 'parabol-client/utils/relay/w
 import {ExportToCSVQuery} from 'parabol-client/__generated__/ExportToCSVQuery.graphql'
 import React, {Component} from 'react'
 import {fetchQuery} from 'react-relay'
+import {PokerCards} from '../../../../client/types/constEnums'
+import {NewMeetingPhaseTypeEnum} from '../../../../client/types/graphql'
 import emailDir from '../../emailDir'
 import AnchorIfEmail from './MeetingSummaryEmail/AnchorIfEmail'
 import EmailBorderBottom from './MeetingSummaryEmail/EmailBorderBottom'
@@ -56,6 +58,25 @@ const query = graphql`
           name
         }
         endedAt
+        ... on PokerMeeting {
+          phases {
+            phaseType
+            ... on EstimatePhase {
+              stages {
+                finalScore
+                dimension {
+                  name
+                }
+                story {
+                  title
+                }
+                scores {
+                  label
+                }
+              }
+            }
+          }
+        }
         ... on ActionMeeting {
           agendaItems {
             content
@@ -104,6 +125,12 @@ const query = graphql`
 type Meeting = NonNullable<NonNullable<ExportToCSVQuery['response']['viewer']>['newMeeting']>
 type ExportableTypeName = 'Task' | 'Reflection' | 'Comment' | 'Reply'
 
+interface CSVPokerRow {
+  story: string
+  dimension: string
+  finalScore: string | number
+  voteCount: number
+}
 interface CSVRetroRow {
   reflectionGroup: string
   author: string
@@ -153,6 +180,27 @@ class ExportToCSV extends Component<Props> {
     }
   }
 
+  handlePokerMeeting(meeting: Meeting) {
+    const rows = [] as CSVPokerRow[]
+    const {phases} = meeting
+    const estimatePhase = phases!.find(
+      (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.ESTIMATE
+    )!
+    const stages = estimatePhase.stages!
+    stages.forEach((stage) => {
+      const {finalScore, dimension, story, scores} = stage
+      const {name} = dimension
+      const title = story?.title ?? 'Unknown Story'
+      const voteCount = scores.filter((score) => score.label !== PokerCards.PASS_CARD).length
+      rows.push({
+        story: title,
+        dimension: name,
+        finalScore: finalScore || '',
+        voteCount
+      })
+    })
+    return rows
+  }
   handleRetroMeeting(newMeeting: Meeting) {
     const {reflectionGroups} = newMeeting
 
@@ -261,8 +309,7 @@ class ExportToCSV extends Component<Props> {
       case 'retrospective':
         return this.handleRetroMeeting(newMeeting)
       case 'poker':
-        // TODO summary
-        return []
+        return this.handlePokerMeeting(newMeeting)
     }
   }
 

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/MeetingMembersWithoutTasks.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/MeetingMembersWithoutTasks.tsx
@@ -6,6 +6,7 @@ import {RETROSPECTIVE} from 'parabol-client/utils/constants'
 import {MeetingMembersWithoutTasks_meeting} from 'parabol-client/__generated__/MeetingMembersWithoutTasks_meeting.graphql'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import {MeetingTypeEnum} from '../../../../../client/types/graphql'
 import EmailBorderBottom from './EmailBorderBottom'
 import SummaryAvatarHeader from './SummaryAvatarHeader'
 
@@ -34,11 +35,12 @@ interface Props {
 const MeetingMembersWithoutTasks = (props: Props) => {
   const {meeting} = props
   const {meetingMembers, meetingType} = meeting
+  if (meetingType === MeetingTypeEnum.poker) return null
   // const meetingMembers = new Array(7).fill(mock)
   const membersWithoutTasks = meetingMembers.filter(
     (member) =>
       ((member.tasks && member.tasks.length) || 0) +
-      ((member.doneTasks && member.doneTasks.length) || 0) ===
+        ((member.doneTasks && member.doneTasks.length) || 0) ===
       0
   )
   membersWithoutTasks.sort((a, b) =>

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/QuickStats.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/QuickStats.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 import makeActionStats from './makeActionStats'
 import makeRetroStats from './makeRetroStats'
+import makePokerStats from './makePokerStats'
 
 const statLabel = (idx, len) =>
   ({
@@ -43,7 +44,8 @@ interface Props {
 
 const quickStatsLookup = {
   [ACTION]: makeActionStats,
-  [RETROSPECTIVE]: makeRetroStats
+  [RETROSPECTIVE]: makeRetroStats,
+  poker: makePokerStats
 }
 
 const QuickStats = (props: Props) => {
@@ -59,10 +61,10 @@ const QuickStats = (props: Props) => {
           {stats.map((stat, idx) => {
             return (
               <td
-                key={stat.label}
+                key={idx}
                 width='25%'
                 align='center'
-                bgcolor={PALETTE.BACKGROUND_MAIN}
+                bgcolor={stat.label ? PALETTE.BACKGROUND_MAIN : undefined}
                 style={statLabel(idx, stats.length)}
               >
                 {stat.value}
@@ -74,10 +76,10 @@ const QuickStats = (props: Props) => {
           {stats.map((stat, idx) => {
             return (
               <td
-                key={stat.label}
+                key={idx}
                 width='25%'
                 align='center'
-                bgcolor={PALETTE.BACKGROUND_MAIN}
+                bgcolor={stat.label ? PALETTE.BACKGROUND_MAIN : undefined}
                 style={descriptionLabel(idx, stats.length)}
               >
                 {stat.label}
@@ -95,6 +97,7 @@ export default createFragmentContainer(QuickStats, {
     fragment QuickStats_meeting on NewMeeting {
       __typename
       meetingType
+      ...makePokerStats_meeting
       ... on RetrospectiveMeeting {
         reflectionGroups(sortBy: voteCount) {
           voteCount

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummaryPokerStories.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummaryPokerStories.tsx
@@ -1,0 +1,115 @@
+import graphql from 'babel-plugin-relay/macro'
+import {PALETTE} from 'parabol-client/styles/paletteV2'
+import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
+import {SummaryPokerStories_meeting} from 'parabol-client/__generated__/SummaryPokerStories_meeting.graphql'
+import React from 'react'
+import {createFragmentContainer} from 'react-relay'
+import {FONT_FAMILY} from '../../../../../client/styles/typographyV2'
+import makeAppLink from '../../../../utils/makeAppLink'
+import AnchorIfEmail from './AnchorIfEmail'
+import EmailBorderBottom from './EmailBorderBottom'
+import {meetingSummaryUrlParams} from 'parabol-server/email/components/MeetingSummaryEmailRootSSR'
+
+const tableStyles = {
+  border: `1px solid ${PALETTE.BORDER_GRAY}`,
+  borderRadius: 8,
+  borderSpacing: 0,
+  marginTop: 24
+}
+
+const rowStyle = {
+  height: 32
+}
+
+const titleStyle = (isLast: boolean) => ({
+  borderBottom: isLast ? undefined : `1px solid ${PALETTE.BORDER_GRAY}`,
+  fontWeight: 600,
+  paddingLeft: 16
+})
+
+const titleLinkStyle = {
+  color: PALETTE.TEXT_BLUE,
+  display: 'block',
+  fontFamily: FONT_FAMILY.SANS_SERIF,
+  fontWeight: 600,
+  textDecoration: 'none'
+}
+
+const scoreStyle = (isLast: boolean) => ({
+  borderBottom: isLast ? undefined : `1px solid ${PALETTE.BORDER_GRAY}`,
+  fontWeight: 600
+})
+
+interface Props {
+  isEmail: boolean
+  meeting: SummaryPokerStories_meeting
+}
+
+const SummaryPokerStories = (props: Props) => {
+  const {isEmail, meeting} = props
+  const {id: meetingId, phases} = meeting
+  const estimatePhase = phases.find((phase) => phase.phaseType === NewMeetingPhaseTypeEnum.ESTIMATE)
+  if (!estimatePhase) return null
+  const stages = estimatePhase.stages!
+  const usedServiceTaskIds = new Set<string>()
+  return (
+    <>
+      <tr>
+        <td>
+          <table width='80%' height='100%' align='center' bgcolor={'#FFFFFF'} style={tableStyles}>
+            <tbody>
+              {stages.map((stage, idx) => {
+                const {id, story, finalScore, serviceTaskId} = stage
+                if (usedServiceTaskIds.has(serviceTaskId)) return null
+                usedServiceTaskIds.add(serviceTaskId)
+                const isLast = idx === stages.length - 1
+                const title = story?.title ?? 'Unknown Story'
+                const urlPath = `meet/${meetingId}/estimate/${usedServiceTaskIds.size}`
+                const to = isEmail
+                  ? makeAppLink(urlPath, {params: meetingSummaryUrlParams})
+                  : `/${urlPath}`
+                return (
+                  <tr style={rowStyle} key={id}>
+                    <td style={titleStyle(isLast)}>
+                      <AnchorIfEmail href={to} isEmail={isEmail} style={titleLinkStyle}>
+                        {title}
+                      </AnchorIfEmail>
+                    </td>
+                    <td align={'center'} style={scoreStyle(isLast)}>
+                      {finalScore || '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      <EmailBorderBottom />
+    </>
+  )
+}
+
+export default createFragmentContainer(SummaryPokerStories, {
+  meeting: graphql`
+    fragment SummaryPokerStories_meeting on PokerMeeting {
+      id
+      phases {
+        phaseType
+        ... on EstimatePhase {
+          stages {
+            id
+            finalScore
+            serviceTaskId
+            story {
+              title
+            }
+            dimension {
+              name
+            }
+          }
+        }
+      }
+    }
+  `
+})

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -15,6 +15,7 @@ import QuickStats from './QuickStats'
 import RetroTopics from './RetroTopics'
 import SummaryHeader from './SummaryHeader'
 import SummarySheetCTA from './SummarySheetCTA'
+import SummaryPokerStories from './SummaryPokerStories'
 
 interface Props {
   emailCSVUrl: string
@@ -55,6 +56,7 @@ const SummarySheet = (props: Props) => {
         <MeetingMembersWithTasks meeting={meeting} />
         <MeetingMembersWithoutTasks meeting={meeting} />
         <RetroTopics isDemo={isDemo} isEmail={referrer === 'email'} meeting={meeting} />
+        <SummaryPokerStories meeting={meeting} isEmail={referrer === 'email'} />
         <ContactUsFooter
           isDemo={isDemo}
           hasLearningLink={meetingType === ACTION}
@@ -76,6 +78,7 @@ export default createFragmentContainer(SummarySheet, {
       ...MeetingMembersWithTasks_meeting
       ...MeetingMembersWithoutTasks_meeting
       ...RetroTopics_meeting
+      ...SummaryPokerStories_meeting
       meetingType
       name
     }

--- a/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/makePokerStats.ts
+++ b/packages/server/email/components/SummaryEmail/MeetingSummaryEmail/makePokerStats.ts
@@ -1,0 +1,50 @@
+import graphql from 'babel-plugin-relay/macro'
+import {NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
+import plural from 'parabol-client/utils/plural'
+import {makePokerStats_meeting} from 'parabol-client/__generated__/makePokerStats_meeting.graphql'
+import {readInlineData} from 'react-relay'
+
+const makePokerStats = (meetingRef: any) => {
+  const meeting = readInlineData<makePokerStats_meeting>(
+    graphql`
+      fragment makePokerStats_meeting on PokerMeeting @inline {
+        meetingMembers {
+          isCheckedIn
+        }
+        phases {
+          phaseType
+          ... on EstimatePhase {
+            stages {
+              finalScore
+              serviceTaskId
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
+
+  const {meetingMembers, phases} = meeting
+  const estimatePhase = phases.find(
+    (phase) => phase.phaseType === NewMeetingPhaseTypeEnum.ESTIMATE
+  )!
+  const stages = estimatePhase.stages!
+  const storyCount = new Set(stages.map((stage) => stage.serviceTaskId)).size
+
+  const meetingMembersCount = meetingMembers.length
+  const meetingMembersPresentCount = meetingMembers.filter((member) => member.isCheckedIn === true)
+    .length
+  const memberCount =
+    meetingMembersPresentCount >= 10
+      ? meetingMembersPresentCount
+      : `${meetingMembersPresentCount}/${meetingMembersCount}`
+  return [
+    {value: '', label: ''},
+    {value: storyCount, label: plural(storyCount, 'Story', 'Stories')},
+    {value: memberCount, label: 'Present'},
+    {value: '', label: ''}
+  ]
+}
+
+export default makePokerStats

--- a/packages/server/graphql/types/JiraIssue.ts
+++ b/packages/server/graphql/types/JiraIssue.ts
@@ -42,6 +42,13 @@ const JiraIssue = new GraphQLObjectType<any, GQLContext>({
       type: GraphQLNonNull(GraphQLString),
       description: 'The plaintext summary of the jira issue'
     },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'Alias for summary used by the Story interface',
+      resolve: ({summary}) => {
+        return summary
+      }
+    },
     description: {
       type: GraphQLNonNull(GraphQLString),
       description: 'The stringified ADF of the jira issue description',

--- a/packages/server/graphql/types/Story.ts
+++ b/packages/server/graphql/types/Story.ts
@@ -1,4 +1,4 @@
-import {GraphQLID, GraphQLNonNull, GraphQLList, GraphQLInterfaceType} from 'graphql'
+import {GraphQLID, GraphQLNonNull, GraphQLList, GraphQLInterfaceType, GraphQLString} from 'graphql'
 import ThreadSource, {threadSourceFields} from './ThreadSource'
 import CommentorDetails from './CommentorDetails'
 
@@ -14,6 +14,10 @@ export const storyFields = () => ({
     resolve: ({commentors = []}) => {
       return commentors
     }
+  },
+  title: {
+    type: GraphQLNonNull(GraphQLString),
+    description: 'The title, independent of the story type'
   }
 })
 

--- a/packages/server/graphql/types/Task.ts
+++ b/packages/server/graphql/types/Task.ts
@@ -103,6 +103,14 @@ const Task = new GraphQLObjectType<any, GQLContext>({
         return dataLoader.get('teams').load(teamId)
       }
     },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'The first block of the content',
+      resolve: ({plaintextContent}) => {
+        const firstBreak = plaintextContent.indexOf('\n')
+        return plaintextContent.slice(0, firstBreak)
+      }
+    },
     userId: {
       type: GraphQLID,
       description:


### PR DESCRIPTION
This adds a summary + svg export for poker meetings.
limited to the first dimension. 
summary follows the same template as the other meetings just so we can get it out the door.
also fixes poker timeline events