### PR TITLE
Sort the reflection goups on server side after REFLECT phase

### DIFF
--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -228,6 +228,11 @@ export default createFragmentContainer(ReflectionCard, {
         id
         isViewerReactji
       }
+      entities {
+        lemma
+        name
+        salience
+      }
       sortOrder
     }
   `,

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -228,11 +228,6 @@ export default createFragmentContainer(ReflectionCard, {
         id
         isViewerReactji
       }
-      entities {
-        lemma
-        name
-        salience
-      }
       sortOrder
     }
   `,

--- a/packages/client/mutations/NavigateMeetingMutation.ts
+++ b/packages/client/mutations/NavigateMeetingMutation.ts
@@ -148,7 +148,7 @@ export const navigateMeetingTeamUpdater: SharedUpdater<NavigateMeetingMutation_t
   }
 
   const reflectionGroups = meeting.getLinkedRecords('reflectionGroups')
-  const sortedReflectionGroups = reflectionGroups.sort((a, b) =>
+  const sortedReflectionGroups = reflectionGroups.slice().sort((a, b) =>
     a.getValue('sortOrder') < b.getValue('sortOrder') ? -1 : 1)
   meeting.setLinkedRecords(sortedReflectionGroups, 'reflectionGroups')
 }

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -9823,6 +9823,11 @@ export interface IReflectPhaseCompletePayload {
    * a list of empty reflection groups to remove
    */
   emptyReflectionGroupIds: Array<string>;
+
+  /**
+   * The grouped reflections
+   */
+  reflectionGroups: Array<IRetroReflectionGroup>;
 }
 
 export interface IGroupPhaseCompletePayload {

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -49,6 +49,7 @@ export const AGENDA_ITEM = 'agendaItem'
 /* Sorting */
 export const SORT_STEP = 1
 export const DND_THROTTLE = 25
+export const AUTO_GROUPING_THRESHOLD = 0.25
 
 /* Areas */
 export const MEETING = 'meeting'

--- a/packages/client/utils/smartGroup/groupReflections.ts
+++ b/packages/client/utils/smartGroup/groupReflections.ts
@@ -27,6 +27,7 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
   )
   // replace the arrays with reflections
   const updatedReflections = [] as Partial<IRetroReflection>[]
