### PR TITLE
Handle null overLimitCopy in RethinkDB vs. PG

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/flagOverLimit.ts
+++ b/packages/server/graphql/intranetSchema/mutations/flagOverLimit.ts
@@ -35,7 +35,7 @@ const flagOverLimit = {
     // RESOLUTION
     const userIds = organizationUsers.map(({userId}) => userId)
     await Promise.all([
-      updateUser({overLimitCopy: copy}, userIds),
+      updateUser({overLimitCopy: copy === null ? '' : copy}, userIds),
       db.writeMany('User', userIds, {overLimitCopy: copy || null})
     ])
     return {userIds}

--- a/packages/server/postgres/migrations/1622701938472_backfillOverLimitCopy.ts
+++ b/packages/server/postgres/migrations/1622701938472_backfillOverLimitCopy.ts
@@ -1,0 +1,47 @@
+import {MigrationBuilder, ColumnDefinitions} from 'node-pg-migrate'
+import updateUser from '../../postgres/queries/updateUser'
+import getRethink from '../../database/rethinkDriver'
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  const r = await getRethink()
+  const batchSize = 3000
+  const doBackfill = async (usersAfterTs?: Date) => {
+    const moreUsersToBackfill = false
+
+    for (let i = 0; i < 1e5; i++) {
+      const offset = batchSize * i
+      const userIds = (await r
+        .table('User')
+        .between(usersAfterTs ?? r.minval, r.maxval, {index: 'updatedAt'})
+        .orderBy('updatedAt', {index: 'updatedAt'})
+        .filter((row) => row('overLimitCopy').eq(null))
+        .pluck('id')
+        .skip(offset)
+        .limit(batchSize)
+        .run()) as {id: string}[]
+      if (!userIds.length) {
+        break
+      }
+      updateUser(
+        {overLimitCopy: ''},
+        userIds.map(({id}) => id)
+      )
+    }
+    return moreUsersToBackfill
+  }
+
+  const doBackfillAccountingForRaceConditions = async (usersAfterTs?: Date) => {
+    for (let i = 0; i < 1e5; i++) {
+      const thisBackfillStartTs = new Date()
+      const moreUsersToBackfill = await doBackfill(usersAfterTs)
+      if (!moreUsersToBackfill) {
+        break
+      }
+      usersAfterTs = thisBackfillStartTs
+    }
+  }
+
+  await doBackfillAccountingForRaceConditions()
+}

--- a/packages/server/postgres/utils/checkEqBase.ts
+++ b/packages/server/postgres/utils/checkEqBase.ts
@@ -93,7 +93,7 @@ const getPgRowCount = async (tableName: string) => {
   const queryRes = await pg.query(`
     SELECT COUNT(*) FROM "${tableName}";
   `)
-  return queryRes.rows[0].count
+  return Number(queryRes.rows[0].count)
 }
 
 export async function checkTableEq(

--- a/packages/server/postgres/utils/checkEqBase.ts
+++ b/packages/server/postgres/utils/checkEqBase.ts
@@ -43,27 +43,28 @@ function getPairNeFields(
       neFields.push(f)
     }
   }
-  for (const [f, defaultValue] of Object.entries(maybeUndefinedFieldsDefaultValues)) {
-    const [rethinkValue, pgValue] = [rethinkRow[f], pgRow[f]]
-    if (rethinkValue !== undefined) {
-      if (
-        rethinkValue === null &&
-        maybeNullFieldsDefaultValues &&
-        maybeNullFieldsDefaultValues[f] !== undefined
-      ) {
-        if (!areEqual(maybeNullFieldsDefaultValues[f], pgValue)) {
-          neFields.push(f)
-        }
-      } else if (!areEqual(rethinkValue, pgValue)) {
-        neFields.push(f)
-      }
-    } else {
-      if (!areEqual(pgValue, defaultValue)) {
-        neFields.push(f)
-      }
-    }
-  }
+  for (const [maybeUndefinedField, defaultValueForUndefinedField] of Object.entries(
+    maybeUndefinedFieldsDefaultValues
+  )) {
+    const [rethinkValue, pgValue] = [rethinkRow[maybeUndefinedField], pgRow[maybeUndefinedField]]
 
+    if (rethinkValue === undefined) {
+      if (areEqual(pgValue, defaultValueForUndefinedField)) {
+        continue
+      }
+    } else if (rethinkValue === null && pgValue !== null) {
+      if (
+        maybeNullFieldsDefaultValues &&
+        areEqual(maybeNullFieldsDefaultValues[maybeUndefinedField], pgValue)
+      ) {
+        continue
+      }
+    } else if (areEqual(pgValue, rethinkValue)) {
+      continue
+    }
+
+    neFields.push(maybeUndefinedField)
+  }
   return neFields
 }
 

--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -27,6 +27,7 @@ const checkTeamEq = async (maxErrors = 10) => {
     getTeamsById,
     alwaysDefinedFields,
     maybeUndefinedFieldsDefaultValues,
+    {},
     maxErrors
   )
   return errors

--- a/packages/server/postgres/utils/checkUserEq.ts
+++ b/packages/server/postgres/utils/checkUserEq.ts
@@ -29,6 +29,14 @@ const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<User>]: any
   inactive: false
 }
 
+/**
+ * if a field is explicitly null in RethinkDB,
+ * what value in PG should we expect?
+ */
+const maybeNullFieldsDefaultValues: {[Property in keyof Partial<User>]: any} = {
+  overLimitCopy: ''
+}
+
 const checkUserEq = async (maxErrors = 10) => {
   const r = await getRethink()
   const rethinkQuery = r.table('User').orderBy('updatedAt', {index: 'updatedAt'})
@@ -38,6 +46,7 @@ const checkUserEq = async (maxErrors = 10) => {
     getUsersById,
     alwaysDefinedFields,
     maybeUndefinedFieldsDefaultValues,
+    maybeNullFieldsDefaultValues,
     maxErrors
   )
   return errors


### PR DESCRIPTION
We have the following "inequality" in the comparison result:
```
“xxxxxxxx”: {
    “error”: [
      “overLimitCopy”
    ],
    “rethinkRow”: {
      “overLimitCopy”: null
    },
    “pgRow”: {
      “overLimitCopy”: “”
    }
  },
```
Field `overLimitCopy` in RethinkDB is used by sales to pop messages like "hey your team are over free tier limit, please contact XXX". When the team is indeed upgraded, we set its value to `null` in RethinkDB. In other words, `undefined` for this field represents "we never bothered this user at all", non-empty string represents a popup message, `null` represents "user is upgraded hence the pop up message is cleared".

In RethinkDB, we use `undefined` to represent non-existence and explicit `null` to represent emptiness. In PostgreSQL, `null` is equivalent as undefined. Hence I propose:

* `undefined` in RethinkDB === `null` in PG
* `null` in RethinkDB === `''` in PG

This PR:
1. Change the update logic to write `''` in PG when the value is explicit `null` in RethinkDB
2. Backfill values in PG according to the logic above
3. Update the logic for equality comparison to handle explicit `null` in RethinkDB