### PR TITLE
Tier update pg

### DIFF
--- a/packages/server/postgres/migrations/postDeploy/1621238616230_backfillTier.ts
+++ b/packages/server/postgres/migrations/postDeploy/1621238616230_backfillTier.ts
@@ -2,7 +2,7 @@ import {ColumnDefinitions} from 'node-pg-migrate'
 import {TierEnum} from 'parabol-client/types/graphql'
 import getRethink from '../../../database/rethinkDriver'
 import getPg from '../../getPg'
-import {backfillTierQuery} from '../../queries/generated/backfillTierQuery'
+import {updateUserTiersQuery} from '../../queries/generated/updateUserTiersQuery'
 import catchAndLog from '../../utils/catchAndLog'
 
 export const shorthands: ColumnDefinitions | undefined = undefined
@@ -23,12 +23,12 @@ export async function up(): Promise<void> {
         .pluck('id', 'tier')
         .skip(offset)
         .limit(batchSize)
-        .run()) as {tier: string; id: string}[]
+        .run()) as {id: string; tier: TierEnum}[]
       if (!affectedUsers.length) {
         break
       }
       moreUsersToBackfill = true
-      await catchAndLog(() => backfillTierQuery.run({users: affectedUsers}, getPg()))
+      await catchAndLog(() => updateUserTiersQuery.run({users: affectedUsers}, getPg()))
     }
     return moreUsersToBackfill
   }

--- a/packages/server/postgres/migrations/postDeploy/1621238616230_backfillTier.ts
+++ b/packages/server/postgres/migrations/postDeploy/1621238616230_backfillTier.ts
@@ -1,0 +1,51 @@
+import {ColumnDefinitions} from 'node-pg-migrate'
+import {TierEnum} from 'parabol-client/types/graphql'
+import getRethink from '../../../database/rethinkDriver'
+import getPg from '../../getPg'
+import {backfillTierQuery} from '../../queries/generated/backfillTierQuery'
+import catchAndLog from '../../utils/catchAndLog'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(): Promise<void> {
+  const r = await getRethink()
+  const batchSize = 3000
+  const doBackfill = async (usersAfterTs?: Date) => {
+    let foundUsers = false
+
+    for (let i = 0; i < 1e5; i++) {
+      console.log('i:', i)
+      const offset = batchSize * i
+      const rethinkUsers = await r
+        .table('User')
+        .between(usersAfterTs ?? r.minval, r.maxval, {index: 'updatedAt'})
+        .orderBy('updatedAt', {index: 'updatedAt'})
+        .filter((row) => row('tier').ne(TierEnum.personal))
+        .pluck('id', 'tier')
+        .skip(offset)
+        .limit(batchSize)
+        .run()
+      if (!rethinkUsers.length) {
+        break
+      }
+      foundUsers = true
+      const pgUsers = rethinkUsers.map(({id, tier}) => ({id, tier}))
+      await catchAndLog(() => backfillTierQuery.run({users: pgUsers}, getPg()))
+    }
+    return foundUsers
+  }
+
+  const doBackfillAccountingForRaceConditions = async (usersAfterTs?: Date) => {
+    for (let i = 0; i < 1e5; i++) {
+      const thisBackfillStartTs = new Date()
+      const backfillFoundUsers = await doBackfill(usersAfterTs)
+      if (!backfillFoundUsers) {
+        break
+      }
+      usersAfterTs = thisBackfillStartTs
+    }
+  }
+
+  await doBackfillAccountingForRaceConditions()
+  console.log('Finished backfilling tier.')
+}

