### PR TITLE
Add retro templates

### DIFF
--- a/packages/server/database/migrations/20210527170505-addAdditionalRetroTemplates.ts
+++ b/packages/server/database/migrations/20210527170505-addAdditionalRetroTemplates.ts
@@ -50,7 +50,7 @@ const makePrompt = (promptInfo: PromptInfo) => {
     sortOrder,
     teamId: 'aGhostTeam',
     templateId,
-    title: `New prompt #${sortOrder + 1}`,
+    title: question,
     updatedAt: createdAt
   }
 }

--- a/packages/server/database/migrations/20210527170505-addAdditionalRetroTemplates.ts
+++ b/packages/server/database/migrations/20210527170505-addAdditionalRetroTemplates.ts
@@ -1,8 +1,8 @@
 import {R} from 'rethinkdb-ts'
-const Redis = require('ioredis')
+import getRedis from '../../utils/getRedis'
 
 const createdAt = new Date()
-const redis = new Redis(process.env.REDIS_URL)
+const redis = getRedis()
 
 const nameToId = (name: string, isTemplate: boolean) => {
   const cleanedName = name
@@ -164,8 +164,8 @@ export const up = async function(r: R) {
         .insert(reflectPrompts)
         .run(),
       // we cache the templates but get the prompts from the db
-      // clear the cache to prevent empty templates
-      redis.flushall()
+      // clear the cache to grab templates from the updated db
+      redis.del('publicTemplates:retrospective')
     ])
     redis.disconnect()
   } catch (e) {
@@ -189,8 +189,8 @@ export const down = async function(r: R) {
         .delete()
         .run(),
       // we cache the templates but get the prompts from the db
-      // clear the cache to prevent empty templates
-      redis.flushall()
+      // clear the cache to grab templates from the updated db
+      redis.del('publicTemplates:retrospective')
     ])
     redis.disconnect()
   } catch (e) {

--- a/packages/server/database/migrations/20210527170505-addAdditionalRetroTemplates.ts
+++ b/packages/server/database/migrations/20210527170505-addAdditionalRetroTemplates.ts
@@ -1,0 +1,195 @@
+import {R} from 'rethinkdb-ts'
+
+const createdAt = new Date()
+
+const nameToId = (name: string, isTemplate: boolean) => {
+  const cleanedName = name
+    .replace(/[^0-9a-z-A-Z ]/g, '') // remove emojis and apostrophes
+    .split(' ')
+    .map(
+      (name, idx) =>
+        (idx === 0 ? name.charAt(0).toLowerCase() : name.charAt(0).toUpperCase()) + name.slice(1)
+    )
+    .join('')
+    .trim()
+  return `${cleanedName}${isTemplate ? 'Template' : 'Prompt'}`
+}
+
+const makeTemplate = (name: string) => ({
+  createdAt,
+  id: nameToId(name, true),
+  isActive: true,
+  name,
+  orgId: 'aGhostOrg',
+  scope: 'PUBLIC',
+  teamId: 'aGhostTeam',
+  type: 'retrospective',
+  updatedAt: createdAt,
+  isStarter: true
+})
+
+type PromptInfo = {
+  question: string
+  description: string
+  groupColor: string
+  templateId: string
+  sortOrder: number
+}
+
+const makePrompt = (promptInfo: PromptInfo) => {
+  const {question, description, groupColor, templateId, sortOrder} = promptInfo
+  return {
+    createdAt,
+    description,
+    groupColor,
+    id: nameToId(question, false),
+    isActive: true,
+    question,
+    sortOrder,
+    teamId: 'aGhostTeam',
+    templateId,
+    title: `New prompt #${sortOrder + 1}`,
+    updatedAt: createdAt
+  }
+}
+
+const templateNames = [
+  'Drop Add Keep Improve (DAKI)',
+  'Lean Coffee ☕',
+  'Starfish ⭐',
+  'What Went Well'
+]
+
+const promptsInfo = [
+  {
+    question: 'Drop',
+    description: 'What should we stop?',
+    groupColor: '#52CC52',
+    templateId: 'dropAddKeepImproveDAKITemplate',
+    sortOrder: 0
+  },
+  {
+    question: 'Add',
+    description: 'What should we try or adopt?',
+    groupColor: '#E55C5C',
+    templateId: 'dropAddKeepImproveDAKITemplate',
+    sortOrder: 1
+  },
+  {
+    question: 'Keep',
+    description: 'What should we continue doing?',
+    groupColor: '#D9D916',
+    templateId: 'dropAddKeepImproveDAKITemplate',
+    sortOrder: 2
+  },
+  {
+    question: 'Improve',
+    description: 'What should we improve or revise?',
+    groupColor: '#7373E5',
+    templateId: 'dropAddKeepImproveDAKITemplate',
+    sortOrder: 3
+  },
+  {
+    question: 'To Discuss',
+    description: `What should we talk about? We'll group related items into topics and vote on them to decide what to chat about`,
+    groupColor: '#45E5E5',
+    templateId: 'leanCoffeeTemplate',
+    sortOrder: 0
+  },
+  {
+    question: 'Keep Doing 🌀',
+    description: `What behaviors are working and adding value?`,
+    groupColor: '#7373E5',
+    templateId: 'starfishTemplate',
+    sortOrder: 0
+  },
+  {
+    question: 'Less of ➖',
+    description: `What are we overdoing or spending too much time on?`,
+    groupColor: '#D9D916',
+    templateId: 'starfishTemplate',
+    sortOrder: 1
+  },
+  {
+    question: 'More of ➕',
+    description: `What should we take advantage of or spend more time on?`,
+    groupColor: '#45E5E5',
+    templateId: 'starfishTemplate',
+    sortOrder: 2
+  },
+  {
+    question: 'Stop ⏹️',
+    description: `What isn't adding value or helping the team?`,
+    groupColor: '#E55C5C',
+    templateId: 'starfishTemplate',
+    sortOrder: 3
+  },
+  {
+    question: 'Start ⏯️',
+    description: `What new things should we explore or start doing?`,
+    groupColor: '#52CC52',
+    templateId: 'starfishTemplate',
+    sortOrder: 4
+  },
+  {
+    question: 'What went well 😄',
+    description: `What good things happened this sprint?`,
+    groupColor: '#7373E5',
+    templateId: 'whatWentWellTemplate',
+    sortOrder: 0
+  },
+  {
+    question: `What didn't go well 😞`,
+    description: `What didn't go as planned or desired this sprint?`,
+    groupColor: '#E55C5C',
+    templateId: 'whatWentWellTemplate',
+    sortOrder: 1
+  }
+] as const
+
+const templates = templateNames.map((templateName) => makeTemplate(templateName))
+const reflectPrompts = promptsInfo.map((promptInfo: PromptInfo) => makePrompt(promptInfo))
+
+export const up = async function(r: R) {
+  try {
+    await Promise.all([
+      r
+        .table('MeetingTemplate')
+        .insert(templates)
+        .run(),
+      r
+        .table('ReflectPrompt')
+        .insert(reflectPrompts)
+        .run()
+    ])
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function(r: R) {
+  const Redis = require('ioredis')
+  const redis = new Redis(process.env.REDIS_URL)
+  const templateIds = templates.map(({id}) => id)
+  const promptIds = reflectPrompts.map(({id}) => id)
+  try {
+    await Promise.all([
+      r
+        .table('MeetingTemplate')
+        .getAll(r.args(templateIds))
+        .delete()
+        .run(),
+      r
+        .table('ReflectPrompt')
+        .getAll(r.args(promptIds))
+        .delete()
+        .run(),
+      // we cache the templates but get the prompts from the db
+      // clear the cache to prevent empty templates
+      redis.flushall()
+    ])
+    redis.disconnect()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/migrations/20210602120505-addAdditionalRetroTemplates.ts
+++ b/packages/server/database/migrations/20210602120505-addAdditionalRetroTemplates.ts
@@ -1,8 +1,6 @@
 import {R} from 'rethinkdb-ts'
-import getRedis from '../../utils/getRedis'
 
 const createdAt = new Date()
-const redis = getRedis()
 
 const nameToId = (name: string, isTemplate: boolean) => {
   const cleanedName = name
@@ -162,12 +160,8 @@ export const up = async function(r: R) {
       r
         .table('ReflectPrompt')
         .insert(reflectPrompts)
-        .run(),
-      // we cache the templates but get the prompts from the db
-      // clear the cache to grab templates from the updated db
-      redis.del('publicTemplates:retrospective')
+        .run()
     ])
-    redis.disconnect()
   } catch (e) {
     console.log(e)
   }
@@ -187,12 +181,8 @@ export const down = async function(r: R) {
         .table('ReflectPrompt')
         .getAll(r.args(promptIds))
         .delete()
-        .run(),
-      // we cache the templates but get the prompts from the db
-      // clear the cache to grab templates from the updated db
-      redis.del('publicTemplates:retrospective')
+        .run()
     ])
-    redis.disconnect()
   } catch (e) {
     console.log(e)
   }


### PR DESCRIPTION
PR to resolve issue #4069 

After deleting the templates and prompts in the down migration, the templates would still show up in the retro template modal but without any prompts.

![template-modal](https://user-images.githubusercontent.com/39854876/119902357-bb6e1a80-bf0c-11eb-8156-0aaf74c69de6.png)

I think this is because we grab the prompts with the dataLoader but we get the templates with `db.read` [here](https://github.com/ParabolInc/parabol/blob/a47534ce10f9b18b2568ab2ee9ad4b41354196fa/packages/server/graphql/types/RetrospectiveMeetingSettings.ts#L95) which initially checks Redis. The templates and prompts were successfully deleted but the templates lived on in the cache.

I'm now clearing the Redis cache in the migrations. After running either migration and then restarting the server, zombie templates no longer show up. Not sure if it's strictly necessary as the cache gets cleared when running `yarn dev` anyway but it saves someone else the surprise of running a down migration and finding empty templates. 

Alternatively / additionally, we could check whether a template contains any prompts but that means requesting all prompts for each template.

Requesting an initial review from @tiffanyhan  