### PR TITLE
fix end time start month

### DIFF
--- a/packages/client/components/StageTimerModalEndTimeDate.tsx
+++ b/packages/client/components/StageTimerModalEndTimeDate.tsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import useMenu from '../hooks/useMenu'
-import {MenuPosition} from '../hooks/useCoords'
 import styled from '@emotion/styled'
-import DropdownMenuToggle from './DropdownMenuToggle'
 import ms from 'ms'
-import Icon from './Icon'
-import {shortDays, shortMonths} from '../utils/makeDateString'
+import React from 'react'
 import DayPicker, {DayModifiers} from 'react-day-picker'
+import {MenuPosition} from '../hooks/useCoords'
+import useMenu from '../hooks/useMenu'
 import '../styles/daypicker.css'
 import {PALETTE} from '../styles/paletteV3'
+import {shortDays, shortMonths} from '../utils/makeDateString'
 import roundDateToNearestHalfHour from '../utils/roundDateToNearestHalfHour'
+import DropdownMenuToggle from './DropdownMenuToggle'
+import Icon from './Icon'
 
 interface Props {
   endTime: Date
@@ -68,7 +68,7 @@ const StageTimerModalEndTimeDate = (props: Props) => {
       {menuPortal(
         <DayPicker
           disabledDays={{before: now}}
-          fromMonth={endTime}
+          fromMonth={now}
           initialMonth={endTime}
           onDayClick={handleDayClick}
           selectedDays={endTime}


### PR DESCRIPTION
fix #4766 

the first month available in the date picker should be the month of today, not the month of the suggested end time