### PR TITLE
refactor commentor to thread conn

### DIFF
--- a/packages/client/clientSchema.graphql
+++ b/packages/client/clientSchema.graphql
@@ -106,3 +106,7 @@ extend type AgendaItemsStage {
 extend type EstimateStage {
   finalScoreError: String
 }
+
+extend type ThreadableConnection {
+  commentors: [User!]!
+}

--- a/packages/client/components/RetroDiscussPhase.tsx
+++ b/packages/client/components/RetroDiscussPhase.tsx
@@ -227,10 +227,6 @@ graphql`
       reflectionGroup {
         ...ReflectionGroup_reflectionGroup
         id
-        commentors {
-          userId
-          preferredName
-        }
         title
         voteCount
         reflections {

--- a/packages/client/mutations/AddCommentMutation.ts
+++ b/packages/client/mutations/AddCommentMutation.ts
@@ -54,8 +54,7 @@ export const addCommentMeetingUpdater: SharedUpdater<AddCommentMutation_meeting>
   }
   const threadSourceId = comment.getValue('threadId')
   if (threadSourceId) {
-    const threadSourceProxy = (threadSourceId && store.get(threadSourceId as string)) || null
-    const threadSourceConn = getThreadSourceThreadConn(threadSourceProxy)
+    const threadSourceConn = getThreadSourceThreadConn(store, threadSourceId)
     safePutNodeInConn(threadSourceConn, comment, store, 'threadSortOrder', true)
   }
 }

--- a/packages/client/mutations/DeleteCommentMutation.ts
+++ b/packages/client/mutations/DeleteCommentMutation.ts
@@ -1,13 +1,13 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
+import {RecordSourceSelectorProxy} from 'relay-runtime'
 import convertToTaskContent from '~/utils/draftjs/convertToTaskContent'
+import safeRemoveNodeFromArray from '~/utils/relay/safeRemoveNodeFromArray'
 import safeRemoveNodeFromConn from '~/utils/relay/safeRemoveNodeFromConn'
 import {DeleteCommentMutation_meeting} from '~/__generated__/DeleteCommentMutation_meeting.graphql'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import {DeleteCommentMutation as TDeleteCommentMutation} from '../__generated__/DeleteCommentMutation.graphql'
 import getThreadSourceThreadConn from './connections/getThreadSourceThreadConn'
-import safeRemoveNodeFromArray from '~/utils/relay/safeRemoveNodeFromArray'
-import {RecordSourceSelectorProxy} from 'relay-runtime'
 
 graphql`
   fragment DeleteCommentMutation_meeting on DeleteCommentSuccess {
@@ -66,8 +66,7 @@ const handleDeleteComment = (comment, store) => {
   } else {
     const threadSourceId = comment.getValue('threadId')
     if (threadSourceId) {
-      const threadSourceProxy = (threadSourceId && store.get(threadSourceId as string)) || null
-      const threadSourceConn = getThreadSourceThreadConn(threadSourceProxy)
+      const threadSourceConn = getThreadSourceThreadConn(store, threadSourceId)
       safeRemoveNodeFromConn(commentId, threadSourceConn)
     }
   }

--- a/packages/client/mutations/connections/getThreadSourceThreadConn.ts
+++ b/packages/client/mutations/connections/getThreadSourceThreadConn.ts
@@ -1,8 +1,12 @@
-import {ConnectionHandler, ReadOnlyRecordProxy} from 'relay-runtime'
+import {ConnectionHandler, RecordSourceSelectorProxy} from 'relay-runtime'
 
-const getThreadSourceThreadConn = (threadSource: ReadOnlyRecordProxy | null | undefined) => {
-  if (threadSource) {
-    return ConnectionHandler.getConnection(threadSource, 'DiscussionThread_thread')
+const getThreadSourceThreadConn = (
+  store: RecordSourceSelectorProxy,
+  threadId: string | null | undefined
+) => {
+  const viewer = store.getRoot().getLinkedRecord('viewer')
+  if (viewer && threadId) {
+    return ConnectionHandler.getConnection(viewer, 'DiscussionThread_thread', {id: threadId})
   }
   return null
 }

--- a/packages/client/mutations/handlers/handleEditCommenting.ts
+++ b/packages/client/mutations/handlers/handleEditCommenting.ts
@@ -1,24 +1,29 @@
+import {RecordProxy} from 'relay-runtime'
 import createProxyRecord from '../../utils/relay/createProxyRecord'
+import getThreadSourceThreadConn from '../connections/getThreadSourceThreadConn'
 
-const handleEditTask = (payload, store) => {
+interface Commentor {
+  userId: string
+  preferredName: string
+}
+const handleEditCommenting = (payload, store) => {
   const threadId = payload.getValue('threadId')
   const commentor = payload.getLinkedRecord('commentor')
   const commentorId = commentor.getValue('id')
   const preferredName = commentor.getValue('preferredName')
   const isCommenting = payload.getValue('isCommenting')
-
-  const thread = store.get(threadId)
+  const thread = getThreadSourceThreadConn(store, threadId)
   if (!thread) return
-  const commentors = thread.getLinkedRecords('commentors') || []
-  if (!commentors || (commentors.length === 1 && !isCommenting)) {
+  const commentors = thread.getLinkedRecords<Commentor[]>('commentors') || []
+  if (commentors.length === 1 && !isCommenting) {
     thread.setValue(null, 'commentors')
     return
   }
 
-  const newCommentors = [] as any
+  const newCommentors = [] as RecordProxy<Commentor>[]
   for (let ii = 0; ii < commentors.length; ii++) {
     const commentor = commentors[ii]
-    if (commentor.getValue('userId') !== commentorId) {
+    if (commentor.getValue('id') !== commentorId) {
       newCommentors.push(commentor)
     }
   }
@@ -37,4 +42,4 @@ const handleEditTask = (payload, store) => {
   }
 }
 
-export default handleEditTask
+export default handleEditCommenting

--- a/packages/client/mutations/handlers/handleRemoveTasks.ts
+++ b/packages/client/mutations/handlers/handleRemoveTasks.ts
@@ -1,16 +1,16 @@
 import {RecordSourceSelectorProxy} from 'relay-runtime'
 import getThreadSourceThreadConn from '~/mutations/connections/getThreadSourceThreadConn'
 import {handleRemoveReply} from '~/mutations/DeleteCommentMutation'
+import {parseUserTaskFilterQueryParams} from '~/utils/useUserTaskFilters'
 import ITask from '../../../server/database/types/Task'
 import IUser from '../../../server/database/types/User'
 import safeRemoveNodeFromArray from '../../utils/relay/safeRemoveNodeFromArray'
 import safeRemoveNodeFromConn from '../../utils/relay/safeRemoveNodeFromConn'
 import getArchivedTasksConn from '../connections/getArchivedTasksConn'
+import getScopingTasksConn from '../connections/getScopingTasksConn'
 import getTeamTasksConn from '../connections/getTeamTasksConn'
 import getUserTasksConn from '../connections/getUserTasksConn'
 import pluralizeHandler from './pluralizeHandler'
-import {parseUserTaskFilterQueryParams} from '~/utils/useUserTaskFilters'
-import getScopingTasksConn from '../connections/getScopingTasksConn'
 
 const handleRemoveTask = (taskId: string, store: RecordSourceSelectorProxy<any>) => {
   const viewer = store.getRoot().getLinkedRecord<IUser>('viewer')
@@ -23,7 +23,6 @@ const handleRemoveTask = (taskId: string, store: RecordSourceSelectorProxy<any>)
     handleRemoveReply(taskId, threadParentId, store)
     return
   }
-  const threadSourceProxy = store.get(threadSourceId!)
   const meetingId = task.getValue('meetingId')
   const meeting = store.get(meetingId!)
   const team = store.get(teamId)
@@ -34,7 +33,7 @@ const handleRemoveTask = (taskId: string, store: RecordSourceSelectorProxy<any>)
   ]
   const teamConn = getTeamTasksConn(team)
   const userConn = getUserTasksConn(viewer, userIds, teamIds)
-  const threadSourceConn = getThreadSourceThreadConn(threadSourceProxy)
+  const threadSourceConn = getThreadSourceThreadConn(store, threadSourceId)
   safeRemoveNodeFromConn(taskId, teamConn)
   safeRemoveNodeFromConn(taskId, userConn)
   archiveConns.forEach((archiveConn) => safeRemoveNodeFromConn(taskId, archiveConn))

--- a/packages/client/mutations/handlers/handleUpsertTasks.ts
+++ b/packages/client/mutations/handlers/handleUpsertTasks.ts
@@ -1,15 +1,15 @@
 import {RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
 import getThreadSourceThreadConn from '~/mutations/connections/getThreadSourceThreadConn'
+import isTaskPrivate from '~/utils/isTaskPrivate'
+import {parseUserTaskFilterQueryParams} from '~/utils/useUserTaskFilters'
 import addNodeToArray from '../../utils/relay/addNodeToArray'
 import safeRemoveNodeFromConn from '../../utils/relay/safeRemoveNodeFromConn'
 import getArchivedTasksConn from '../connections/getArchivedTasksConn'
+import getScopingTasksConn from '../connections/getScopingTasksConn'
 import getTeamTasksConn from '../connections/getTeamTasksConn'
 import getUserTasksConn from '../connections/getUserTasksConn'
 import pluralizeHandler from './pluralizeHandler'
 import safePutNodeInConn from './safePutNodeInConn'
-import isTaskPrivate from '~/utils/isTaskPrivate'
-import {parseUserTaskFilterQueryParams} from '~/utils/useUserTaskFilters'
-import getScopingTasksConn from '../connections/getScopingTasksConn'
 
 type Task = RecordProxy<{
   readonly id: string
@@ -48,8 +48,7 @@ const handleUpsertTask = (task: Task | null, store: RecordSourceSelectorProxy<an
   const teamConn = getTeamTasksConn(team)
   const userConn = getUserTasksConn(viewer, userIds, teamIds)
   const threadSourceId = task.getValue('threadId')
-  const threadSourceProxy = (threadSourceId && store.get(threadSourceId as string)) || null
-  const threadSourceConn = getThreadSourceThreadConn(threadSourceProxy)
+  const threadSourceConn = getThreadSourceThreadConn(store, threadSourceId)
   const meeting = meetingId ? store.get(meetingId) : null
 
   if (isNowArchived) {

--- a/packages/client/subscriptions/MeetingSubscription.ts
+++ b/packages/client/subscriptions/MeetingSubscription.ts
@@ -17,6 +17,7 @@ import {
 import {pokerAnnounceDeckHoverMeetingUpdater} from '../mutations/PokerAnnounceDeckHoverMutation'
 import {promoteNewMeetingFacilitatorMeetingOnNext} from '../mutations/PromoteNewMeetingFacilitatorMutation'
 import {removeReflectionMeetingUpdater} from '../mutations/RemoveReflectionMutation'
+import {resetMeetingToStageUpdater} from '../mutations/ResetMeetingToStageMutation'
 import {setStageTimerMeetingUpdater} from '../mutations/SetStageTimerMutation'
 import {startDraggingReflectionMeetingUpdater} from '../mutations/StartDraggingReflectionMutation'
 
@@ -76,6 +77,7 @@ const updateHandlers = {
   JiraCreateIssuePayload: jiraCreateIssueUpdater,
   RemoveReflectionPayload: removeReflectionMeetingUpdater,
   SetStageTimerPayload: setStageTimerMeetingUpdater,
+  ResetMeetingToStagePayload: resetMeetingToStageUpdater,
   StartDraggingReflectionPayload: startDraggingReflectionMeetingUpdater,
   PokerAnnounceDeckHoverSuccess: pokerAnnounceDeckHoverMeetingUpdater
 }

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -43986,6 +43986,11 @@ export interface IUser {
   timeline: ITimelineEventConnection;
 
   /**
+   * the comments and tasks created from the discussion
+   */
+  thread: IThreadableConnection;
+
+  /**
    * the ID of the newest feature, null if the user has dismissed it
    */
   newFeatureId: string | null;
@@ -44155,6 +44160,23 @@ export interface ITimelineOnUserArguments {
    * the number of timeline events to return
    */
   first: number;
+}
+
+export interface IThreadOnUserArguments {
+  /**
+   * The ID of the thread source
+   */
+  id: string;
+
+  /**
+   * How many items to show. optional if only comments are desired
+   */
+  first?: number | null;
+
+  /**
+   * the incrementing sort order in string format
+   */
+  after?: string | null;
 }
 
 export interface IMeetingMemberOnUserArguments {
@@ -44404,6 +44426,7 @@ export interface ITask {
 
   /**
    * A list of users currently commenting
+   * @deprecated "Moved to ThreadConnection. Can remove Jun-01-2021"
    */
   commentors: Array<ICommentorDetails> | null;
 
@@ -44619,6 +44642,11 @@ export interface IThreadableConnection {
    * A list of edges.
    */
   edges: Array<IThreadableEdge>;
+
+  /**
+   * A list of userIds currently commenting
+   */
+  commentorIds: Array<string>;
 }
 
 /**
@@ -44684,6 +44712,7 @@ export interface IStory {
 
   /**
    * A list of users currently commenting
+   * @deprecated "Moved to ThreadConnection. Can remove Jun-01-2021"
    */
   commentors: Array<ICommentorDetails> | null;
 
@@ -44737,6 +44766,7 @@ export interface IAgendaItem {
 
   /**
    * A list of users currently commenting
+   * @deprecated "Moved to ThreadConnection. Can remove Jun-01-2021"
    */
   commentors: Array<ICommentorDetails> | null;
 
@@ -45121,6 +45151,7 @@ export interface IJiraIssue {
 
   /**
    * A list of users currently commenting
+   * @deprecated "Moved to ThreadConnection. Can remove Jun-01-2021"
    */
   commentors: Array<ICommentorDetails> | null;
 
@@ -47750,6 +47781,7 @@ export interface IRetroReflectionGroup {
 
   /**
    * A list of users currently commenting
+   * @deprecated "Moved to ThreadConnection. Can remove Jun-01-2021"
    */
   commentors: Array<ICommentorDetails> | null;
 

--- a/packages/server/graphql/types/AgendaItem.ts
+++ b/packages/server/graphql/types/AgendaItem.ts
@@ -25,6 +25,7 @@ const AgendaItem = new GraphQLObjectType<any, GQLContext>({
     },
     commentors: {
       type: new GraphQLList(new GraphQLNonNull(CommentorDetails)),
+      deprecationReason: 'Moved to ThreadConnection. Can remove Jun-01-2021',
       description: 'A list of users currently commenting',
       resolve: ({commentors = []}) => {
         return commentors

--- a/packages/server/graphql/types/RetroReflectionGroup.ts
+++ b/packages/server/graphql/types/RetroReflectionGroup.ts
@@ -41,6 +41,7 @@ const RetroReflectionGroup = new GraphQLObjectType<any, GQLContext>({
     commentors: {
       type: new GraphQLList(new GraphQLNonNull(CommentorDetails)),
       description: 'A list of users currently commenting',
+      deprecationReason: 'Moved to ThreadConnection. Can remove Jun-01-2021',
       resolve: ({commentor = []}) => {
         return commentor
       }

--- a/packages/server/graphql/types/Story.ts
+++ b/packages/server/graphql/types/Story.ts
@@ -1,6 +1,6 @@
-import {GraphQLID, GraphQLNonNull, GraphQLList, GraphQLInterfaceType, GraphQLString} from 'graphql'
-import ThreadSource, {threadSourceFields} from './ThreadSource'
+import {GraphQLID, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLString} from 'graphql'
 import CommentorDetails from './CommentorDetails'
+import ThreadSource, {threadSourceFields} from './ThreadSource'
 
 export const storyFields = () => ({
   ...threadSourceFields(),
@@ -11,6 +11,7 @@ export const storyFields = () => ({
   commentors: {
     type: new GraphQLList(new GraphQLNonNull(CommentorDetails)),
     description: 'A list of users currently commenting',
+    deprecationReason: 'Moved to ThreadConnection. Can remove Jun-01-2021',
     resolve: ({commentors = []}) => {
       return commentors
     }

--- a/packages/server/graphql/types/Threadable.ts
+++ b/packages/server/graphql/types/Threadable.ts
@@ -38,10 +38,6 @@ export const threadableFields = () => ({
       return dataLoader.get('users').load(createdBy)
     }
   },
-  // isThreadTombstone: {
-  //   type: GraphQLBoolean,
-  //   description: 'true if the item has been deleted but still has replies, else falsy'
-  // },
   replies: {
     type: GraphQLNonNull(GraphQLList(GraphQLNonNull(Threadable))),
     description: 'the replies to this threadable item',
@@ -87,6 +83,12 @@ const {connectionType, edgeType} = connectionDefinitions({
     }
   }),
   connectionFields: () => ({
+    commentorIds: {
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLID))),
+      description: 'A list of userIds currently commenting',
+      // WE CURRENTLY DON'T USE THIS, LET'S PUT THIS STUFF IN REDIS SOON!
+      resolve: () => []
+    },
     pageInfo: {
       type: PageInfo,
       description: 'Page info with strings (sortOrder) as cursors'

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -20,6 +20,7 @@ import {GQLContext} from '../graphql'
 import invoiceDetails from '../queries/invoiceDetails'
 import invoices from '../queries/invoices'
 import organization from '../queries/organization'
+import resolveThread from '../resolvers/resolveThread'
 import AuthIdentity from './AuthIdentity'
 import Company from './Company'
 import GraphQLEmailType from './GraphQLEmailType'
@@ -33,6 +34,7 @@ import SuggestedAction from './SuggestedAction'
 import Team from './Team'
 import TeamInvitationPayload from './TeamInvitationPayload'
 import TeamMember from './TeamMember'
+import {ThreadableConnection} from './Threadable'
 import TierEnum from './TierEnum'
 import {TimelineEventConnection} from './TimelineEvent'
 import UserFeatureFlags from './UserFeatureFlags'
@@ -229,6 +231,31 @@ const User = new GraphQLObjectType<any, GQLContext>({
             hasNextPage: events.length > edges.length
           }
         }
+      }
+    },
+    thread: {
+      type: GraphQLNonNull(ThreadableConnection),
+      args: {
+        id: {
+          type: GraphQLNonNull(GraphQLID),
+          description: 'The ID of the thread source'
+        },
+        // type: {
+        //   type: GraphQLNonNull(ThreadSourceEnum),
+        //   description: 'The type of item the ID refers to'
+        // },
+        first: {
+          type: GraphQLInt,
+          description: 'How many items to show. optional if only comments are desired'
+        },
+        after: {
+          type: GraphQLString,
+          description: 'the incrementing sort order in string format'
+        }
+      },
+      description: 'the comments and tasks created from the discussion',
+      resolve: async (_source, {id, first, after}, {dataLoader}) => {
+        return resolveThread({id}, {first, after}, {dataLoader})
       }
     },
     newFeatureId: {


### PR DESCRIPTION
fix #4973

This works does 2 things:
- it moves `commentors` from `ThreadSource` to  `ThreadConnection` (unblocks #4965)
- it moves `thread` from `ThreadSource` to `User` (supports future discussions outside of meetings)

TEST
- [ ] can CRUD tasks in a discussion thread & participants see the subscribed changes
- [ ] can CRUD comments in a discussion thread & participants see the subscribed changes
- [ ] can write a new comment  in a discussion thread & participants see that someone is commenting
- [ ] can create a discussion thread, reset the meeting back to the group phase, advance back to the discussion thread & it is empty

