### PR TITLE
Log authToken in User query

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -280,7 +280,7 @@ export default class Atmosphere extends Environment {
         uploadables: uploadables || undefined
       },
       // if sink is nully, then the server doesn't send a response
-      sink!
+      sink
     )
   }
 

--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -30,7 +30,7 @@ import {AuthToken} from './types/AuthToken'
 import {LocalStorageKey, TrebuchetCloseReason} from './types/constEnums'
 import handlerProvider from './utils/relay/handlerProvider'
 import {InviteToTeamMutation_notification} from './__generated__/InviteToTeamMutation_notification.graphql'
-(RelayFeatureFlags as any).ENABLE_RELAY_CONTAINERS_SUSPENSE = false
+;(RelayFeatureFlags as any).ENABLE_RELAY_CONTAINERS_SUSPENSE = false
 
 interface QuerySubscription {
   subKey: string
@@ -280,7 +280,7 @@ export default class Atmosphere extends Environment {
         uploadables: uploadables || undefined
       },
       // if sink is nully, then the server doesn't send a response
-      sink
+      sink!
     )
   }
 
@@ -406,8 +406,8 @@ export default class Atmosphere extends Environment {
     this.querySubscriptions.forEach((querySub) => {
       this.unregisterQuery(querySub.queryKey)
     })
-      // remove all records
-      ; (this.getStore().getSource() as any).clear()
+    // remove all records
+    ;(this.getStore().getSource() as any).clear()
     this.upgradeTransportPromise = null
     this.authObj = null
     this.authToken = null

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -74,7 +74,14 @@ const AnalyticsPage = () => {
     if (logRocketId) {
       const email = window.localStorage.getItem(LocalStorageKey.EMAIL)
       LogRocket.init(logRocketId, {
-        release: __APP_VERSION__
+        release: __APP_VERSION__,
+        network: {
+          requestSanitizer: (request) => {
+            const body = request?.body?.toLowerCase()
+            if (body?.includes('password')) return null
+            return request
+          }
+        }
       })
       if (email) {
         LogRocket.identify(atmosphere.viewerId, {

--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser'
 import React, {Component, ErrorInfo, ReactNode} from 'react'
 import ErrorComponent from './ErrorComponent/ErrorComponent'
 import withAtmosphere, {WithAtmosphereProps} from '~/decorators/withAtmosphere/withAtmosphere'
+import LogRocket from 'logrocket'
 
 interface Props extends WithAtmosphereProps {
   fallback?: (error: Error, eventId: string) => ReactNode
@@ -31,6 +32,7 @@ class ErrorBoundary extends Component<Props, State> {
         scope.setUser({email, id: viewerId})
       })
     }
+    LogRocket.track('Fatal error')
     // Catch errors in any components below and re-render with error message
     Sentry.withScope((scope) => {
       scope.setExtras(errorInfo)

--- a/packages/server/graphql/rootQuery.ts
+++ b/packages/server/graphql/rootQuery.ts
@@ -6,6 +6,7 @@ import massInvitation from './queries/massInvitation'
 import SAMLIdP from './queries/SAMLIdP'
 import verifiedInvitation from './queries/verifiedInvitation'
 import User from './types/User'
+import * as Sentry from '@sentry/browser'
 
 export default new GraphQLObjectType<any, GQLContext>({
   name: 'Query',
@@ -14,7 +15,13 @@ export default new GraphQLObjectType<any, GQLContext>({
       type: User,
       resolve: async (_source, _args, {authToken, dataLoader}) => {
         const viewerId = getUserId(authToken)
-        return viewerId ? dataLoader.get('users').load(viewerId) : null
+        if (!viewerId) {
+          Sentry.captureException(
+            new Error(`viewerId is null in User query. authToken: ${authToken}`)
+          )
+          return null
+        }
+        return dataLoader.get('users').load(viewerId)
       }
     },
     getDemoEntities,


### PR DESCRIPTION
Logging `authToken` in User query. Some users have been able to login but get a `null` response from the User query. 

This should help us narrow down whether there's a problem with the dataLoader or the token.

This PR also:

- Prevents a network request from being sent to LogRocket
- Sends a custom event to LogRocket so that we can track fatal errors