### PR TITLE
Add type safety to deleteUser

### DIFF
--- a/packages/server/graphql/mutations/deleteUser.ts
+++ b/packages/server/graphql/mutations/deleteUser.ts
@@ -27,7 +27,11 @@ export default {
       description: 'the reason why the user wants to delete their account'
     }
   },
-  resolve: async (_source, {userId, email, reason}, {authToken, dataLoader}: GQLContext) => {
+  resolve: async (
+    _source,
+    {userId, email, reason}: {userId?: string; email?: string; reason?: string},
+    {authToken, dataLoader}: GQLContext
+  ) => {
     const r = await getRethink()
     // AUTH
     if (userId && email) {
@@ -42,7 +46,7 @@ export default {
     const index = userId ? 'id' : 'email'
     const user = (await r
       .table('User')
-      .getAll(userId || email, {index})
+      .getAll((userId || email)!, {index})
       .nth(0)
       .default(null)
       .run()) as User
@@ -53,22 +57,23 @@ export default {
     } else if (!user) {
       return {error: {message: 'User not found'}}
     }
-    const validReason = reason.trim().slice(0, 2000)
     const {id: userIdToDelete} = user
     const orgUsers = await dataLoader.get('organizationUsersByUserId').load(userIdToDelete)
     const orgIds = orgUsers.map((orgUser) => orgUser.orgId)
     await Promise.all(
       orgIds.map((orgId) => removeFromOrg(userIdToDelete, orgId, undefined, dataLoader))
     )
-    segmentIo.track({
-      userId,
-      event: 'Account Removed',
-      properties: {
-        reason: validReason
-      }
-    })
+    const validReason = reason?.trim().slice(0, 2000) || 'No reason provided'
+    if (userId) {
+      segmentIo.track({
+        userId,
+        event: 'Account Removed',
+        properties: {
+          reason: validReason
+        }
+      })
+    }
     // do this after 30 seconds so any segment API calls can still get the email
-
     setTimeout(() => {
       db.write('User', userIdToDelete, {
         isRemoved: true,


### PR DESCRIPTION
PR to resolve issue #4825 

This PR defines the argument types & checks if `reason` exists so that an error isn't returned when it's not provided. 