### PR TITLE
Migrate RethinkDB Provider table to GitHubAuth

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,5 @@ packages/client/types/graphql.ts
 packages/client/serviceWorker/*
 packages/client/types/graphql.ts
 packages/server/database
+packages/server/postgres/queries/generated
 packages/server/segmentFns/*

--- a/packages/client/components/GitHubConfigMenu.tsx
+++ b/packages/client/components/GitHubConfigMenu.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import MenuItem from './MenuItem'
-import Menu from './Menu'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
-import RemoveGitHubAuthMutation from '../mutations/RemoveGitHubAuthMutation'
 import {MenuMutationProps} from '../hooks/useMutationProps'
+import RemoveGitHubAuthMutation from '../mutations/RemoveGitHubAuthMutation'
 import GitHubClientManager from '../utils/GitHubClientManager'
+import Menu from './Menu'
+import MenuItem from './MenuItem'
 
 interface Props {
   menuProps: MenuProps
@@ -24,7 +24,10 @@ const GitHubConfigMenu = (props: Props) => {
   const removeGitHub = () => {
     if (submitting) return
     submitMutation()
-    RemoveGitHubAuthMutation(atmosphere, {teamId}, {onCompleted, onError})
+    // wait for the portal to animate closed before removing, otherwise it'll stick around forever
+    setTimeout(() => {
+      RemoveGitHubAuthMutation(atmosphere, {teamId}, {onCompleted, onError})
+    }, 300)
   }
   return (
     <Menu ariaLabel={'Configure your GitHub integration'} {...menuProps}>

--- a/packages/client/shared/gqlIds/GitHubIntegrationId.ts
+++ b/packages/client/shared/gqlIds/GitHubIntegrationId.ts
@@ -1,0 +1,9 @@
+const GitHubIntegrationId = {
+  join: (teamId: string, userId: string) => `ghi:${teamId}:${userId}`,
+  split: (id: string) => {
+    const [, teamId, userId] = id.split(':')
+    return {teamId, userId}
+  }
+}
+
+export default GitHubIntegrationId

--- a/packages/client/utils/promiseAllPartial.ts
+++ b/packages/client/utils/promiseAllPartial.ts
@@ -1,8 +1,10 @@
+// DEPRECATED! We can now use the native Promise.allSettled
 /*
  * Promise.all fails fast, which means if promsie 2 of 100 fails, it aborts on 2
  * Sometimes, we want all the results & replace the errors with some generic value like null
  * This does that, and does it quickly, assuming that the first promise in the array will resolve first
  */
+
 
 import {NotVoid} from '../types/generics'
 

--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -127,10 +127,6 @@ export type RethinkSchema = {
     type: PasswordResetRequest
     index: 'email' | 'ip' | 'token'
   }
-  Provider: {
-    type: any
-    index: 'providerUserId' | 'teamId'
-  }
   PushInvitation: {
     type: PushInvitation
     index: 'userId'

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -291,7 +291,7 @@ export const freshAtlassianAuth = (parent: RethinkDataLoader) => {
   )
 }
 
