### PR TITLE
Remove IM scopes in Slack

### DIFF
--- a/packages/client/hooks/useSlackChannels.ts
+++ b/packages/client/hooks/useSlackChannels.ts
@@ -1,7 +1,6 @@
 import {useEffect, useState} from 'react'
 import {SlackChannelDropdownChannels} from '../components/SlackChannelDropdown'
 import SlackClientManager from '../utils/SlackClientManager'
-import {isSlackIMArray} from '~/utils/isSlackIMArray.ts'
 
 const useSlackChannels = (
   slackAuth: {botAccessToken: string | null; slackUserId: string} | null
@@ -11,10 +10,10 @@ const useSlackChannels = (
     if (!slackAuth || !slackAuth.botAccessToken) return
     let isMounted = true
     const getChannels = async () => {
-      const botManager = new SlackClientManager(slackAuth.botAccessToken!)
-      const [publicChannelRes, slackIMRes, privateChannelRes] = await Promise.all([
+      const {botAccessToken, slackUserId} = slackAuth
+      const botManager = new SlackClientManager(botAccessToken!)
+      const [publicChannelRes, privateChannelRes] = await Promise.all([
         botManager.getConversationList(),
-        botManager.getConversationList(['im']),
         botManager.getConversationList(['private_channel'])
       ])
       if (!isMounted) return
@@ -24,22 +23,18 @@ const useSlackChannels = (
       }
 
       let availableChannels
-      if (!isSlackIMArray(publicChannelRes.channels)) {
-        const {channels: publicChannels} = publicChannelRes
-        if (privateChannelRes.ok && privateChannelRes.channels.length) {
-          availableChannels = [...privateChannelRes.channels, ...publicChannels]
-        } else {
-          availableChannels = publicChannels
-        }
-        availableChannels.sort((a, b) => (a.name > b.name ? 1 : -1))
+      const {channels: publicChannels} = publicChannelRes
+      if (privateChannelRes.ok && privateChannelRes.channels.length) {
+        availableChannels = [...privateChannelRes.channels, ...publicChannels]
+      } else {
+        availableChannels = publicChannels
       }
-      if (slackIMRes.ok && isSlackIMArray(slackIMRes.channels)) {
-        const {channels: ims} = slackIMRes
-        const botChannel = ims.find((im) => im.is_im && im.user === slackAuth.slackUserId) as any
-        if (botChannel) {
-          availableChannels.unshift({...botChannel, name: '@Parabol'})
-        }
+      availableChannels.sort((a, b) => (a.name > b.name ? 1 : -1))
+      const botChannel = {
+        id: slackUserId,
+        name: '@Parabol'
       }
+      availableChannels.unshift({...botChannel, name: '@Parabol'})
       setChannels(availableChannels)
     }
     getChannels().catch()

--- a/packages/client/hooks/useSlackChannels.ts
+++ b/packages/client/hooks/useSlackChannels.ts
@@ -21,7 +21,6 @@ const useSlackChannels = (
         console.error(publicChannelRes.error)
         return
       }
-
       let availableChannels
       const {channels: publicChannels} = publicChannelRes
       if (privateChannelRes.ok && privateChannelRes.channels.length) {

--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -3,17 +3,7 @@ interface ErrorResponse {
   error: string
 }
 
-export interface SlackIM {
-  created: number
-  id: string
-  is_im: true
-  is_org_shared: boolean
-  is_user_deleted: boolean
-  priority: number
-  user: string
-}
-
-export interface SlackPublicConversation {
+export interface SlackConversation {
   id: string
   name: string
   is_channel: boolean
@@ -67,20 +57,11 @@ export interface SlackPublicConversation {
   locale: string
 }
 
-type SlackConversation = SlackPublicConversation | SlackIM
-
 interface ConversationListResponse {
   ok: true
-  channels: SlackPublicConversation[] | SlackIM[]
+  channels: SlackConversation[]
 }
 interface ConversationJoinResponse {
-  ok: true
-  channel: {
-    id: string
-  }
-}
-
-interface ConversationOpenResponse {
   ok: true
   channel: {
     id: string
@@ -149,11 +130,10 @@ interface ConversationInfoResponse {
   channel: SlackConversation
 }
 
-type ConversationType = 'public_channel' | 'private_channel' | 'im' | 'mpim'
+type ConversationType = 'public_channel' | 'private_channel'
 
 abstract class SlackManager {
-  static SCOPE =
-    'incoming-webhook,channels:read,channels:join,chat:write,im:read,im:write,users:read'
+  static SCOPE = 'incoming-webhook,channels:read,channels:join,chat:write,users:read'
   token: string
   abstract fetch: any
   // the any is for node until we can use tsc in nodeland
@@ -219,12 +199,6 @@ abstract class SlackManager {
   joinConversation(channelId: string) {
     return this.get<ConversationJoinResponse>(
       `https://slack.com/api/conversations.join?token=${this.token}&channel=${channelId}`
-    )
-  }
-
-  openDM(userId) {
-    return this.get<ConversationOpenResponse>(
-      `https://slack.com/api/conversations.open?token=${this.token}&users=${userId}`
     )
   }
 

--- a/packages/client/utils/isSlackIMArray.ts
+++ b/packages/client/utils/isSlackIMArray.ts
@@ -1,7 +1,0 @@
-import {SlackIM, SlackPublicConversation} from './SlackManager'
-
-export const isSlackIMArray = (
-  channels: SlackPublicConversation[] | SlackIM[]
-): channels is SlackIM[] => {
-  return !!(channels as SlackIM[]).find((channel) => channel.is_im)
-}

--- a/packages/server/graphql/mutations/addSlackAuth.ts
+++ b/packages/server/graphql/mutations/addSlackAuth.ts
@@ -115,20 +115,17 @@ export default {
     const {response} = manager
     const slackUserId = response.authed_user.id
     const defaultChannelId = response.incoming_webhook.channel_id
-    const [joinConvoRes, userInfoRes, openDMRes] = await Promise.all([
+    const [joinConvoRes, userInfoRes] = await Promise.all([
       manager.joinConversation(defaultChannelId),
-      manager.getUserInfo(slackUserId),
-      manager.openDM(slackUserId)
+      manager.getUserInfo(slackUserId)
     ])
     if (!userInfoRes.ok) {
       return standardError(new Error(userInfoRes.error), {userId: viewerId})
     }
-    if (!openDMRes.ok) {
-      return standardError(new Error(openDMRes.error), {userId: viewerId})
-    }
 
     // The default channel could be anything: public, private, im, mpim. Only allow public channels or the @Parabol channel
-    const teamChannelId = joinConvoRes.ok ? joinConvoRes.channel.id : openDMRes.channel.id
+    // Using the slackUserId sends a DM to the user as @Parabol
+    const teamChannelId = joinConvoRes.ok ? joinConvoRes.channel.id : slackUserId
 
     const [, slackAuthId] = await Promise.all([
       upsertNotifications(viewerId, teamId, teamChannelId, defaultChannelId),

--- a/packages/server/graphql/mutations/addSlackAuth.ts
+++ b/packages/server/graphql/mutations/addSlackAuth.ts
@@ -124,7 +124,7 @@ export default {
     }
 
     // The default channel could be anything: public, private, im, mpim. Only allow public channels or the @Parabol channel
-    // Using the slackUserId sends a DM to the user as @Parabol
+    // Using the slackUserId sends a DM to the user from @Parabol
     const teamChannelId = joinConvoRes.ok ? joinConvoRes.channel.id : slackUserId
 
     const [, slackAuthId] = await Promise.all([

--- a/packages/server/graphql/mutations/setDefaultSlackChannel.ts
+++ b/packages/server/graphql/mutations/setDefaultSlackChannel.ts
@@ -37,10 +37,10 @@ const setDefaultSlackChannel = {
     const channelInfo = await manager.getConversationInfo(slackChannelId)
 
     // should either be a public / private channel or the slackUserId if messaging from @Parabol
-    if (!channelInfo.ok && slackChannelId !== slackUserId) {
-      return standardError(new Error(channelInfo.error), {userId: viewerId})
-    }
-    if (channelInfo.ok) {
+    if (slackChannelId !== slackUserId) {
+      if (!channelInfo.ok) {
+        return standardError(new Error(channelInfo.error), {userId: viewerId})
+      }
       const {channel} = channelInfo
       const {id: channelId, is_member: isMember, is_archived: isArchived} = channel
       if (isArchived) {

--- a/packages/server/graphql/mutations/setDefaultSlackChannel.ts
+++ b/packages/server/graphql/mutations/setDefaultSlackChannel.ts
@@ -32,15 +32,16 @@ const setDefaultSlackChannel = {
     if (!slackAuth) {
       return standardError(new Error('Slack authentication not found'), {userId: viewerId})
     }
-    const {id: slackAuthId, botAccessToken, defaultTeamChannelId} = slackAuth
+    const {id: slackAuthId, botAccessToken, defaultTeamChannelId, slackUserId} = slackAuth
     const manager = new SlackServerManager(botAccessToken)
     const channelInfo = await manager.getConversationInfo(slackChannelId)
 
-    if (!channelInfo.ok) {
+    // should either be a public / private channel or the slackUserId if messaging from @Parabol
+    if (!channelInfo.ok && slackChannelId !== slackUserId) {
       return standardError(new Error(channelInfo.error), {userId: viewerId})
     }
-    const {channel} = channelInfo
-    if (!channel.is_im) {
+    if (channelInfo.ok && !channelInfo.channel.is_im) {
+      const {channel} = channelInfo
       const {id: channelId, is_member: isMember, is_archived: isArchived} = channel
       if (isArchived) {
         return standardError(new Error('Slack channel archived'), {userId: viewerId})

--- a/packages/server/graphql/mutations/setDefaultSlackChannel.ts
+++ b/packages/server/graphql/mutations/setDefaultSlackChannel.ts
@@ -40,7 +40,7 @@ const setDefaultSlackChannel = {
     if (!channelInfo.ok && slackChannelId !== slackUserId) {
       return standardError(new Error(channelInfo.error), {userId: viewerId})
     }
-    if (channelInfo.ok && !channelInfo.channel.is_im) {
+    if (channelInfo.ok) {
       const {channel} = channelInfo
       const {id: channelId, is_member: isMember, is_archived: isArchived} = channel
       if (isArchived) {


### PR DESCRIPTION
To send a DM from the `@Parabol` bot, we were using the [conversations.open](https://api.slack.com/methods/conversations.open) method and the [conversations.list](https://api.slack.com/methods/conversations.list) method to get the bot's channel id. Both methods required the IM scope.

The [postMessage](https://api.slack.com/methods/chat.postMessage) method requires a Slack channel id as an argument. However, instead of using `conversations.list` to get the bot's channel id (using the IM scope), the fine print explains that you can pass the user's id as the channel id which will then send a notification from `@Parabol`. 

This PR:

- Uses the user's id as the channel id when using the `@Parabol` bot
- Removes references to IM

In the `Parabol-staging` app, I've removed the IM scopes but I haven't removed the `localhost` redirect URL in case you want to test the functionality. 