### PR TITLE
Fixed meeting control bar width

### DIFF
--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -47,7 +47,7 @@ const Wrapper = styled('div')<{left: number}>(({left}) => ({
     borderRadius: 4,
     bottom: 8,
     boxShadow: desktopBarShadow,
-    width: 'fit-content'
+    width: 'auto'
   }
 }))
 


### PR DESCRIPTION
 There's an issue with `MeetingControlBar` width and `fit-content` usage. In this case `width: auto` fixes the issue. 
### Before
![CleanShot 2021-04-01 at 22 20 00](https://user-images.githubusercontent.com/1017620/113356647-e2f89a80-9342-11eb-945f-9adec06b2751.gif)
### After
![CleanShot 2021-04-01 at 22 20 39](https://user-images.githubusercontent.com/1017620/113356652-e68c2180-9342-11eb-8ae4-88e6d80ce434.gif)
