### PR TITLE
Fix tator being kicked out of Poker

### DIFF
--- a/packages/client/hooks/useUpdatedSafeRoute.ts
+++ b/packages/client/hooks/useUpdatedSafeRoute.ts
@@ -2,7 +2,6 @@ import graphql from 'babel-plugin-relay/macro'
 import {Dispatch, SetStateAction, useEffect, useRef} from 'react'
 import {readInlineData} from 'relay-runtime'
 import {useUpdatedSafeRoute_meeting} from '~/__generated__/useUpdatedSafeRoute_meeting.graphql'
-import findStageBeforeId from '../utils/meetings/findStageBeforeId'
 import findStageById from '../utils/meetings/findStageById'
 import fromStageIdToUrl from '../utils/meetings/fromStageIdToUrl'
 import updateLocalStage from '../utils/relay/updateLocalStage'
@@ -54,19 +53,11 @@ const useUpdatedSafeRoute = (setSafeRoute: Dispatch<SetStateAction<boolean>>, me
     // if the stage changes or the order of the stages changes, update the url
     const isNewLocalStageId = localStageId && localStageId !== oldLocalStageId
     const isUpdatedPhase = localStages !== oldLocalStages
-    let stageId = facilitatorStageId
     if (isNewLocalStageId || isUpdatedPhase) {
       if (isUpdatedPhase && !findStageById(phases, localStageId)) {
-        // an item was removed and the local stage may be missing
-        const tatorStageExists = findStageById(phases, facilitatorStageId)
-        if (!tatorStageExists) {
-          const prevStage = findStageBeforeId(oldMeeting.phases, localStageId)
-          const prevStageId = prevStage?.stage.id
-          if (prevStageId) stageId = prevStageId
-        }
-        updateLocalStage(atmosphere, meetingId, stageId)
+        updateLocalStage(atmosphere, meetingId, facilitatorStageId)
       }
-      const nextPathname = fromStageIdToUrl(localStageId, meeting, stageId)
+      const nextPathname = fromStageIdToUrl(localStageId, meeting, facilitatorStageId)
       if (nextPathname !== location.pathname) {
         history.replace(nextPathname)
         // do not set as unsafe (repro: start meeting, end, start again)

--- a/packages/client/hooks/useUpdatedSafeRoute.ts
+++ b/packages/client/hooks/useUpdatedSafeRoute.ts
@@ -2,6 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {Dispatch, SetStateAction, useEffect, useRef} from 'react'
 import {readInlineData} from 'relay-runtime'
 import {useUpdatedSafeRoute_meeting} from '~/__generated__/useUpdatedSafeRoute_meeting.graphql'
+import findStageBeforeId from '../utils/meetings/findStageBeforeId'
 import findStageById from '../utils/meetings/findStageById'
 import fromStageIdToUrl from '../utils/meetings/fromStageIdToUrl'
 import updateLocalStage from '../utils/relay/updateLocalStage'
@@ -53,13 +54,19 @@ const useUpdatedSafeRoute = (setSafeRoute: Dispatch<SetStateAction<boolean>>, me
     // if the stage changes or the order of the stages changes, update the url
     const isNewLocalStageId = localStageId && localStageId !== oldLocalStageId
     const isUpdatedPhase = localStages !== oldLocalStages
+    let stageId = facilitatorStageId
     if (isNewLocalStageId || isUpdatedPhase) {
       if (isUpdatedPhase && !findStageById(phases, localStageId)) {
         // an item was removed and the local stage may be missing
-        updateLocalStage(atmosphere, meetingId, facilitatorStageId)
+        const tatorStageExists = findStageById(phases, facilitatorStageId)
+        if (!tatorStageExists) {
+          const prevStage = findStageBeforeId(oldMeeting.phases, localStageId)
+          const prevStageId = prevStage?.stage.id
+          if (prevStageId) stageId = prevStageId
+        }
+        updateLocalStage(atmosphere, meetingId, stageId)
       }
-
-      const nextPathname = fromStageIdToUrl(localStageId, meeting, facilitatorStageId)
+      const nextPathname = fromStageIdToUrl(localStageId, meeting, stageId)
       if (nextPathname !== location.pathname) {
         history.replace(nextPathname)
         // do not set as unsafe (repro: start meeting, end, start again)

--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -12,6 +12,7 @@ import {
 graphql`
   fragment UpdatePokerScopeMutation_meeting on UpdatePokerScopeSuccess {
     meeting {
+      facilitatorStageId
       phases {
         ...useMakeStageSummaries_phase
         ... on EstimatePhase {

--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -127,6 +127,12 @@ const updatePokerScope = {
             removingTatorStage.id,
             phases
           )
+          for (const stage of stages) {
+            if (stage.id === nextStage.id) {
+              stage.startAt = now
+              break
+            }
+          }
           meeting.facilitatorStageId = nextStage.id
         }
         if (stagesToRemove.length > 0) {


### PR DESCRIPTION
PR to resolve issue #4811 

Steps to reproduce:

- User A, the facilitator, goes to a Story in the Estimate Phase
- User B goes back to the Scope phase and removes the Story that User A is currently on
- User A will be kicked out of the meeting and won't be able to go back to the meeting unless they change the phase in the URL

One solution would be to prevent users from removing Stories that are active in the Estimate Phase but I think users should have that power and we should accommodate.

The solution in this PR doesn't update the `facilitatorStageId`. I think that's OK as the local stage updates and the `facilitatorStageId` will change when the facilitator makes their next move. If that seems problematic, I could update the `facilitatorStageId` in `updatePokerScope`. 


### AC

- [ ] Follow steps to reproduce but instead of being kicked out the meeting, the facilitator goes back to the previous stage