### PR TITLE
scale editor ui refinements

### DIFF
--- a/packages/client/modules/meeting/components/AddPokerTemplateScaleValue.tsx
+++ b/packages/client/modules/meeting/components/AddPokerTemplateScaleValue.tsx
@@ -1,17 +1,22 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import {PALETTE} from '~/styles/paletteV2'
 import Icon from '../../../components/Icon'
 import LinkButton from '../../../components/LinkButton'
 
 const AddScaleValueLink = styled(LinkButton)({
   alignItems: 'center',
+  borderBottom: `1px solid ${PALETTE.BORDER_LIGHTER}`,
   display: 'flex',
   justifyContent: 'flex-start',
-  fontSize: 16,
+  fontSize: 14, // match the scale item font-size
   lineHeight: '24px',
   margin: 0,
   outline: 'none',
-  padding: '8px 0'
+  padding: '8px 0',
+  ':hover': {
+    backgroundColor: PALETTE.BACKGROUND_LIGHTEST
+  }
 })
 
 const AddScaleValueLinkPlus = styled(Icon)({

--- a/packages/client/modules/meeting/components/PokerTemplateScaleDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateScaleDetails.tsx
@@ -4,7 +4,6 @@ import React, {useEffect} from 'react'
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import FlatButton from '../../../components/FlatButton'
 import Icon from '../../../components/Icon'
-import MenuItemHR from '../../../components/MenuItemHR'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import textOverflow from '../../../styles/helpers/textOverflow'
 import {PALETTE} from '../../../styles/paletteV2'
@@ -72,11 +71,6 @@ const ScaleDetailsTitle = styled('div')({
   userSelect: 'none'
 })
 
-const HR = styled(MenuItemHR)({
-  width: '100%',
-  marginTop: 0
-})
-
 const ScaleValues = styled('div')({
   ...textOverflow,
   color: PALETTE.TEXT_GRAY,
@@ -112,7 +106,6 @@ const PokerTemplateScaleDetails = (props: Props) => {
         </IconButton>
         <ScaleDetailsTitle>{'Edit Scale'}</ScaleDetailsTitle>
       </ScaleDetailHeader>
-      <HR />
       <ScaleHeader>
         <ScaleNameAndValues>
           <EditableTemplateScaleName

--- a/packages/client/modules/meeting/components/TemplateScaleValueItem.tsx
+++ b/packages/client/modules/meeting/components/TemplateScaleValueItem.tsx
@@ -75,13 +75,14 @@ const TemplateScaleValueItem = (props: Props) => {
     submitMutation()
     RemovePokerTemplateScaleValueMutation(atmosphere, {scaleId, label}, {}, onError, onCompleted)
   }
+  const isSpecial = isSpecialPokerLabel(label)
   return (
     <ScaleValueItem
       ref={dragProvided?.innerRef}
       {...dragProvided?.dragHandleProps}
       {...dragProvided?.draggableProps}
       isDragging={isDragging}
-      isHover={isHover}
+      isHover={!isSpecial && isHover}
       onMouseOver={onMouseOver}
       onMouseOut={onMouseOut}
     >
@@ -95,7 +96,7 @@ const TemplateScaleValueItem = (props: Props) => {
         />
       </ScaleAndDescription>
       {
-        !isSpecialPokerLabel(label) &&
+        !isSpecial &&
         <RemoveScaleValueIcon isHover={isHover} onClick={removeScaleValue}>
           cancel
         </RemoveScaleValueIcon>


### PR DESCRIPTION
- The inline action to create items uses the same font-size as items; adds a hover state
- Adds a border to separate editable items from special items
- No hover for special items
- Yanks the HR in the header