### PR TITLE
Provide feedback for old browser bugs

### DIFF
--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -27,6 +27,21 @@ const ErrorComponent = (props: Props) => {
   const {error, eventId} = props
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
+  const oldBrowserErrs = ['flatMap is not a function']
+
+  const handleClick = () => {
+    const url = 'https://browser-update.org/update-browser.html'
+    window.open(url)
+  }
+  const isOldBrowserErr = oldBrowserErrs.find((err) => error.message.includes(err))
+  if (isOldBrowserErr) {
+    return (
+      <ErrorBlock>
+        {"Oh no! You've found a bug because the browser you're using needs to be updated."}
+        {<Button onClick={handleClick}>Update now</Button>}
+      </ErrorBlock>
+    )
+  }
   return (
     <ErrorBlock>
       {'An error has occurred! We’ve alerted the developers. Try refreshing the page'}

--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -18,6 +18,10 @@ const Button = styled(PrimaryButton)({
   marginTop: 8
 })
 
+const Link = styled('a')({
+  color: 'inherit'
+})
+
 interface Props {
   error: Error
   eventId: string
@@ -29,16 +33,19 @@ const ErrorComponent = (props: Props) => {
   const {modalPortal, openPortal, closePortal} = useModal()
   const oldBrowserErrs = ['flatMap is not a function']
 
-  const handleClick = () => {
-    const url = 'https://browser-update.org/update-browser.html'
-    window.open(url)
-  }
   const isOldBrowserErr = oldBrowserErrs.find((err) => error.message.includes(err))
   if (isOldBrowserErr) {
+    const url = 'https://browser-update.org/update-browser.html'
     return (
       <ErrorBlock>
         {"Oh no! You've found a bug because the browser you're using needs to be updated."}
-        {<Button onClick={handleClick}>Update now</Button>}
+        {
+          <Button>
+            <Link href={url} target='_blank' rel='noreferrer'>
+              Update now
+            </Link>
+          </Button>
+        }
       </ErrorBlock>
     )
   }


### PR DESCRIPTION
This PR resolves issue #4751 

Rather than just showing a message asking the user to upgrade, I thought it'd be helpful to provide a link. 

We could write a bunch of conditionals ([like so](https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser)) to detect the browser and render a link based on the browser they're using. But browsers change, the conditionals may break and we would probably never know if Opera v8 is no longer showing the correct error message.

So I suggest that we show [this link](https://browser-update.org/update-browser.html) which explains why they should upgrade their browser & provides links to popular browsers. 


### Acceptance Criteria

- [ ]  When a user encounters the flatMap error, don't render the default error message
- [ ]  Instead, explain why they encountered the bug & ask them to upgrade their browser
- [ ]  Don't send the error message to Sentry as it's not a bug we intend to resolve