### PR TITLE
poker subnav item styles (merge into branch ‘fix-4671’)

### DIFF
--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -8,7 +8,7 @@ const lineHeight = NavSidebar.SUB_LINE_HEIGHT
 
 interface ItemRootProps {
   isActive: boolean
-  isComplete: boolean
+  isComplete?: boolean
   isDisabled: boolean
   isDragging: boolean
   onClick: ((e: React.MouseEvent) => void) | undefined
@@ -17,6 +17,7 @@ interface ItemRootProps {
 
 const ItemRoot = styled('div')<ItemRootProps>(
   ({isActive, isComplete, isDisabled, isDragging, onClick}) => ({
+    alignItems: 'center',
     backgroundColor: isActive ? PALETTE.SLATE_100 : isDragging ? PALETTE.SLATE_100 : 'transparent',
     borderRadius: '0 4px 4px 0',
     color: PALETTE.SLATE_700,
@@ -43,11 +44,10 @@ const ItemRoot = styled('div')<ItemRootProps>(
     }
 )
 
-const ItemLabel = styled('div')<{isComplete: boolean}>(({isComplete}) => ({
+const ItemLabel = styled('div')<{isComplete?: boolean}>(({isComplete}) => ({
   color: 'inherit',
   fontSize: NavSidebar.SUB_FONT_SIZE,
   flex: 1,
-  lineHeight,
   paddingLeft: 56,
   textDecoration: isComplete ? 'line-through' : undefined,
   wordBreak: 'break-word',
@@ -66,7 +66,7 @@ const ItemMeta = styled('div')({
 
 interface Props {
   isActive: boolean
-  isComplete: boolean
+  isComplete?: boolean
   isDisabled: boolean
   isDragging: boolean
   isUnsyncedFacilitatorStage: boolean

--- a/packages/client/components/PokerSidebarEstimateSection.tsx
+++ b/packages/client/components/PokerSidebarEstimateSection.tsx
@@ -43,10 +43,10 @@ const Title = styled('div')({
 })
 
 const Subtitle = styled('div')({
+  color: PALETTE.SLATE_500,
   fontSize: 11,
   fontWeight: 600,
-  color: PALETTE.SLATE_500,
-  lineHeight: '8px'
+  lineHeight: '12px'
 })
 
 const PokerSidebarEstimateSection = (props: Props) => {
@@ -127,7 +127,6 @@ const PokerSidebarEstimateSection = (props: Props) => {
                     title,
                     subtitle,
                     isActive,
-                    isComplete,
                     isNavigable,
                     finalScores
                   } = summary
@@ -156,7 +155,6 @@ const PokerSidebarEstimateSection = (props: Props) => {
                               metaContent={<PokerSidebarEstimateMeta finalScores={finalScores} />}
                               onClick={() => handleClick(stageIds)}
                               isActive={isActive}
-                              isComplete={isComplete}
                               isDisabled={!isNavigable}
                               isUnsyncedFacilitatorStage={isUnsyncedFacilitatorStage}
                             >


### PR DESCRIPTION
¡**Ojo**! This merges into branch `fix-4671` **not** master

- [ ] Adjusts alignment and spacing (e.g. Parabol task label wasn’t aligned vertically; Jira issue number was too cramped IMO)
- [ ] `isComplete` styles are now optional; the poker subnav items don’t need it per UX case