### PR TITLE
explicitly send call stack to sentry from server

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
+++ b/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
@@ -26,6 +26,8 @@ const addNewFeature = {
     }
   },
   resolve: async (_source, {copy, url}, {authToken, dataLoader}) => {
+    sendToSentry(new Error('something bad happened'))
+
     const r = await getRethink()
     const redis = getRedis()
 

--- a/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
+++ b/packages/server/graphql/intranetSchema/mutations/addNewFeature.ts
@@ -26,8 +26,6 @@ const addNewFeature = {
     }
   },
   resolve: async (_source, {copy, url}, {authToken, dataLoader}) => {
-    sendToSentry(new Error('something bad happened'))
-
     const r = await getRethink()
     const redis = getRedis()
 

--- a/packages/server/utils/sendToSentry.ts
+++ b/packages/server/utils/sendToSentry.ts
@@ -22,8 +22,11 @@ const sendToSentry = async (error: Error, options: SentryOptions = {}) => {
   if (user && ip) {
     ;(user as any).ip_address = ip
   }
+  const stack = error.stack
+
   Sentry.withScope((scope) => {
     user && scope.setUser(user)
+    stack && scope.setExtra('stack', stack)
     if (tags) {
       Object.keys(tags).forEach((tag) => {
         scope.setTag(tag, String(tags[tag]))


### PR DESCRIPTION
Resolve #4931

AC
- [ ] server errors sent to sentry contain a call stack as a first-class citizen