### PR TITLE
fix escape handler, reset editingscaleId on exit

### DIFF
--- a/packages/client/components/EditableText.tsx
+++ b/packages/client/components/EditableText.tsx
@@ -167,7 +167,8 @@ class EditableText extends Component<Props, State> {
 
   onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
-      this.reset()
+      // wait a tick so other escape listeners see that this is the active element
+      setTimeout(this.reset)
     }
   }
 

--- a/packages/client/hooks/usePortal.tsx
+++ b/packages/client/hooks/usePortal.tsx
@@ -76,10 +76,19 @@ const usePortal = (options: UsePortalOptions = {}) => {
 
   const handleKeydown = useEventCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') {
-      if (originRef.current) {
-        // give focus back to the thing that opened it
-        originRef.current.focus()
+      const children = Array.from(portalRef.current?.children ?? [])
+      const hasChildModal = children.some((child) => child.id)
+      if (hasChildModal) return
+      const {activeElement, body} = document
+      if (activeElement && activeElement !== body) {
+        const {contentEditable, tagName} = activeElement as HTMLElement
+        // if viewer is typing something, don't close the portal on escape
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || contentEditable === 'true') {
+          return
+        }
       }
+      // give focus back to the thing that opened it
+      originRef.current?.focus()
       closePortal()
     }
   })

--- a/packages/client/modules/meeting/components/PokerTemplateScaleDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateScaleDetails.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useEffect} from 'react'
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import FlatButton from '../../../components/FlatButton'
 import Icon from '../../../components/Icon'
@@ -113,6 +113,7 @@ const PokerTemplateScaleDetails = (props: Props) => {
       store.get(team.id)?.setValue(null, 'editingScaleId')
     })
   }
+  useEffect(() => gotoTemplateDetail, [])
 
   return (
     <ScaleValueEditor>


### PR DESCRIPTION
TEST
- [ ] open the template modal & select a scale. see the scale menu open. hit escape. the scale menu closes but the template modal stays open.
- [ ] edit a scale. then, click a scale value to begin editing. hit escape. the input field blurs, but the modal stays open.
- [ ] hit escape again & the entire modal closes. open it up again & it opens to the template view, not the scale view.
