### PR TITLE
Fix migration

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,7 +63,7 @@
     "relay-compiler-language-typescript": "^13.0.2",
     "relay-config": "^8.0.0",
     "relay-runtime": "https://github.com/mattkrick/relay/tarball/ea411fa5aa507b9c1082f12e6111bdea7186c817",
-    "rethinkdb-ts-migrate": "^0.2.1",
+    "rethinkdb-ts-migrate": "^0.3.1",
     "script-ext-html-webpack-plugin": "2.1.5",
     "style-loader": "2.0.0",
     "sucrase": "^3.16.0",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,13 +1,14 @@
-import path from 'path'
-import * as migrate from 'rethinkdb-ts-migrate'
-import {parse} from 'url'
-import getProjectRoot from '../webpack/utils/getProjectRoot'
-import * as driver from 'rethinkdb-ts'
+require('./webpack/utils/dotenv')
+const path = require('path')
+const migrate = require('rethinkdb-ts-migrate')
+const {parse} = require('url')
+const getProjectRoot = require('./webpack/utils/getProjectRoot')
 
 const startMigration = async (direction = 'up') => {
 
   // migrating up goes all the way, migrating down goes down by 1
   const all = direction === 'up'
+  console.log('running migration', direction)
   if (process.env.NODE_ENV === 'test') {
     console.log('NODE_ENV is test, loading .env.test...')
   }
@@ -18,18 +19,18 @@ const startMigration = async (direction = 'up') => {
   process.env.port = port
   process.env.db = urlPath.slice(1)
   process.env.r = process.cwd()
+  let r
   try {
-    await migrate[direction]({all, root: DB_ROOT})
+    r = await migrate[direction]({all, root: DB_ROOT})
   } catch (e) {
     console.error('Migration error', e)
-  } finally {
-    await driver.r.getPoolMaster().drain()
   }
 }
 
 if (require.main === module) {
   const [, , direction = 'up'] = process.argv
-  startMigration(direction)
+  const dir = direction === 'up' || direction === 'down' ? direction : undefined
+  startMigration(dir)
 }
 
-export default startMigration
+module.exports = startMigration

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -19,9 +19,8 @@ const startMigration = async (direction = 'up') => {
   process.env.port = port
   process.env.db = urlPath.slice(1)
   process.env.r = process.cwd()
-  let r
   try {
-    r = await migrate[direction]({all, root: DB_ROOT})
+    await migrate[direction]({all, root: DB_ROOT})
   } catch (e) {
     console.error('Migration error', e)
   }

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -8,7 +8,6 @@ const startMigration = async (direction = 'up') => {
 
   // migrating up goes all the way, migrating down goes down by 1
   const all = direction === 'up'
-  console.log('running migration', direction)
   if (process.env.NODE_ENV === 'test') {
     console.log('NODE_ENV is test, loading .env.test...')
   }

--- a/scripts/webpack/toolbox.config.js
+++ b/scripts/webpack/toolbox.config.js
@@ -21,7 +21,6 @@ module.exports = {
   },
   entry: {
     updateSchema: [DOTENV, path.join(SERVER_ROOT, 'utils', 'updateGQLSchema.ts')],
-    migrateDB: [DOTENV, path.join(TOOLBOX_SRC, 'migrate.ts')],
     createMigration: [DOTENV, path.join(TOOLBOX_SRC, 'migrate-create.ts')],
     postDeploy: [DOTENV, path.join(TOOLBOX_SRC, 'postDeploy.ts')],
     softenDurability: [DOTENV, path.join(TOOLBOX_SRC, 'softenDurability.ts')],


### PR DESCRIPTION
pulling from a fresh computer & i noticed `db:migrate` wasn't doing what it was supposed to do.
this fixes that

the problem was that require.main !== module for webpack assets. TBH i'm not sure how this worked before...
the fix was to remove migrate from the toolbox, that way it can be called by CLI & imported.
the DB pool was also not drained. this was because rethinkdb-ts-migrate was using a different version of the driver so we couldn't access that singleton. this was fixed by having that package drain the pool after migrating.