### PR TITLE
UI fix-ups

### DIFF
--- a/packages/client/components/NewJiraIssueInput.tsx
+++ b/packages/client/components/NewJiraIssueInput.tsx
@@ -27,6 +27,7 @@ const StyledButton = styled(PlainButton)({
   justifyContent: 'flex-start',
   margin: 0,
   opacity: 1,
+  width: 'fit-content',
   ':hover, :focus': {
     backgroundColor: 'transparent'
   }
@@ -115,7 +116,7 @@ const NewJiraIssueInput = (props: Props) => {
   const projectKey = suggestedIntegration?.projectKey
   const [selectedProjectKey, setSelectedProjectKey] = useState(projectKey)
   const {originRef, menuPortal, menuProps, togglePortal, portalStatus} = useMenu(
-    MenuPosition.UPPER_RIGHT
+    MenuPosition.UPPER_LEFT
   )
   const {fields, onChange, validateField, setDirtyField} = useForm({
     newIssue: {

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryAvatarHeader.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryAvatarHeader.tsx
@@ -5,15 +5,6 @@ import {SummaryAvatarHeader_meetingMember} from 'parabol-client/__generated__/Su
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 
-const presentLabelStyle = {
-  color: PALETTE.JADE_400,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontSize: '14px',
-  fontStyle: 'italic',
-  fontWeight: 600,
-  paddingTop: 4
-}
-
 const avatarCell = {
   paddingTop: 24
 }
@@ -48,11 +39,6 @@ const SummaryAvatarHeader = (props: Props) => {
       <tr>
         <td align='center' style={nameStyle}>
           {preferredName}
-        </td>
-      </tr>
-      <tr>
-        <td align='center' style={presentLabelStyle}>
-          {'Present'}
         </td>
       </tr>
     </>


### PR DESCRIPTION
This PR resolves two small issues that I've noticed:

1. The Jira new issue menu width is too wide. This was because the menu ref was attached to a full width button

![new-issue-menu](https://user-images.githubusercontent.com/39854876/120008820-f588fc00-bfa0-11eb-9c04-9432d57868c0.png)

2. The meeting summary shows each team member as "Present". As we now only show team members that have joined the meeting rather than all team members, perhaps we can remove "Present" from the meeting summary as all team members will always be present?

<img width="679" alt="summary" src="https://user-images.githubusercontent.com/39854876/120008974-1e10f600-bfa1-11eb-8ffd-48833e30fded.png">