-export const gitHubAuth = (parent: RethinkDataLoader) => {
+export const githubAuth = (parent: RethinkDataLoader) => {
   return new DataLoader<
     {teamId: string; userId: string},
     GetGitHubAuthByUserIdTeamIdResult | null,

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -14,12 +14,14 @@ import MeetingTemplate from '../database/types/MeetingTemplate'
 import {Reactable} from '../database/types/Reactable'
 import Task from '../database/types/Task'
 import {ThreadSource} from '../database/types/ThreadSource'
+import getGitHubAuthByUserIdTeamId, {
+  GetGitHubAuthByUserIdTeamIdResult
+} from '../postgres/queries/getGitHubAuthByUserIdTeamId'
 import AtlassianServerManager from '../utils/AtlassianServerManager'
 import sendToSentry from '../utils/sendToSentry'
 import normalizeRethinkDbResults from './normalizeRethinkDbResults'
 import ProxiedCache from './ProxiedCache'
 import RethinkDataLoader from './RethinkDataLoader'
-
 type TeamUserKey = {teamId: string; userId: string}
 export interface JiraRemoteProjectKey {
   accessToken: string
@@ -213,7 +215,9 @@ export const userTasks = (parent: RethinkDataLoader) => {
               .filter((task) =>
                 archived
                   ? task('tags').contains('archived')
-                  : task('tags').contains('archived').not()
+                  : task('tags')
+                      .contains('archived')
+                      .not()
               )
               .filter((task) => {
                 if (includeUnassigned) return true
@@ -283,6 +287,26 @@ export const freshAtlassianAuth = (parent: RethinkDataLoader) => {
     {
       ...parent.dataLoaderOptions,
       cacheKeyFn: (key) => `${key.userId}:${key.teamId}`
+    }
+  )
+}
+
+export const gitHubAuth = (parent: RethinkDataLoader) => {
+  return new DataLoader<
+    {teamId: string; userId: string},
+    GetGitHubAuthByUserIdTeamIdResult | null,
+    string
+  >(
+    async (keys) => {
+      const results = await Promise.allSettled(
+        keys.map(async ({teamId, userId}) => getGitHubAuthByUserIdTeamId(userId, teamId))
+      )
+      const vals = results.map((result) => (result.status === 'fulfilled' ? result.value : null))
+      return vals
+    },
+    {
+      ...parent.dataLoaderOptions,
+      cacheKeyFn: ({teamId, userId}) => `${userId}:${teamId}`
     }
   )
 }

--- a/packages/server/graphql/intranetSchema/mutations/backupOrganization.ts
+++ b/packages/server/graphql/intranetSchema/mutations/backupOrganization.ts
@@ -52,7 +52,10 @@ const backupOrganization = {
       .run()
 
     // get all the teams for the orgIds
-    const team = await r.table('Team').getAll(r.args(orgIds), {index: 'orgId'}).run()
+    const team = await r
+      .table('Team')
+      .getAll(r.args(orgIds), {index: 'orgId'})
+      .run()
     const teamIds = team.map((team) => team.id)
     await r({
       // easy things to clone
@@ -67,76 +70,166 @@ const backupOrganization = {
         ),
       agendaItem: (r.table('AgendaItem').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('AgendaItem').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('AgendaItem')
+            .insert(items)
+        ),
       atlassianAuth: (r.table('AtlassianAuth').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('AtlassianAuth').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('AtlassianAuth')
+            .insert(items)
+        ),
       invoice: (r.table('Invoice').filter((row) => r(orgIds).contains(row('orgId'))) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('Invoice').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('Invoice')
+            .insert(items)
+        ),
       invoiceItemHook: (r
         .table('InvoiceItemHook')
         .filter((row) => r(orgIds).contains(row('orgId'))) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('InvoiceItemHook').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('InvoiceItemHook')
+            .insert(items)
+        ),
       meetingMember: (r.table('MeetingMember').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('MeetingMember').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('MeetingMember')
+            .insert(items)
+        ),
       meetingSettings: (r
         .table('MeetingSettings')
         .getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('MeetingSettings').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('MeetingSettings')
+            .insert(items)
+        ),
       newMeeting: (r.table('NewMeeting').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('NewMeeting').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('NewMeeting')
+            .insert(items)
+        ),
       organization: (r.table('Organization').getAll(r.args(orgIds)) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('Organization').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('Organization')
+            .insert(items)
+        ),
       organizationUser: (r
         .table('OrganizationUser')
         .getAll(r.args(orgIds), {index: 'orgId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('OrganizationUser').insert(items)),
-      provider: (r.table('Provider').getAll(r.args(teamIds), {index: 'teamId'}) as any)
-        .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('Provider').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('OrganizationUser')
+            .insert(items)
+        ),
       reflectPrompt: (r.table('ReflectPrompt').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('ReflectPrompt').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('ReflectPrompt')
+            .insert(items)
+        ),
       meetingTemplate: (r
         .table('MeetingTemplate')
         .getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('MeetingTemplate').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('MeetingTemplate')
+            .insert(items)
+        ),
       templateDimension: (r
         .table('TemplateDimension')
         .filter((row) => r(teamIds).contains(row('teamId'))) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('TemplateDimension').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('TemplateDimension')
+            .insert(items)
+        ),
       templateScale: (r
         .table('TemplateScale')
         .filter((row) => r(teamIds).contains(row('teamId'))) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('TemplateScale').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('TemplateScale')
+            .insert(items)
+        ),
       slackAuth: (r.table('SlackAuth').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('SlackAuth').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('SlackAuth')
+            .insert(items)
+        ),
       slackNotification: (r
         .table('SlackNotification')
         .getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('SlackNotification').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('SlackNotification')
+            .insert(items)
+        ),
       task: (r.table('Task').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('Task').insert(items)),
-      team: r.db(DESTINATION).table('Team').insert(team),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('Task')
+            .insert(items)
+        ),
+      team: r
+        .db(DESTINATION)
+        .table('Team')
+        .insert(team),
       teamInvitation: (r.table('TeamInvitation').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('TeamInvitation').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('TeamInvitation')
+            .insert(items)
+        ),
       teamMember: (r.table('TeamMember').getAll(r.args(teamIds), {index: 'teamId'}) as any)
         .coerceTo('array')
-        .do((items) => r.db(DESTINATION).table('TeamMember').insert(items)),
+        .do((items) =>
+          r
+            .db(DESTINATION)
+            .table('TeamMember')
+            .insert(items)
+        ),
       // hard things to clone
       userIds: r
         .table('TeamMember')
@@ -148,24 +241,47 @@ const backupOrganization = {
               .table('Notification')
               .getAll(r.args(userIds), {index: 'userId'}) as any)
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('Notification').insert(items)),
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('Notification')
+                  .insert(items)
+              ),
             suggestedAction: (r
               .table('SuggestedAction')
               .getAll(r.args(userIds), {index: 'userId'}) as any)
               .filter((row) =>
-                r.or(row('teamId').default(null).eq(null), r(teamIds).contains(row('teamId')))
+                r.or(
+                  row('teamId')
+                    .default(null)
+                    .eq(null),
+                  r(teamIds).contains(row('teamId'))
+                )
               )
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('SuggestedAction').insert(items)),
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('SuggestedAction')
+                  .insert(items)
+              ),
             timelineEvent: (r
               .table('TimelineEvent')
               .filter((row) => r(userIds).contains(row('userId'))) as any)
               .filter((row) => r.branch(row('teamId'), r(teamIds).contains(row('teamId')), true))
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('TimelineEvent').insert(items)),
-            user: (r.table('User').getAll(r.args(userIds)) as any)
-              .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('User').insert(items))
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('TimelineEvent')
+                  .insert(items)
+              ),
+            user: (r.table('User').getAll(r.args(userIds)) as any).coerceTo('array').do((items) =>
+              r
+                .db(DESTINATION)
+                .table('User')
+                .insert(items)
+            )
           })
         }),
       activeDomains: r
@@ -176,12 +292,22 @@ const backupOrganization = {
           return r({
             SAML: (r.table('SAML').getAll(r.args(domains), {index: 'domains'}) as any)
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('SAML').insert(items)),
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('SAML')
+                  .insert(items)
+              ),
             secureDomain: (r
               .table('SecureDomain')
               .getAll(r.args(domains), {index: 'domain'}) as any)
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('SecureDomain').insert(items))
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('SecureDomain')
+                  .insert(items)
+              )
           })
         }),
       meetingIds: r
@@ -194,12 +320,22 @@ const backupOrganization = {
               .table('RetroReflection')
               .getAll(r.args(meetingIds), {index: 'meetingId'}) as any)
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('RetroReflection').insert(items)),
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('RetroReflection')
+                  .insert(items)
+              ),
             retroReflectionGroup: (r
               .table('RetroReflectionGroup')
               .getAll(r.args(meetingIds), {index: 'meetingId'}) as any)
               .coerceTo('array')
