### PR TITLE
EmojiMart

### DIFF
--- a/packages/client/components/ReactjiPicker.tsx
+++ b/packages/client/components/ReactjiPicker.tsx
@@ -16,17 +16,6 @@ interface Props {
   menuProps: MenuProps
 }
 
-const recent = [
-  'heart',
-  'tada',
-  'smile',
-  'rocket',
-  'fire',
-  'white_check_mark',
-  'confused',
-  'cry',
-  'x'
-]
 const ReactjiPicker = (props: Props) => {
   const {menuProps, onClick} = props
   const {closePortal} = menuProps
@@ -46,7 +35,8 @@ const ReactjiPicker = (props: Props) => {
         onClick={handleClick}
         showPreview={false}
         showSkinTones={false}
-        recent={recent}
+        autoFocus={true}
+        enableFrequentEmojiSort={true}
         style={{borderRadius: 4}}
       />
     </TallMenu>


### PR DESCRIPTION
Fixes #3639
- [x] autofocus on open
- [x] persist frequently used in the local storage

AutoFocus on Emoji Search Bar on Mount 

By default, EmojiMart will store user-chosen skin and frequently used emojis in localStorage.In passing the " recent" array we give it preassigned values. Setting enableFrequentEmojiSort to true will Instantly sort the “Frequently Used” category based on user selection 