### PR TITLE
Retro columns fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ yarn db:start
 $ yarn dev
 ```
 
-If yarn db:start failed and localhost:5050 isn't working, a docker
+If `yarn db:start` failed and `localhost:5050` isn't working, a docker
 container, volume or image may be corrupted and need to be pruned.
 
 Build for production and start application:

--- a/packages/client/components/GroupingKanbanColumn.tsx
+++ b/packages/client/components/GroupingKanbanColumn.tsx
@@ -53,7 +53,8 @@ const ColumnScrollContainer = styled('div')({
   display: 'flex',
   // must hide X on firefox v84
   overflowX: 'hidden',
-  overflowY: 'auto'
+  overflowY: 'auto',
+  height: '100%'
 })
 
 const ColumnBody = styled('div')<{isDesktop: boolean; isWidthExpanded: boolean}>(

--- a/packages/client/components/GroupingKanbanColumn.tsx
+++ b/packages/client/components/GroupingKanbanColumn.tsx
@@ -67,7 +67,8 @@ const ColumnBody = styled('div')<{isDesktop: boolean; isWidthExpanded: boolean}>
     maxHeight: 'fit-content',
     minHeight: 200,
     padding: `${isWidthExpanded ? 12 : 6}px ${isDesktop ? 12 : 8}px`,
-    transition: `all 100ms ${BezierCurve.DECELERATE}`
+    transition: `all 100ms ${BezierCurve.DECELERATE}`,
+    minWidth: ElementWidth.REFLECTION_COLUMN
   })
 )
 


### PR DESCRIPTION
While working on issue #4531, I noticed two UI bugs that this PR resolves:

1. On Windows, removing a reflection from a reflection group can cause `ColumnScrollContainer` to show a vertical scrollbar
2. If a column has two sub columns and you remove all of the reflections from one of the sub columns, the column will automatically minimise. By adding a `minWidth`, the column will only expand or minimise when the user decides.