### PR TITLE
Sentry server stack

### DIFF
--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -1,3 +1,4 @@
+const DOTENV = path.join(PROJECT_ROOT, 'scripts/webpack/utils/dotenv.js') // we need to load this first
 const path = require('path')
 const nodeExternals = require('webpack-node-externals')
 const transformRules = require('./utils/transformRules')
@@ -12,9 +13,17 @@ const CLIENT_ROOT = path.join(PROJECT_ROOT, 'packages', 'client')
 const SERVER_ROOT = path.join(PROJECT_ROOT, 'packages', 'server')
 const GQL_ROOT = path.join(PROJECT_ROOT, 'packages', 'gql-executor')
 const SFU_ROOT = path.join(PROJECT_ROOT, 'packages', 'sfu')
-const DOTENV = path.join(PROJECT_ROOT, 'scripts/webpack/utils/dotenv.js')
 const publicPath = getWebpackPublicPath()
 const distPath = path.join(PROJECT_ROOT, 'dist')
+
+const getNormalizedWebpackPublicPath = () => {
+  let publicPath = getWebpackPublicPath()
+  if (publicPath.startsWith('//')) {
+    // protocol-relative url? normalize it:
+    publicPath = `https:${publicPath}`
+  }
+  return publicPath
+}
 
 module.exports = ({isDeploy}) => ({
   mode: 'production',
@@ -52,7 +61,7 @@ module.exports = ({isDeploy}) => ({
   plugins: [
     new webpack.SourceMapDevToolPlugin({
       filename: '[name]_[contenthash].js.map',
-      append: `\n//# sourceMappingURL=${publicPath}[url]`
+      append: `\n//# sourceMappingURL=${getNormalizedWebpackPublicPath()}[url]`
     }),
     isDeploy &&
     new S3Plugin({

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -1,4 +1,4 @@
-const DOTENV = path.join(PROJECT_ROOT, 'scripts/webpack/utils/dotenv.js') // we need to load this first
+require('./utils/dotenv')
 const path = require('path')
 const nodeExternals = require('webpack-node-externals')
 const transformRules = require('./utils/transformRules')
@@ -13,7 +13,7 @@ const CLIENT_ROOT = path.join(PROJECT_ROOT, 'packages', 'client')
 const SERVER_ROOT = path.join(PROJECT_ROOT, 'packages', 'server')
 const GQL_ROOT = path.join(PROJECT_ROOT, 'packages', 'gql-executor')
 const SFU_ROOT = path.join(PROJECT_ROOT, 'packages', 'sfu')
-const publicPath = getWebpackPublicPath()
+const DOTENV = path.join(PROJECT_ROOT, 'scripts/webpack/utils/dotenv.js')
 const distPath = path.join(PROJECT_ROOT, 'dist')
 
 const getNormalizedWebpackPublicPath = () => {


### PR DESCRIPTION
Resolves #4908

**AC**
- [ ] sentry server errors have stack traces pointing to typescript src files, with code snippet in the display

This branch is deployed to dev server. Development also has extra code to trigger sending to sentry from staging or development branches.

This is a sentry error triggered from dev server, with successfully resolved source maps: https://sentry.io/organizations/parabol/issues/2410288689/?project=107915&query=is%3Aunresolved

When this PR is first merged to staging, any errors triggered from staging server won't have resolved source maps. This is bc the default behavior is to send to sentry only on pushes to production. Once this PR is in production, server stack traces in sentry will display correctly.