### PR TITLE
update ci backup command to use new breaking interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       PRODUCTION_BACKUP_VOLUME: '/mnt/volume_nyc1_01/action-production-rethinkdb-nyc1-01'
       SENTRY_ORG: 'parabol'
       SENTRY_PROJECT: 'action-production'
+      S3_DB_BACKUPS_BUCKET: 'db-backups.parabol.co'
     working_directory: ~/action
     steps:
       - add_ssh_keys:
@@ -122,6 +123,7 @@ jobs:
               ssh -o StrictHostKeyChecking=no "${PRODUCTION_BACKUP_LOCATION}" -T >/dev/null
               $DEVOPS_WORKDIR/rethinkdb/rethinkdb-backup.sh \
                 -s "${PRODUCTION_BACKUP_LOCATION}" -d "${PRODUCTION_BACKUP_VOLUME}"
+                -b "${S3_DB_BACKUPS_BUCKET}" -p "${CIRCLE_BRANCH}"
             fi &&
             if [ -n "${GITHUB_REMOTE}" ]; then
               git push -f dokku $CIRCLE_BRANCH:master


### PR DESCRIPTION
**AC**
- [ ] On prod deployment, CI passes and output logs show that rethinkdb was backed up successfully