### PR TITLE
Implement grouping sorting, using the autoGroupReflection method

### DIFF
--- a/packages/client/utils/smartGroup/computeDistanceMatrix.ts
+++ b/packages/client/utils/smartGroup/computeDistanceMatrix.ts
@@ -5,7 +5,7 @@
  */
 
 const computeDistanceMatrix = (
-  reflectionEntities: {lemma?: string, name: string, salience: number}[][],
+  reflectionEntities: (readonly {lemma?: string, name: string, salience: number}[])[],
   uniqueLemmaArr: string[]
 ) => {
   return reflectionEntities.map((entities) => {

--- a/packages/client/utils/smartGroup/getAllLemmasFromReflections.ts
+++ b/packages/client/utils/smartGroup/getAllLemmasFromReflections.ts
@@ -2,7 +2,7 @@
  * Make a list of all the entities mentioned across all the reflections
  */
 
-const getAllLemmasFromReflections = (reflectionEntities: {lemma?: string, name: string, salience: number}[][] = []) => {
+const getAllLemmasFromReflections = (reflectionEntities: (readonly {lemma?: string, name: string, salience: number}[])[] = []) => {
   const lemmaSet = new Set<string>()
   for (let jj = 0; jj < reflectionEntities.length; jj++) {
     const entities = reflectionEntities[jj]

--- a/packages/client/utils/smartGroup/groupReflections.ts
+++ b/packages/client/utils/smartGroup/groupReflections.ts
@@ -9,9 +9,8 @@ import getTitleFromComputedGroup from './getTitleFromComputedGroup'
  */
 
 interface Reflection {
-  entities: any[]
-  reflectionGroupId: string
-
+  readonly entities: readonly any[]
+  readonly reflectionGroupId: string
 }
 const groupReflections = <T extends Reflection>(reflections: T[], groupingThreshold: number) => {
   const allReflectionEntities = reflections.map(({entities}) => entities!)
@@ -27,6 +26,7 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
   )
   // replace the arrays with reflections
   const updatedReflections = [] as Partial<IRetroReflection>[]
+  const reflectionGroupMapping = {} as Record<string, string>
   const updatedGroups = (groupedArrays as any[]).map((group) => {
     // look up the reflection by its vector, put them all in the same group
     let reflectionGroupId = ''
@@ -52,6 +52,11 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
     )
 
     updatedReflections.push(...groupedReflections)
+
+    groupedReflections.forEach((groupedReflection) => {
+      reflectionGroupMapping[groupedReflection.id] = reflectionGroupId
+    })
+
     return {
       id: reflectionGroupId,
       smartTitle,
@@ -69,6 +74,7 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
     autoGroupThreshold: thresh,
     groups: updatedGroups,
     groupedReflections: updatedReflections,
+    reflectionGroupMapping,
     removedReflectionGroupIds,
     nextThresh
   }


### PR DESCRIPTION
implements #4495 

Pretty simple & lightweight implementation, uses the already well-written `groupReflections` method. Algorithm:
1. Group the reflections behind the scene
2. Sort the reflections based on their group membership
3. Reflections that belong to the same group sit together