+  const reflectionGroupMapping = {} as Record<string, string>
   const updatedGroups = (groupedArrays as any[]).map((group) => {
     // look up the reflection by its vector, put them all in the same group
     let reflectionGroupId = ''
@@ -35,7 +36,8 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
       const reflection = reflections[idx]
       reflectionGroupId = (reflectionGroupId || reflection.reflectionGroupId) as string
       return {
-        ...reflection,
+        entities: reflection.entities,
+        oldReflectionGroupId: reflection.reflectionGroupId,
         sortOrder,
         reflectionGroupId
       }
@@ -52,6 +54,11 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
     )
 
     updatedReflections.push(...groupedReflections)
+
+    groupedReflections.forEach((groupedReflection) => {
+      reflectionGroupMapping[groupedReflection.oldReflectionGroupId] = reflectionGroupId
+    })
+
     return {
       id: reflectionGroupId,
       smartTitle,
@@ -69,6 +76,7 @@ const groupReflections = <T extends Reflection>(reflections: T[], groupingThresh
     autoGroupThreshold: thresh,
     groups: updatedGroups,
     groupedReflections: updatedReflections,
+    reflectionGroupMapping,
     removedReflectionGroupIds,
     nextThresh
   }

--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -1,9 +1,17 @@
-import {GROUP, REFLECT, RETROSPECTIVE, VOTE} from 'parabol-client/utils/constants'
+import {
+  AUTO_GROUPING_THRESHOLD,
+  GROUP,
+  REFLECT,
+  RETROSPECTIVE,
+  VOTE
+} from 'parabol-client/utils/constants'
 import addDiscussionTopics from './addDiscussionTopics'
 import removeEmptyReflections from './removeEmptyReflections'
 import Meeting from '../../../database/types/Meeting'
 import {DataLoaderWorker} from '../../graphql'
 import GenericMeetingStage from '../../../database/types/GenericMeetingStage'
+import groupReflections from '../../../../client/utils/smartGroup/groupReflections'
+import getRethink from '../../../database/rethinkDriver'
 
 /*
  * handle side effects when a stage is completed
@@ -16,7 +24,47 @@ const handleCompletedRetrospectiveStage = async (
   dataLoader: DataLoaderWorker
 ) => {
   if (stage.phaseType === REFLECT || stage.phaseType === GROUP) {
-    const data = await removeEmptyReflections(meeting)
+    const data: Record<string, any> = await removeEmptyReflections(meeting)
+
+    if (stage.phaseType === REFLECT) {
+      const r = await getRethink()
+      const now = new Date()
+      const reflectionGroups = await dataLoader
+        .get('retroReflectionGroupsByMeetingId')
+        .load(meeting.id)
+      const reflections = await r
+        .table('RetroReflection')
+        .getAll(meeting.id, {index: 'meetingId'})
+        .filter({isActive: true})
+        .orderBy('createdAt')
+        .run()
+      const {reflectionGroupMapping, autoGroupThreshold, nextThresh} = groupReflections(
+        reflections,
+        AUTO_GROUPING_THRESHOLD
+      )
+      console.log(`autoGroupThreshold = ${autoGroupThreshold}; nextThresh = ${nextThresh}`)
+
+      reflectionGroups.sort((groupA, groupB) => {
+        const newGroupIdA = reflectionGroupMapping[groupA.id]
+        const newGroupIdB = reflectionGroupMapping[groupB.id]
+        return newGroupIdA.localeCompare(newGroupIdB)
+      })
+
+      reflectionGroups.forEach(async (group, index) => {
+        group.sortOrder = index
+        await r
+          .table('RetroReflectionGroup')
+          .get(group.id)
+          .update({
+            sortOrder: index,
+            updatedAt: now
+          } as any)
+          .run()
+      })
+
+      data.reflectionGroups = reflectionGroups
+    }
+
     return {[stage.phaseType]: data}
   } else if (stage.phaseType === VOTE) {
     // mutates the meeting discuss phase.stages array

--- a/packages/server/graphql/mutations/helpers/updateReflectionLocation/removeReflectionFromGroup.ts
+++ b/packages/server/graphql/mutations/helpers/updateReflectionLocation/removeReflectionFromGroup.ts
@@ -12,10 +12,22 @@ const removeReflectionFromGroup = async (reflectionId, {dataLoader}) => {
     .run()
   if (!reflection) throw new Error('Reflection not found')
   const {reflectionGroupId: oldReflectionGroupId, meetingId, promptId} = reflection
+  const oldReflectionGroup = await r
+    .table('RetroReflectionGroup')
+    .get(oldReflectionGroupId)
+    .run()
+  const {sortOrder: oldSortOrder} = oldReflectionGroup
+  const maxSortOrder = await r
+    .table('RetroReflectionGroup')
+    .getAll("1kHnE9uN5C", {index: 'meetingId'})('sortOrder')
+    .max()
+    .default(0)
+    .run()
   const meeting = await dataLoader.get('newMeetings').load(meetingId)
 
   // RESOLUTION
-  const reflectionGroup = new ReflectionGroup({meetingId, promptId})
+  const newSortOrder = oldSortOrder === maxSortOrder ? oldSortOrder + 1 : (oldSortOrder + (oldSortOrder + 1)) / 2
+  const reflectionGroup = new ReflectionGroup({meetingId, promptId, sortOrder: newSortOrder})
   await r
     .table('RetroReflectionGroup')
     .insert(reflectionGroup)

--- a/packages/server/graphql/types/ReflectPhaseCompletePayload.ts
+++ b/packages/server/graphql/types/ReflectPhaseCompletePayload.ts
@@ -1,5 +1,6 @@
 import {GraphQLNonNull, GraphQLID, GraphQLList, GraphQLObjectType} from 'graphql'
 import {GQLContext} from '../graphql'
+import RetroReflectionGroup from './RetroReflectionGroup'
 
 const ReflectPhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
   name: 'ReflectPhaseCompletePayload',
@@ -7,8 +8,12 @@ const ReflectPhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
     emptyReflectionGroupIds: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLID))),
       description: 'a list of empty reflection groups to remove'
+    },
+    reflectionGroups: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(RetroReflectionGroup))),
+      description: 'The grouped reflections',
     }
-  })
+  }),
 })
 
 export default ReflectPhaseCompletePayload


### PR DESCRIPTION
Resolves #4495

Tests:

- [ ] When user navigates from reflect phase to group phase, the reflection cards are sorted within each column
- [ ] If user creates reflection groups, the column won't sort again
- [ ] When user ungroups, the left-alone card stays close with the old group
- [ ] Expanding sub-columns won't break any of the above-mentioned behaviors