### PR TITLE
support varying github scopes

### DIFF
--- a/packages/client/components/ScopePhaseAreaGitHub.tsx
+++ b/packages/client/components/ScopePhaseAreaGitHub.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import {Providers} from '../types/constEnums'
 import {ScopePhaseAreaGitHub_meeting} from '../__generated__/ScopePhaseAreaGitHub_meeting.graphql'
 import ScopePhaseAreaAddGitHub from './ScopePhaseAreaAddGitHub'
 // import ScopePhaseAreaGitHubScoping from './ScopePhaseAreaGitHubScoping'
@@ -25,7 +26,7 @@ const ScopePhaseAreaGitHub = (props: Props) => {
   if (!viewerMeetingMember || !isActive) return null
   const {teamMember} = viewerMeetingMember
   const {integrations} = teamMember
-  const hasAuth = integrations?.github?.isActive ?? false
+  const hasAuth = integrations?.github?.scope === Providers.GITHUB_SCOPE
   if (!hasAuth) return <ScopePhaseAreaAddGitHub gotoParabol={gotoParabol} meeting={meeting} />
   return <ComingSoon>Coming Soon!</ComingSoon>
   // return <ScopePhaseAreaGitHubScoping meeting={meeting} />
@@ -41,6 +42,7 @@ export default createFragmentContainer(ScopePhaseAreaGitHub, {
           integrations {
             github {
               isActive
+              scope
             }
           }
         }

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -234,6 +234,7 @@ export const enum Providers {
   ATLASSIAN_DESC = 'Create Jira issues from Parabol',
   GITHUB_NAME = 'GitHub',
   GITHUB_DESC = 'Create issues from Parabol',
+  GITHUB_SCOPE = 'admin:org_hook,read:org,repo,user:email,write:repo_hook',
   SLACK_NAME = 'Slack',
   SLACK_DESC = 'Push notifications to Slack'
 }

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -45300,6 +45300,11 @@ export interface IGitHubIntegration {
   login: string;
 
   /**
+   * The comma-separated list of scopes requested from GitHub
+   */
+  scope: string;
+
+  /**
    * *The team that the token is linked to
    */
   teamId: string;

--- a/packages/client/utils/GitHubManager.ts
+++ b/packages/client/utils/GitHubManager.ts
@@ -1,4 +1,5 @@
 import {DocumentNode} from 'graphql-typed'
+import {Providers} from '../types/constEnums'
 import {ICreateIssueInput} from '../types/githubGraphql'
 import createIssue from './githubQueries/createIssue.graphql'
 import getProfile from './githubQueries/getProfile.graphql'
@@ -22,7 +23,7 @@ type DocVariables = any
 // type DocVariables<T> = T extends DocumentNode<any, infer V> ? V : never
 
 abstract class GitHubManager {
-  static SCOPE = 'admin:org_hook,read:org,repo,user:email,write:repo_hook'
+  static SCOPE = Providers.GITHUB_SCOPE
   accessToken: string
   abstract fetch: any
   // the any is for node until we can use tsc in nodeland
@@ -35,7 +36,7 @@ abstract class GitHubManager {
       'Content-Type': 'application/json',
       // an Authorization requires a preflight request, ie reqs are slow
       Authorization: `Bearer ${accessToken}`,
-      Accept: 'application/json' as 'application/json'
+      Accept: 'application/json' as const
     }
   }
 

--- a/packages/server/graphql/mutations/addGitHubAuth.ts
+++ b/packages/server/graphql/mutations/addGitHubAuth.ts
@@ -26,7 +26,7 @@ export default {
 
     // RESOLUTION
 
-    const manager = await GitHubServerManager.init(code)
+    const {manager, scope} = await GitHubServerManager.init(code)
     const {accessToken} = manager
     const profile = await manager.getProfile()
 
@@ -46,7 +46,7 @@ export default {
     const {viewer} = profileData
     const {login} = viewer
 
-    await upsertGitHubAuth({accessToken, login, teamId, userId: viewerId})
+    await upsertGitHubAuth({accessToken, login, teamId, userId: viewerId, scope})
     segmentIo.track({
       userId: viewerId,
       event: 'Added Integration',

--- a/packages/server/graphql/types/GitHubIntegration.ts
+++ b/packages/server/graphql/types/GitHubIntegration.ts
@@ -1,4 +1,11 @@
-import {GraphQLBoolean, GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import {
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString
+} from 'graphql'
 import ms from 'ms'
 import GitHubIntegrationId from '../../../client/shared/gqlIds/GitHubIntegrationId'
 import {getUserId} from '../../utils/authorization'
@@ -57,6 +64,10 @@ const GitHubIntegration = new GraphQLObjectType<any, GQLContext>({
     login: {
       type: new GraphQLNonNull(GraphQLID),
       description: '*The GitHub login used for queries'
+    },
+    scope: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'The comma-separated list of scopes requested from GitHub'
     },
     teamId: {
       type: new GraphQLNonNull(GraphQLID),

--- a/packages/server/postgres/migrations/1621283671444_gh-scope.ts
+++ b/packages/server/postgres/migrations/1621283671444_gh-scope.ts
@@ -1,0 +1,25 @@
+import {ColumnDefinitions, MigrationBuilder} from 'node-pg-migrate'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+    ALTER TABLE "GitHubAuth"
+    ADD COLUMN IF NOT EXISTS "scope" VARCHAR(250);
+  `)
+  await pgm.db.query(`
+    UPDATE "GitHubAuth"
+    SET "scope" = 'admin:org_hook,read:org,repo,user:email,write:repo_hook'
+  `)
+  await pgm.db.query(`
+    ALTER TABLE "GitHubAuth"
+    ALTER COLUMN "scope" SET NOT NULL
+  `)
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  await pgm.db.query(`
+    ALTER TABLE "GitHubAuth"
+    DROP COLUMN "scope";
+  `)
+}

--- a/packages/server/postgres/queries/generated/getGitHubAuthByUserIdTeamIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getGitHubAuthByUserIdTeamIdQuery.ts
@@ -19,6 +19,7 @@ export interface IGetGitHubAuthByUserIdTeamIdQueryResult {
   teamId: string
   userId: string
   githubSearchQueries: JsonArray
+  scope: string
 }
 
 /** 'GetGitHubAuthByUserIdTeamIdQuery' query type */

--- a/packages/server/postgres/queries/generated/upsertGitHubAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/upsertGitHubAuthQuery.ts
@@ -8,6 +8,7 @@ export interface IUpsertGitHubAuthQueryParams {
     login: string | null | void
     teamId: string | null | void
     userId: string | null | void
+    scope: string | null | void
   }
 }
 
@@ -27,27 +28,27 @@ const upsertGitHubAuthQueryIR: any = {
       name: 'auth',
       codeRefs: {
         defined: {a: 42, b: 45, line: 3, col: 9},
-        used: [{a: 168, b: 171, line: 6, col: 8}]
+        used: [{a: 184, b: 187, line: 6, col: 8}]
       },
-      transform: {type: 'pick_tuple', keys: ['accessToken', 'login', 'teamId', 'userId']}
+      transform: {type: 'pick_tuple', keys: ['accessToken', 'login', 'teamId', 'userId', 'scope']}
     }
   ],
   usedParamSet: {auth: true},
   statement: {
     body:
-      'INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId")\nVALUES :auth\nON CONFLICT ("userId", "teamId")\nDO UPDATE\nSET ("accessToken", "updatedAt", "isActive", "login") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login)',
-    loc: {a: 90, b: 336, line: 5, col: 0}
+      'INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId", "scope")\nVALUES :auth\nON CONFLICT ("userId", "teamId")\nDO UPDATE\nSET ("accessToken", "updatedAt", "isActive", "login", "scope") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login, EXCLUDED.scope)',
+    loc: {a: 97, b: 377, line: 5, col: 0}
   }
 }
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId")
+ * INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId", "scope")
  * VALUES :auth
  * ON CONFLICT ("userId", "teamId")
  * DO UPDATE
- * SET ("accessToken", "updatedAt", "isActive", "login") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login)
+ * SET ("accessToken", "updatedAt", "isActive", "login", "scope") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login, EXCLUDED.scope)
  * ```
  */
 export const upsertGitHubAuthQuery = new PreparedQuery<

--- a/packages/server/postgres/queries/src/upsertGitHubAuthQuery.sql
+++ b/packages/server/postgres/queries/src/upsertGitHubAuthQuery.sql
@@ -1,9 +1,9 @@
 /*
   @name upsertGitHubAuthQuery
-  @param auth -> (accessToken, login, teamId, userId)
+  @param auth -> (accessToken, login, teamId, userId, scope)
 */
-INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId")
+INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId", "scope")
 VALUES :auth
 ON CONFLICT ("userId", "teamId")
 DO UPDATE
-SET ("accessToken", "updatedAt", "isActive", "login") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login);
+SET ("accessToken", "updatedAt", "isActive", "login", "scope") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login, EXCLUDED.scope);

--- a/packages/server/utils/GitHubServerManager.ts
+++ b/packages/server/utils/GitHubServerManager.ts
@@ -1,9 +1,9 @@
 import fetch from 'node-fetch'
 import GitHubManager from 'parabol-client/utils/GitHubManager'
 import {stringify} from 'querystring'
+import {GetRepositoriesQuery, SearchIssuesQuery} from '../../server/types/typed-document-nodes'
 import {getRepositories} from './githubQueries/getRepositories'
 import {searchIssues} from './githubQueries/searchIssues'
-import {GetRepositoriesQuery, SearchIssuesQuery} from '../../server/types/typed-document-nodes'
 
 interface OAuth2Response {
   access_token: string
@@ -63,14 +63,7 @@ class GitHubServerManager extends GitHubManager {
     if (error) {
       throw new Error(`GitHub: ${error}`)
     }
-    const providedScope = scope.split(',')
-    const matchingScope =
-      new Set([...GitHubServerManager.SCOPE.split(','), ...providedScope]).size ===
-      providedScope.length
-    if (!matchingScope) {
-      throw new Error(`GitHub Bad scope: ${scope}`)
-    }
-    return new GitHubServerManager(accessToken)
+    return {manager: new GitHubServerManager(accessToken), scope}
   }
   fetch = fetch
 


### PR DESCRIPTION
unblocks #4930, which will need extra github scope to show private repos
fix #4970 

TEST
- [ ] current github auth is backfilled with a `scope` column in the DB
- [ ] can refresh github auth & the scope updates
- [ ] can create a new github integration & it adds the scope to the githubauth table
- [ ] if the poker scoping area for github requires a scope that doesn't match what the user has, it asks you to re-integrate