### PR TITLE
Do not scroll to the last meeting type in meeting lobby when selected team is changed

### DIFF
--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -137,7 +137,7 @@ const NewMeeting = (props: Props) => {
     const {lastMeetingType} = selectedTeam
     const meetingIdx = newMeetingOrder.indexOf(lastMeetingType)
     setIdx(meetingIdx)
-  }, [teamId])
+  }, [])
   if (!teamId || !selectedTeam) return null
   return (
     <NewMeetingBlock innerWidth={innerWidth} isDesktop={isDesktop}>


### PR DESCRIPTION
Resolves #4484 

Tests:
- [ ] When user enters meeting lobby from team dash, it automatically selects the type of last meeting the team held
- [ ] If user changes the team, the meeting type stays unchanged