### PR TITLE
Fix a bug where user cannot clone a public scale

### DIFF
--- a/packages/client/modules/meeting/components/ScaleActions.tsx
+++ b/packages/client/modules/meeting/components/ScaleActions.tsx
@@ -19,14 +19,16 @@ const CloneAndDelete = styled('div')({
 interface Props {
   scale: ScaleActions_scale
   scaleCount: number
+  teamId: string
 }
 
 const ScaleActions = (props: Props) => {
   const {
     scale,
     scaleCount,
+    teamId
   } = props
-  const {id: scaleId, teamId, isStarter} = scale
+  const {id: scaleId, isStarter} = scale
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
   const canClone = scaleCount < Threshold.MAX_POKER_TEMPLATE_SCALES

--- a/packages/client/modules/meeting/components/ScaleDropdownMenuItem.tsx
+++ b/packages/client/modules/meeting/components/ScaleDropdownMenuItem.tsx
@@ -103,6 +103,7 @@ const ScaleDropdownMenuItem = forwardRef((props: Props, ref) => {
             <ScaleActions
               scale={scale}
               scaleCount={scaleCount}
+              teamId={dimension.team.id}
             />
           </ScaleActionButtonGroup>
         </ScaleDetails>
@@ -116,6 +117,9 @@ export default createFragmentContainer(ScaleDropdownMenuItem, {
     fragment ScaleDropdownMenuItem_dimension on TemplateDimension {
       id
       selectedScale {
+        id
+      }
+      team {
         id
       }
     }


### PR DESCRIPTION
Resolves #4457 

The bug is that when we clone a scale, we should not use the `teamId` for that scale. For pre-defined the scale, the `teamId` is _aGhostTeam_ so not matching with the viewer from server side, hence the request was rejected. The fix is to use the `teamId` for the dimension.

Tests:
- [ ] User can clone a pre-defined scale
- [ ] User can still create a new scale