### PR TITLE
Slack im:scope fix 

### DIFF
--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -208,7 +208,8 @@ abstract class SlackManager {
     if (!prop) throw new Error('Invalid Slack postMessage')
     const defaultPayload = {
       channel: channelId,
-      unfurl_links: true,
+      unfurl_links: false,
+      unfurl_media: false,
       [prop]: text
     }
     const payload =

--- a/packages/server/graphql/mutations/addSlackAuth.ts
+++ b/packages/server/graphql/mutations/addSlackAuth.ts
@@ -1,6 +1,5 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {SlackIM} from '../../../client/utils/SlackManager'
 import getRethink from '../../database/rethinkDriver'
 import SlackAuth from '../../database/types/SlackAuth'
 import SlackNotification, {SlackNotificationEvent} from '../../database/types/SlackNotification'
@@ -116,28 +115,17 @@ export default {
     const {response} = manager
     const slackUserId = response.authed_user.id
     const defaultChannelId = response.incoming_webhook.channel_id
-    const [convoInfoRes, joinConvoRes, userInfoRes, imRes] = await Promise.all([
-      manager.getConversationInfo(defaultChannelId),
+    const [joinConvoRes, userInfoRes] = await Promise.all([
       manager.joinConversation(defaultChannelId),
-      manager.getUserInfo(slackUserId),
-      manager.getConversationList(['im'])
+      manager.getUserInfo(slackUserId)
     ])
     if (!userInfoRes.ok) {
       return standardError(new Error(userInfoRes.error), {userId: viewerId})
     }
-    if (!imRes.ok) {
-      return standardError(new Error(imRes.error), {userId: viewerId})
-    }
-    const slackbotIm = (imRes.channels as SlackIM[]).find((channel) => channel.user === slackUserId)
 
-    // The default channel could be anything: public, private, im, mpim. We use public & private
-    // channels or the @Parabol im bot
-    let teamChannelId
-    if (convoInfoRes.ok && convoInfoRes.channel.is_member) {
-      teamChannelId = convoInfoRes.channel.id
-    } else if (joinConvoRes.ok && joinConvoRes.channel.id) {
-      teamChannelId = joinConvoRes.channel.id
-    } else teamChannelId = slackbotIm?.id || slackUserId
+    // The default channel could be anything: public, private, im, mpim. Only allow public channels or the @Parabol channel
+    // Using the slackUserId sends a DM to the user from @Parabol
+    const teamChannelId = joinConvoRes.ok ? joinConvoRes.channel.id : slackUserId
 
     const [, slackAuthId] = await Promise.all([
       upsertNotifications(viewerId, teamId, teamChannelId, defaultChannelId),

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -1,4 +1,3 @@
-import ms from 'ms'
 import {Unpromise} from 'parabol-client/types/generics'
 import formatTime from 'parabol-client/utils/date/formatTime'
 import formatWeekday from 'parabol-client/utils/date/formatWeekday'
@@ -65,8 +64,6 @@ const notifySlack = async (
     const {channelId} = notification
     const {botAccessToken, userId} = auth
     const manager = new SlackServerManager(botAccessToken)
-    console.log('🚀 ~ notificationText', notificationText)
-    console.log('🚀 ~ slackMessage', slackMessage)
     const res = await manager.postMessage(channelId!, slackMessage, notificationText)
     segmentIo.track({
       userId,
@@ -226,28 +223,30 @@ const upsertSlackMessage = async (
   const {botAccessToken} = auth
   if (!channelId) return
   const manager = new SlackServerManager(botAccessToken)
-  const convoInfo = await manager.getConversationInfo(channelId)
-  if (convoInfo.ok && 'latest' in convoInfo.channel) {
-    const {channel} = convoInfo
-    const {latest} = channel
-    if (latest) {
-      const {ts, bot_profile} = latest
-      const {name} = bot_profile
-      if (name === 'Parabol') {
-        const timestamp = new Date(Number.parseFloat(ts) * 1000)
-        const ageThresh = new Date(Date.now() - ms('5m'))
-        if (timestamp >= ageThresh) {
-          const res = await manager.updateMessage(channelId, blocks, ts)
-          if (!res.ok) {
-            console.error(res.error)
-          }
-          return
-        }
-      }
-    }
-  } else {
-    // handle error?
-  }
+  // need im:read scope to get the bot channelId so that we can upsert
+
+  // const convoInfo = await manager.getConversationInfo(channelId)
+  // if (convoInfo.ok && 'latest' in convoInfo.channel) {
+  //   const {channel} = convoInfo
+  //   const {latest} = channel
+  //   if (latest) {
+  //     const {ts, bot_profile} = latest
+  //     const {name} = bot_profile
+  //     if (name === 'Parabol') {
+  //       const timestamp = new Date(Number.parseFloat(ts) * 1000)
+  //       const ageThresh = new Date(Date.now() - ms('5m'))
+  //       if (timestamp >= ageThresh) {
+  //         const res = await manager.updateMessage(channelId, blocks, ts)
+  //         if (!res.ok) {
+  //           console.error(res.error)
+  //         }
+  //         return
+  //       }
+  //     }
+  //   }
+  // } else {
+  //   // handle error?
+  // }
   const res = await manager.postMessage(channelId, blocks, title)
   if (!res.ok) {
     console.error(res.error)

--- a/packages/server/graphql/mutations/setDefaultSlackChannel.ts
+++ b/packages/server/graphql/mutations/setDefaultSlackChannel.ts
@@ -28,20 +28,19 @@ const setDefaultSlackChannel = {
 
     // VALIDATION
     const slackAuths = await dataLoader.get('slackAuthByUserId').load(viewerId)
-
     const slackAuth = slackAuths.find((auth) => auth.teamId === teamId)
     if (!slackAuth) {
       return standardError(new Error('Slack authentication not found'), {userId: viewerId})
     }
-    const {id: slackAuthId, botAccessToken, defaultTeamChannelId} = slackAuth
+    const {id: slackAuthId, botAccessToken, defaultTeamChannelId, slackUserId} = slackAuth
     const manager = new SlackServerManager(botAccessToken)
     const channelInfo = await manager.getConversationInfo(slackChannelId)
 
-    if (!channelInfo.ok) {
-      return standardError(new Error(channelInfo.error), {userId: viewerId})
-    }
-    // should either be a public / private channel or @Parabol im id
-    if (!channelInfo.channel.is_im) {
+    // should either be a public / private channel or the slackUserId if messaging from @Parabol
+    if (slackChannelId !== slackUserId) {
+      if (!channelInfo.ok) {
+        return standardError(new Error(channelInfo.error), {userId: viewerId})
+      }
       const {channel} = channelInfo
       const {id: channelId, is_member: isMember, is_archived: isArchived} = channel
       if (isArchived) {


### PR DESCRIPTION
We've got another case of the prod Slack app working differently to the dev Slack app.

There are two differences:

1. In the recent update, to enable upserting Slack messages when the timer changes, I searched through IMs to get the bot app `channelId`. While this worked in dev, it looks like the im:read scope is required in prod. I suspected this might happen after a similar thing happened with private channels so I included a back-up channelId here. However, now after auth'ing Slack, the channel menu doesn't show-up. I suspect [this line](https://github.com/ParabolInc/parabol/blob/cf2fe59da68edd9a44035baa8d02aa3ea279e736/packages/server/graphql/mutations/addSlackAuth.ts#L129) is the issue - it shouldn't be a return statement.

I've reverted the `addSlackAuth` logic back to how it was before so we don't check the ims. I will submit an application to Slack requesting the im:read and groups:read and, once approved, re-add the update message logic.

In the application, I'll also include a dummy interactivity request mentioned in the description [here](https://github.com/ParabolInc/parabol/pull/4988) to prevent a warning icon from showing when clicking an interactive button.

2. Links seems to unfurl in prod but not dev. Not sure why this is the case but switching unfurl_links from true to false [here](https://github.com/ParabolInc/parabol/blob/d0dde546db3662fb592eaaa207182b3b052a5671/packages/client/utils/SlackManager.ts#L221) should work as I don't see any examples where we would want the link to unfurl. Alternatively, we could remove the protocal from the short link which would prevent unfurling according to [the docs](https://api.slack.com/reference/messaging/link-unfurling#no_unfurling_please__examples).

This PR also adds a notification preview when notification that contain blocks. It currently says "Content can't be displayed" which was my mistake.