### PR TITLE
Make Slack notifications pretty

### DIFF
--- a/packages/client/components/SlackChannelDropdown.tsx
+++ b/packages/client/components/SlackChannelDropdown.tsx
@@ -3,7 +3,7 @@ import Menu from './Menu'
 import MenuItem from './MenuItem'
 import {MenuProps} from '../hooks/useMenu'
 
-export type SlackChannelDropdownChannels = readonly {id: string | null; name: string}[]
+export type SlackChannelDropdownChannels = {id: string; name: string}[]
 export type SlackChannelDropdownOnClick = (
   channelId: string | null
 ) => (e: React.MouseEvent) => void

--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -57,10 +57,21 @@ export interface SlackConversation {
   locale: string
 }
 
+export interface SlackIM {
+  created: number
+  id: string
+  is_im: true
+  is_org_shared: boolean
+  is_user_deleted: boolean
+  priority: number
+  user: string
+}
+
 interface ConversationListResponse {
   ok: true
-  channels: SlackConversation[]
+  channels: SlackConversation[] | SlackIM[]
 }
+
 interface ConversationJoinResponse {
   ok: true
   channel: {
@@ -130,7 +141,7 @@ interface ConversationInfoResponse {
   channel: SlackConversation
 }
 
-type ConversationType = 'public_channel' | 'private_channel'
+type ConversationType = 'public_channel' | 'private_channel' | 'im'
 
 abstract class SlackManager {
   static SCOPE = 'incoming-webhook,channels:read,channels:join,chat:write,users:read'
@@ -213,9 +224,9 @@ abstract class SlackManager {
     return this.post<PostMessageResponse>('https://slack.com/api/chat.postMessage', payload)
   }
 
-  updateMessage(channelId: string, text: string, ts: string) {
+  updateMessage(channelId: string, blocks: string | Array<{type: string}>, ts: string) {
     return this.get<UpdateMessageResponse>(
-      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&text=${text}&ts=${ts}`
+      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&blocks=${blocks}&ts=${ts}`
     )
   }
 }

--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -225,8 +225,9 @@ abstract class SlackManager {
   }
 
   updateMessage(channelId: string, blocks: string | Array<{type: string}>, ts: string) {
+    const stringifiedBlocks = JSON.stringify(blocks)
     return this.get<UpdateMessageResponse>(
-      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&blocks=${blocks}&ts=${ts}`
+      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&blocks=${stringifiedBlocks}&ts=${ts}`
     )
   }
 }

--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -225,9 +225,9 @@ abstract class SlackManager {
   }
 
   updateMessage(channelId: string, blocks: string | Array<{type: string}>, ts: string) {
-    const stringifiedBlocks = JSON.stringify(blocks)
+    const newBlocks = typeof blocks === 'string' ? blocks : JSON.stringify(blocks)
     return this.get<UpdateMessageResponse>(
-      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&blocks=${stringifiedBlocks}&ts=${ts}`
+      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&blocks=${newBlocks}&ts=${ts}`
     )
   }
 }

--- a/packages/server/database/types/MeetingAction.ts
+++ b/packages/server/database/types/MeetingAction.ts
@@ -10,6 +10,7 @@ interface Input {
 }
 
 export default class MeetingAction extends Meeting {
+  meetingType!: 'action'
   taskCount?: number
   commentCount?: number
   agendaItemCount?: number

--- a/packages/server/database/types/MeetingPoker.ts
+++ b/packages/server/database/types/MeetingPoker.ts
@@ -12,6 +12,7 @@ interface Input {
 }
 
 export default class MeetingPoker extends Meeting {
+  meetingType!: 'poker'
   templateId: string
   templateRefId: string
   storyCount?: number

--- a/packages/server/database/types/MeetingRetrospective.ts
+++ b/packages/server/database/types/MeetingRetrospective.ts
@@ -14,6 +14,7 @@ interface Input {
 }
 
 export default class MeetingRetrospective extends Meeting {
+  meetingType!: 'retrospective'
   showConversionModal?: boolean
   autoGroupThreshold?: number | null
   nextAutoGroupThreshold?: number | null

--- a/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
+++ b/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
@@ -6,6 +6,7 @@ import isCompanyDomain from '../../../utils/isCompanyDomain'
 import SlackServerManager from '../../../utils/SlackServerManager'
 import GraphQLISO8601Type from '../../types/GraphQLISO8601Type'
 import authCountByDomain from './helpers/authCountByDomain'
+import {makeSections} from '../../mutations/helpers/makeSlackBlocks'
 
 interface TypeField {
   type: 'mrkdwn'
@@ -69,14 +70,6 @@ const makeTopXSection = async (domainCount: DomainCount[]) => {
   }
 }
 
-const makeSection = (text: string) => ({
-  type: 'section',
-  text: {
-    type: 'mrkdwn',
-    text
-  }
-})
-
 const dailyPulse = {
   type: GraphQLBoolean,
   args: {
@@ -131,11 +124,11 @@ const dailyPulse = {
     const start = toEpochSeconds(after)
 
     const blocks = [
-      makeSection(
+      makeSections([
         `We've had *${totalSignups} Signups* and *${totalLogins} Logins* since <!date^${start}^{date_short} {time}|Yesterday>\n *Top Signups*`
-      ),
+      ]),
       signupsList,
-      makeSection(`*Top Logins*`),
+      makeSections([`*Top Logins*`]),
       loginsList
     ]
     const manager = new SlackServerManager(botAccessToken)

--- a/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
+++ b/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
@@ -6,7 +6,7 @@ import isCompanyDomain from '../../../utils/isCompanyDomain'
 import SlackServerManager from '../../../utils/SlackServerManager'
 import GraphQLISO8601Type from '../../types/GraphQLISO8601Type'
 import authCountByDomain from './helpers/authCountByDomain'
-import {makeSections} from '../../mutations/helpers/makeSlackBlocks'
+import {makeSection} from '../../mutations/helpers/makeSlackBlocks'
 
 interface TypeField {
   type: 'mrkdwn'
@@ -124,11 +124,11 @@ const dailyPulse = {
     const start = toEpochSeconds(after)
 
     const blocks = [
-      makeSections([
+      makeSection(
         `We've had *${totalSignups} Signups* and *${totalLogins} Logins* since <!date^${start}^{date_short} {time}|Yesterday>\n *Top Signups*`
-      ]),
+      ),
       signupsList,
-      makeSections([`*Top Logins*`]),
+      makeSection(`*Top Logins*`),
       loginsList
     ]
     const manager = new SlackServerManager(botAccessToken)

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -224,13 +224,14 @@ export default {
     }
 
     // remove any empty tasks
-    const [meetingMembers, team, teamMembers, removedTaskIds, result] = await Promise.all([
+    const [meetingMembers, team, teamMembers, removedTaskIds] = await Promise.all([
       dataLoader.get('meetingMembersByMeetingId').load(meetingId),
       dataLoader.get('teams').load(teamId),
       dataLoader.get('teamMembersByTeamId').load(teamId),
-      removeEmptyTasks(meetingId),
-      finishCheckInMeeting(completedCheckIn, dataLoader)
+      removeEmptyTasks(meetingId)
     ])
+    // need to wait for removeEmptyTasks before finishing the meeting
+    const result = await finishCheckInMeeting(completedCheckIn, dataLoader)
     endSlackMeeting(meetingId, teamId, dataLoader).catch(console.log)
     const updatedTaskIds = (result && result.updatedTaskIds) || []
     sendMeetingEndToSegment(completedCheckIn, meetingMembers as MeetingMember[])

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -120,9 +120,11 @@ export default {
       dataLoader.get('teams').load(teamId),
       dataLoader.get('teamMembersByTeamId').load(teamId),
       removeEmptyTasks(meetingId),
-      dataLoader.get('meetingTemplates').load(templateId),
-      finishRetroMeeting(completedRetrospective, dataLoader)
+      dataLoader.get('meetingTemplates').load(templateId)
     ])
+    // wait for removeEmptyTasks before finishRetroMeeting & wait for meeting stats
+    // to be generated in finishRetroMeeting before sending Slack notifications
+    await finishRetroMeeting(completedRetrospective, dataLoader)
     endSlackMeeting(meetingId, teamId, dataLoader).catch(console.log)
     sendMeetingEndToSegment(completedRetrospective, meetingMembers as MeetingMember[], template)
     sendNewMeetingSummary(completedRetrospective, context).catch(console.log)

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -120,10 +120,10 @@ export default {
       dataLoader.get('teams').load(teamId),
       dataLoader.get('teamMembersByTeamId').load(teamId),
       removeEmptyTasks(meetingId),
-      dataLoader.get('meetingTemplates').load(templateId)
+      dataLoader.get('meetingTemplates').load(templateId),
+      finishRetroMeeting(completedRetrospective, dataLoader)
     ])
     endSlackMeeting(meetingId, teamId, dataLoader).catch(console.log)
-    finishRetroMeeting(completedRetrospective, dataLoader)
     sendMeetingEndToSegment(completedRetrospective, meetingMembers as MeetingMember[], template)
     sendNewMeetingSummary(completedRetrospective, context).catch(console.log)
     const events = teamMembers.map(

--- a/packages/server/graphql/mutations/helpers/makeSlackBlocks.ts
+++ b/packages/server/graphql/mutations/helpers/makeSlackBlocks.ts
@@ -1,3 +1,5 @@
+import generateUID from '../../../generateUID'
+
 export const makeSection = (text: string) => ({
   type: 'section',
   text: {
@@ -22,7 +24,7 @@ type ButtonInput = {
 
 export const makeButtons = (buttons: ButtonInput[]) => ({
   type: 'actions',
-  block_id: `actionblock${new Date().toISOString()}`,
+  block_id: `actionblock${generateUID()}`,
   elements: buttons.map((button) => ({
     type: 'button',
     text: {

--- a/packages/server/graphql/mutations/helpers/makeSlackBlocks.ts
+++ b/packages/server/graphql/mutations/helpers/makeSlackBlocks.ts
@@ -1,3 +1,11 @@
+export const makeSection = (text: string) => ({
+  type: 'section',
+  text: {
+    type: 'mrkdwn',
+    text
+  }
+})
+
 export const makeSections = (fields: string[]) => ({
   type: 'section',
   fields: fields.map((field) => ({

--- a/packages/server/graphql/mutations/helpers/makeSlackBlocks.ts
+++ b/packages/server/graphql/mutations/helpers/makeSlackBlocks.ts
@@ -1,0 +1,27 @@
+export const makeSections = (fields: string[]) => ({
+  type: 'section',
+  fields: fields.map((field) => ({
+    type: 'mrkdwn',
+    text: field
+  }))
+})
+
+type ButtonInput = {
+  text: string
+  url: string
+  type?: 'primary' | 'danger'
+}
+
+export const makeButtons = (buttons: ButtonInput[]) => ({
+  type: 'actions',
+  block_id: `actionblock${new Date().toISOString()}`,
+  elements: buttons.map((button) => ({
+    type: 'button',
+    text: {
+      type: 'plain_text',
+      text: button.text
+    },
+    style: button.type,
+    url: button.url
+  }))
+})

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -121,12 +121,7 @@ export const startSlackMeeting = async (
 
 const getSummaryText = (meeting: MeetingRetrospective | MeetingAction | MeetingPoker) => {
   if (meeting.meetingType === 'retrospective') {
-    const {
-      commentCount = 0,
-      reflectionCount = 0,
-      topicCount = 0,
-      taskCount = 0
-    } = meeting as MeetingRetrospective
+    const {commentCount = 0, reflectionCount = 0, topicCount = 0, taskCount = 0} = meeting
     return `Your team shared ${reflectionCount} ${plural(
       reflectionCount,
       'reflection'
@@ -135,13 +130,7 @@ const getSummaryText = (meeting: MeetingRetrospective | MeetingAction | MeetingP
       'comment'
     )} and created ${taskCount} ${plural(taskCount, 'task')}.`
   } else if (meeting.meetingType === 'action') {
-    const {
-      createdAt,
-      endedAt,
-      agendaItemCount = 0,
-      commentCount = 0,
-      taskCount = 0
-    } = meeting as MeetingAction
+    const {createdAt, endedAt, agendaItemCount = 0, commentCount = 0, taskCount = 0} = meeting
     const meetingDuration = relativeDate(createdAt, {
       now: endedAt,
       max: 2,
@@ -156,7 +145,7 @@ const getSummaryText = (meeting: MeetingRetrospective | MeetingAction | MeetingP
       'comment'
     )}.`
   } else {
-    const estimatePhase = (meeting as MeetingPoker).phases.find(
+    const estimatePhase = meeting.phases.find(
       (phase) => phase.phaseType === 'ESTIMATE'
     ) as EstimatePhase
     const stages = estimatePhase.stages

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -21,7 +21,7 @@ import MeetingAction from '../../../database/types/MeetingAction'
 import MeetingPoker from '../../../database/types/MeetingPoker'
 import plural from 'parabol-client/utils/plural'
 import EstimatePhase from '../../../database/types/EstimatePhase'
-import {makeSections, makeButtons} from './makeSlackBlocks'
+import {makeSection, makeSections, makeButtons} from './makeSlackBlocks'
 
 const getSlackDetails = async (
   event: SlackNotificationEvent,
@@ -108,13 +108,12 @@ export const startSlackMeeting = async (
     dataLoader.get('teams').load(teamId),
     dataLoader.get('newMeetings').load(meetingId)
   ])
-  const meetingUrlWithParams = makeAppURL(appOrigin, `meet/${meetingId}`, options)
-  const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`)
-  const button = {text: 'Join meeting', url: meetingUrlWithParams, type: 'primary'} as const
+  const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`, options)
+  const button = {text: 'Join meeting', url: meetingUrl, type: 'primary'} as const
   const blocks = [
-    makeSections(['Meeting started :wave: ']),
+    makeSection('Meeting started :wave: '),
     makeSections([`*Team:*\n${team.name}`, `*Meeting:*\n${meeting.name}`]),
-    makeSections([`*Link:*\n${meetingUrl}`]),
+    makeSection(`*Link:*\n<${meetingUrl}|https:/prbl.in/${meetingId}>`),
     makeButtons([button])
   ]
   notifySlack('meetingStart', dataLoader, teamId, blocks).catch(console.log)
@@ -181,9 +180,9 @@ export const endSlackMeeting = async (meetingId, teamId, dataLoader: DataLoaderW
     url: summaryUrl
   } as const
   const blocks = [
-    makeSections(['Meeting completed :tada:']),
+    makeSection('Meeting completed :tada:'),
     makeSections([`*Team:*\n${teamName}`, `*Meeting:*\n${meetingName}`]),
-    makeSections([summaryText]),
+    makeSection(summaryText),
     makeButtons([discussionButton, summaryButton])
   ]
   notifySlack('meetingEnd', dataLoader, teamId, blocks).catch(console.log)
@@ -258,10 +257,10 @@ export const notifySlackTimeLimitStart = async (
     )}^{date_short_pretty} at {time}|${fallback}>* to complete it.`
     const button = {text: 'Open meeting', url: meetingUrl, type: 'primary'} as const
     const blocks = [
-      makeSections([`The *${phaseLabel} Phase* has begun :hourglass_flowing_sand:`]),
+      makeSection(`The *${phaseLabel} Phase* has begun :hourglass_flowing_sand:`),
       makeSections([`*Team:*\n${teamName}`, `*Meeting:*\n${meetingName}`]),
-      makeSections([constraint]),
-      makeSections([`*Link:*\n${meetingUrl}`]),
+      makeSection(constraint),
+      makeSection(`*Link:*\n<${meetingUrl}|https:/prbl.in/${meetingId}>`),
       makeButtons([button])
     ]
     upsertSlackMessage(slackDetail, blocks).catch(console.error)

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -15,6 +15,12 @@ import SlackServerManager from '../../../utils/SlackServerManager'
 import errorFilter from '../../errorFilter'
 import {DataLoaderWorker} from '../../graphql'
 import appOrigin from '../../../appOrigin'
+import relativeDate from 'parabol-client/utils/date/relativeDate'
+import MeetingRetrospective from '../../../database/types/MeetingRetrospective'
+import MeetingAction from '../../../database/types/MeetingAction'
+import MeetingPoker from '../../../database/types/MeetingPoker'
+import plural from 'parabol-client/utils/plural'
+import EstimatePhase from '../../../database/types/EstimatePhase'
 
 const getSlackDetails = async (
   event: SlackNotificationEvent,
@@ -149,6 +155,41 @@ export const startSlackMeeting = async (
   notifySlack('meetingStart', dataLoader, teamId, blocks).catch(console.log)
 }
 
+const getSummaryText = (meeting: MeetingRetrospective | MeetingAction | MeetingPoker) => {
+  if ('reflectionCount' in meeting) {
+    const {commentCount = 0, reflectionCount = 0, topicCount = 0, taskCount = 0} = meeting
+    return `Your team shared ${reflectionCount} ${plural(
+      reflectionCount,
+      'reflection'
+    )} and grouped them into ${topicCount} topics.\nYou added ${commentCount} ${plural(
+      commentCount,
+      'comment'
+    )} and created ${taskCount} ${plural(taskCount, 'task')}.`
+  } else if ('agendaItemCount' in meeting) {
+    const {createdAt, endedAt, agendaItemCount = 0, commentCount = 0, taskCount = 0} = meeting
+    const meetingDuration = relativeDate(createdAt, {
+      now: endedAt,
+      max: 2,
+      suffix: false,
+      smallDiff: 'less than a minute'
+    })
+    return `It lasted ${meetingDuration} and generated ${taskCount} ${plural(
+      taskCount,
+      'task'
+    )}, ${agendaItemCount} ${plural(agendaItemCount, 'agenda item')} and ${commentCount} ${plural(
+      commentCount,
+      'comment'
+    )}.`
+  } else {
+    const estimatePhase = meeting.phases.find(
+      (phase) => phase.phaseType === 'ESTIMATE'
+    ) as EstimatePhase
+    const stages = estimatePhase.stages
+    const storyCount = new Set(stages.map(({serviceTaskId}) => serviceTaskId)).size
+    return `You voted on ${storyCount} ${plural(storyCount, 'story', 'stories')}.`
+  }
+}
+
 export const endSlackMeeting = async (meetingId, teamId, dataLoader: DataLoaderWorker) => {
   const searchParams = {
     utm_source: 'slack summary',
@@ -161,6 +202,11 @@ export const endSlackMeeting = async (meetingId, teamId, dataLoader: DataLoaderW
     dataLoader.get('newMeetings').load(meetingId)
   ])
   const summaryUrl = makeAppURL(appOrigin, `new-summary/${meetingId}`, options)
+  const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}/discuss/1`)
+  const pokerUrl = makeAppURL(appOrigin, `meet/${meetingId}/estimate/1`)
+  const summaryText = getSummaryText(meeting)
+  const {name: teamName} = team
+  const {meetingType, name: meetingName} = meeting
   const blocks = [
     {
       type: 'section',
@@ -174,11 +220,11 @@ export const endSlackMeeting = async (meetingId, teamId, dataLoader: DataLoaderW
       fields: [
         {
           type: 'mrkdwn',
-          text: `*Team:*\n${team.name}`
+          text: `*Team:*\n${teamName}`
         },
         {
           type: 'mrkdwn',
-          text: `*Meeting:*\n${meeting.name}`
+          text: `*Meeting:*\n${meetingName}`
         }
       ]
     },
@@ -186,7 +232,7 @@ export const endSlackMeeting = async (meetingId, teamId, dataLoader: DataLoaderW
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `It lasted and generated tasks, agenda items and comments.`
+        text: summaryText
       }
     },
     {
@@ -197,9 +243,9 @@ export const endSlackMeeting = async (meetingId, teamId, dataLoader: DataLoaderW
           text: {
             type: 'plain_text',
             emoji: true,
-            text: meeting.meetingType === 'poker' ? 'See estimates' : 'See discussion'
+            text: meetingType === 'poker' ? 'See estimates' : 'See discussion'
           },
-          value: 'click_me_123'
+          value: meetingType === 'poker' ? pokerUrl : meetingUrl
         },
         {
           type: 'button',

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -206,9 +206,7 @@ const upsertSlackMessage = async (
       const timestamp = new Date(Number.parseFloat(ts) * 1000)
       const ageThresh = new Date(Date.now() - ms('5m'))
       if (timestamp >= ageThresh) {
-        // blocks need to be stringified when updating but not posting
-        const stringifiedBlocks = JSON.stringify(blocks)
-        const res = await manager.updateMessage(channelId, stringifiedBlocks, ts)
+        const res = await manager.updateMessage(channelId, blocks, ts)
         if (!res.ok) {
           console.error(res.error)
           const postRes = await manager.postMessage(channelId, blocks)

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -108,8 +108,9 @@ export const startSlackMeeting = async (
     dataLoader.get('teams').load(teamId),
     dataLoader.get('newMeetings').load(meetingId)
   ])
-  const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`, options)
-  const button = {text: 'Join meeting', url: meetingUrl, type: 'primary'} as const
+  const meetingUrlWithParams = makeAppURL(appOrigin, `meet/${meetingId}`, options)
+  const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`)
+  const button = {text: 'Join meeting', url: meetingUrlWithParams, type: 'primary'} as const
   const blocks = [
     makeSections(['Meeting started :wave: ']),
     makeSections([`*Team:*\n${team.name}`, `*Meeting:*\n${meeting.name}`]),

--- a/packages/server/graphql/mutations/setDefaultSlackChannel.ts
+++ b/packages/server/graphql/mutations/setDefaultSlackChannel.ts
@@ -28,19 +28,20 @@ const setDefaultSlackChannel = {
 
     // VALIDATION
     const slackAuths = await dataLoader.get('slackAuthByUserId').load(viewerId)
+
     const slackAuth = slackAuths.find((auth) => auth.teamId === teamId)
     if (!slackAuth) {
       return standardError(new Error('Slack authentication not found'), {userId: viewerId})
     }
-    const {id: slackAuthId, botAccessToken, defaultTeamChannelId, slackUserId} = slackAuth
+    const {id: slackAuthId, botAccessToken, defaultTeamChannelId} = slackAuth
     const manager = new SlackServerManager(botAccessToken)
     const channelInfo = await manager.getConversationInfo(slackChannelId)
 
-    // should either be a public / private channel or the slackUserId if messaging from @Parabol
-    if (slackChannelId !== slackUserId) {
-      if (!channelInfo.ok) {
-        return standardError(new Error(channelInfo.error), {userId: viewerId})
-      }
+    if (!channelInfo.ok) {
+      return standardError(new Error(channelInfo.error), {userId: viewerId})
+    }
+    // should either be a public / private channel or @Parabol im id
+    if (!channelInfo.channel.is_im) {
       const {channel} = channelInfo
       const {id: channelId, is_member: isMember, is_archived: isArchived} = channel
       if (isArchived) {

--- a/packages/server/graphql/mutations/startCheckIn.ts
+++ b/packages/server/graphql/mutations/startCheckIn.ts
@@ -2,7 +2,6 @@ import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import getRethink from '../../database/rethinkDriver'
 import ActionMeetingMember from '../../database/types/ActionMeetingMember'
-import {MeetingTypeEnum} from '../../database/types/Meeting'
 import MeetingAction from '../../database/types/MeetingAction'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
@@ -37,7 +36,7 @@ export default {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
 
-    const meetingType = 'action' as MeetingTypeEnum
+    const meetingType = 'action'
 
     // RESOLUTION
     const meetingCount = await r

--- a/packages/server/graphql/mutations/startRetrospective.ts
+++ b/packages/server/graphql/mutations/startRetrospective.ts
@@ -1,7 +1,6 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import getRethink from '../../database/rethinkDriver'
-import {MeetingTypeEnum} from '../../database/types/Meeting'
 import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import MeetingSettingsRetrospective from '../../database/types/MeetingSettingsRetrospective'
 import Organization from '../../database/types/Organization'
@@ -40,7 +39,7 @@ export default {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
 
-    const meetingType = 'retrospective' as MeetingTypeEnum
+    const meetingType = 'retrospective'
 
     // RESOLUTION
     const meetingCount = await r

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -2,7 +2,6 @@ import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import getRethink from '../../database/rethinkDriver'
-import {MeetingTypeEnum} from '../../database/types/Meeting'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import PokerMeetingMember from '../../database/types/PokerMeetingMember'
 import getPg from '../../postgres/getPg'
@@ -80,7 +79,7 @@ export default {
       return standardError(new Error('Not on team'), {userId: viewerId})
     }
 
-    const meetingType = 'poker' as MeetingTypeEnum
+    const meetingType = 'poker'
 
     // RESOLUTION
     const meetingCount = await r


### PR DESCRIPTION
PR to resolve issue #4911. 

It also resolves an undocumented bug where timer adjustments send new notifications rather than update the previous one. I've commented inline about this. 

A few additional notes:

- The issue mentioned using Slack's default green `#007a5a` but with Slack's blocks, you choose whether it's a primary button, regular or danger button rather than specify the colour. On a dark mode theme, we get the darker button and in a light mode, it's a lighter button
- I haven't come across a good, free tool for creating short links so I've included the regular link without utm params which is still shortish
- I've added a dummy interactivity request URL to the [Slack app](https://api.slack.com/apps/A01EGHDU7PZ/interactive-messages?). Otherwise, a warning sign shows after clicking the button. See Slack issue [here](https://github.com/CircleCI-Public/slack-orb/issues/188#issuecomment-708988009)
- I noticed that the comment count is currently `undefined` when ending poker meetings. I've created an issue to fix this [here](https://github.com/ParabolInc/parabol/issues/4983). When it's fixed, we can add comment count to the poker notifications

### To test

- Go to the `.env` file and change the `SLACK_CLIENT_ID` & `SLACK_CLIENT_SECRET` to the client ID and secret found in the `Parabol-staging` bot [here](https://api.slack.com/apps/A01EGHDU7PZ)
- Kill and restart the server with `yarn dev`
- You may need to install the Parabol-staging Slackbot in Slack
- Integrate Slack in Parabol (remove it first if it's already integrated),
- See the new notifications styles when you create, set a timer & end a meeting
- If the notifications are sent to `@Parabol-staging` the previous notification should be updated when you adjust the timer rather than sending a new notification