### PR TITLE
Fix Sentry error message in renderQuery

### DIFF
--- a/packages/client/utils/relay/renderQuery.tsx
+++ b/packages/client/utils/relay/renderQuery.tsx
@@ -3,6 +3,7 @@ import {TransitionGroup} from 'react-transition-group'
 import AnimatedFade from '../../components/AnimatedFade'
 import ErrorComponent from '../../components/ErrorComponent/ErrorComponent'
 import LoadingComponent from '../../components/LoadingComponent/LoadingComponent'
+import * as Sentry from '@sentry/browser'
 
 interface Options {
   Loader?: ReactNode
@@ -29,8 +30,9 @@ const renderQuery = (ReadyComponent: ComponentType<any>, options: Options = {}) 
   let child
   let key
   if (error) {
+    const eventId = Sentry.captureException(error)
     key = 'Error'
-    child = <Error error={error} eventId={''} />
+    child = <Error error={error} eventId={eventId} />
   } else if (props) {
     key = 'Ready'
     child = <ReadyComponent {...(options.props || {})} viewer={props.viewer} retry={retry} />


### PR DESCRIPTION
PR to help debug issue #4542.

This PR adds an event id to the render query so that the error is sent to Sentry.

I haven't been able to reproduce this bug after:
- Replicating the `AcceptTeamInvitationMutation` and accepting new joiners _many, many_ times
- Using CrossBrowserTesting to test Chrome, Edge and Firefox on Windows. I've tested those same browsers on a Mac as well as Safari and tested Chrome on my iPhone. 
- Throttling the network speed

It looks like the `tags` error that you mentioned Matt has only surfaced in the past [couple of weeks](https://sentry.io/organizations/parabol/discover/results/?environment=server&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=107196&query=Cannot+read+property+%27tags%27+of+undefined&sort=-timestamp&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1) and as this issue has been going on for longer, I think it's unlikely that they're related.

Hopefully, fixing the Sentry error message will point us in the right direction. It's unlikely but possible that locking `AcceptTeamInvitationMutation` could help resolve this bug too.

I suggest that I send the customer an email updating them and asking them to let me know if the error occurs during their next Retro.