### PR TITLE
Send exceptions to LogRocket too

### DIFF
--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -32,6 +32,7 @@ class ErrorBoundary extends Component<Props, State> {
         scope.setUser({email, id: viewerId})
       })
     }
+    LogRocket.captureException(error)
     LogRocket.track('Fatal error')
     // Catch errors in any components below and re-render with error message
     Sentry.withScope((scope) => {

--- a/packages/server/graphql/rootQuery.ts
+++ b/packages/server/graphql/rootQuery.ts
@@ -7,6 +7,7 @@ import SAMLIdP from './queries/SAMLIdP'
 import verifiedInvitation from './queries/verifiedInvitation'
 import User from './types/User'
 import * as Sentry from '@sentry/browser'
+import LogRocket from 'logrocket'
 
 export default new GraphQLObjectType<any, GQLContext>({
   name: 'Query',
@@ -16,9 +17,9 @@ export default new GraphQLObjectType<any, GQLContext>({
       resolve: async (_source, _args, {authToken, dataLoader}) => {
         const viewerId = getUserId(authToken)
         if (!viewerId) {
-          Sentry.captureException(
-            new Error(`viewerId is null in User query. authToken: ${authToken}`)
-          )
+          const error = new Error(`viewerId is null in User query. authToken: ${authToken}`)
+          Sentry.captureException(error)
+          LogRocket.captureException(error)
           return null
         }
         return dataLoader.get('users').load(viewerId)


### PR DESCRIPTION
Sending exceptions to LogRocket as well as Sentry. Also, sending an exception to LogRocket when the `viewerId` is null in the `User` query to help debug https://github.com/ParabolInc/parabol/issues/4802

Merging right away as the change is trivial 