### PR TITLE
Fix editing too bug

### DIFF
--- a/packages/client/components/EditingStatus/EditingStatusText.tsx
+++ b/packages/client/components/EditingStatus/EditingStatusText.tsx
@@ -54,7 +54,7 @@ const EditingStatusText = (props: Props) => {
     return (
       <span>
         {editor}
-        {' editing'}
+        {' is editing'}
         {isEditing ? ' too' : ''}
         <Ellipsis />
       </span>
@@ -64,21 +64,21 @@ const EditingStatusText = (props: Props) => {
     if (isEditing) {
       return (
         <span>
-          several are editing
+          several people are editing
           <Ellipsis />
         </span>
       )
     }
     return (
       <span>
-        {`${editorNames[0]} and ${editorNames[1]} editing`}
+        {`${editorNames[0]} and ${editorNames[1]} are editing`}
         <Ellipsis />
       </span>
     )
   }
   return (
     <span>
-      {'Several are editing'}
+      {'Several people are editing'}
       <Ellipsis />
     </span>
   )

--- a/packages/client/mutations/CreateTaskMutation.ts
+++ b/packages/client/mutations/CreateTaskMutation.ts
@@ -64,12 +64,11 @@ export const createTaskTaskUpdater: SharedUpdater<CreateTaskMutation_task> = (pa
   const task = payload.getLinkedRecord('task')
   if (!task) return
   const taskId = task.getValue('id')
-  const userId = task.getValue('userId')
   const content = task.getValue('content')
   const rawContent = JSON.parse(content)
   const {blocks} = rawContent
   const isEditing = blocks.length === 0 || (blocks.length === 1 && blocks[0].text === '')
-  const editorPayload = getOptimisticTaskEditor(store, userId, taskId, isEditing)
+  const editorPayload = getOptimisticTaskEditor(store, taskId, isEditing)
   handleEditTask(editorPayload, store)
   handleUpsertTasks(task, store)
 }
@@ -113,8 +112,9 @@ const CreateTaskMutation: StandardMutation<TCreateTaskMutation, OptionalHandlers
       const now = new Date().toJSON()
       const taskId = clientTempId(teamId)
       const viewer = store.getRoot().getLinkedRecord('viewer')
-      const plaintextContent = newTask.plaintextContent || (
-        newTask.content ? extractTextFromDraftString(newTask.content) : '')
+      const plaintextContent =
+        newTask.plaintextContent ||
+        (newTask.content ? extractTextFromDraftString(newTask.content) : '')
       const optimisticTask = {
         ...newTask,
         id: taskId,
@@ -132,7 +132,7 @@ const CreateTaskMutation: StandardMutation<TCreateTaskMutation, OptionalHandlers
         .setLinkedRecord(userId ? store.get(userId)! : null, 'user')
         .setLinkedRecord(viewer, 'createdByUser')
         .setLinkedRecords([], 'replies')
-      const editorPayload = getOptimisticTaskEditor(store, userId, taskId, isEditing)
+      const editorPayload = getOptimisticTaskEditor(store, taskId, isEditing)
       handleEditTask(editorPayload, store)
       handleUpsertTasks(task as any, store)
     },

--- a/packages/client/mutations/EditTaskMutation.ts
+++ b/packages/client/mutations/EditTaskMutation.ts
@@ -34,7 +34,6 @@ export const editTaskTaskUpdater = (payload, store) => {
 
 const EditTaskMutation = (environment, taskId, isEditing, onCompleted?, onError?) => {
   if (isTempId(taskId)) return undefined
-  const {viewerId} = environment
   return commitMutation(environment, {
     mutation,
     variables: {taskId, isEditing},
@@ -44,7 +43,7 @@ const EditTaskMutation = (environment, taskId, isEditing, onCompleted?, onError?
       editTaskTaskUpdater(payload, store)
     },
     optimisticUpdater: (store) => {
-      const payload = getOptimisticTaskEditor(store, viewerId, taskId, isEditing)
+      const payload = getOptimisticTaskEditor(store, taskId, isEditing)
       handleEditTask(payload, store)
     },
     onCompleted,

--- a/packages/client/utils/relay/getOptimisticTaskEditor.js
+++ b/packages/client/utils/relay/getOptimisticTaskEditor.js
@@ -1,12 +1,12 @@
 import createProxyRecord from './createProxyRecord'
 
-const getOptimisticTaskEditor = (store, userId, taskId, isEditing) => {
+const getOptimisticTaskEditor = (store, taskId, isEditing) => {
+  const viewer = store.getRoot().getLinkedRecord('viewer')
   const task = store.get(taskId)
-  const user = store.get(userId) || createProxyRecord(store, 'User', {id: userId})
   const payload = createProxyRecord(store, 'EditTaskMutationPayload', {
     isEditing
   })
-  return payload.setLinkedRecord(user, 'editor').setLinkedRecord(task, 'task')
+  return payload.setLinkedRecord(viewer, 'editor').setLinkedRecord(task, 'task')
 }
 
 export default getOptimisticTaskEditor


### PR DESCRIPTION
PR to resolve issue #4829 

Repro the issue:

- Go to team kanban
- filter by another team member (not you)
- add a task
- see that it says "X is editing too..."

The `userId` field in `task` tells us who owns the task but the task owner can be different from the task editor. Using the `viewer` instead of the task `user` resolves this bug.

### AC

- [ ] Filter by another team member, add a task and see "Editing..." rather than "X is editing too..."