### PR TITLE
Add clock tolerance to getVerifiedAuthToken

### DIFF
--- a/packages/server/utils/getVerifiedAuthToken.ts
+++ b/packages/server/utils/getVerifiedAuthToken.ts
@@ -1,13 +1,22 @@
 import {verify} from 'jsonwebtoken'
 import AuthToken from '../database/types/AuthToken'
+import sendToSentry from './sendToSentry'
 
 const SERVER_SECRET_BUFFER = Buffer.from(process.env.SERVER_SECRET!, 'base64')
 
 const getVerifiedAuthToken = (jwt: string | undefined | null, ignoreExp?: boolean) => {
-  if (!jwt) return {} as AuthToken
+  if (!jwt) {
+    const error = new Error('We do not have a jwt in getVerifiedAuthToken')
+    sendToSentry(error)
+    return {} as AuthToken
+  }
   try {
-    return verify(jwt, SERVER_SECRET_BUFFER, {ignoreExpiration: ignoreExp}) as AuthToken
+    return verify(jwt, SERVER_SECRET_BUFFER, {
+      ignoreExpiration: ignoreExp,
+      clockTolerance: 10
+    }) as AuthToken
   } catch (e) {
+    sendToSentry(e, {tags: {jwt}})
     return {} as AuthToken
   }
 }


### PR DESCRIPTION
PR to _possibly_ resolve issue #4802. 

[This Sentry error](https://sentry.io/organizations/parabol/issues/2407373705/events/302584b819ea433681ce0b9cfeb39c97/?project=107196&statsPeriod=14d) shows that the `authToken` is an empty object which could be because the [getVerifiedAuthToken](https://github.com/ParabolInc/parabol/blob/9fd7b20f991e900ca307d5d8913ee15b0c544230/packages/server/utils/getVerifiedAuthToken.ts) fails to verify the jwt. 

This PR adds a 10 second clock tolerance to give us more leeway and adds extra Sentry logging