### PR TITLE
Fix the bug where reflect prompts and dimensions cannot be deleted

### DIFF
--- a/packages/client/mutations/handlers/handleRemovePokerTemplateDimension.ts
+++ b/packages/client/mutations/handlers/handleRemovePokerTemplateDimension.ts
@@ -13,9 +13,9 @@ const handleRemovePokerTemplateDimension = (
     meetingType: MeetingTypeEnum.poker
   })
   if (!settings) return
-  const selectedTemplate = settings.getLinkedRecord('selectedTemplate')
-  if (!selectedTemplate) return
-  safeRemoveNodeFromArray(dimensionId, selectedTemplate, 'dimensions')
+  const activeTemplate = settings.getLinkedRecord('activeTemplate')
+  if (!activeTemplate) return
+  safeRemoveNodeFromArray(dimensionId, activeTemplate, 'dimensions')
 }
 
 const handleRemovePokerTemplateDimensions = pluralizeHandler(handleRemovePokerTemplateDimension)

--- a/packages/client/mutations/handlers/handleRemoveReflectTemplatePrompt.ts
+++ b/packages/client/mutations/handlers/handleRemoveReflectTemplatePrompt.ts
@@ -13,9 +13,9 @@ const handleRemoveReflectTemplatePrompt = (
     meetingType: MeetingTypeEnum.retrospective
   })
   if (!settings) return
-  const selectedTemplate = settings.getLinkedRecord('selectedTemplate')
-  if (!selectedTemplate) return
-  safeRemoveNodeFromArray(promptId, selectedTemplate, 'prompts')
+  const activeTemplate = settings.getLinkedRecord('activeTemplate')
+  if (!activeTemplate) return
+  safeRemoveNodeFromArray(promptId, activeTemplate, 'prompts')
 }
 
 const handleRemoveReflectTemplatePrompts = pluralizeHandler(handleRemoveReflectTemplatePrompt)


### PR DESCRIPTION
Fixes support issue reported [here](https://parabol.slack.com/archives/C4JAUUZ9P/p1613668617087100). Notice that the user reported that he could not rename a reflect but that was actually a side effect of not being able to remove it from front end. Hence the "Prompt not found" error. I looked at in our DB, from server side, the prompt was removed already.

Tests:

- [ ] User can remove prompts from retro templates
- [ ] User can remove dimensions from poker templates
- [ ] User can rename prompts
- [ ] User can rename dimensions