### PR TITLE
jira search touchups

### DIFF
--- a/packages/client/components/JiraScopingSearchFilterMenu.tsx
+++ b/packages/client/components/JiraScopingSearchFilterMenu.tsx
@@ -116,7 +116,9 @@ const JiraScopingSearchFilterMenu = (props: Props) => {
   const toggleJQL = () => {
     commitLocalUpdate(atmosphere, (store) => {
       const searchQueryId = `jiraSearchQuery:${meetingId}`
-      const jiraSearchQuery = store.get<IJiraSearchQuery>(searchQueryId)!
+      const jiraSearchQuery = store.get<IJiraSearchQuery>(searchQueryId)
+      // this might bork if the checkbox is ticked before the full query loads
+      if (!jiraSearchQuery) return
       jiraSearchQuery.setValue(!isJQL, 'isJQL')
       jiraSearchQuery.setValue([], 'projectKeyFilters')
     })

--- a/packages/client/components/JiraScopingSearchInput.tsx
+++ b/packages/client/components/JiraScopingSearchInput.tsx
@@ -3,15 +3,15 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import Atmosphere from '~/Atmosphere'
+import {SearchQueryMeetingPropName} from '~/utils/relay/LocalPokerHandler'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {PALETTE} from '../styles/paletteV2'
 import {JiraScopingSearchInput_meeting} from '../__generated__/JiraScopingSearchInput_meeting.graphql'
 import Icon from './Icon'
-import {SearchQueryMeetingPropName} from '~/utils/relay/LocalPokerHandler'
 
 const SearchInput = styled('input')({
   appearance: 'none',
-  border: '1px solid transparent',
+  border: 'none',
   color: PALETTE.TEXT_MAIN,
   fontSize: 16,
   margin: 0,
@@ -49,9 +49,10 @@ interface Props {
 const JiraScopingSearchInput = (props: Props) => {
   const {meeting} = props
   const {id: meetingId, jiraSearchQuery} = meeting
-  const {queryString} = jiraSearchQuery
+  const {isJQL, queryString} = jiraSearchQuery
   const isEmpty = !queryString
   const atmosphere = useAtmosphere()
+  const placeholder = isJQL ? `SPRINT = fun AND PROJECT = dev` : 'Search issues on Jira'
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const {value} = e.target
     setSearch(atmosphere, meetingId, value)
@@ -61,7 +62,7 @@ const JiraScopingSearchInput = (props: Props) => {
   }
   return (
     <Wrapper>
-      <SearchInput value={queryString} placeholder={'Search issues on Jira'} onChange={onChange} />
+      <SearchInput value={queryString} placeholder={placeholder} onChange={onChange} />
       <ClearSearchIcon isEmpty={isEmpty} onClick={clearSearch}>
         close
       </ClearSearchIcon>
@@ -75,6 +76,7 @@ export default createFragmentContainer(JiraScopingSearchInput, {
       id
       jiraSearchQuery {
         queryString
+        isJQL
       }
     }
   `


### PR DESCRIPTION
Kinda fixes #4568.
The root cause of that issue is jira's own API sucks for searching.
This PR does the following:
- Adds a placeholder with example JQL when JQL search is turned on
- fixes a bug if someone turns on JQL too fast
- shows the mock loading bars when a search is in progress. this is a little more jerky than ideal, but we need to show folks that a search is pending