-              .do((items) => r.db(DESTINATION).table('RetroReflectionGroup').insert(items)),
+              .do((items) =>
+                r
+                  .db(DESTINATION)
+                  .table('RetroReflectionGroup')
+                  .insert(items)
+              ),
             // really hard things to clone
             reflectionGroupComments: r
               .table('RetroReflectionGroup')
@@ -208,7 +344,12 @@ const backupOrganization = {
               .do((threadIds) => {
                 return (r.table('Comment').getAll(r.args(threadIds), {index: 'threadId'}) as any)
                   .coerceTo('array')
-                  .do((items) => r.db(DESTINATION).table('Comment').insert(items))
+                  .do((items) =>
+                    r
+                      .db(DESTINATION)
+                      .table('Comment')
+                      .insert(items)
+                  )
               }),
             agendaItemComments: r
               .table('AgendaItem')
@@ -217,7 +358,12 @@ const backupOrganization = {
               .do((threadIds) => {
                 return (r.table('Comment').getAll(r.args(threadIds), {index: 'threadId'}) as any)
                   .coerceTo('array')
-                  .do((items) => r.db(DESTINATION).table('Comment').insert(items))
+                  .do((items) =>
+                    r
+                      .db(DESTINATION)
+                      .table('Comment')
+                      .insert(items)
+                  )
               })
           })
         })

