### PR TITLE
Enable multidomain SAML

### DIFF
--- a/packages/client/utils/getSSODomainFromEmail.ts
+++ b/packages/client/utils/getSSODomainFromEmail.ts
@@ -1,9 +1,7 @@
-const getSSODomainFromEmail = (email) => {
+const getSSODomainFromEmail = (email: string) => {
   const [, domainWithTld] = email.toLowerCase().split('@')
   if (!domainWithTld) return null
-  const lastDotIdx = domainWithTld.lastIndexOf('.')
-  const lastSafeDotIdx = lastDotIdx === -1 ? 1e6 : lastDotIdx
-  return domainWithTld.slice(0, lastSafeDotIdx)
+  return domainWithTld
 }
 
 export default getSSODomainFromEmail

--- a/packages/server/database/migrations/20201222114114-samlDomains.ts
+++ b/packages/server/database/migrations/20201222114114-samlDomains.ts
@@ -1,0 +1,42 @@
+import {R} from 'rethinkdb-ts'
+export const up = async function (r: R) {
+  try {
+    await Promise.all([
+      r.table('SAML').indexCreate('domains', {multi: true}).run(),
+      r.table('SAML').indexDrop('domain')
+    ])
+  } catch (e) {
+    // noop
+  }
+  try {
+    await r.table('SAML')
+      .replace((row) => row
+        .merge({domains: [row('domain').add('.com')]})
+        .without('domain', 'cert')
+      )
+      .run()
+  } catch (e) {
+    // noop
+  }
+}
+
+export const down = async function (r: R) {
+  try {
+    await Promise.all([
+      r.table('SAML').indexCreate('domain').run(),
+      r.table('SAML').indexDrop('domains')
+    ])
+  } catch (e) {
+    // noop
+  }
+  try {
+    await r.table('SAML')
+      .replace((row) => row
+        .merge({domain: row('domain').nth(0).split('.').nth(0)})
+        .without('domains')
+      )
+      .run()
+  } catch (e) {
+    // noop
+  }
+}

--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -106,13 +106,13 @@ export type RethinkSchema = {
   }
   Notification: {
     type:
-      | NotificationTaskInvolves
-      | NotificationTeamArchived
-      | NotificationMeetingStageTimeLimitEnd
-      | NotificationPaymentRejected
-      | NotificationKickedOut
-      | NotificationPromoteToBillingLeader
-      | NotificationTeamInvitation
+    | NotificationTaskInvolves
+    | NotificationTeamArchived
+    | NotificationMeetingStageTimeLimitEnd
+    | NotificationPaymentRejected
+    | NotificationKickedOut
+    | NotificationPromoteToBillingLeader
+    | NotificationTeamInvitation
     index: 'userId'
   }
   Organization: {
@@ -153,7 +153,7 @@ export type RethinkSchema = {
   }
   SAML: {
     type: SAML
-    index: 'domain'
+    index: 'domains'
   }
   ScheduledJob: {
     type: ScheduledJob

--- a/packages/server/database/types/SAML.ts
+++ b/packages/server/database/types/SAML.ts
@@ -1,31 +1,25 @@
-import shortid from 'shortid'
-
 interface Input {
-  id?: string
-  domain: string
-  cert: string
+  id: string
+  domains: string[]
   url: string
   metadata: string
 }
 
 export default class SAML {
   id: string
-  domain: string
-  cert: string
+  domains: string[]
   url: string
   metadata: string
 
   constructor(input: Input) {
     const {
       id,
-      domain,
-      cert,
+      domains,
       url,
       metadata
     } = input
-    this.id = id || shortid.generate()
-    this.domain = domain
-    this.cert = cert
+    this.id = id
+    this.domains = domains
     this.url = url
     this.metadata = metadata
   }

--- a/packages/server/graphql/intranetSchema/mutations/backupOrganization.ts
+++ b/packages/server/graphql/intranetSchema/mutations/backupOrganization.ts
@@ -298,7 +298,7 @@ const backupOrganization = {
         .coerceTo('array')
         .do((domains) => {
           return r({
-            SAML: (r.table('SAML').getAll(r.args(domains), {index: 'domain'}) as any)
+            SAML: (r.table('SAML').getAll(r.args(domains), {index: 'domains'}) as any)
               .coerceTo('array')
               .do((items) =>
                 r

--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -1,39 +1,101 @@
-import {GraphQLNonNull, GraphQLString, GraphQLBoolean} from 'graphql'
+import {GraphQLID, GraphQLList, GraphQLNonNull, GraphQLString} from 'graphql'
+import * as samlify from 'samlify'
+import {v4 as uuid} from 'uuid'
+import zlib from 'zlib'
 import getRethink from '../../../database/rethinkDriver'
+import EnableSAMLForDomainPayload from '../types/EnableSAMLForDomainPayload'
+
+const AZURE_AD_LOGIN_URL_HOSTNAME = `microsoftonline`
+
+const isMicrosoft = (url: string): boolean =>
+  new URL(url).hostname.includes(AZURE_AD_LOGIN_URL_HOSTNAME)
+
+const getURLWithSAMLRequestParam = (destination: string, slug: string) => {
+  const template = `
+  <samlp:AuthnRequest
+      xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_${uuid()}" Version="2.0" IssueInstant="${new Date().toISOString()}" Destination="${destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://action.parabol.co/saml/${slug}">
+  <saml:Issuer>https://action.parabol.co/saml-metadata/${slug}</saml:Issuer>
+      <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" AllowCreate="false"/>
+  </samlp:AuthnRequest>
+  `
+  const SAMLRequest = encodeURIComponent(zlib.deflateRawSync(template).toString('base64'))
+  const url = new URL(destination)
+  url.searchParams.append('SAMLRequest', SAMLRequest)
+  return url.toString()
+}
 
 const enableSAMLForDomain = {
-  type: new GraphQLNonNull(GraphQLBoolean),
+  type: new GraphQLNonNull(EnableSAMLForDomainPayload),
   description: 'Enable SAML for domain',
   args: {
-    url: {
-      type: new GraphQLNonNull(GraphQLString)
+    name: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'A name to use for the redirect URL. Usually the company name without any spaces'
     },
-    domain: {
-      type: GraphQLNonNull(GraphQLString)
+    domains: {
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLID))),
+      description: 'a list of domains that the account has control over. usually the part after the @ of their email'
     },
     metadata: {
-      type: GraphQLNonNull(GraphQLString)
+      type: GraphQLNonNull(GraphQLString),
+      description: 'A big chunk of XML data containing th redirect URL and X.509 certificate'
     }
   },
-  async resolve(_source, {url, domain, metadata}) {
+  async resolve(_source, {name, domains, metadata}) {
     const r = await getRethink()
-    const normalizedDomain = domain.toLowerCase()
-    const normalizedUrl = url.toLowerCase()
+    const normalizedDomains = domains.map((domain) => domain.toLowerCase())
+    const normalizedName = name.trim().toLowerCase()
 
+    // VALIDATION
+    const nameRegex = /^[a-z0-9_-]+$/
+    if (!nameRegex.test(normalizedName)) {
+      return {error: {message: 'Name must be letters and numbers or _ or - with no spaces'}}
+    }
+    const idp = samlify.IdentityProvider({metadata})
+    const {singleSignOnService} = idp.entityMeta.meta
+    const [fallbackKey] = Object.keys(singleSignOnService)
+    if (!fallbackKey) {
+      return {error: {message: 'Invalid metadata. Does not contain sign on URL'}}
+    }
+    const postKey = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
+    const signOnURL = singleSignOnService[postKey] || singleSignOnService[fallbackKey]
+    try {
+      new URL(signOnURL)
+    } catch (e) {
+      return {error: {message: `Invalid Sign on URL: ${signOnURL}`}}
+    }
+
+    const conflictingRecord = await r
+      .table('SAML')
+      .getAll(r.args(normalizedDomains), {index: 'domains'})
+      .filter({id: name})
+      .nth(0)
+      .default(null)
+      .run()
+
+    if (conflictingRecord) {
+      const {id: conflictId, domains: conflictDomains} = conflictingRecord
+      const domainStr = conflictDomains.join(', ')
+      return {error: {message: `${conflictId} already controls ${domainStr}`}}
+    }
+
+    // RESOLUTION
+    const url = isMicrosoft(signOnURL) ? getURLWithSAMLRequestParam(signOnURL, normalizedName) : signOnURL
     await r
       .table('SAML')
       .insert(
         {
-          id: normalizedDomain,
-          domain: normalizedDomain,
-          url: normalizedUrl,
+          id: normalizedName,
+          domains: normalizedDomains,
+          url,
           metadata: metadata
         },
         {conflict: 'replace'}
       )
       .run()
 
-    return true
+    return {success: true}
   }
 }
 

--- a/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
+++ b/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
@@ -1,6 +1,6 @@
 import * as validator from '@authenio/samlify-node-xmllint'
 import base64url from 'base64url'
-import {GraphQLNonNull, GraphQLString} from 'graphql'
+import {GraphQLID, GraphQLNonNull, GraphQLString} from 'graphql'
 import {TierEnum} from 'parabol-client/types/graphql'
 import getSSODomainFromEmail from 'parabol-client/utils/getSSODomainFromEmail'
 import querystring from 'querystring'
@@ -8,7 +8,6 @@ import * as samlify from 'samlify'
 import shortid from 'shortid'
 import getRethink from '../../../database/rethinkDriver'
 import AuthToken from '../../../database/types/AuthToken'
-import SAML from '../../../database/types/SAML'
 import User from '../../../database/types/User'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
 import bootstrapNewUser from '../../mutations/helpers/bootstrapNewUser'
@@ -35,26 +34,25 @@ const loginSAML = {
   args: {
     queryString: {
       type: new GraphQLNonNull(GraphQLString),
-      description: 'The querystring provided by the iDP including SAMLResponse and RelayState'
+      description: 'The querystring provided by the IdP including SAMLResponse and RelayState'
     },
-    domain: {
-      type: GraphQLNonNull(GraphQLString),
-      description: 'The domain the viewer is attempting to login to'
+    samlName: {
+      type: GraphQLNonNull(GraphQLID),
+      description: 'The name of the SAML identifier. The slug used in the redirect URL'
     }
   },
-  async resolve(_source, {domain, queryString}) {
+  async resolve(_source, {samlName, queryString}) {
     const r = await getRethink()
     const now = new Date()
     const body = querystring.parse(queryString)
-    const normalizedDomain = domain.toLowerCase()
-    const doc = (await r
+    const normalizedName = samlName.trim().toLowerCase()
+    const doc = await r
       .table('SAML')
-      .getAll(normalizedDomain, {index: 'domain'})
-      .nth(0)
-      .default(null)
-      .run()) as SAML | null
-    if (!doc) return {error: {message: 'Domain not yet created on Parabol'}}
-    const {metadata} = doc
+      .get(normalizedName)
+      .run()
+
+    if (!doc) return {error: {message: `${normalizedName} has not been created in Parabol yet`}}
+    const {domains, metadata} = doc
     const idp = samlify.IdentityProvider({metadata})
     let loginResponse
     try {
@@ -74,9 +72,9 @@ const loginSAML = {
       return {error: {message: 'Email attribute was not included in SAML response'}}
     }
     const ssoDomain = getSSODomainFromEmail(email)
-    if (ssoDomain !== normalizedDomain) {
+    if (!ssoDomain || !domains.includes(ssoDomain)) {
       // don't blindly trust the IdP
-      return {error: {message: `Email domain must be ${normalizedDomain}`}}
+      return {error: {message: `${email} does not belong to ${domains.join(', ')}`}}
     }
 
     const user = await r

--- a/packages/server/graphql/intranetSchema/types/EnableSAMLForDomainPayload.ts
+++ b/packages/server/graphql/intranetSchema/types/EnableSAMLForDomainPayload.ts
@@ -1,0 +1,16 @@
+import {GraphQLBoolean, GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import {GQLContext} from '../../graphql'
+import makeMutationPayload from '../../types/makeMutationPayload'
+
+export const EnableSAMLForDomainSuccess = new GraphQLObjectType<any, GQLContext>({
+  name: 'EnableSAMLForDomainSuccess',
+  fields: () => ({
+    success: {
+      type: GraphQLNonNull(GraphQLBoolean)
+    }
+  })
+})
+
+const EnableSAMLForDomainPayload = makeMutationPayload('EnableSAMLForDomainPayload', EnableSAMLForDomainSuccess)
+
+export default EnableSAMLForDomainPayload

--- a/packages/server/utils/SAMLHandler.ts
+++ b/packages/server/utils/SAMLHandler.ts
@@ -4,8 +4,8 @@ import parseBody from '../parseBody'
 import publishWebhookGQL from './publishWebhookGQL'
 
 const query = `
-mutation LoginSAML($queryString: String!, $domain: String!) {
-  loginSAML(queryString: $queryString, domain: $domain) {
+mutation LoginSAML($queryString: String!, $samlName: ID!) {
+  loginSAML(queryString: $queryString, samlName: $samlName) {
     error {
       message
     }
@@ -24,14 +24,14 @@ const redirectOnError = (res: HttpResponse, error: string) => {
 const GENERIC_ERROR = 'Error signing in|Please try again'
 
 const SAMLHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
-  const domain = req.getParameter(0)
-  if (!domain) {
-    redirectOnError(res, 'No Domain Provided!|Did you set up the service provider correctly?')
+  const samlName = req.getParameter(0)
+  if (!samlName) {
+    redirectOnError(res, 'Invalid redirect URL!|Did you set up the service provider correctly?')
     return
   }
   const parser = (buffer: Buffer) => buffer.toString()
   const queryString = await parseBody({res, parser})
-  const payload = await publishWebhookGQL(query, {domain, queryString})
+  const payload = await publishWebhookGQL(query, {samlName, queryString})
   if (!payload) return
   const {data, errors} = payload
   if (!data || errors) {

--- a/packages/server/utils/getSAMLURLFromEmail.ts
+++ b/packages/server/utils/getSAMLURLFromEmail.ts
@@ -17,7 +17,7 @@ const getSAMLURLFromEmail = async (email: string, isInvited?: boolean | null) =>
   const r = await getRethink()
   const baseURL = (await r
     .table('SAML')
-    .getAll(domainName, {index: 'domain'})
+    .getAll(domainName, {index: 'domains'})
     .nth(0)('url')
     .default(null)
     .run()) as string | null


### PR DESCRIPTION
we've got a customer who's been waiting for this, so we gotta get this out.
This replaces #4440 

Big picture, this replaces SAML.domain with SAML.domains. It also adds the tld to all domains. that way, a company like "parabol" can have ownership over "prbl.in" and "parabol.co" and folks with either email can still log in via saml. 