### PR TITLE
init sentry in gqlExecutor

### DIFF
--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -1,5 +1,5 @@
 import "./tracer"
-
+import '../server/initSentry'
 import Redis from 'ioredis'
 import {ServerChannel} from 'parabol-client/types/constEnums'
 


### PR DESCRIPTION
**AC:**
- run `yarn build` then `yarn start`
- go to graphiql and do the mutation below, which will trigger a server error
- go to [sentry staging](https://sentry.io/organizations/parabol/issues/?project=107915) and see that the error shows up

```
mutation {
  addAgendaItem(newAgendaItem: {
    content: "content",
    pinned: false,
    teamId: "teamid",
    teamMemberId: "team member id",
    sortOrder: 1,
    meetingId: "meeting id"
  }) {
    error {
      title
      message
    }
  }
}
```