### PR TITLE
atomic update poker scope

### DIFF
--- a/packages/server/billing/helpers/processInvoiceItemHook.ts
+++ b/packages/server/billing/helpers/processInvoiceItemHook.ts
@@ -40,7 +40,7 @@ const getSafeProrationDate = async (
 
 const processInvoiceItemHook = async (stripeSubscriptionId: string) => {
   const redisLock = new RedisLock(stripeSubscriptionId, 3000)
-  const lockTTL = await redisLock.lock()
+  const lockTTL = await redisLock.checkLock()
   if (lockTTL > 0) {
     // it's possible that the subscription is unlocked before this is up & another call jumps in line
     // but the work to be done is decided after the lock, not before, so order isn't important

--- a/packages/server/graphql/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/mutations/acceptTeamInvitation.ts
@@ -79,7 +79,7 @@ export default {
       // make sure that same invite can't be accepted at the same moment
       const ttl = 3000
       const redisLock = new RedisLock(`acceptTeamInvitation:${viewerId}:${orgId}`, ttl)
-      const lockTTL = await redisLock.lock()
+      const lockTTL = await redisLock.checkLock()
       if (lockTTL > 0) {
         return {
           error: {message: `You already called this ${ttl - lockTTL}ms ago!`}

--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -28,8 +28,11 @@ const updatePokerScope = {
       description: 'The list of items to add/remove to the estimate phase'
     }
   },
-  resolve: async (_source, {meetingId, updates}, context: GQLContext) => {
-    const {authToken, dataLoader, socketId: mutatorId} = context
+  resolve: async (
+    _source,
+    {meetingId, updates},
+    {authToken, dataLoader, socketId: mutatorId}: GQLContext
+  ) => {
     const r = await getRethink()
     const redis = getRedis()
     const viewerId = getUserId(authToken)

--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -10,6 +10,7 @@ import {getUserId, isTeamMember} from '../../utils/authorization'
 import ensureJiraDimensionField from '../../utils/ensureJiraDimensionField'
 import getRedis from '../../utils/getRedis'
 import publish from '../../utils/publish'
+import RedisLock from '../../utils/RedisLock'
 import {GQLContext} from '../graphql'
 import UpdatePokerScopeItemInput from '../types/UpdatePokerScopeItemInput'
 import UpdatePokerScopePayload from '../types/UpdatePokerScopePayload'
@@ -27,11 +28,8 @@ const updatePokerScope = {
       description: 'The list of items to add/remove to the estimate phase'
     }
   },
-  resolve: async (
-    _source,
-    {meetingId, updates},
-    {authToken, dataLoader, socketId: mutatorId}: GQLContext
-  ) => {
+  resolve: async (_source, {meetingId, updates}, context: GQLContext) => {
+    const {authToken, dataLoader, socketId: mutatorId} = context
     const r = await getRethink()
     const redis = getRedis()
     const viewerId = getUserId(authToken)
@@ -55,6 +53,10 @@ const updatePokerScope = {
     if (meetingType !== 'poker') {
       return {error: {message: 'Not a poker meeting'}}
     }
+
+    // lock the meeting while the scope is updating
+    const redisLock = new RedisLock(`meeting:${meetingId}`, 3000)
+    await redisLock.lock(10000)
 
     // RESOLUTION
     const requiredJiraMappers = [] as {
@@ -136,6 +138,7 @@ const updatePokerScope = {
       })
       .run()
 
+    await redisLock.unlock()
     const data = {meetingId}
     publish(SubscriptionChannel.MEETING, meetingId, 'UpdatePokerScopeSuccess', data, subOptions)
     return data

--- a/packages/server/utils/RedisLock.ts
+++ b/packages/server/utils/RedisLock.ts
@@ -1,3 +1,4 @@
+import sleep from '../../client/utils/sleep'
 import generateUID from '../generateUID'
 import getRedis from './getRedis'
 
@@ -5,14 +6,16 @@ export default class RedisLock {
   value = generateUID()
   key: string
   ttl: number
+  waitTime: number
   redis = getRedis()
 
   constructor(key: string, ttl: number) {
     this.key = `lock:${key}`
     this.ttl = ttl
+    this.waitTime = 0
   }
 
-  lock = async () => {
+  checkLock = async () => {
     // returns time left until key expires. 0 means it doesn't exist
     const res = await this.redis.set(this.key, this.value, 'PX', this.ttl, 'NX')
     if (res === 'OK') return -1
@@ -26,5 +29,17 @@ export default class RedisLock {
       return true
     }
     return undefined
+  }
+
+  lock = async (maxWait: number) => {
+    for (let i = 0; i < 1000; i++) {
+      const lockTTL = await this.checkLock()
+      if (lockTTL <= 0) return
+      this.waitTime += lockTTL
+      if (this.waitTime > maxWait) {
+        throw new Error(`Could not achieve lock for ${this.key} after ${maxWait}ms`)
+      }
+      await sleep(lockTTL)
+    }
   }
 }


### PR DESCRIPTION
fix #4719 

I decided to go with a document lock instead of a nested in-place update.
Reason being, that nested update would have to operate on 1 update at a time, and in the case of a large select-all, it could actually take longer than using a lock.

Also updated the lock API so it's easier to just wait until we have a lock

TEST
- [x] follow the repro steps in #4719
