### PR TITLE
add "i dont vote" button

### DIFF
--- a/packages/client/components/DeckActivityAvatars.tsx
+++ b/packages/client/components/DeckActivityAvatars.tsx
@@ -13,6 +13,7 @@ const DeckActivityPanel = styled('div')({
   // let things underneath this be clickable
   pointerEvents: 'none',
   right: 0,
+  top: 32, // stay below the header
   width: 64,
   zIndex: 100 // show above dimension column
 })

--- a/packages/client/components/DeckActivityAvatars.tsx
+++ b/packages/client/components/DeckActivityAvatars.tsx
@@ -7,10 +7,11 @@ import useTransition, {TransitionStatus} from '../hooks/useTransition'
 import {DeckActivityAvatars_stage} from '../__generated__/DeckActivityAvatars_stage.graphql'
 import PokerVotingAvatar from './PokerVotingAvatar'
 
-
 const DeckActivityPanel = styled('div')({
   height: '100%',
   position: 'absolute',
+  // let things underneath this be clickable
+  pointerEvents: 'none',
   right: 0,
   width: 64,
   zIndex: 100 // show above dimension column
@@ -18,7 +19,12 @@ const DeckActivityPanel = styled('div')({
 
 const PeekingAvatar = styled(PokerVotingAvatar)<{status?: TransitionStatus}>(({status}) => ({
   opacity: status === TransitionStatus.EXITING ? 0 : 1,
-  transform: status === TransitionStatus.MOUNTED ? `translate(64px)` : status === TransitionStatus.EXITING ? 'scale(0)' : undefined,
+  transform:
+    status === TransitionStatus.MOUNTED
+      ? `translate(64px)`
+      : status === TransitionStatus.EXITING
+        ? 'scale(0)'
+        : undefined
 }))
 
 interface Props {
@@ -54,17 +60,23 @@ const DeckActivityAvatars = (props: Props) => {
         const visibleScoreIdx = peekingUsers.findIndex((user) => user.id === userId)
         const displayIdx = visibleScoreIdx === -1 ? idx : visibleScoreIdx
         return (
-          <PeekingAvatar key={userId} status={status} onTransitionEnd={onTransitionEnd} user={child} idx={displayIdx} isColumn isInitialStageRender={false} />
+          <PeekingAvatar
+            key={userId}
+            status={status}
+            onTransitionEnd={onTransitionEnd}
+            user={child}
+            idx={displayIdx}
+            isColumn
+            isInitialStageRender={false}
+          />
         )
       })}
     </DeckActivityPanel>
   )
 }
 
-export default createFragmentContainer(
-  DeckActivityAvatars,
-  {
-    stage: graphql`
+export default createFragmentContainer(DeckActivityAvatars, {
+  stage: graphql`
     fragment DeckActivityAvatars_stage on EstimateStage {
       id
       hoveringUsers {
@@ -75,6 +87,6 @@ export default createFragmentContainer(
       scores {
         userId
       }
-    }`
-  }
-)
+    }
+  `
+})

--- a/packages/client/components/EstimateDimensionColumn.tsx
+++ b/packages/client/components/EstimateDimensionColumn.tsx
@@ -11,6 +11,7 @@ import SetPokerSpectateMutation from '../mutations/SetPokerSpectateMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {EstimateDimensionColumn_meeting} from '../__generated__/EstimateDimensionColumn_meeting.graphql'
 import {EstimateDimensionColumn_stage} from '../__generated__/EstimateDimensionColumn_stage.graphql'
+import DeckActivityAvatars from './DeckActivityAvatars'
 import LinkButton from './LinkButton'
 import PokerActiveVoting from './PokerActiveVoting'
 import PokerDiscussVoting from './PokerDiscussVoting'
@@ -98,6 +99,7 @@ const EstimateDimensionColumn = (props: Props) => {
           </StyledLinkButton>
         )}
       </DimensionHeader>
+      <DeckActivityAvatars stage={stage} />
       {showVoting ? (
         <PokerActiveVoting
           meeting={meeting}
@@ -121,6 +123,7 @@ export default createFragmentContainer(EstimateDimensionColumn, {
     fragment EstimateDimensionColumn_stage on EstimateStage {
       ...PokerActiveVoting_stage
       ...PokerDiscussVoting_stage
+      ...DeckActivityAvatars_stage
       id
       isVoting
       dimensionRef {

--- a/packages/client/components/EstimateDimensionColumn.tsx
+++ b/packages/client/components/EstimateDimensionColumn.tsx
@@ -7,6 +7,7 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import useIsInitializing from '../hooks/useIsInitializing'
 import useIsPokerVotingClosing from '../hooks/useIsPokerVotingClosing'
 import PokerResetDimensionMutation from '../mutations/PokerResetDimensionMutation'
+import SetPokerSpectateMutation from '../mutations/SetPokerSpectateMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {EstimateDimensionColumn_meeting} from '../__generated__/EstimateDimensionColumn_meeting.graphql'
 import {EstimateDimensionColumn_stage} from '../__generated__/EstimateDimensionColumn_stage.graphql'
@@ -56,7 +57,8 @@ const EstimateDimensionColumn = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
   const {meeting, stage} = props
-  const {endedAt, facilitatorUserId, id: meetingId} = meeting
+  const {endedAt, facilitatorUserId, id: meetingId, viewerMeetingMember} = meeting
+  const isSpectating = viewerMeetingMember?.isSpectating
   const isFacilitator = viewerId === facilitatorUserId
   const {id: stageId, dimensionRef} = stage
   const {name} = dimensionRef
@@ -69,6 +71,11 @@ const EstimateDimensionColumn = (props: Props) => {
     submitMutation()
     PokerResetDimensionMutation(atmosphere, {meetingId, stageId}, {onError, onCompleted})
   }
+  const setSpectating = (isSpectating: boolean) => () => {
+    if (submitting) return
+    submitMutation()
+    SetPokerSpectateMutation(atmosphere, {meetingId, isSpectating}, {onError, onCompleted})
+  }
   const showVoting = isVoting || isClosing
   return (
     <ColumnInner>
@@ -78,6 +85,16 @@ const EstimateDimensionColumn = (props: Props) => {
         {!isVoting && isFacilitator && !endedAt && (
           <StyledLinkButton onClick={reset} palette={'blue'}>
             {'Team Revote'}
+          </StyledLinkButton>
+        )}
+        {isVoting && !endedAt && isSpectating && (
+          <StyledLinkButton onClick={setSpectating(false)} palette={'blue'}>
+            {'Let me vote!'}
+          </StyledLinkButton>
+        )}
+        {isVoting && !endedAt && !isSpectating && (
+          <StyledLinkButton onClick={setSpectating(true)} palette={'blue'}>
+            {'I don’t vote'}
           </StyledLinkButton>
         )}
       </DimensionHeader>
@@ -118,6 +135,9 @@ export default createFragmentContainer(EstimateDimensionColumn, {
       facilitatorUserId
       id
       endedAt
+      viewerMeetingMember {
+        isSpectating
+      }
     }
   `
 })

--- a/packages/client/components/EstimatePhaseArea.tsx
+++ b/packages/client/components/EstimatePhaseArea.tsx
@@ -8,7 +8,6 @@ import useGotoStageId from '~/hooks/useGotoStageId'
 import {PALETTE} from '~/styles/paletteV3'
 import {Breakpoint} from '~/types/constEnums'
 import {EstimatePhaseArea_meeting} from '~/__generated__/EstimatePhaseArea_meeting.graphql'
-import DeckActivityAvatars from './DeckActivityAvatars'
 import EstimateDimensionColumn from './EstimateDimensionColumn'
 import PokerCardDeck from './PokerCardDeck'
 
@@ -104,7 +103,6 @@ const EstimatePhaseArea = (props: Props) => {
         </StepperDots>
       )}
       <PokerCardDeck meeting={meeting} estimateAreaRef={estimateAreaRef} />
-      <DeckActivityAvatars stage={localStage} />
       <SwipeableViews
         containerStyle={containerStyle}
         enableMouseEvents
@@ -125,7 +123,6 @@ const EstimatePhaseArea = (props: Props) => {
 
 graphql`
   fragment EstimatePhaseAreaStage on EstimateStage {
-    ...DeckActivityAvatars_stage
     id
     serviceTaskId
   }

--- a/packages/client/components/PokerCardDeck.tsx
+++ b/packages/client/components/PokerCardDeck.tsx
@@ -46,7 +46,8 @@ const PokerCardDeck = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
   const {meeting, estimateAreaRef} = props
-  const {id: meetingId, isRightDrawerOpen, localStage, showSidebar} = meeting
+  const {id: meetingId, isRightDrawerOpen, localStage, showSidebar, viewerMeetingMember} = meeting
+  const isSpectating = viewerMeetingMember?.isSpectating
   const stageId = localStage.id!
   const {dimensionRef} = localStage
   const scores = localStage.scores!
@@ -175,12 +176,13 @@ const PokerCardDeck = (props: Props) => {
     swipe.isSwipe = null
   })
   useEffect(() => {
-    if (maxSlide === 0 || isCollapsed) {
+    if (deckRef.current && (maxSlide === 0 || isCollapsed)) {
       swipe.translateX = 0
-      deckRef.current!.style.transform = ''
+      deckRef.current.style.transform = ''
     }
   }, [maxSlide, isCollapsed])
   // const transform = maxSlide > 0 && !isCollapsed ? `translateX(${swipe.translateX}px)` : undefined
+  if (isSpectating) return null
   return (
     <Deck
       ref={deckRef}
@@ -266,6 +268,9 @@ export default createFragmentContainer(PokerCardDeck, {
       }
       localStage {
         ...PokerCardDeckStage @relay(mask: false)
+      }
+      viewerMeetingMember {
+        isSpectating
       }
     }
   `

--- a/packages/client/mutations/SetPokerSpectateMutation.ts
+++ b/packages/client/mutations/SetPokerSpectateMutation.ts
@@ -1,0 +1,49 @@
+import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
+import {StandardMutation} from '../types/relayMutations'
+import toTeamMemberId from '../utils/relay/toTeamMemberId'
+import {SetPokerSpectateMutation as TSetPokerSpectateMutation} from '../__generated__/SetPokerSpectateMutation.graphql'
+
+graphql`
+  fragment SetPokerSpectateMutation_team on SetPokerSpectateSuccess {
+    meetingMember {
+      isSpectating
+    }
+  }
+`
+
+const mutation = graphql`
+  mutation SetPokerSpectateMutation($meetingId: ID!, $isSpectating: Boolean!) {
+    setPokerSpectate(meetingId: $meetingId, isSpectating: $isSpectating) {
+      ... on ErrorPayload {
+        error {
+          message
+        }
+      }
+      ...SetPokerSpectateMutation_team @relay(mask: false)
+    }
+  }
+`
+
+const SetPokerSpectateMutation: StandardMutation<TSetPokerSpectateMutation> = (
+  atmosphere,
+  variables,
+  {onError, onCompleted}
+) => {
+  return commitMutation<TSetPokerSpectateMutation>(atmosphere, {
+    mutation,
+    variables,
+    optimisticUpdater: (store) => {
+      const {viewerId} = atmosphere
+      const {isSpectating, meetingId} = variables
+      const meetingMemberId = toTeamMemberId(meetingId, viewerId)
+      const meetingMember = store.get(meetingMemberId)
+      if (!meetingMember) return
+      meetingMember.setValue(isSpectating, 'isSpectating')
+    },
+    onCompleted,
+    onError
+  })
+}
+
+export default SetPokerSpectateMutation

--- a/packages/client/subscriptions/MeetingSubscription.ts
+++ b/packages/client/subscriptions/MeetingSubscription.ts
@@ -24,6 +24,7 @@ const subscription = graphql`
   subscription MeetingSubscription($meetingId: ID!) {
     meetingSubscription(meetingId: $meetingId) {
       __typename
+      ...SetPokerSpectateMutation_team @relay(mask: false)
       ...JoinMeetingMutation_meeting @relay(mask: false)
       ...PokerSetFinalScoreMutation_meeting @relay(mask: false)
       ...PokerAnnounceDeckHoverMutation_meeting @relay(mask: false)

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -1327,6 +1327,11 @@ export interface ITeamMember {
   isLead: boolean | null;
 
   /**
+   * true if the user prefers to not vote during a poker meeting
+   */
+  isSpectatingPoker: boolean;
+
+  /**
    * hide the agenda list on the dashboard
    */
   hideAgenda: boolean;
@@ -7269,6 +7274,11 @@ export interface IMutation {
    * Create a meeting member for a user
    */
   joinMeeting: JoinMeetingPayload;
+
+  /**
+   * Set whether the user is spectating poker meeting
+   */
+  setPokerSpectate: SetPokerSpectatePayload;
 }
 
 export interface IAcceptTeamInvitationOnMutationArguments {
@@ -8435,6 +8445,15 @@ export interface IJoinMeetingOnMutationArguments {
   meetingId: string;
 }
 
+export interface ISetPokerSpectateOnMutationArguments {
+  meetingId: string;
+
+  /**
+   * true if the viewer is spectating poker and does not want to vote. else false
+   */
+  isSpectating: boolean;
+}
+
 export interface IAcceptTeamInvitationPayload {
   __typename: 'AcceptTeamInvitationPayload';
   error: IStandardMutationError | null;
@@ -9341,6 +9360,11 @@ export interface IPokerMeetingMember {
    * The last time a meeting was updated (stage completed, finished, etc)
    */
   updatedAt: any;
+
+  /**
+   * true if the user is not voting and does not want their vote to count towards aggregates
+   */
+  isSpectating: boolean;
 }
 
 export interface IEditCommentingPayload {
@@ -10889,6 +10913,22 @@ export interface IJoinMeetingSuccess {
   meeting: NewMeeting;
 }
 
+/**
+ * Return object for SetPokerSpectatePayload
+ */
+export type SetPokerSpectatePayload = IErrorPayload | ISetPokerSpectateSuccess;
+
+export interface ISetPokerSpectateSuccess {
+  __typename: 'SetPokerSpectateSuccess';
+  meetingId: string;
+  userId: string;
+
+  /**
+   * The meeting member with the updated isSpectating value
+   */
+  meetingMember: IPokerMeetingMember;
+}
+
 export interface ISubscription {
   __typename: 'Subscription';
   meetingSubscription: MeetingSubscriptionPayload;
@@ -10937,7 +10977,8 @@ export type MeetingSubscriptionPayload =
   | IPokerResetDimensionSuccess
   | IPokerAnnounceDeckHoverSuccess
   | IPokerSetFinalScoreSuccess
-  | IJoinMeetingSuccess;
+  | IJoinMeetingSuccess
+  | ISetPokerSpectateSuccess;
 
 export interface IAddReactjiToReflectionSuccess {
   __typename: 'AddReactjiToReflectionSuccess';

--- a/packages/server/database/migrations/20210319135548-pokerSpectate.ts
+++ b/packages/server/database/migrations/20210319135548-pokerSpectate.ts
@@ -1,0 +1,27 @@
+export const up = async function(r) {
+  try {
+    await r({
+      teamMembers: r.table('TeamMember').update({isSpectatingPoker: false}),
+      meetingMembers: r
+        .table('MeetingMember')
+        .filter({meetingType: 'poker'})
+        .update({isSpectating: false})
+    }).run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function(r) {
+  try {
+    await r({
+      teamMembers: r.table('TeamMember').replace((row) => row.without('isSpectatingPoker')),
+      meetingMembers: r
+        .table('MeetingMember')
+        .filter({meetingType: 'poker'})
+        .replace((row) => row.without('isSpectating'))
+    }).run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -1,5 +1,4 @@
 import {r} from 'rethinkdb-ts'
-import MeetingMember from '../database/types/MeetingMember'
 import Organization from '../database/types/Organization'
 import SlackAuth from '../database/types/SlackAuth'
 import SlackNotification from '../database/types/SlackNotification'
@@ -7,6 +6,7 @@ import TeamInvitation from '../database/types/TeamInvitation'
 import TeamMember from '../database/types/TeamMember'
 import getRethinkConfig from './getRethinkConfig'
 import {R} from './stricterR'
+import ActionMeetingMember from './types/ActionMeetingMember'
 import AgendaItem from './types/AgendaItem'
 import AtlassianAuth from './types/AtlassianAuth'
 import Comment from './types/Comment'
@@ -30,9 +30,11 @@ import NotificationTeamArchived from './types/NotificationTeamArchived'
 import NotificationTeamInvitation from './types/NotificationTeamInvitation'
 import OrganizationUser from './types/OrganizationUser'
 import PasswordResetRequest from './types/PasswordResetRequest'
+import PokerMeetingMember from './types/PokerMeetingMember'
 import PushInvitation from './types/PushInvitation'
 import Reflection from './types/Reflection'
 import ReflectionGroup from './types/ReflectionGroup'
+import RetroMeetingMember from './types/RetroMeetingMember'
 import RetrospectivePrompt from './types/RetrospectivePrompt'
 import SAML from './types/SAML'
 import ScheduledJob from './types/ScheduledJob'
@@ -92,7 +94,7 @@ export type RethinkSchema = {
     index: 'teamId'
   }
   MeetingMember: {
-    type: MeetingMember
+    type: PokerMeetingMember | RetroMeetingMember | ActionMeetingMember
     index: 'meetingId' | 'teamId' | 'userId'
   }
   NewMeeting: {

--- a/packages/server/database/types/PokerMeetingMember.ts
+++ b/packages/server/database/types/PokerMeetingMember.ts
@@ -6,10 +6,14 @@ interface Input {
   teamId: string
   userId: string
   meetingId: string
+  isSpectating: boolean
 }
 
 export default class PokerMeetingMember extends MeetingMember {
+  isSpectating: boolean
   constructor(input: Input) {
+    const {isSpectating} = input
     super({...input, meetingType: 'poker'})
+    this.isSpectating = isSpectating
   }
 }

--- a/packages/server/database/types/TeamMember.ts
+++ b/packages/server/database/types/TeamMember.ts
@@ -4,6 +4,7 @@ interface Input {
   isNotRemoved?: boolean
   isLead?: boolean
   hideAgenda?: boolean
+  isSpectatingPoker?: boolean
   email: string
   picture: string
   preferredName: string
@@ -16,6 +17,7 @@ export default class TeamMember {
   id: string
   isNotRemoved: boolean
   isLead: boolean
+  isSpectatingPoker: boolean
   hideAgenda: boolean
   email: string
   picture: string
@@ -25,12 +27,23 @@ export default class TeamMember {
   createdAt: Date
   updatedAt: Date
   constructor(input: Input) {
-    const {teamId, email, hideAgenda, isLead, isNotRemoved, picture, preferredName, userId} = input
+    const {
+      teamId,
+      email,
+      hideAgenda,
+      isLead,
+      isNotRemoved,
+      picture,
+      preferredName,
+      userId,
+      isSpectatingPoker
+    } = input
     this.id = toTeamMemberId(teamId, userId)
     this.teamId = teamId
     this.email = email
     this.hideAgenda = hideAgenda || false
     this.isLead = isLead || false
+    this.isSpectatingPoker = isSpectatingPoker || false
     this.isNotRemoved = isNotRemoved === undefined ? true : isNotRemoved
     this.picture = picture
     this.preferredName = preferredName

--- a/packages/server/graphql/executeGraphQL.ts
+++ b/packages/server/graphql/executeGraphQL.ts
@@ -70,7 +70,7 @@ const executeGraphQL = async (req: GQLRequest) => {
     }
   }
   if (!PROD && response.errors) {
-    console.trace({error: JSON.stringify(response.errors)})
+    console.trace({error: JSON.stringify(response)})
   }
   dataLoader.dispose()
   return response

--- a/packages/server/graphql/mutations/pokerRevealVotes.ts
+++ b/packages/server/graphql/mutations/pokerRevealVotes.ts
@@ -77,7 +77,8 @@ const pokerRevealVotes = {
     // add a pass card for everyone who was present but did not vote
     const {scores} = stage
     meetingMembers.forEach((meetingMember) => {
-      const {userId} = meetingMember
+      const {userId, isSpectating} = meetingMember
+      if (isSpectating) return
       const userScore = scores.find((score) => score.userId === userId)
       if (!userScore) {
         const passScore = new EstimateUserScore({userId, label: PokerCards.PASS_CARD as string})

--- a/packages/server/graphql/mutations/setPokerSpectate.ts
+++ b/packages/server/graphql/mutations/setPokerSpectate.ts
@@ -1,0 +1,60 @@
+import {GraphQLBoolean, GraphQLID, GraphQLNonNull} from 'graphql'
+import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
+import getRethink from '../../database/rethinkDriver'
+import {getUserId} from '../../utils/authorization'
+import publish from '../../utils/publish'
+import {GQLContext} from '../graphql'
+import SetPokerSpectatePayload from '../types/SetPokerSpectatePayload'
+
+const setPokerSpectate = {
+  type: GraphQLNonNull(SetPokerSpectatePayload),
+  description: `Set whether the user is spectating poker meeting`,
+  args: {
+    meetingId: {
+      type: GraphQLNonNull(GraphQLID)
+    },
+    isSpectating: {
+      type: GraphQLNonNull(GraphQLBoolean),
+      description: 'true if the viewer is spectating poker and does not want to vote. else false'
+    }
+  },
+  resolve: async (
+    _source,
+    {meetingId, isSpectating},
+    {authToken, dataLoader, socketId: mutatorId}: GQLContext
+  ) => {
+    const r = await getRethink()
+    const viewerId = getUserId(authToken)
+    const now = new Date()
+    const operationId = dataLoader.share()
+    const subOptions = {mutatorId, operationId}
+
+    //AUTH
+    const meetingMemberId = toTeamMemberId(meetingId, viewerId)
+    const meetingMember = await dataLoader.get('meetingMembers').load(meetingMemberId)
+
+    if (!meetingMember) {
+      return {error: {message: 'Not in meeting'}}
+    }
+    // RESOLUTION
+    const {teamId} = meetingMember
+    const teamMemberId = toTeamMemberId(teamId, viewerId)
+    await r({
+      meetingMember: r
+        .table('MeetingMember')
+        .get(meetingMemberId)
+        .update({isSpectating}),
+      teamMember: r
+        .table('TeamMember')
+        .get(teamMemberId)
+        .update({isSpectatingPoker: isSpectating, updatedAt: now})
+    }).run()
+    meetingMember.isSpectating = isSpectating
+    const data = {meetingId, userId: viewerId}
+    publish(SubscriptionChannel.MEETING, meetingId, 'SetPokerSpectateSuccess', data, subOptions)
+    return data
+  }
+}
+
+export default setPokerSpectate

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -1,5 +1,6 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import getRethink from '../../database/rethinkDriver'
 import {MeetingTypeEnum} from '../../database/types/Meeting'
 import MeetingPoker from '../../database/types/MeetingPoker'
@@ -135,10 +136,20 @@ export default {
       return {error: {message: 'Meeting already started'}}
     }
 
+    const teamMemberId = toTeamMemberId(teamId, viewerId)
+    const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
+    const {isSpectatingPoker} = teamMember
     await Promise.all([
       r
         .table('MeetingMember')
-        .insert(new PokerMeetingMember({meetingId, userId: viewerId, teamId}))
+        .insert(
+          new PokerMeetingMember({
+            meetingId,
+            userId: viewerId,
+            teamId,
+            isSpectating: isSpectatingPoker
+          })
+        )
         .run(),
       r
         .table('Team')

--- a/packages/server/graphql/rootMutation.ts
+++ b/packages/server/graphql/rootMutation.ts
@@ -131,6 +131,7 @@ import uploadUserImage from './mutations/uploadUserImage'
 import verifyEmail from './mutations/verifyEmail'
 import voteForPokerStory from './mutations/voteForPokerStory'
 import joinMeeting from './mutations/joinMeeting'
+import setPokerSpectate from './mutations/setPokerSpectate'
 import voteForReflectionGroup from './mutations/voteForReflectionGroup'
 
 interface Context extends InternalContext, GQLContext {}
@@ -270,6 +271,7 @@ export default new GraphQLObjectType<any, Context>({
       pokerSetFinalScore,
       movePokerTemplateScaleValue,
       updateJiraDimensionField,
-      joinMeeting
+      joinMeeting,
+      setPokerSpectate
     } as any)
 })

--- a/packages/server/graphql/types/MeetingSubscriptionPayload.ts
+++ b/packages/server/graphql/types/MeetingSubscriptionPayload.ts
@@ -23,6 +23,7 @@ import RemoveReflectionPayload from './RemoveReflectionPayload'
 import ResetMeetingToStagePayload from './ResetMeetingToStagePayload'
 import {SetAppLocationSuccess} from './SetAppLocationPayload'
 import SetPhaseFocusPayload from './SetPhaseFocusPayload'
+import {SetPokerSpectateSuccess} from './SetPokerSpectatePayload'
 import SetStageTimerPayload from './SetStageTimerPayload'
 import StartDraggingReflectionPayload from './StartDraggingReflectionPayload'
 import {UpdateCommentContentSuccess} from './UpdateCommentContentPayload'
@@ -71,7 +72,8 @@ const types = [
   PokerResetDimensionSuccess,
   PokerAnnounceDeckHoverSuccess,
   PokerSetFinalScoreSuccess,
-  JoinMeetingSuccess
+  JoinMeetingSuccess,
+  SetPokerSpectateSuccess
 ]
 
 export default graphQLSubscriptionType('MeetingSubscriptionPayload', types)

--- a/packages/server/graphql/types/PokerMeetingMember.ts
+++ b/packages/server/graphql/types/PokerMeetingMember.ts
@@ -1,4 +1,4 @@
-import {GraphQLObjectType} from 'graphql'
+import {GraphQLBoolean, GraphQLNonNull, GraphQLObjectType} from 'graphql'
 import {GQLContext} from '../graphql'
 import MeetingMember, {meetingMemberFields} from './MeetingMember'
 
@@ -7,7 +7,12 @@ const PokerMeetingMember = new GraphQLObjectType<any, GQLContext>({
   interfaces: () => [MeetingMember],
   description: 'All the meeting specifics for a user in a poker meeting',
   fields: () => ({
-    ...meetingMemberFields()
+    ...meetingMemberFields(),
+    isSpectating: {
+      type: GraphQLNonNull(GraphQLBoolean),
+      description:
+        'true if the user is not voting and does not want their vote to count towards aggregates'
+    }
   })
 })
 

--- a/packages/server/graphql/types/SetPokerSpectatePayload.ts
+++ b/packages/server/graphql/types/SetPokerSpectatePayload.ts
@@ -1,0 +1,33 @@
+import {GraphQLID, GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
+import {GQLContext} from '../graphql'
+import makeMutationPayload from './makeMutationPayload'
+import PokerMeetingMember from './PokerMeetingMember'
+
+export const SetPokerSpectateSuccess = new GraphQLObjectType<any, GQLContext>({
+  name: 'SetPokerSpectateSuccess',
+  fields: () => ({
+    meetingId: {
+      type: GraphQLNonNull(GraphQLID)
+    },
+    userId: {
+      type: GraphQLNonNull(GraphQLID)
+    },
+    meetingMember: {
+      type: GraphQLNonNull(PokerMeetingMember),
+      description: 'The meeting member with the updated isSpectating value',
+      resolve: async ({userId, meetingId}, _args, {dataLoader}) => {
+        const meetingMemberId = toTeamMemberId(meetingId, userId)
+        const meetingMember = await dataLoader.get('meetingMembers').load(meetingMemberId)
+        return meetingMember
+      }
+    }
+  })
+})
+
+const SetPokerSpectatePayload = makeMutationPayload(
+  'SetPokerSpectatePayload',
+  SetPokerSpectateSuccess
+)
+
+export default SetPokerSpectatePayload

--- a/packages/server/graphql/types/TeamMember.ts
+++ b/packages/server/graphql/types/TeamMember.ts
@@ -40,6 +40,11 @@ const TeamMember = new GraphQLObjectType<any, GQLContext>({
       description: 'true if the user is a part of the team, false if they no longer are'
     },
     isLead: {type: GraphQLBoolean, description: 'Is user a team lead?'},
+    isSpectatingPoker: {
+      type: GraphQLNonNull(GraphQLBoolean),
+      description: 'true if the user prefers to not vote during a poker meeting',
+      resolve: ({isSpectatingPoker}) => !!isSpectatingPoker
+    },
     hideAgenda: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'hide the agenda list on the dashboard',


### PR DESCRIPTION
fixes #4571

- Added `isSpectating` to the PokerMeetingMember
- Added `isSpectatingPoker` to the TeamMember (so we remember their preference for future meetings)

TEST
- [ ] During the estimate phase, click "I dont vote" see the deck go away
- [ ] Progress to the discuss step. Notice that the person who doesn't vote doesn't show up in the "Pass" row
- [ ] Start a new poker meeting, it remembers that you don't vote
- [ ] Click "Let me vote" during the estimate phase. you see a poker deck again
- [ ] the deck activity avatars area does not sit on top of the buttons
