### PR TITLE
Fix team invitation

### DIFF
--- a/packages/client/components/ViewerNotOnTeam.tsx
+++ b/packages/client/components/ViewerNotOnTeam.tsx
@@ -23,14 +23,11 @@ interface Props {
 const ViewerNotOnTeam = (props: Props) => {
   const {viewer} = props
   const {
-    meeting,
-    team,
     teamInvitation: {teamInvitation, meetingId, teamId}
   } = viewer
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   useDocumentTitle(`Invitation Required`, 'Invitation Required')
-
   useEffect(
     () => {
       if (teamInvitation) {
@@ -41,9 +38,7 @@ const ViewerNotOnTeam = (props: Props) => {
           {history, meetingId}
         )
         return
-      } else if (meeting) history.replace(`/meet/${meetingId}`)
-      else if (team) history.replace(`/team/${teamId}`)
-      else if (teamId) PushInvitationMutation(atmosphere, {meetingId, teamId})
+      } else if (teamId) PushInvitationMutation(atmosphere, {meetingId, teamId})
       return undefined
     },
     [
@@ -51,9 +46,7 @@ const ViewerNotOnTeam = (props: Props) => {
     ]
   )
 
-  if (teamInvitation || team) {
-    return null
-  }
+  if (teamInvitation) return null
   return (
     <TeamInvitationWrapper>
       <InviteDialog>
@@ -77,12 +70,6 @@ const ViewerNotOnTeam = (props: Props) => {
 export default createFragmentContainer(ViewerNotOnTeam, {
   viewer: graphql`
     fragment ViewerNotOnTeam_viewer on User {
-      meeting(meetingId: $meetingId) {
-        meetingType
-      }
-      team(teamId: $teamId) {
-        name
-      }
       teamInvitation(teamId: $teamId, meetingId: $meetingId) {
         teamInvitation {
           token

--- a/packages/client/mutations/InviteToTeamMutation.ts
+++ b/packages/client/mutations/InviteToTeamMutation.ts
@@ -4,7 +4,7 @@ import {commitMutation} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import {matchPath} from 'react-router'
 import handleAddNotifications from './handlers/handleAddNotifications'
-import {OnNextHistoryContext, StandardMutation} from '../types/relayMutations'
+import {LocalHandlers, OnNextHistoryContext, StandardMutation} from '../types/relayMutations'
 import AcceptTeamInvitationMutation from './AcceptTeamInvitationMutation'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
 
@@ -94,7 +94,7 @@ export const inviteToTeamNotificationOnNext = (
   }
 }
 
-const InviteToTeamMutation: StandardMutation<TInviteToTeamMutation> = (
+const InviteToTeamMutation: StandardMutation<TInviteToTeamMutation, LocalHandlers> = (
   atmosphere,
   variables,
   {onError, onCompleted}

--- a/packages/client/mutations/PushInvitationMutation.ts
+++ b/packages/client/mutations/PushInvitationMutation.ts
@@ -9,7 +9,6 @@ import {
 import {PushInvitationMutation_team} from '../__generated__/PushInvitationMutation_team.graphql'
 import InviteToTeamMutation from './InviteToTeamMutation'
 import DenyPushInvitationMutation from './DenyPushInvitationMutation'
-import useMutationProps from '../hooks/useMutationProps'
 
 graphql`
   fragment PushInvitationMutation_team on PushInvitationPayload {
@@ -41,7 +40,6 @@ export const pushInvitationTeamOnNext: OnNextHandler<PushInvitationMutation_team
   payload,
   {atmosphere}
 ) => {
-  const {onError, onCompleted} = useMutationProps()
   const {user, team, meetingId} = payload
   if (!user || !team) return
   const {preferredName, email, id: userId} = user
@@ -53,11 +51,7 @@ export const pushInvitationTeamOnNext: OnNextHandler<PushInvitationMutation_team
     action: {
       label: 'Accept',
       callback: () => {
-        InviteToTeamMutation(
-          atmosphere,
-          {meetingId, teamId, invitees: [email]},
-          {onError, onCompleted}
-        )
+        InviteToTeamMutation(atmosphere, {meetingId, teamId, invitees: [email]}, {})
       }
     },
     secondaryAction: {


### PR DESCRIPTION
PR to resolve issue #4744 

Current problems:

1. If a user tries to join a team, the team members in that team may see a React Hooks error.
2. The `team` and `meeting` queries in `ViewerNotOnTeam` are invalid as `teamId` and `meetingId` can be null.

Solutions:

1. This is being caused by `PushInvitationMutation` breaking the rules of hooks which explains why the bug only happens in development and not production.
2. A bug in the Relay compiler prevented it from detecting the error (if we use a regular query instead of a fragment, it does detect the error). It looks like we don't need to check whether `team` or `meeting` exist in `ViewerNotOnTeam` as [MeetingSelector](https://github.com/ParabolInc/parabol/blob/235b57d1790f74b6170f8c3ebd5acf30839a472c/packages/client/components/MeetingSelector.tsx#L34) and [TeamContainer](https://github.com/ParabolInc/parabol/blob/f9693de81dd203521b9d1862b744c186936d636c/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx#L34) already do this for us. If they don't exist, the viewer will be sent back to `ViewerNotOnTeam`.


### AC

- [ ] If a user tries to join a team, the team members of that team don't see an error in development
- [ ] If a user tries to join a team, the server doesn't complain that the query is invalid
- [ ] A user can successfully join a team by going to `/team`, an active meeting or using the invitation link