### PR TITLE
refines avatar group layout

### DIFF
--- a/packages/client/components/AvatarList.tsx
+++ b/packages/client/components/AvatarList.tsx
@@ -8,9 +8,12 @@ import {AvatarList_users} from '../__generated__/AvatarList_users.graphql'
 import AvatarListUser from './AvatarListUser'
 import OverflowAvatar from './OverflowAvatar'
 
-const Wrapper = styled('div')<{minHeight: number}>(({minHeight}) => ({
+const Wrapper = styled('div')<{minHeight: number, size: number}>(({minHeight, size}) => ({
   alignItems: 'center',
   display: 'flex',
+  // This left margin accounts for the border on the avatar
+  // giving us tighter vertical alignment on the left edge
+  marginLeft: size >= 40 ? -3 : -2,
   position: 'relative',
   width: '100%',
   transition: `min-height 100ms ${BezierCurve.DECELERATE}`,
@@ -18,16 +21,23 @@ const Wrapper = styled('div')<{minHeight: number}>(({minHeight}) => ({
 }))
 
 const widthToOverlap = {
-  24: 10,
-  46: 10
+  28: 8,
+  46: 16
+}
+
+// hard coding for now until we have
+// a better solution for handling gutters
+// for a component that may not be there
+const sizeToHeightBump = {
+  28: 4,
+  46: 0
 }
 
 interface Props {
   users: AvatarList_users
   onUserClick?: (userId: string) => void
   onOverflowClick?: () => void
-  className?: string
-  size: 24 | 46
+  size: 28 | 46
   emptyEl?: ReactElement
   isAnimated?: boolean
   borderColor?: string
@@ -40,10 +50,9 @@ const AvatarList = (props: Props) => {
   const offsetSize = size - overlap
   const transitionChildren = useOverflowAvatars(rowRef, users, size, overlap)
   const showAnimated = isAnimated ?? true
-  // hardcoded 8px padding for now
-  const minHeight = transitionChildren.length === 0 ? 0 : size + 8
+  const minHeight = transitionChildren.length === 0 ? 0 : size + sizeToHeightBump[size]
   return (
-    <Wrapper ref={rowRef} minHeight={minHeight}>
+    <Wrapper ref={rowRef} minHeight={minHeight} size={size}>
       {transitionChildren.length === 0 && emptyEl}
       {transitionChildren.map(({onTransitionEnd, child, status, displayIdx}) => {
         const {id: userId} = child

--- a/packages/client/components/AvatarListUser.tsx
+++ b/packages/client/components/AvatarListUser.tsx
@@ -18,19 +18,20 @@ const Wrapper = styled('div')<{offset: number; isColumn?: boolean}>(({offset, is
 const StyledAvatar = styled(Avatar)<{
   status?: TransitionStatus
   isAnimated: boolean
-  borderColor?: string
-}>(({status, isAnimated, borderColor = '#fff'}) => ({
+  borderColor?: string,
+  width: number
+}>(({status, isAnimated, borderColor = '#fff', width}) => ({
+  border: `${width >= 40 ? '3px' : '2px'} solid ${borderColor}`,
   opacity: !isAnimated
     ? undefined
     : status === TransitionStatus.EXITING || status === TransitionStatus.MOUNTED
-    ? 0
-    : 1,
-  border: `2px solid ${borderColor}`,
+      ? 0
+      : 1,
   transform: !isAnimated
     ? undefined
     : status === TransitionStatus.EXITING || status === TransitionStatus.MOUNTED
-    ? 'scale(0)'
-    : 'scale(1)',
+      ? 'scale(0)'
+      : 'scale(1)',
   transition: `all 300ms ${BezierCurve.DECELERATE}`
 }))
 
@@ -81,6 +82,7 @@ const AvatarListUser = (props: Props) => {
         size={width}
         isAnimated={isAnimated}
         borderColor={borderColor}
+        width={width}
       />
       {tooltipPortal(preferredName)}
     </Wrapper>

--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -38,19 +38,26 @@ const CardWrapper = styled('div')<{maybeTabletPlus: boolean}>(({maybeTabletPlus}
 }))
 
 const MeetingInfo = styled('div')({
-  padding: '12px 16px'
+  // tighter padding for options, meta, avatars
+  // keep a nice left edge
+  padding: '8px 8px 8px 16px'
 })
 
 const Name = styled('div')({
   color: PALETTE.SLATE_700,
   fontSize: 20,
-  lineHeight: '32px'
+  lineHeight: '24px',
+  // add right padding to keep a long name from falling under the options button
+  // add top and bottom padding to keep a single line at 32px to match the options button
+  padding: '4px 32px 4px 0'
 })
 
 const Meta = styled('div')({
   color: PALETTE.SLATE_600,
   fontSize: 14,
-  lineHeight: '24px'
+  lineHeight: '24px',
+  // partial grid bottom padding accounts for maybe avatar whitespace and offset
+  paddingBottom: '4px'
 })
 
 const MeetingImgWrapper = styled('div')({
@@ -91,6 +98,7 @@ const Options = styled(CardButton)({
     backgroundColor: PALETTE.SLATE_200
   }
 })
+
 interface Props {
   meeting: MeetingCard_meeting
 }
@@ -157,7 +165,7 @@ const MeetingCard = (props: Props) => {
             {teamName} • {meetingPhaseLabel}
           </Meta>
         </Link>
-        <AvatarList users={connectedUsers} size={24} />
+        <AvatarList users={connectedUsers} size={28} />
       </MeetingInfo>
       {menuPortal(
         <MeetingCardOptionsMenuRoot

--- a/packages/client/components/PokerActiveVoting.tsx
+++ b/packages/client/components/PokerActiveVoting.tsx
@@ -80,6 +80,11 @@ const RevealButtonIcon = styled(Icon)<{color: string}>(({color}) => ({
   width: 40
 }))
 
+const MiniCardWrapper = styled('div')({
+  // This adds the gutter between the mini card and the avatars
+  marginRight: 16
+})
+
 interface Props {
   isClosing: boolean
   meeting: PokerActiveVoting_meeting
@@ -119,9 +124,11 @@ const PokerActiveVoting = (props: Props) => {
   return (
     <>
       <PokerVotingRowBase>
-        <MiniPokerCard>
-          <CheckIcon>check</CheckIcon>
-        </MiniPokerCard>
+        <MiniCardWrapper>
+          <MiniPokerCard>
+            <CheckIcon>check</CheckIcon>
+          </MiniPokerCard>
+        </MiniCardWrapper>
         <AvatarList
           users={isClosing ? [] : users}
           size={PokerCards.AVATAR_WIDTH as 46}

--- a/packages/client/components/PokerVotingRow.tsx
+++ b/packages/client/components/PokerVotingRow.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
@@ -17,15 +18,22 @@ interface Props {
   isInitialStageRender: boolean
 }
 
+const MiniCardWrapper = styled('div')({
+  // This adds the gutter between the mini card and the avatars
+  marginRight: 16
+})
+
 const PokerVotingRow = (props: Props) => {
   const {scaleValue, scores, setFinalScore, isInitialStageRender} = props
   const {label, color} = scaleValue
   const users = scores.map(({user}) => user)
   return (
     <PokerVotingRowBase>
-      <MiniPokerCard color={color} onClick={setFinalScore}>
-        {label}
-      </MiniPokerCard>
+      <MiniCardWrapper>
+        <MiniPokerCard color={color} onClick={setFinalScore}>
+          {label}
+        </MiniPokerCard>
+      </MiniCardWrapper>
       <AvatarList
         size={PokerCards.AVATAR_WIDTH as 46}
         users={users}

--- a/packages/client/components/PokerVotingRowBase.tsx
+++ b/packages/client/components/PokerVotingRowBase.tsx
@@ -5,7 +5,7 @@ const PokerVotingRowBase = styled('div')({
   display: 'flex',
   flexShrink: 0,
   minHeight: 56, // maintain tallest height, account for avatar group plus padding
-  padding: '6px 0 6px 16px' // 6px over 8px, account for overlapping 2px border of avatars
+  padding: '5px 0 5px 16px' // 5px instead of 8px, account for overlapping 3px border of avatars
 })
 
 export default PokerVotingRowBase


### PR DESCRIPTION
Having an avatar with a hanging border, and overlapping other avatars, is a challenge on the 8px grid.

- For smaller avatars let’s use a 2px border, for larger (GTE 40px) let’s use 3px. It looks crisp for the larger sizes.
- If we want gutters and edges to fall on the 8px grid we have to offset for the 2 or 3 pixels. So you may see partial padding sizes like 5px (+3) or 4px (+2 +2 vertically)
- To get an avatar of 24 we have to call it 28 (24 + 2 + 2), and for 40 we measure 46 (40 + 3 + 3).
- There’s not a good solution yet for the growing whitespace + any optional vertical gutter so I hard-coded offsets to account for a row of 24px avatars
