### PR TITLE
Jira stories, can’t add points as a comment

### DIFF
--- a/packages/client/components/MockFieldList.tsx
+++ b/packages/client/components/MockFieldList.tsx
@@ -1,6 +1,6 @@
+import styled from '@emotion/styled'
 import React, {forwardRef} from 'react'
 import MockFieldLine from '../modules/meeting/components/MockFieldLine'
-import styled from '@emotion/styled'
 
 const Container = styled('div')({
   padding: '0px 16px'
@@ -16,8 +16,8 @@ const MockFieldList = forwardRef(() => {
     <Container>
       {Array.from(Array(3).keys()).map((idx) => {
         return (
-          <Wrapper>
-            <MockFieldLine key={idx} delay={idx * 40} />
+          <Wrapper key={idx}>
+            <MockFieldLine delay={idx * 40} />
           </Wrapper>
         )
       })}

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -243,7 +243,7 @@ export const userTasks = (parent: RethinkDataLoader) => {
   )
 }
 
-interface FreshAtlassianAuth extends AtlassianAuth {
+export interface FreshAtlassianAuth extends AtlassianAuth {
   accessToken: string
 }
 export const freshAtlassianAuth = (parent: RethinkDataLoader) => {


### PR DESCRIPTION
Related issue: https://github.com/ParabolInc/parabol/issues/5028 

The reason it doesn't work is that `UpdateJiraDimensionField` mutation fails when `As Comment` or `Do Not Update` is selected. See the screenshot below. 
<img width="1010" alt="Screenshot 2021-06-09 at 17 20 33" src="https://user-images.githubusercontent.com/1017620/121558054-994cc000-ca15-11eb-8e9b-97f7bebbb25d.png">

@mattkrick I went through the commit history and I can't find any changes that could break that functionality. Before this fix, `UpdateJiraDimensionField` just iterates through Jira fields and throws an error if the field is not found. As `As Comment` or `Do Not Update` aren't normal Jira fields they can't be found in the list of standard Jira fields. This PR checks if any of these custom fields is selected and then just skips the Jira field array search. Otherwise, it just works as before. 
 