### PR TITLE
Update new version snackbar

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -102,7 +102,6 @@ export default class Atmosphere extends Environment {
   eventEmitter: StrictEventEmitter<EventEmitter, AtmosphereEvents> = new EventEmitter()
   queryCache = {} as {[key: string]: GraphQLResponse}
   upgradeTransportPromise: Promise<void> | null = null
-  version: string | null = null
   // it's only null before login, so it's just a little white lie
   viewerId: string = null!
   userId: string | null = null // DEPRECATED

--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -102,6 +102,7 @@ export default class Atmosphere extends Environment {
   eventEmitter: StrictEventEmitter<EventEmitter, AtmosphereEvents> = new EventEmitter()
   queryCache = {} as {[key: string]: GraphQLResponse}
   upgradeTransportPromise: Promise<void> | null = null
+  version: string | null = null
   // it's only null before login, so it's just a little white lie
   viewerId: string = null!
   userId: string | null = null // DEPRECATED

--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import PrimaryButton from '~/components/PrimaryButton'
 import ReportErrorFeedback from '~/components/ReportErrorFeedback'
 import useModal from '~/hooks/useModal'
+import useAtmosphere from '../../hooks/useAtmosphere'
 
 const ErrorBlock = styled('div')({
   alignItems: 'center',
@@ -32,20 +33,35 @@ const ErrorComponent = (props: Props) => {
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
   const oldBrowserErrs = ['flatMap is not a function']
+  const atmosphere = useAtmosphere()
+  const {version} = atmosphere
 
+  if (version && version !== __APP_VERSION__) {
+    const handleClick = () => {
+      window.location.reload()
+    }
+    return (
+      <ErrorBlock>
+        {`Oh no! You've found a bug because you're using an old version of Parabol. Try refreshing the page.`}
+        <Button>
+          <Link onClick={handleClick} target='_blank' rel='noreferrer'>
+            Refresh
+          </Link>
+        </Button>
+      </ErrorBlock>
+    )
+  }
   const isOldBrowserErr = oldBrowserErrs.find((err) => error.message.includes(err))
   if (isOldBrowserErr) {
     const url = 'https://browser-update.org/update-browser.html'
     return (
       <ErrorBlock>
         {"Oh no! You've found a bug because the browser you're using needs to be updated."}
-        {
-          <Button>
-            <Link href={url} target='_blank' rel='noreferrer'>
-              Update now
-            </Link>
-          </Button>
-        }
+        <Button>
+          <Link href={url} target='_blank' rel='noreferrer'>
+            Update now
+          </Link>
+        </Button>
       </ErrorBlock>
     )
   }

--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import PrimaryButton from '~/components/PrimaryButton'
 import ReportErrorFeedback from '~/components/ReportErrorFeedback'
 import useModal from '~/hooks/useModal'
-import useAtmosphere from '../../hooks/useAtmosphere'
 
 const ErrorBlock = styled('div')({
   alignItems: 'center',
@@ -33,24 +32,6 @@ const ErrorComponent = (props: Props) => {
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
   const oldBrowserErrs = ['flatMap is not a function']
-  const atmosphere = useAtmosphere()
-  const {version} = atmosphere
-
-  if (version && version !== __APP_VERSION__) {
-    const handleClick = () => {
-      window.location.reload()
-    }
-    return (
-      <ErrorBlock>
-        {`Oh no! You've found a bug because you're using an old version of Parabol. Try refreshing the page.`}
-        <Button>
-          <Link onClick={handleClick} target='_blank' rel='noreferrer'>
-            Refresh
-          </Link>
-        </Button>
-      </ErrorBlock>
-    )
-  }
   const isOldBrowserErr = oldBrowserErrs.find((err) => error.message.includes(err))
   if (isOldBrowserErr) {
     const url = 'https://browser-update.org/update-browser.html'

--- a/packages/client/hooks/useServiceWorkerUpdater.ts
+++ b/packages/client/hooks/useServiceWorkerUpdater.ts
@@ -16,12 +16,13 @@ const useServiceWorkerUpdater = () => {
       }
       atmosphere.eventEmitter.emit('addSnackbar', {
         key: 'newVersion',
-        autoDismiss: 0,
-        message: 'A new version of Parabol is available',
+        autoDismiss: 5,
+        message: 'A new version of Parabol is available 🎉',
         action: {
-          label: 'Refresh to upgrade',
+          label: `See what's changed`,
           callback: () => {
-            window.location.reload()
+            const url = `https://www.google.com/`
+            window.open(url, '_blank', 'noopener')?.focus()
           }
         }
       })

--- a/packages/client/hooks/useServiceWorkerUpdater.ts
+++ b/packages/client/hooks/useServiceWorkerUpdater.ts
@@ -21,7 +21,8 @@ const useServiceWorkerUpdater = () => {
         action: {
           label: `See what's changed`,
           callback: () => {
-            const url = 'https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#parabol-change-log'
+            const url =
+              'https://github.com/ParabolInc/parabol/blob/production/CHANGELOG.md#parabol-change-log'
             window.open(url, '_blank', 'noopener')?.focus()
           }
         }

--- a/packages/client/hooks/useServiceWorkerUpdater.ts
+++ b/packages/client/hooks/useServiceWorkerUpdater.ts
@@ -21,7 +21,7 @@ const useServiceWorkerUpdater = () => {
         action: {
           label: `See what's changed`,
           callback: () => {
-            const url = `https://www.google.com/`
+            const url = 'https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#parabol-change-log'
             window.open(url, '_blank', 'noopener')?.focus()
           }
         }

--- a/packages/client/hooks/useTrebuchetEvents.ts
+++ b/packages/client/hooks/useTrebuchetEvents.ts
@@ -63,6 +63,7 @@ const useTrebuchetEvents = () => {
       // hacky but that way we don't have to double parse huge json payloads. SSE graphql payloads are pre-parsed
       if (typeof payload !== 'string' || !payload.startsWith('{"version":')) return
       const obj = JSON.parse(payload)
+      if (obj.version) atmosphere.version = obj.version
       if (obj.version !== __APP_VERSION__ && 'serviceWorker' in navigator) {
         const registration = await navigator.serviceWorker.getRegistration()
         registration?.update().catch()

--- a/packages/client/hooks/useTrebuchetEvents.ts
+++ b/packages/client/hooks/useTrebuchetEvents.ts
@@ -61,10 +61,8 @@ const useTrebuchetEvents = () => {
 
     const onData = async (payload: string | object) => {
       // hacky but that way we don't have to double parse huge json payloads. SSE graphql payloads are pre-parsed
-      if (typeof payload !== 'string' || !payload.startsWith('{"version":')) return
-      const obj = JSON.parse(payload)
-      if (obj.version) atmosphere.version = obj.version
-      if (obj.version !== __APP_VERSION__ && 'serviceWorker' in navigator) {
+      const obj = typeof payload === 'string' ? JSON.parse(payload) : payload
+      if (obj.version && obj.version !== __APP_VERSION__ && 'serviceWorker' in navigator) {
         const registration = await navigator.serviceWorker.getRegistration()
         registration?.update().catch()
       }


### PR DESCRIPTION
PR to resolve issue #4691. I'm having difficulty comparing the app version and the server version in the error component but I've implemented a possible solution, written up my understanding of how things are working and left a couple of questions.

I can see that the `__APP_VERSION__` is set in the webpack config [here](https://github.com/ParabolInc/parabol/blob/0ea032bfa3d57a52212278d47cee0bbe3d1972e2/scripts/webpack/prod.client.config.js#L127) and that it looks at the package json file for the latest version.

Using service workers, we create a cache in [sw.ts](https://github.com/ParabolInc/parabol/blob/8c68bf771a350b31c7948e6bd11c5c110e30c977/packages/client/serviceWorker/sw.ts) with `__APP_VERSION__` as the suffix.

In [useTrebuchetEvents](https://github.com/ParabolInc/parabol/blob/8c68bf771a350b31c7948e6bd11c5c110e30c977/packages/client/hooks/useTrebuchetEvents.ts#L66), the `onData` function is triggered when the page loads and when the user visits a page that isn't stored in the cache. When the page loads, [handleOpen](https://github.com/ParabolInc/parabol/blob/cf62b042bae754836bf58275144eed5b089af165/packages/server/socketHandlers/handleOpen.ts) checks the version in the package json and sends it to the `onData` function. 

To add service workers to my local environment, I added [InjectManifest](https://github.com/ParabolInc/parabol/blob/0ea032bfa3d57a52212278d47cee0bbe3d1972e2/scripts/webpack/prod.client.config.js#L139) to dev.client.config. I can see that the `__APP_VERSION__` is set when running `yarn dev` whereas `handleOpen` fires when refreshing the page.

`__APP_VERSION__` could therefore be outdated so [we check](https://github.com/ParabolInc/parabol/blob/8c68bf771a350b31c7948e6bd11c5c110e30c977/packages/client/hooks/useTrebuchetEvents.ts#L66) whether the version is the same as the more recent `handleOpen` version. If it isn't, we update the registration which triggers the [controllerChange](https://github.com/ParabolInc/parabol/blob/8c68bf771a350b31c7948e6bd11c5c110e30c977/packages/client/hooks/useServiceWorkerUpdater.ts#L31) event listener function which emits the "Refresh to upgrade" snackbar.

As we get the most recent version of the app in `onData` thanks to `handleOpen`, we can save that version to the atmosphere. In the error component, we can compare whether the atmosphere version is the same as the potentially outdated `__APP_VERSION__` and return a different error message if so.

Questions:

1. Why does the user need to refresh the page? If there's a mismatch between the app versions, the cache typically updates without the user doing anything. I guess we ask them as a precaution? Refreshing the page ensures the `onInstall` function fires in the `sw.ts` file and creates a new cache?
2. In dev, `__APP_VERSION__` can be outdated as it's updated when building the app on `yarn dev` whereas `onData` gets the latest version when refreshing the page. In prod, I imagine `__APP_VERSION__` is updated when we push to production which means it may actually be more up-to-date than the version in `onData`?

P.S. I could create a section in Notion that explains how parts of the codebase work and jot down notes on how this works there.