### PR TITLE
User can pick the color of special cards in scale editor

### DIFF
--- a/packages/client/modules/meeting/components/AddPokerTemplateScaleValue.tsx
+++ b/packages/client/modules/meeting/components/AddPokerTemplateScaleValue.tsx
@@ -1,17 +1,22 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import {PALETTE} from '~/styles/paletteV2'
 import Icon from '../../../components/Icon'
 import LinkButton from '../../../components/LinkButton'
 
 const AddScaleValueLink = styled(LinkButton)({
   alignItems: 'center',
+  borderBottom: `1px solid ${PALETTE.BORDER_LIGHTER}`,
   display: 'flex',
   justifyContent: 'flex-start',
-  fontSize: 16,
+  fontSize: 14, // match the scale item font-size
   lineHeight: '24px',
   margin: 0,
   outline: 'none',
-  padding: '8px 0'
+  padding: '8px 0',
+  ':hover': {
+    backgroundColor: PALETTE.BACKGROUND_LIGHTEST
+  }
 })
 
 const AddScaleValueLinkPlus = styled(Icon)({

--- a/packages/client/modules/meeting/components/AddPokerTemplateScaleValue.tsx
+++ b/packages/client/modules/meeting/components/AddPokerTemplateScaleValue.tsx
@@ -10,7 +10,6 @@ const AddScaleValueLink = styled(LinkButton)({
   fontSize: 16,
   lineHeight: '24px',
   margin: 0,
-  marginBottom: 16,
   outline: 'none',
   padding: '8px 0'
 })

--- a/packages/client/modules/meeting/components/EditableTemplateScaleValueLabel.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplateScaleValueLabel.tsx
@@ -10,13 +10,15 @@ import {EditableTemplateScaleValueLabel_scaleValue} from '~/__generated__/Editab
 import {EditableTemplateScaleValueLabel_scale} from '~/__generated__/EditableTemplateScaleValueLabel_scale.graphql'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
+import isSpecialPokerLabel from '../../../utils/isSpecialPokerLabel'
 
-const StyledEditableText = styled(EditableText)({
+const StyledEditableText = styled(EditableText)<{disabled: boolean | undefined}>(({disabled}) => ({
   fontFamily: PALETTE.TEXT_MAIN,
   fontSize: 14,
   lineHeight: '24px',
-  padding: 0
-})
+  padding: 0,
+  userSelect: disabled ? 'none' : 'auto'
+}))
 
 interface Props {
   isHover: boolean
@@ -67,6 +69,7 @@ const EditableTemplateScaleValueLabel = (props: Props) => {
 
   return (
     <StyledEditableText
+      disabled={isSpecialPokerLabel(scaleValue.label)}
       error={error?.message}
       hideIcon={!isHover}
       handleSubmit={handleSubmit}

--- a/packages/client/modules/meeting/components/PokerTemplateScaleDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateScaleDetails.tsx
@@ -4,7 +4,6 @@ import React, {useEffect} from 'react'
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import FlatButton from '../../../components/FlatButton'
 import Icon from '../../../components/Icon'
-import MenuItemHR from '../../../components/MenuItemHR'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import textOverflow from '../../../styles/helpers/textOverflow'
 import {PALETTE} from '../../../styles/paletteV2'
@@ -72,11 +71,6 @@ const ScaleDetailsTitle = styled('div')({
   userSelect: 'none'
 })
 
-const HR = styled(MenuItemHR)({
-  width: '100%',
-  marginTop: 0
-})
-
 const ScaleValues = styled('div')({
   ...textOverflow,
   color: PALETTE.TEXT_GRAY,
@@ -112,7 +106,6 @@ const PokerTemplateScaleDetails = (props: Props) => {
         </IconButton>
         <ScaleDetailsTitle>{'Edit Scale'}</ScaleDetailsTitle>
       </ScaleDetailHeader>
-      <HR />
       <ScaleHeader>
         <ScaleNameAndValues>
           <EditableTemplateScaleName

--- a/packages/client/modules/meeting/components/TemplateScaleValueItem.tsx
+++ b/packages/client/modules/meeting/components/TemplateScaleValueItem.tsx
@@ -75,13 +75,14 @@ const TemplateScaleValueItem = (props: Props) => {
     submitMutation()
     RemovePokerTemplateScaleValueMutation(atmosphere, {scaleId, label}, {}, onError, onCompleted)
   }
+  const isSpecial = isSpecialPokerLabel(label)
   return (
     <ScaleValueItem
       ref={dragProvided?.innerRef}
       {...dragProvided?.dragHandleProps}
       {...dragProvided?.draggableProps}
       isDragging={isDragging}
-      isHover={isHover}
+      isHover={!isSpecial && isHover}
       onMouseOver={onMouseOver}
       onMouseOut={onMouseOut}
     >
@@ -95,7 +96,7 @@ const TemplateScaleValueItem = (props: Props) => {
         />
       </ScaleAndDescription>
       {
-        !isSpecialPokerLabel(label) &&
+        !isSpecial &&
         <RemoveScaleValueIcon isHover={isHover} onClick={removeScaleValue}>
           cancel
         </RemoveScaleValueIcon>

--- a/packages/client/modules/meeting/components/TemplateScaleValueItem.tsx
+++ b/packages/client/modules/meeting/components/TemplateScaleValueItem.tsx
@@ -10,6 +10,7 @@ import {TemplateScaleValueItem_scale} from '~/__generated__/TemplateScaleValueIt
 import Icon from '../../../components/Icon'
 import {PALETTE} from '../../../styles/paletteV2'
 import {ICON_SIZE} from '../../../styles/typographyV2'
+import isSpecialPokerLabel from '../../../utils/isSpecialPokerLabel'
 import {TemplateScaleValueItem_scaleValue} from '../../../__generated__/TemplateScaleValueItem_scaleValue.graphql'
 import EditableTemplateScaleValueColor from './EditableTemplateScaleValueColor'
 import EditableTemplateScaleValueLabel from './EditableTemplateScaleValueLabel'
@@ -18,7 +19,7 @@ interface Props {
   isDragging: boolean
   scale: TemplateScaleValueItem_scale
   scaleValue: TemplateScaleValueItem_scaleValue
-  dragProvided: DraggableProvided
+  dragProvided?: DraggableProvided
 }
 
 const ScaleValueItem = styled('div')<{isHover: boolean, isDragging: boolean}>(
@@ -76,9 +77,9 @@ const TemplateScaleValueItem = (props: Props) => {
   }
   return (
     <ScaleValueItem
-      ref={dragProvided.innerRef}
-      {...dragProvided.dragHandleProps}
-      {...dragProvided.draggableProps}
+      ref={dragProvided?.innerRef}
+      {...dragProvided?.dragHandleProps}
+      {...dragProvided?.draggableProps}
       isDragging={isDragging}
       isHover={isHover}
       onMouseOver={onMouseOver}
@@ -93,9 +94,12 @@ const TemplateScaleValueItem = (props: Props) => {
           scaleValue={scaleValue}
         />
       </ScaleAndDescription>
-      <RemoveScaleValueIcon isHover={isHover} onClick={removeScaleValue}>
-        cancel
-      </RemoveScaleValueIcon>
+      {
+        !isSpecialPokerLabel(label) &&
+        <RemoveScaleValueIcon isHover={isHover} onClick={removeScaleValue}>
+          cancel
+        </RemoveScaleValueIcon>
+      }
     </ScaleValueItem >
   )
 }

--- a/packages/client/modules/meeting/components/TemplateScaleValueList.tsx
+++ b/packages/client/modules/meeting/components/TemplateScaleValueList.tsx
@@ -4,10 +4,10 @@ import React from 'react'
 import {DragDropContext, Droppable, Draggable, DropResult} from 'react-beautiful-dnd'
 import {createFragmentContainer} from 'react-relay'
 import {TemplateScaleValueList_scale} from '~/__generated__/TemplateScaleValueList_scale.graphql'
-import isSpecialPokerLabel from '../../../utils/isSpecialPokerLabel'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import MovePokerTemplateScaleValueMutation from '../../../mutations/MovePokerTemplateScaleValueMutation'
+import isSpecialPokerLabel from '../../../utils/isSpecialPokerLabel'
 import AddScaleValueButtonInput from './AddScaleValueButtonInput'
 import TemplateScaleValueItem from './TemplateScaleValueItem'
 
@@ -82,6 +82,15 @@ const TemplateScaleValueList = (props: Props) => {
           }}
         </Droppable>
       </DragDropContext>
+      {values
+        .filter(({label}) => isSpecialPokerLabel(label))
+        .map((scaleValue) => (
+          <TemplateScaleValueItem
+            scale={scale}
+            scaleValue={scaleValue}
+            isDragging={false}
+          />
+        ))}
       <AddScaleValueButtonInput scale={scale} />
     </ScaleList>
   )

--- a/packages/client/modules/meeting/components/TemplateScaleValueList.tsx
+++ b/packages/client/modules/meeting/components/TemplateScaleValueList.tsx
@@ -82,6 +82,7 @@ const TemplateScaleValueList = (props: Props) => {
           }}
         </Droppable>
       </DragDropContext>
+      <AddScaleValueButtonInput scale={scale} />
       {values
         .filter(({label}) => isSpecialPokerLabel(label))
         .map((scaleValue) => (
@@ -91,7 +92,6 @@ const TemplateScaleValueList = (props: Props) => {
             isDragging={false}
           />
         ))}
-      <AddScaleValueButtonInput scale={scale} />
     </ScaleList>
   )
 }

--- a/packages/server/graphql/mutations/updatePokerTemplateScaleValue.ts
+++ b/packages/server/graphql/mutations/updatePokerTemplateScaleValue.ts
@@ -49,8 +49,9 @@ const updatePokerTemplateScaleValue = {
 
     // VALIDATION
     const {label: oldScaleLabel} = oldScaleValue
-    if (isSpecialPokerLabel(oldScaleLabel)) {
-      return {error: {message: 'Cannot change a special value'}}
+    const {label: newScaleLabel} = newScaleValue
+    if (isSpecialPokerLabel(oldScaleLabel) && oldScaleLabel !== newScaleLabel) {
+      return {error: {message: 'Cannot change the label for a special scale value'}}
     }
 
     const {values: oldScaleValues} = existingScale

--- a/packages/server/graphql/mutations/updatePokerTemplateScaleValue.ts
+++ b/packages/server/graphql/mutations/updatePokerTemplateScaleValue.ts
@@ -68,7 +68,7 @@ const updatePokerTemplateScaleValue = {
     if (!validateColorValue(color)) {
       return standardError(new Error('Invalid scale color'), {userId: viewerId})
     }
-    if (!validateScaleLabel(label)) {
+    if (!isSpecialPokerLabel(label) && !validateScaleLabel(label)) {
       return standardError(new Error('Invalid scale label'), {userId: viewerId})
     }
 


### PR DESCRIPTION
Resolves #4419 

Tests:
- [ ] ? and Pass values show in the scale details view
- [ ] They are read-only; they can’t be removed
- [ ] They come after all values and can’t be sorted (e.g. 1, 2, 3, ?, Pass where 1, 2, 3 are sortable to a position before ? and Pass)
- [ ] Folks can change the color