--- a/packages/server/postgres/queries/generated/backfillTierQuery.ts
+++ b/packages/server/postgres/queries/generated/backfillTierQuery.ts
@@ -1,0 +1,53 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/backfillTierQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'BackfillTierQuery' parameters type */
+export interface IBackfillTierQueryParams {
+  users: Array<{
+    tier: string | null | void
+    id: string | null | void
+  }>
+}
+
+/** 'BackfillTierQuery' return type */
+export type IBackfillTierQueryResult = void
+
+/** 'BackfillTierQuery' query type */
+export interface IBackfillTierQueryQuery {
+  params: IBackfillTierQueryParams
+  result: IBackfillTierQueryResult
+}
+
+const backfillTierQueryIR: any = {
+  name: 'backfillTierQuery',
+  params: [
+    {
+      name: 'users',
+      codeRefs: {
+        defined: {a: 38, b: 42, line: 3, col: 9},
+        used: [{a: 135, b: 139, line: 7, col: 14}]
+      },
+      transform: {type: 'pick_array_spread', keys: ['tier', 'id']}
+    }
+  ],
+  usedParamSet: {users: true},
+  statement: {
+    body:
+      'UPDATE "User" AS u SET\n  "tier" = c."tier"::"TierEnum"\nFROM (VALUES :users) AS c("tier", "id") \nWHERE c."id" = u."id"',
+    loc: {a: 66, b: 182, line: 5, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE "User" AS u SET
+ *   "tier" = c."tier"::"TierEnum"
+ * FROM (VALUES :users) AS c("tier", "id")
+ * WHERE c."id" = u."id"
+ * ```
+ */
+export const backfillTierQuery = new PreparedQuery<
+  IBackfillTierQueryParams,
+  IBackfillTierQueryResult
+>(backfillTierQueryIR)

--- a/packages/server/postgres/queries/generated/getTeamsByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getTeamsByIdQuery.ts
@@ -26,7 +26,6 @@ export interface IGetTeamsByIdQueryResult {
   orgId: string
   isOnboardTeam: boolean
   updatedAt: Date
-  eqChecked: Date
   lockMessageHTML: string | null
 }
 

--- a/packages/server/postgres/queries/generated/getUsersByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getUsersByIdQuery.ts
@@ -36,7 +36,6 @@ export interface IGetUsersByIdQueryResult {
   reasonRemoved: string | null
   rol: AuthTokenRole | null
   payLaterClickCount: number
-  eqChecked: Date
 }
 
 /** 'GetUsersByIdQuery' query type */

--- a/packages/server/postgres/queries/generated/updateUserTiersQuery.ts
+++ b/packages/server/postgres/queries/generated/updateUserTiersQuery.ts
@@ -1,0 +1,53 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/updateUserTiersQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'UpdateUserTiersQuery' parameters type */
+export interface IUpdateUserTiersQueryParams {
+  users: Array<{
+    tier: string | null | void
+    id: string | null | void
+  }>
+}
+
+/** 'UpdateUserTiersQuery' return type */
+export type IUpdateUserTiersQueryResult = void
+
+/** 'UpdateUserTiersQuery' query type */
+export interface IUpdateUserTiersQueryQuery {
+  params: IUpdateUserTiersQueryParams
+  result: IUpdateUserTiersQueryResult
+}
+
+const updateUserTiersQueryIR: any = {
+  name: 'updateUserTiersQuery',
+  params: [
+    {
+      name: 'users',
+      codeRefs: {
+        defined: {a: 41, b: 45, line: 3, col: 9},
+        used: [{a: 138, b: 142, line: 7, col: 14}]
+      },
+      transform: {type: 'pick_array_spread', keys: ['tier', 'id']}
+    }
+  ],
+  usedParamSet: {users: true},
+  statement: {
+    body:
+      'UPDATE "User" AS u SET\n  "tier" = c."tier"::"TierEnum"\nFROM (VALUES :users) AS c("tier", "id") \nWHERE c."id" = u."id"',
+    loc: {a: 69, b: 185, line: 5, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE "User" AS u SET
+ *   "tier" = c."tier"::"TierEnum"
+ * FROM (VALUES :users) AS c("tier", "id")
+ * WHERE c."id" = u."id"
+ * ```
+ */
+export const updateUserTiersQuery = new PreparedQuery<
+  IUpdateUserTiersQueryParams,
+  IUpdateUserTiersQueryResult
+>(updateUserTiersQueryIR)

--- a/packages/server/postgres/queries/src/backfillTierQuery.sql
+++ b/packages/server/postgres/queries/src/backfillTierQuery.sql
@@ -1,0 +1,8 @@
+/*
+  @name backfillTierQuery
+  @param users -> ((tier, id)...)
+*/
+UPDATE "User" AS u SET
+  "tier" = c."tier"::"TierEnum"
+FROM (VALUES :users) AS c("tier", "id") 
+WHERE c."id" = u."id";

--- a/packages/server/postgres/queries/src/updateUserTiersQuery.sql
+++ b/packages/server/postgres/queries/src/updateUserTiersQuery.sql
@@ -1,5 +1,5 @@
 /*
-  @name backfillTierQuery
+  @name updateUserTiersQuery
   @param users -> ((tier, id)...)
 */
 UPDATE "User" AS u SET

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -1,5 +1,7 @@
 import getRethink from '../database/rethinkDriver'
 import db from '../db'
+import {TierEnum} from '../postgres/queries/generated/updateUserQuery'
+import updateUser from '../postgres/queries/updateUser'
 import segmentIo from './segmentIo'
 
 const setUserTierForUserIds = async (userIds: string[]) => {
@@ -35,6 +37,32 @@ const setUserTierForUserIds = async (userIds: string[]) => {
       {nonAtomic: true}
     )
     .run()
+
+  const userTiers = (await r
+    .table('OrganizationUser')
+    .getAll(r.args(userIds), {index: 'userId'})
+    .filter({removedAt: null})
+    .merge((orgUser) => ({
+      tier: r
+        .db('actionDevelopment')
+        .table('Organization')
+        .get(orgUser('orgId'))('tier')
+        .default('personal')
+    }))
+    .group('userId')('tier')
+    .ungroup()
+    .merge((row) => ({
+      tier: row('reduction')
+        .reduce((_left, right) => {
+          return r.branch(right.eq('enterprise'), 'enterprise', right.eq('pro'), 'pro', 'personal')
+        })
+        .default('personal')
+    }))
+    .run()) as {group: string; reduction: string[]; tier: TierEnum}[]
+  userTiers.forEach(({group: userId, tier}) => {
+    updateUser({tier}, userId)
+  })
+
   await Promise.all(userIds.map((userId) => db.clear('User', userId)))
   const users = await db.readMany('User', userIds)
   users.forEach((user) => {


### PR DESCRIPTION
Changes:

1. Update `setUserTierForUserIds` to update the `tier` column to PG. As the `Organization` table has not been migrated to PG, we need to join with RethinkDB today.
2. A backfill script for the `tier` column for `User` table in PG.

Tests:
- [ ] Run the backfill script with `yarn postmigrate` and observes that `tier` columns in PG are backfilled with non `personal` tiers
- [ ] Upgrade a local user to `pro` tier and observes the `tier` column in PG has been updated to `pro` as well