### PR TITLE
Fix new joiner infinite loop 

### DIFF
--- a/packages/client/components/ViewerNotOnTeam.tsx
+++ b/packages/client/components/ViewerNotOnTeam.tsx
@@ -24,6 +24,7 @@ interface Props {
 const ViewerNotOnTeam = (props: Props) => {
   const {viewer} = props
   const {
+    meeting,
     teamInvitation: {teamInvitation, meetingId, teamId}
   } = viewer
   const atmosphere = useAtmosphere()
@@ -41,10 +42,15 @@ const ViewerNotOnTeam = (props: Props) => {
           {invitationToken: teamInvitation.token},
           {history, meetingId}
         )
-      } else if (isOnTeam) {
-        // if already on the team, goto team dash
-        const redirectTo = getValidRedirectParam()
-        const nextRoute = redirectTo || `/team/${teamId}`
+        return
+      }
+      const redirectTo = getValidRedirectParam()
+      // if already on the team, go to team dash
+      const nextRoute = redirectTo || `/team/${teamId}`
+      const isRoutingToMeeting = nextRoute === `/meet/${meetingId}`
+      const isRoutingToTeam = nextRoute === `/team/${teamId}`
+      const isNextRoutePossible = (isOnTeam && isRoutingToTeam) || (meeting && isRoutingToMeeting)
+      if (isNextRoutePossible) {
         history.replace(nextRoute)
       } else if (teamId) {
         PushInvitationMutation(atmosphere, {meetingId, teamId})
@@ -82,6 +88,9 @@ const ViewerNotOnTeam = (props: Props) => {
 export default createFragmentContainer(ViewerNotOnTeam, {
   viewer: graphql`
     fragment ViewerNotOnTeam_viewer on User {
+      meeting(meetingId: $meetingId) {
+        meetingType
+      }
       teamInvitation(teamId: $teamId, meetingId: $meetingId) {
         teamInvitation {
           token

--- a/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
@@ -4,7 +4,6 @@ import {createFragmentContainer} from 'react-relay'
 import {Route} from 'react-router'
 import {matchPath, Switch} from 'react-router-dom'
 import ErrorBoundary from '~/components/ErrorBoundary'
-import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useRouter from '../../../../hooks/useRouter'
 import {TeamContainer_viewer} from '../../../../__generated__/TeamContainer_viewer.graphql'
 import Team from '../../components/Team/Team'
@@ -31,16 +30,12 @@ const TeamContainer = (props: Props) => {
   const {history, match} = useRouter()
   const {location} = window
   const {pathname} = location
-  const atmosphere = useAtmosphere()
   useEffect(() => {
     if (viewer && !viewer.team) {
-      const tms = atmosphere.authObj?.tms ?? []
-      if (!tms.includes(teamId)) {
-        history.replace({
-          pathname: `/invitation-required`,
-          search: `?redirectTo=${encodeURIComponent(pathname)}&teamId=${teamId}`
-        })
-      }
+      history.replace({
+        pathname: `/invitation-required`,
+        search: `?redirectTo=${encodeURIComponent(pathname)}&teamId=${teamId}`
+      })
     }
   })
   if (viewer && !viewer.team) return null
@@ -60,7 +55,9 @@ const TeamContainer = (props: Props) => {
             <Route path={`${match.path}/settings`} component={TeamSettings} />
             <Route
               path={`${match.path}/archive`}
-              render={(p) => <ArchivedTasks {...p} team={team} returnToTeamId={teamId} teamIds={[teamId]} />}
+              render={(p) => (
+                <ArchivedTasks {...p} team={team} returnToTeamId={teamId} teamIds={[teamId]} />
+              )}
             />
           </Switch>
         </Suspense>


### PR DESCRIPTION
This PR _may_ resolve issue #4542. 

[This](https://sentry.io/organizations/parabol/issues/1641789488/?project=107196&query=level%3Afatal&statsPeriod=14d) and [this](https://sentry.io/organizations/parabol/issues/2109105416/?project=107196&query=level%3Afatal&statsPeriod=14d) Sentry issue suggest that the new joiner can infinitely bounce between the [ViewerNotOnTeam](https://github.com/ParabolInc/parabol/blob/91aff6e5c28bf344521db5701b0113401a2bc1dc/packages/client/components/ViewerNotOnTeam.tsx#L44) and the [MeetingSelector](https://github.com/ParabolInc/parabol/blob/01bfad9f162ef8f69c034a956bfbce9db3b1e9b9/packages/client/components/MeetingSelector.tsx#L35) components.

I haven't been able to reproduce the issue but I suspect that the `teamId` may be added to Relay's `authObj` before the server updates with the meeting. `isOnTeam` is therefore true in `ViewerNotOnTeam` but the `MeetingSelector` sends the viewer back to `ViewerNotOnTeam` as it doesn't have the `meeting` yet.