### PR TITLE
(bug): make SAML Issuer and AssertionConsumerServiceURL dynamic

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -14,8 +14,8 @@ const getURLWithSAMLRequestParam = (destination: string, slug: string) => {
   const template = `
   <samlp:AuthnRequest
       xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_${uuid()}" Version="2.0" IssueInstant="${new Date().toISOString()}" Destination="${destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://action.parabol.co/saml/${slug}">
-  <saml:Issuer>https://action.parabol.co/saml-metadata/${slug}</saml:Issuer>
+      xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_${uuid()}" Version="2.0" IssueInstant="${new Date().toISOString()}" Destination="${destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://${process.env.HOST}/saml/${slug}">
+  <saml:Issuer>https://${process.env.HOST}/saml-metadata/${slug}</saml:Issuer>
       <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" AllowCreate="false"/>
   </samlp:AuthnRequest>
   `


### PR DESCRIPTION
Makes the domain name used in SAML template dynamic.

closes #4679