--- a/packages/server/graphql/mutations/createGitHubIssue.ts
+++ b/packages/server/graphql/mutations/createGitHubIssue.ts
@@ -65,7 +65,7 @@ export default {
 
     // RESOLUTION
     const {userId, content: rawContentStr, meetingId} = task
-    const [viewerAuth, assigneeAuth] = await dataLoader.get('gitHubAuth').loadMany([
+    const [viewerAuth, assigneeAuth] = await dataLoader.get('githubAuth').loadMany([
       {teamId, userId: viewerId},
       {teamId, userId}
     ])

--- a/packages/server/graphql/mutations/helpers/removeTeamMember.ts
+++ b/packages/server/graphql/mutations/helpers/removeTeamMember.ts
@@ -103,19 +103,7 @@ const removeTeamMember = async (
         },
         {returnChanges: true}
       )('changes')('new_val')
-      .default([]) as unknown) as Task[],
-    // not adjusting atlassian, if they join the team again, they'll be ready to go
-    changedProviders: r
-      .table('Provider')
-      .getAll(teamId, {index: 'teamId'})
-      .filter({userId, isActive: true})
-      .update(
-        {
-          isActive: false
-        },
-        {returnChanges: true}
-      )('changes')('new_val')
-      .default([])
+      .default([]) as unknown) as Task[]
   }).run()
 
   const reqlUpdater = (user) => ({

--- a/packages/server/graphql/mutations/removeGitHubAuth.ts
+++ b/packages/server/graphql/mutations/removeGitHubAuth.ts
@@ -1,12 +1,10 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
-import getRethink from '../../database/rethinkDriver'
-import RemoveGitHubAuthPayload from '../types/RemoveGitHubAuthPayload'
+import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import removeGitHubAuthDB from '../../postgres/queries/removeGitHubAuth'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
-import {GITHUB} from 'parabol-client/utils/constants'
-import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-
+import RemoveGitHubAuthPayload from '../types/RemoveGitHubAuthPayload'
 export default {
   name: 'RemoveGitHubAuth',
   type: new GraphQLNonNull(RemoveGitHubAuthPayload),
@@ -18,11 +16,9 @@ export default {
     }
   },
   resolve: async (_source, {teamId}, {authToken, socketId: mutatorId, dataLoader}) => {
-    const r = await getRethink()
     const operationId = dataLoader.share()
     const subOptions = {mutatorId, operationId}
     const viewerId = getUserId(authToken)
-    const now = new Date()
 
     // AUTH
     if (!isTeamMember(authToken, teamId)) {
@@ -30,25 +26,9 @@ export default {
     }
 
     // RESOLUTION
-    const existingAuth = await r
-      .table('Provider')
-      .getAll(teamId, {index: 'teamId'})
-      .filter({service: GITHUB, userId: viewerId})
-      .nth(0)
-      .default(null)
-      .run()
-    if (!existingAuth) {
-      return standardError(new Error('Auth not found'), {userId: viewerId})
-    }
+    await removeGitHubAuthDB(viewerId, teamId)
 
-    const authId = existingAuth.id
-    await r
-      .table('Provider')
-      .get(authId)
-      .update({accessToken: null, isActive: false, updatedAt: now})
-      .run()
-
-    const data = {authId, teamId, userId: viewerId}
+    const data = {teamId, userId: viewerId}
     publish(SubscriptionChannel.TEAM, teamId, 'RemoveGitHubAuthPayload', data, subOptions)
     return data
   }

--- a/packages/server/graphql/queries/helpers/fetchAllIntegrations.ts
+++ b/packages/server/graphql/queries/helpers/fetchAllIntegrations.ts
@@ -9,7 +9,7 @@ const fetchAllIntegrations = async (
 ) => {
   const [atlassianProjects, githubRepos] = await Promise.all([
     fetchAtlassianProjects(dataLoader, teamId, userId),
-    fetchGitHubRepos(teamId, userId)
+    fetchGitHubRepos(teamId, userId, dataLoader)
   ])
   const allIntegrations = [...atlassianProjects, ...githubRepos]
   const getValue = (item) => (item.nameWithOwner || item.projectName).toLowerCase()

--- a/packages/server/graphql/queries/helpers/fetchGitHubRepos.ts
+++ b/packages/server/graphql/queries/helpers/fetchGitHubRepos.ts
@@ -1,8 +1,7 @@
-import getRethink from '../../../database/rethinkDriver'
-import GitHubServerManager from '../../../utils/GitHubServerManager'
 import {Omit} from 'parabol-client/types/generics'
 import {ISuggestedIntegrationGitHub} from 'parabol-client/types/graphql'
-import {GITHUB} from 'parabol-client/utils/constants'
+import GitHubServerManager from '../../../utils/GitHubServerManager'
+import {DataLoaderWorker} from '../../graphql'
 // import {GetReposQueryData} from 'parabol-client/utils/githubQueries/getRepos.graphql'
 
 namespace GetReposQueryData {
@@ -41,15 +40,8 @@ const getUniqueRepos = (
   return repos
 }
 
-const fetchGitHubRepos = async (teamId: string, userId: string) => {
-  const r = await getRethink()
-  const auth = await r
-    .table('Provider')
-    .getAll(teamId, {index: 'teamId'})
-    .filter({service: GITHUB, userId, isActive: true})
-    .nth(0)
-    .default(null)
-    .run()
+const fetchGitHubRepos = async (teamId: string, userId: string, dataLoader: DataLoaderWorker) => {
+  const auth = await dataLoader.get('githubAuth').load({teamId, userId})
   if (!auth) return []
   const {accessToken} = auth
   const manager = new GitHubServerManager(accessToken)

--- a/packages/server/graphql/queries/helpers/suggestedIntegrationHelpers.ts
+++ b/packages/server/graphql/queries/helpers/suggestedIntegrationHelpers.ts
@@ -1,7 +1,7 @@
 import ms from 'ms'
+import makeSuggestedIntegrationId from 'parabol-client/utils/makeSuggestedIntegrationId'
 import getRethink from '../../../database/rethinkDriver'
 import {DataLoaderWorker} from '../../graphql'
-import makeSuggestedIntegrationId from 'parabol-client/utils/makeSuggestedIntegrationId'
 
 export interface IntegrationByUserId {
   id: string
@@ -89,25 +89,14 @@ export const getPermsByTaskService = async (
   teamId: string,
   userId: string
 ) => {
-  const r = await getRethink()
   // we need to see which team integrations the user has access to
-  const [atlassianAuth, githubAuthForTeam] = await Promise.all([
+  const [atlassianAuth, githubAuth] = await Promise.all([
     dataLoader.get('freshAtlassianAuth').load({teamId, userId}),
-    r
-      .table('Provider')
-      .getAll(teamId, {index: 'teamId'})
-      .filter({
-        userId,
-        service: 'GitHubIntegration',
-        isActive: true
-      })
-      .nth(0)
-      .default(null)
-      .run()
+    dataLoader.get('githubAuth').load({teamId, userId})
   ])
 
   return {
     jira: !!atlassianAuth,
-    github: !!githubAuthForTeam
+    github: !!githubAuth
   }
 }

--- a/packages/server/graphql/types/AddGitHubAuthPayload.ts
+++ b/packages/server/graphql/types/AddGitHubAuthPayload.ts
@@ -1,7 +1,5 @@
 import {GraphQLObjectType} from 'graphql'
-import {GITHUB} from 'parabol-client/utils/constants'
 import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
-import getRethink from '../../database/rethinkDriver'
 import {GQLContext} from '../graphql'
 import GitHubIntegration from './GitHubIntegration'
 import StandardMutationError from './StandardMutationError'
@@ -17,15 +15,8 @@ const AddGitHubAuthPayload = new GraphQLObjectType<any, GQLContext>({
     githubIntegration: {
       type: GitHubIntegration,
       description: 'The newly created auth',
-      resolve: async ({teamId, userId}) => {
-        const r = await getRethink()
-        return r
-          .table('Provider')
-          .getAll(teamId, {index: 'teamId'})
-          .filter({service: GITHUB, isActive: true, userId})
-          .nth(0)
-          .default(null)
-          .run()
+      resolve: async ({teamId, userId}, _args, {dataLoader}) => {
+        return dataLoader.get('githubAuth').load({teamId, userId})
       }
     },
     teamMember: {

--- a/packages/server/graphql/types/GitHubIntegration.ts
+++ b/packages/server/graphql/types/GitHubIntegration.ts
@@ -1,7 +1,8 @@
 import {GraphQLBoolean, GraphQLID, GraphQLNonNull, GraphQLObjectType} from 'graphql'
-import GraphQLISO8601Type from './GraphQLISO8601Type'
+import GitHubIntegrationId from '../../../client/shared/gqlIds/GitHubIntegrationId'
 import {getUserId} from '../../utils/authorization'
 import {GQLContext} from '../graphql'
+import GraphQLISO8601Type from './GraphQLISO8601Type'
 
 const GitHubIntegration = new GraphQLObjectType<any, GQLContext>({
   name: 'GitHubIntegration',
@@ -9,7 +10,8 @@ const GitHubIntegration = new GraphQLObjectType<any, GQLContext>({
   fields: () => ({
     id: {
       type: new GraphQLNonNull(GraphQLID),
-      description: 'shortid'
+      description: 'composite key',
+      resolve: ({teamId, userId}) => GitHubIntegrationId.join(teamId, userId)
     },
     isActive: {
       description: 'true if an access token exists, else false',
@@ -26,8 +28,7 @@ const GitHubIntegration = new GraphQLObjectType<any, GQLContext>({
     },
     login: {
       type: new GraphQLNonNull(GraphQLID),
-      description: '*The GitHub login used for queries',
-      resolve: ({providerUserId}) => providerUserId
+      description: '*The GitHub login used for queries'
     },
     createdAt: {
       type: new GraphQLNonNull(GraphQLISO8601Type),

--- a/packages/server/graphql/types/RemoveGitHubAuthPayload.ts
+++ b/packages/server/graphql/types/RemoveGitHubAuthPayload.ts
@@ -11,10 +11,6 @@ const RemoveGitHubAuthPayload = new GraphQLObjectType<any, GQLContext>({
     error: {
       type: StandardMutationError
     },
-    authId: {
-      type: GraphQLID,
-      description: 'The ID of the authorization removed'
-    },
     teamId: {
       type: GraphQLID
     },

--- a/packages/server/graphql/types/TeamMemberIntegrations.ts
+++ b/packages/server/graphql/types/TeamMemberIntegrations.ts
@@ -29,7 +29,7 @@ const TeamMemberIntegrations = new GraphQLObjectType<any, GQLContext>({
       description: 'All things associated with a GitHub integration for a team member',
       resolve: async ({teamId, userId}, _args, {authToken, dataLoader}) => {
         if (!isTeamMember(authToken, teamId)) return null
-        return dataLoader.get('gitHubAuth').load({teamId, userId})
+        return dataLoader.get('githubAuth').load({teamId, userId})
       }
     },
     slack: {

--- a/packages/server/graphql/types/TeamMemberIntegrations.ts
+++ b/packages/server/graphql/types/TeamMemberIntegrations.ts
@@ -1,11 +1,10 @@
 import {GraphQLID, GraphQLNonNull, GraphQLObjectType} from 'graphql'
-import getRethink from '../../database/rethinkDriver'
+import getGitHubAuthByUserIdTeamId from '../../postgres/queries/getGitHubAuthByUserIdTeamId'
 import {isTeamMember} from '../../utils/authorization'
 import {GQLContext} from '../graphql'
 import AtlassianIntegration from './AtlassianIntegration'
 import GitHubIntegration from './GitHubIntegration'
 import SlackIntegration from './SlackIntegration'
-
 const TeamMemberIntegrations = new GraphQLObjectType<any, GQLContext>({
   name: 'TeamMemberIntegrations',
   description: 'All the available integrations available for this team member',
@@ -31,14 +30,7 @@ const TeamMemberIntegrations = new GraphQLObjectType<any, GQLContext>({
       description: 'All things associated with a GitHub integration for a team member',
       resolve: async ({teamId, userId}, _args, {authToken}) => {
         if (!isTeamMember(authToken, teamId)) return null
-        const r = await getRethink()
-        return r
-          .table('Provider')
-          .getAll(teamId, {index: 'teamId'})
-          .filter({service: 'GitHubIntegration', isActive: true, userId})
-          .nth(0)
-          .default(null)
-          .run()
+        return getGitHubAuthByUserIdTeamId(userId, teamId)
       }
     },
     slack: {

--- a/packages/server/graphql/types/TeamMemberIntegrations.ts
+++ b/packages/server/graphql/types/TeamMemberIntegrations.ts
@@ -1,5 +1,4 @@
 import {GraphQLID, GraphQLNonNull, GraphQLObjectType} from 'graphql'
-import getGitHubAuthByUserIdTeamId from '../../postgres/queries/getGitHubAuthByUserIdTeamId'
 import {isTeamMember} from '../../utils/authorization'
 import {GQLContext} from '../graphql'
 import AtlassianIntegration from './AtlassianIntegration'
@@ -28,9 +27,9 @@ const TeamMemberIntegrations = new GraphQLObjectType<any, GQLContext>({
     github: {
       type: GitHubIntegration,
       description: 'All things associated with a GitHub integration for a team member',
-      resolve: async ({teamId, userId}, _args, {authToken}) => {
+      resolve: async ({teamId, userId}, _args, {authToken, dataLoader}) => {
         if (!isTeamMember(authToken, teamId)) return null
-        return getGitHubAuthByUserIdTeamId(userId, teamId)
+        return dataLoader.get('gitHubAuth').load({teamId, userId})
       }
     },
     slack: {

--- a/packages/server/postgres/getPgConfig.ts
+++ b/packages/server/postgres/getPgConfig.ts
@@ -1,15 +1,12 @@
 import PROD from '../PROD'
 
-const getPgConfig = () => {
-  const config = {
-    user: process.env.POSTGRES_USER,
-    password: process.env.POSTGRES_PASSWORD,
-    database: process.env.POSTGRES_DB,
-    host: process.env.POSTGRES_HOST,
-    port: Number(process.env.POSTGRES_PORT),
-    max: PROD ? 85 : 5 // leave 15 conns for su management in production
-  }
-  return config
-}
+const getPgConfig = () => ({
+  user: process.env.POSTGRES_USER,
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB,
+  host: process.env.POSTGRES_HOST,
+  port: Number(process.env.POSTGRES_PORT),
+  max: PROD ? 85 : 5
+})
 
 export default getPgConfig

--- a/packages/server/postgres/migrations/1614361628531_github-auth.ts
+++ b/packages/server/postgres/migrations/1614361628531_github-auth.ts
@@ -25,8 +25,7 @@ export async function up(): Promise<void> {
     )
     .run()
   const auths = ghIntegrations.map(
-    ({accessToken, createdAt, id, isActive, providerUserName, teamId, updatedAt, userId}) => ({
-      id,
+    ({accessToken, createdAt, isActive, providerUserName, teamId, updatedAt, userId}) => ({
       accessToken,
       createdAt,
       updatedAt,
@@ -38,14 +37,14 @@ export async function up(): Promise<void> {
   )
   await client.query(`
     CREATE TABLE IF NOT EXISTS "GitHubAuth" (
-      "id" VARCHAR(100) PRIMARY KEY,
       "accessToken" VARCHAR(40) NOT NULL,
       "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
       "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
       "isActive" BOOLEAN DEFAULT TRUE NOT NULL,
       "login" VARCHAR(200) NOT NULL,
       "teamId" VARCHAR(100) NOT NULL,
-      "userId" VARCHAR(100) NOT NULL
+      "userId" VARCHAR(100) NOT NULL,
+      PRIMARY KEY ("userId", "teamId")
     );
   `)
   if (auths.length) {

--- a/packages/server/postgres/migrations/1614361628531_github-auth.ts
+++ b/packages/server/postgres/migrations/1614361628531_github-auth.ts
@@ -1,0 +1,58 @@
+import {ColumnDefinitions, MigrationBuilder} from 'node-pg-migrate'
+import {Client} from 'pg'
+import {r} from 'rethinkdb-ts'
+import {parse} from 'url'
+import getPgConfig from '../getPgConfig'
+import {insertGitHubAuthsQuery} from '../queries/generated/insertGitHubAuthsQuery'
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(): Promise<void> {
+  const {hostname: host, port, path} = parse(process.env.RETHINKDB_URL)
+  await r.connectPool({
+    host,
+    port: parseInt(port, 10),
+    db: path.split('/')[1]
+  })
+  const client = new Client(getPgConfig())
+  await client.connect()
+  const ghIntegrations = await r
+    .table('Provider')
+    .filter({service: 'GitHubIntegration', isActive: true})
+    .filter((row) =>
+      row('accessToken')
+        .default(null)
+        .ne(null)
+    )
+    .run()
+  const auths = ghIntegrations.map(
+    ({accessToken, createdAt, id, isActive, providerUserName, teamId, updatedAt, userId}) => ({
+      id,
+      accessToken,
+      createdAt,
+      updatedAt,
+      isActive,
+      login: providerUserName,
+      teamId,
+      userId
+    })
+  )
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS "GitHubAuth" (
+      "id" VARCHAR(100) PRIMARY KEY,
+      "accessToken" VARCHAR(40) NOT NULL,
+      "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      "isActive" BOOLEAN DEFAULT TRUE NOT NULL,
+      "login" VARCHAR(200) NOT NULL,
+      "teamId" VARCHAR(100) NOT NULL,
+      "userId" VARCHAR(100) NOT NULL
+    );
+  `)
+  if (auths.length) {
+    await insertGitHubAuthsQuery.run({auths}, client)
+  }
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`DROP TABLE "GitHubAuth";`)
+}

--- a/packages/server/postgres/queries/generated/getGitHubAuthByUserIdTeamIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getGitHubAuthByUserIdTeamIdQuery.ts
@@ -1,0 +1,59 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/getGitHubAuthByUserIdTeamIdQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'GetGitHubAuthByUserIdTeamIdQuery' parameters type */
+export interface IGetGitHubAuthByUserIdTeamIdQueryParams {
+  userId: string | null | void
+  teamId: string | null | void
+}
+
+/** 'GetGitHubAuthByUserIdTeamIdQuery' return type */
+export interface IGetGitHubAuthByUserIdTeamIdQueryResult {
+  accessToken: string
+  createdAt: Date
+  updatedAt: Date
+  isActive: boolean
+  login: string
+  teamId: string
+  userId: string
+}
+
+/** 'GetGitHubAuthByUserIdTeamIdQuery' query type */
+export interface IGetGitHubAuthByUserIdTeamIdQueryQuery {
+  params: IGetGitHubAuthByUserIdTeamIdQueryParams
+  result: IGetGitHubAuthByUserIdTeamIdQueryResult
+}
+
+const getGitHubAuthByUserIdTeamIdQueryIR: any = {
+  name: 'getGitHubAuthByUserIdTeamIdQuery',
+  params: [
+    {
+      name: 'userId',
+      transform: {type: 'scalar'},
+      codeRefs: {used: [{a: 92, b: 97, line: 5, col: 18}]}
+    },
+    {
+      name: 'teamId',
+      transform: {type: 'scalar'},
+      codeRefs: {used: [{a: 115, b: 120, line: 5, col: 41}]}
+    }
+  ],
+  usedParamSet: {userId: true, teamId: true},
+  statement: {
+    body:
+      'SELECT * from "GitHubAuth"\nWHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE',
+    loc: {a: 47, b: 142, line: 4, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * from "GitHubAuth"
+ * WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE
+ * ```
+ */
+export const getGitHubAuthByUserIdTeamIdQuery = new PreparedQuery<
+  IGetGitHubAuthByUserIdTeamIdQueryParams,
+  IGetGitHubAuthByUserIdTeamIdQueryResult
+>(getGitHubAuthByUserIdTeamIdQueryIR)

--- a/packages/server/postgres/queries/generated/insertGitHubAuthsQuery.ts
+++ b/packages/server/postgres/queries/generated/insertGitHubAuthsQuery.ts
@@ -1,0 +1,69 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/insertGitHubAuthsQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'InsertGitHubAuthsQuery' parameters type */
+export interface IInsertGitHubAuthsQueryParams {
+  auths: Array<{
+    id: string | null | void
+    accessToken: string | null | void
+    createdAt: Date | null | void
+    updatedAt: Date | null | void
+    isActive: boolean | null | void
+    login: string | null | void
+    teamId: string | null | void
+    userId: string | null | void
+  }>
+}
+
+/** 'InsertGitHubAuthsQuery' return type */
+export type IInsertGitHubAuthsQueryResult = void
+
+/** 'InsertGitHubAuthsQuery' query type */
+export interface IInsertGitHubAuthsQueryQuery {
+  params: IInsertGitHubAuthsQueryParams
+  result: IInsertGitHubAuthsQueryResult
+}
+
+const insertGitHubAuthsQueryIR: any = {
+  name: 'insertGitHubAuthsQuery',
+  params: [
+    {
+      name: 'auths',
+      codeRefs: {
+        defined: {a: 43, b: 47, line: 3, col: 9},
+        used: [{a: 255, b: 259, line: 6, col: 8}]
+      },
+      transform: {
+        type: 'pick_array_spread',
+        keys: [
+          'id',
+          'accessToken',
+          'createdAt',
+          'updatedAt',
+          'isActive',
+          'login',
+          'teamId',
+          'userId'
+        ]
+      }
+    }
+  ],
+  usedParamSet: {auths: true},
+  statement: {
+    body:
+      'INSERT INTO "GitHubAuth" ("id", "accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")\nVALUES :auths',
+    loc: {a: 133, b: 259, line: 5, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO "GitHubAuth" ("id", "accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")
+ * VALUES :auths
+ * ```
+ */
+export const insertGitHubAuthsQuery = new PreparedQuery<
+  IInsertGitHubAuthsQueryParams,
+  IInsertGitHubAuthsQueryResult
+>(insertGitHubAuthsQueryIR)

--- a/packages/server/postgres/queries/generated/insertGitHubAuthsQuery.ts
+++ b/packages/server/postgres/queries/generated/insertGitHubAuthsQuery.ts
@@ -4,7 +4,6 @@ import {PreparedQuery} from '@pgtyped/query'
 /** 'InsertGitHubAuthsQuery' parameters type */
 export interface IInsertGitHubAuthsQueryParams {
   auths: Array<{
-    id: string | null | void
     accessToken: string | null | void
     createdAt: Date | null | void
     updatedAt: Date | null | void
@@ -31,35 +30,26 @@ const insertGitHubAuthsQueryIR: any = {
       name: 'auths',
       codeRefs: {
         defined: {a: 43, b: 47, line: 3, col: 9},
-        used: [{a: 255, b: 259, line: 6, col: 8}]
+        used: [{a: 245, b: 249, line: 6, col: 8}]
       },
       transform: {
         type: 'pick_array_spread',
-        keys: [
-          'id',
-          'accessToken',
-          'createdAt',
-          'updatedAt',
-          'isActive',
-          'login',
-          'teamId',
-          'userId'
-        ]
+        keys: ['accessToken', 'createdAt', 'updatedAt', 'isActive', 'login', 'teamId', 'userId']
       }
     }
   ],
   usedParamSet: {auths: true},
   statement: {
     body:
-      'INSERT INTO "GitHubAuth" ("id", "accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")\nVALUES :auths',
-    loc: {a: 133, b: 259, line: 5, col: 0}
+      'INSERT INTO "GitHubAuth" ("accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")\nVALUES :auths',
+    loc: {a: 129, b: 249, line: 5, col: 0}
   }
 }
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO "GitHubAuth" ("id", "accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")
+ * INSERT INTO "GitHubAuth" ("accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")
  * VALUES :auths
  * ```
  */

--- a/packages/server/postgres/queries/generated/removeGitHubAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/removeGitHubAuthQuery.ts
@@ -1,0 +1,52 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/removeGitHubAuthQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'RemoveGitHubAuthQuery' parameters type */
+export interface IRemoveGitHubAuthQueryParams {
+  userId: string | null | void
+  teamId: string | null | void
+}
+
+/** 'RemoveGitHubAuthQuery' return type */
+export type IRemoveGitHubAuthQueryResult = void
+
+/** 'RemoveGitHubAuthQuery' query type */
+export interface IRemoveGitHubAuthQueryQuery {
+  params: IRemoveGitHubAuthQueryParams
+  result: IRemoveGitHubAuthQueryResult
+}
+
+const removeGitHubAuthQueryIR: any = {
+  name: 'removeGitHubAuthQuery',
+  params: [
+    {
+      name: 'userId',
+      transform: {type: 'scalar'},
+      codeRefs: {used: [{a: 130, b: 135, line: 6, col: 18}]}
+    },
+    {
+      name: 'teamId',
+      transform: {type: 'scalar'},
+      codeRefs: {used: [{a: 153, b: 158, line: 6, col: 41}]}
+    }
+  ],
+  usedParamSet: {userId: true, teamId: true},
+  statement: {
+    body:
+      'UPDATE "GitHubAuth"\nSET "isActive" = FALSE, "updatedAt" = CURRENT_TIMESTAMP\nWHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE',
+    loc: {a: 36, b: 180, line: 4, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE "GitHubAuth"
+ * SET "isActive" = FALSE, "updatedAt" = CURRENT_TIMESTAMP
+ * WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE
+ * ```
+ */
+export const removeGitHubAuthQuery = new PreparedQuery<
+  IRemoveGitHubAuthQueryParams,
+  IRemoveGitHubAuthQueryResult
+>(removeGitHubAuthQueryIR)

--- a/packages/server/postgres/queries/generated/upsertGitHubAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/upsertGitHubAuthQuery.ts
@@ -1,0 +1,56 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/upsertGitHubAuthQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'UpsertGitHubAuthQuery' parameters type */
+export interface IUpsertGitHubAuthQueryParams {
+  auth: {
+    accessToken: string | null | void
+    login: string | null | void
+    teamId: string | null | void
+    userId: string | null | void
+  }
+}
+
+/** 'UpsertGitHubAuthQuery' return type */
+export type IUpsertGitHubAuthQueryResult = void
+
+/** 'UpsertGitHubAuthQuery' query type */
+export interface IUpsertGitHubAuthQueryQuery {
+  params: IUpsertGitHubAuthQueryParams
+  result: IUpsertGitHubAuthQueryResult
+}
+
+const upsertGitHubAuthQueryIR: any = {
+  name: 'upsertGitHubAuthQuery',
+  params: [
+    {
+      name: 'auth',
+      codeRefs: {
+        defined: {a: 42, b: 45, line: 3, col: 9},
+        used: [{a: 168, b: 171, line: 6, col: 8}]
+      },
+      transform: {type: 'pick_tuple', keys: ['accessToken', 'login', 'teamId', 'userId']}
+    }
+  ],
+  usedParamSet: {auth: true},
+  statement: {
+    body:
+      'INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId")\nVALUES :auth\nON CONFLICT ("userId", "teamId")\nDO UPDATE\nSET ("accessToken", "updatedAt", "isActive", "login") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login)',
+    loc: {a: 90, b: 336, line: 5, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId")
+ * VALUES :auth
+ * ON CONFLICT ("userId", "teamId")
+ * DO UPDATE
+ * SET ("accessToken", "updatedAt", "isActive", "login") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login)
+ * ```
+ */
+export const upsertGitHubAuthQuery = new PreparedQuery<
+  IUpsertGitHubAuthQueryParams,
+  IUpsertGitHubAuthQueryResult
+>(upsertGitHubAuthQueryIR)

--- a/packages/server/postgres/queries/getGitHubAuthByUserIdTeamId.ts
+++ b/packages/server/postgres/queries/getGitHubAuthByUserIdTeamId.ts
@@ -1,8 +1,17 @@
 import getPg from '../getPg'
-import {getGitHubAuthByUserIdTeamIdQuery} from './generated/getGitHubAuthByUserIdTeamIdQuery'
+import {
+  getGitHubAuthByUserIdTeamIdQuery,
+  IGetGitHubAuthByUserIdTeamIdQueryResult
+} from './generated/getGitHubAuthByUserIdTeamIdQuery'
 
+// this table has a composite primary key (userId, teamId),
+// which cannot use the index with a WHERE IN or JOIN on VALUES
+// so if we want to query multiple userIds/teamIds, just call this multiple times
+export interface GetGitHubAuthByUserIdTeamIdResult extends IGetGitHubAuthByUserIdTeamIdQueryResult {
+  isActive: true
+}
 const getGitHubAuthByUserIdTeamId = async (userId: string, teamId: string) => {
   const [res] = await getGitHubAuthByUserIdTeamIdQuery.run({teamId, userId}, getPg())
-  return res
+  return res as GetGitHubAuthByUserIdTeamIdResult
 }
 export default getGitHubAuthByUserIdTeamId

--- a/packages/server/postgres/queries/getGitHubAuthByUserIdTeamId.ts
+++ b/packages/server/postgres/queries/getGitHubAuthByUserIdTeamId.ts
@@ -1,0 +1,8 @@
+import getPg from '../getPg'
+import {getGitHubAuthByUserIdTeamIdQuery} from './generated/getGitHubAuthByUserIdTeamIdQuery'
+
+const getGitHubAuthByUserIdTeamId = async (userId: string, teamId: string) => {
+  const [res] = await getGitHubAuthByUserIdTeamIdQuery.run({teamId, userId}, getPg())
+  return res
+}
+export default getGitHubAuthByUserIdTeamId

--- a/packages/server/postgres/queries/removeGitHubAuth.ts
+++ b/packages/server/postgres/queries/removeGitHubAuth.ts
@@ -1,0 +1,7 @@
+import getPg from '../getPg'
+import {removeGitHubAuthQuery} from './generated/removeGitHubAuthQuery'
+
+const removeGitHubAuth = async (userId: string, teamId: string) => {
+  await removeGitHubAuthQuery.run({userId, teamId}, getPg())
+}
+export default removeGitHubAuth

--- a/packages/server/postgres/queries/src/getGitHubAuthByUserIdTeamIdQuery.sql
+++ b/packages/server/postgres/queries/src/getGitHubAuthByUserIdTeamIdQuery.sql
@@ -1,0 +1,5 @@
+/*
+  @name getGitHubAuthByUserIdTeamIdQuery
+*/
+SELECT * from "GitHubAuth"
+WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE;

--- a/packages/server/postgres/queries/src/insertGitHubAuthsQuery.sql
+++ b/packages/server/postgres/queries/src/insertGitHubAuthsQuery.sql
@@ -1,0 +1,6 @@
+/*
+  @name insertGitHubAuthsQuery
+  @param auths -> ((id, accessToken, createdAt, updatedAt, isActive, login, teamId, userId)...)
+*/
+INSERT INTO "GitHubAuth" ("id", "accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")
+VALUES :auths;

--- a/packages/server/postgres/queries/src/insertGitHubAuthsQuery.sql
+++ b/packages/server/postgres/queries/src/insertGitHubAuthsQuery.sql
@@ -1,6 +1,6 @@
 /*
   @name insertGitHubAuthsQuery
-  @param auths -> ((id, accessToken, createdAt, updatedAt, isActive, login, teamId, userId)...)
+  @param auths -> ((accessToken, createdAt, updatedAt, isActive, login, teamId, userId)...)
 */
-INSERT INTO "GitHubAuth" ("id", "accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")
+INSERT INTO "GitHubAuth" ("accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")
 VALUES :auths;

--- a/packages/server/postgres/queries/src/removeGitHubAuthQuery.sql
+++ b/packages/server/postgres/queries/src/removeGitHubAuthQuery.sql
@@ -1,0 +1,6 @@
+/*
+  @name removeGitHubAuthQuery
+*/
+UPDATE "GitHubAuth"
+SET "isActive" = FALSE, "updatedAt" = CURRENT_TIMESTAMP
+WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE;

--- a/packages/server/postgres/queries/src/upsertGitHubAuthQuery.sql
+++ b/packages/server/postgres/queries/src/upsertGitHubAuthQuery.sql
@@ -1,0 +1,9 @@
+/*
+  @name upsertGitHubAuthQuery
+  @param auth -> (accessToken, login, teamId, userId)
+*/
+INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId")
+VALUES :auth
+ON CONFLICT ("userId", "teamId")
+DO UPDATE
+SET ("accessToken", "updatedAt", "isActive", "login") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login);

--- a/packages/server/postgres/queries/upsertGitHubAuth.ts
+++ b/packages/server/postgres/queries/upsertGitHubAuth.ts
@@ -1,0 +1,10 @@
+import getPg from '../getPg'
+import {
+  IUpsertGitHubAuthQueryParams,
+  upsertGitHubAuthQuery
+} from './generated/upsertGitHubAuthQuery'
+
+const upsertGitHubAuth = async (auth: IUpsertGitHubAuthQueryParams['auth']) => {
+  await upsertGitHubAuthQuery.run({auth}, getPg())
+}
+export default upsertGitHubAuth


### PR DESCRIPTION
Before starting the github integration for sprint poker, I wanted to get rid of the Provider table in RethinkDB & move it to postgres.
Doing this first means I don't have write a bunch of stuff that will get deleted when we move it over later.

TEST
- [ ] if you were integrated with GitHub before, you're still integrated
- [ ] Can add a GH integration from the Team Settings page
- [ ] Can remove a GH integration from the Team Settings page

