### PR TITLE
Add poker comment & story count

### DIFF
--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -25,11 +25,8 @@ const Link = styled(StyledLink)({
 const TimelineEventPokerComplete = (props: Props) => {
   const {timelineEvent} = props
   const {meeting, team} = timelineEvent
-  const {id: meetingId, name: meetingName, commentCount, phases} = meeting
+  const {id: meetingId, name: meetingName, commentCount, storyCount} = meeting
   const {name: teamName} = team
-  const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')!
-  const stages = estimatePhase.stages!
-  const storyCount = new Set(stages.map(({serviceTaskId}) => serviceTaskId)).size
   return (
     <TimelineEventCard
       IconSVG={<CardsSVG />}
@@ -63,6 +60,7 @@ export default createFragmentContainer(TimelineEventPokerComplete, {
       meeting {
         id
         commentCount
+        storyCount
         name
         phases {
           phaseType

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/makePokerStats.ts
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/makePokerStats.ts
@@ -10,25 +10,13 @@ const makePokerStats = (meetingRef: any) => {
         meetingMembers {
           id
         }
-        phases {
-          phaseType
-          ... on EstimatePhase {
-            stages {
-              finalScore
-              serviceTaskId
-            }
-          }
-        }
+        storyCount
       }
     `,
     meetingRef
   )
 
-  const {meetingMembers, phases} = meeting
-  const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')!
-  const stages = estimatePhase.stages!
-  const storyCount = new Set(stages.map((stage) => stage.serviceTaskId)).size
-
+  const {meetingMembers, storyCount} = meeting
   const meetingMembersCount = meetingMembers.length
   return [
     {value: '', label: ''},

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -43658,8 +43658,8 @@ export const enum NewMeetingPhaseTypeEnum {
   vote = 'vote',
   discuss = 'discuss',
   SUMMARY = 'SUMMARY',
-  SCOPE = 'SCOPE',
-  ESTIMATE = 'ESTIMATE'
+  ESTIMATE = 'ESTIMATE',
+  SCOPE = 'SCOPE'
 }
 
 /**
@@ -49879,12 +49879,180 @@ export interface ITimelineEventPokerComplete {
   /**
    * The meeting that was completed
    */
-  meeting: IRetrospectiveMeeting;
+  meeting: IPokerMeeting;
 
   /**
    * The meetingId that was completed
    */
   meetingId: string;
+}
+
+/**
+ * A Poker meeting
+ */
+export interface IPokerMeeting {
+  __typename: 'PokerMeeting';
+
+  /**
+   * The unique meeting id. shortid.
+   */
+  id: string;
+
+  /**
+   * The timestamp the meeting was created
+   */
+  createdAt: any;
+
+  /**
+   * The id of the user that created the meeting
+   */
+  createdBy: string;
+
+  /**
+   * The user that created the meeting
+   */
+  createdByUser: IUser;
+
+  /**
+   * The timestamp the meeting officially ended
+   */
+  endedAt: any | null;
+
+  /**
+   * The location of the facilitator in the meeting
+   */
+  facilitatorStageId: string;
+
+  /**
+   * The userId (or anonymousId) of the most recent facilitator
+   */
+  facilitatorUserId: string;
+
+  /**
+   * The facilitator team member
+   */
+  facilitator: ITeamMember;
+
+  /**
+   * The team members that were active during the time of the meeting
+   */
+  meetingMembers: Array<IPokerMeetingMember>;
+
+  /**
+   * The auto-incrementing meeting number for the team
+   */
+  meetingNumber: number;
+  meetingType: MeetingTypeEnum;
+
+  /**
+   * The name of the meeting
+   */
+  name: string;
+
+  /**
+   * The organization this meeting belongs to
+   */
+  organization: IOrganization;
+
+  /**
+   * The phases the meeting will go through, including all phase-specific state
+   */
+  phases: Array<NewMeetingPhase>;
+
+  /**
+   * true if should show the org the conversion modal, else false
+   */
+  showConversionModal: boolean;
+
+  /**
+   * The time the meeting summary was emailed to the team
+   */
+  summarySentAt: any | null;
+  teamId: string;
+
+  /**
+   * The team that ran the meeting
+   */
+  team: ITeam;
+
+  /**
+   * The last time a meeting was updated (stage completed, finished, etc)
+   */
+  updatedAt: any | null;
+
+  /**
+   * The Poker meeting member of the viewer
+   */
+  viewerMeetingMember: IPokerMeetingMember | null;
+
+  /**
+   * The number of comments generated in the meeting
+   */
+  commentCount: number;
+
+  /**
+   * The number of stories scored during a meeting
+   */
+  storyCount: number;
+
+  /**
+   * The settings that govern the Poker meeting
+   */
+  settings: IPokerMeetingSettings;
+
+  /**
+   * A single story created in a Sprint Poker meeting
+   */
+  story: Story | null;
+
+  /**
+   * The ID of the template used for the meeting. Note the underlying template could have changed!
+   * @deprecated "The underlying template could be mutated. Use templateRefId"
+   */
+  templateId: string;
+
+  /**
+   * The ID of the immutable templateRef used for the meeting
+   */
+  templateRefId: string;
+}
+
+export interface IStoryOnPokerMeetingArguments {
+  storyId: string;
+}
+
+/**
+ * All the meeting specifics for a user in a poker meeting
+ */
+export interface IPokerMeetingMember {
+  __typename: 'PokerMeetingMember';
+
+  /**
+   * A composite of userId::meetingId
+   */
+  id: string;
+
+  /**
+   * true if present, false if absent, else null
+   * @deprecated "Members are checked in when they enter the meeting now & not created beforehand"
+   */
+  isCheckedIn: boolean | null;
+  meetingId: string;
+  meetingType: MeetingTypeEnum;
+  teamId: string;
+  teamMember: ITeamMember;
+  user: IUser;
+  userId: string;
+
+  /**
+   * The last time a meeting was updated (stage completed, finished, etc)
+   */
+  updatedAt: any;
+
+  /**
+   * true if the user is not voting and does not want their vote to count towards aggregates
+   */
+  isSpectating: boolean;
 }
 
 /**
@@ -52717,174 +52885,6 @@ export interface IDragEstimatingTaskSuccess {
   meeting: IPokerMeeting;
   stageId: string;
   stage: IEstimateStage;
-}
-
-/**
- * A Poker meeting
- */
-export interface IPokerMeeting {
-  __typename: 'PokerMeeting';
-
-  /**
-   * The unique meeting id. shortid.
-   */
-  id: string;
-
-  /**
-   * The timestamp the meeting was created
-   */
-  createdAt: any;
-
-  /**
-   * The id of the user that created the meeting
-   */
-  createdBy: string;
-
-  /**
-   * The user that created the meeting
-   */
-  createdByUser: IUser;
-
-  /**
-   * The timestamp the meeting officially ended
-   */
-  endedAt: any | null;
-
-  /**
-   * The location of the facilitator in the meeting
-   */
-  facilitatorStageId: string;
-
-  /**
-   * The userId (or anonymousId) of the most recent facilitator
-   */
-  facilitatorUserId: string;
-
-  /**
-   * The facilitator team member
-   */
-  facilitator: ITeamMember;
-
-  /**
-   * The team members that were active during the time of the meeting
-   */
-  meetingMembers: Array<IPokerMeetingMember>;
-
-  /**
-   * The auto-incrementing meeting number for the team
-   */
-  meetingNumber: number;
-  meetingType: MeetingTypeEnum;
-
-  /**
-   * The name of the meeting
-   */
-  name: string;
-
-  /**
-   * The organization this meeting belongs to
-   */
-  organization: IOrganization;
-
-  /**
-   * The phases the meeting will go through, including all phase-specific state
-   */
-  phases: Array<NewMeetingPhase>;
-
-  /**
-   * true if should show the org the conversion modal, else false
-   */
-  showConversionModal: boolean;
-
-  /**
-   * The time the meeting summary was emailed to the team
-   */
-  summarySentAt: any | null;
-  teamId: string;
-
-  /**
-   * The team that ran the meeting
-   */
-  team: ITeam;
-
-  /**
-   * The last time a meeting was updated (stage completed, finished, etc)
-   */
-  updatedAt: any | null;
-
-  /**
-   * The Poker meeting member of the viewer
-   */
-  viewerMeetingMember: IPokerMeetingMember | null;
-
-  /**
-   * The number of comments generated in the meeting
-   */
-  commentCount: number;
-
-  /**
-   * The number of stories scored during a meeting
-   */
-  storyCount: number;
-
-  /**
-   * The settings that govern the Poker meeting
-   */
-  settings: IPokerMeetingSettings;
-
-  /**
-   * A single story created in a Sprint Poker meeting
-   */
-  story: Story | null;
-
-  /**
-   * The ID of the template used for the meeting. Note the underlying template could have changed!
-   * @deprecated "The underlying template could be mutated. Use templateRefId"
-   */
-  templateId: string;
-
-  /**
-   * The ID of the immutable templateRef used for the meeting
-   */
-  templateRefId: string;
-}
-
-export interface IStoryOnPokerMeetingArguments {
-  storyId: string;
-}
-
-/**
- * All the meeting specifics for a user in a poker meeting
- */
-export interface IPokerMeetingMember {
-  __typename: 'PokerMeetingMember';
-
-  /**
-   * A composite of userId::meetingId
-   */
-  id: string;
-
-  /**
-   * true if present, false if absent, else null
-   * @deprecated "Members are checked in when they enter the meeting now & not created beforehand"
-   */
-  isCheckedIn: boolean | null;
-  meetingId: string;
-  meetingType: MeetingTypeEnum;
-  teamId: string;
-  teamMember: ITeamMember;
-  user: IUser;
-  userId: string;
-
-  /**
-   * The last time a meeting was updated (stage completed, finished, etc)
-   */
-  updatedAt: any;
-
-  /**
-   * true if the user is not voting and does not want their vote to count towards aggregates
-   */
-  isSpectating: boolean;
 }
 
 /**

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -43658,8 +43658,8 @@ export const enum NewMeetingPhaseTypeEnum {
   vote = 'vote',
   discuss = 'discuss',
   SUMMARY = 'SUMMARY',
-  ESTIMATE = 'ESTIMATE',
-  SCOPE = 'SCOPE'
+  SCOPE = 'SCOPE',
+  ESTIMATE = 'ESTIMATE'
 }
 
 /**

--- a/packages/server/database/migrations/20210622170418-addPokerStats.ts
+++ b/packages/server/database/migrations/20210622170418-addPokerStats.ts
@@ -1,0 +1,54 @@
+import {R} from 'rethinkdb-ts'
+import {MeetingTypeEnum, NewMeetingPhaseTypeEnum} from 'parabol-client/types/graphql'
+
+export const up = async function(r: R) {
+  try {
+    const getDiscussionIds = (meetingRow) => {
+      return meetingRow('phases')
+        .filter({phaseType: NewMeetingPhaseTypeEnum.ESTIMATE})('stages')
+        .concatMap((row) => row('discussionId'))
+    }
+    const getStories = (meetingRow) => {
+      return meetingRow('phases')
+        .filter({phaseType: NewMeetingPhaseTypeEnum.ESTIMATE})('stages')
+        .concatMap((row) => row('serviceTaskId'))
+    }
+
+    await r
+      .table('NewMeeting')
+      .filter({meetingType: MeetingTypeEnum.poker})
+      .filter((row) =>
+        row('endedAt')
+          .default(null)
+          .ne(null)
+      )
+      .update(
+        (row) => ({
+          commentCount: r
+            .table('Comment')
+            .getAll(r.args(getDiscussionIds(row)), {index: 'discussionId'})
+            .count()
+            .default(0),
+          storyCount: getStories(row)
+            .count()
+            .default(0)
+        }),
+        {nonAtomic: true}
+      )
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function(r: R) {
+  try {
+    await r
+      .table('NewMeeting')
+      .filter({meetingType: MeetingTypeEnum.poker})
+      .replace((row) => row.without('commentCount', 'storyCount'))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/migrations/20210624120419-addPokerStats.ts
+++ b/packages/server/database/migrations/20210624120419-addPokerStats.ts
@@ -8,10 +8,12 @@ export const up = async function(r: R) {
         .filter({phaseType: NewMeetingPhaseTypeEnum.ESTIMATE})('stages')
         .concatMap((row) => row('discussionId'))
     }
-    const getStories = (meetingRow) => {
+    const getCompletedStories = (meetingRow) => {
       return meetingRow('phases')
         .filter({phaseType: NewMeetingPhaseTypeEnum.ESTIMATE})('stages')
-        .concatMap((row) => row('serviceTaskId'))
+        .nth(0)
+        .filter({isComplete: true})
+        .map((row) => row('serviceTaskId'))
     }
 
     await r
@@ -29,7 +31,7 @@ export const up = async function(r: R) {
             .getAll(r.args(getDiscussionIds(row)), {index: 'discussionId'})
             .count()
             .default(0),
-          storyCount: getStories(row)
+          storyCount: getCompletedStories(row)
             .count()
             .default(0)
         }),

--- a/packages/server/database/types/MeetingPoker.ts
+++ b/packages/server/database/types/MeetingPoker.ts
@@ -20,6 +20,7 @@ export default class MeetingPoker extends Meeting {
   templateId: string
   templateRefId: string
   storyCount?: number
+  commentCount?: number
   constructor(input: Input) {
     const {
       id,

--- a/packages/server/graphql/mutations/dragDiscussionTopic.ts
+++ b/packages/server/graphql/mutations/dragDiscussionTopic.ts
@@ -3,10 +3,9 @@ import getRethink from '../../database/rethinkDriver'
 import DragDiscussionTopicPayload from '../types/DragDiscussionTopicPayload'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
-import {DISCUSS} from 'parabol-client/utils/constants'
 import standardError from '../../utils/standardError'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import DiscussPhase from '../../database/types/DiscussPhase'
+import getPhase from '../../utils/getPhase'
 
 export default {
   description: 'Changes the priority of the discussion topics',
@@ -43,7 +42,7 @@ export default {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
     if (endedAt) return standardError(new Error('Meeting already ended'), {userId: viewerId})
-    const discussPhase = phases.find((phase) => phase.phaseType === DISCUSS) as DiscussPhase
+    const discussPhase = getPhase(phases, 'discuss')
     if (!discussPhase) {
       return standardError(new Error('Meeting stage not found'), {userId: viewerId})
     }

--- a/packages/server/graphql/mutations/dragEstimatingTask.ts
+++ b/packages/server/graphql/mutations/dragEstimatingTask.ts
@@ -1,7 +1,7 @@
 import {GraphQLFloat, GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import EstimatePhase from '../../database/types/EstimatePhase'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -42,7 +42,7 @@ export default {
       return standardError(new Error('Not on team'), {userId: viewerId})
     }
     if (endedAt) return standardError(new Error('Meeting already ended'), {userId: viewerId})
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE') as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     if (!estimatePhase) {
       return standardError(new Error('Meeting phase not found'), {userId: viewerId})
     }

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -4,9 +4,9 @@ import {AGENDA_ITEMS, DONE, LAST_CALL} from 'parabol-client/utils/constants'
 import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 import {SuggestedActionTypeEnum} from '../../../client/types/constEnums'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
 import AgendaItem from '../../database/types/AgendaItem'
-import AgendaItemsPhase from '../../database/types/AgendaItemsPhase'
 import MeetingAction from '../../database/types/MeetingAction'
 import MeetingMember from '../../database/types/MeetingMember'
 import Task from '../../database/types/Task'
@@ -132,9 +132,7 @@ const finishCheckInMeeting = async (meeting: MeetingAction, dataLoader: DataLoad
       .run()
   ])
 
-  const agendaItemPhase = phases.find(
-    (phase) => phase.phaseType === 'agendaitems'
-  ) as AgendaItemsPhase
+  const agendaItemPhase = getPhase(phases, 'agendaitems')
   const {stages} = agendaItemPhase
   const discussionIds = stages.map((stage) => stage.discussionId)
   const userIds = meetingMembers.map(({userId}) => userId)

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -4,8 +4,8 @@ import {DISCUSS} from 'parabol-client/utils/constants'
 import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 import {SuggestedActionTypeEnum} from '../../../client/types/constEnums'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import DiscussPhase from '../../database/types/DiscussPhase'
 import MeetingMember from '../../database/types/MeetingMember'
 import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import TimelineEventRetroComplete from '../../database/types/TimelineEventRetroComplete'
@@ -27,7 +27,7 @@ const finishRetroMeeting = async (meeting: MeetingRetrospective, dataLoader: Dat
     dataLoader.get('retroReflectionGroupsByMeetingId').load(meetingId),
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId)
   ])
-  const discussPhase = phases.find((phase) => phase.phaseType === 'discuss') as DiscussPhase
+  const discussPhase = getPhase(phases, 'discuss')
   const {stages} = discussPhase
   const discussionIds = stages.map((stage) => stage.discussionId)
 

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -65,7 +65,9 @@ export default {
     if (!currentStageRes) {
       return standardError(new Error('Cannot find facilitator stage'), {userId: viewerId})
     }
-    const storyCount = new Set(estimateStages.map(({serviceTaskId}) => serviceTaskId)).size
+    const storyCount = new Set(
+      estimateStages.filter(({isComplete}) => isComplete).map(({serviceTaskId}) => serviceTaskId)
+    ).size
     const discussionIds = estimateStages.map((stage) => stage.discussionId)
     const {stage} = currentStageRes
     const phase = getMeetingPhase(phases)

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -3,7 +3,6 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 import getRethink from '../../database/rethinkDriver'
-import EstimatePhase from '../../database/types/EstimatePhase'
 import Meeting from '../../database/types/Meeting'
 import MeetingMember from '../../database/types/MeetingMember'
 import MeetingPoker from '../../database/types/MeetingPoker'
@@ -18,6 +17,7 @@ import sendMeetingEndToSegment from './helpers/endMeeting/sendMeetingEndToSegmen
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import {endSlackMeeting} from './helpers/notifySlack'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
+import getPhase from '../../utils/getPhase'
 
 export default {
   type: GraphQLNonNull(EndSprintPokerPayload),
@@ -53,7 +53,7 @@ export default {
 
     // RESOLUTION
     // remove hovering data from redis
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')! as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     const {stages: estimateStages} = estimatePhase
     if (estimateStages.length > 0) {
       const redisKeys = estimateStages.map((stage) => `pokerHover:${stage.id}`)

--- a/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
+++ b/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
@@ -1,5 +1,5 @@
+import getPhase from '../../../utils/getPhase'
 import getRethink from '../../../database/rethinkDriver'
-import AgendaItemsPhase from '../../../database/types/AgendaItemsPhase'
 import AgendaItemsStage from '../../../database/types/AgendaItemsStage'
 import MeetingAction from '../../../database/types/MeetingAction'
 import insertDiscussions from '../../../postgres/queries/insertDiscussions'
@@ -21,9 +21,7 @@ const addAgendaItemToActiveActionMeeting = async (
   ) as MeetingAction | undefined
   if (!actionMeeting) return undefined
   const {id: meetingId, phases} = actionMeeting
-  const agendaItemPhase = phases.find(
-    (phase) => phase.phaseType === 'agendaitems'
-  ) as AgendaItemsPhase
+  const agendaItemPhase = getPhase(phases, 'agendaitems')
   if (!agendaItemPhase) return undefined
 
   const {stages} = agendaItemPhase

--- a/packages/server/graphql/mutations/helpers/notifySlack.ts
+++ b/packages/server/graphql/mutations/helpers/notifySlack.ts
@@ -19,7 +19,6 @@ import MeetingRetrospective from '../../../database/types/MeetingRetrospective'
 import MeetingAction from '../../../database/types/MeetingAction'
 import MeetingPoker from '../../../database/types/MeetingPoker'
 import plural from 'parabol-client/utils/plural'
-import EstimatePhase from '../../../database/types/EstimatePhase'
 import {makeSection, makeSections, makeButtons} from './makeSlackBlocks'
 
 const getSlackDetails = async (
@@ -146,12 +145,12 @@ const getSummaryText = (meeting: MeetingRetrospective | MeetingAction | MeetingP
       'comment'
     )}.`
   } else {
-    const estimatePhase = meeting.phases.find(
-      (phase) => phase.phaseType === 'ESTIMATE'
-    ) as EstimatePhase
-    const stages = estimatePhase.stages
-    const storyCount = new Set(stages.map(({serviceTaskId}) => serviceTaskId)).size
-    return `You voted on ${storyCount} ${plural(storyCount, 'story', 'stories')}.`
+    const {storyCount = 0, commentCount = 0} = meeting
+    return `You voted on ${storyCount} ${plural(
+      storyCount,
+      'story',
+      'stories'
+    )} and added ${commentCount} ${plural(commentCount, 'comment')}.`
   }
 }
 

--- a/packages/server/graphql/mutations/joinMeeting.ts
+++ b/packages/server/graphql/mutations/joinMeeting.ts
@@ -1,10 +1,10 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import getPhase from '../../utils/getPhase'
 import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import getRethink from '../../database/rethinkDriver'
 import rMapIf from '../../database/rMapIf'
 import ActionMeetingMember from '../../database/types/ActionMeetingMember'
-import CheckInPhase from '../../database/types/CheckInPhase'
 import CheckInStage from '../../database/types/CheckInStage'
 import {NewMeetingPhaseTypeEnum} from '../../database/types/GenericMeetingPhase'
 import Meeting from '../../database/types/Meeting'
@@ -12,7 +12,6 @@ import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import PokerMeetingMember from '../../database/types/PokerMeetingMember'
 import RetroMeetingMember from '../../database/types/RetroMeetingMember'
 import TeamMember from '../../database/types/TeamMember'
-import UpdatesPhase from '../../database/types/UpdatesPhase'
 import UpdatesStage from '../../database/types/UpdatesStage'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
@@ -123,14 +122,14 @@ const joinMeeting = {
     }
 
     const appendToCheckin = async () => {
-      const checkInPhase = phases.find((phase) => phase.phaseType === 'checkin') as CheckInPhase
+      const checkInPhase = getPhase(phases, 'checkin')
       if (!checkInPhase) return
       const checkInStage = new CheckInStage(teamMemberId)
       return addStageToPhase(checkInStage, 'checkin')
     }
 
     const appendToUpdate = async () => {
-      const updatesPhase = phases.find((phase) => phase.phaseType === 'updates') as UpdatesPhase
+      const updatesPhase = getPhase(phases, 'updates')
       if (!updatesPhase) return
       const updatesStage = new UpdatesStage(teamMemberId)
       return addStageToPhase(updatesStage, 'updates')

--- a/packages/server/graphql/mutations/pokerAnnounceDeckHover.ts
+++ b/packages/server/graphql/mutations/pokerAnnounceDeckHover.ts
@@ -2,7 +2,7 @@ import {GraphQLBoolean, GraphQLID, GraphQLNonNull} from 'graphql'
 import ms from 'ms'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
-import EstimatePhase from '../../database/types/EstimatePhase'
+import getPhase from '../../utils/getPhase'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import getRedis from '../../utils/getRedis'
@@ -54,7 +54,7 @@ const pokerAnnounceDeckHover = {
     }
 
     // VALIDATION
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')! as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     const {stages} = estimatePhase
     const stage = stages.find((stage) => stage.id === stageId)
     if (!stage) {

--- a/packages/server/graphql/mutations/pokerResetDimension.ts
+++ b/packages/server/graphql/mutations/pokerResetDimension.ts
@@ -1,7 +1,6 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
-import EstimatePhase from '../../database/types/EstimatePhase'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import updateStage from '../../database/updateStage'
 import MeetingMember from '../../database/types/MeetingMember'
@@ -10,6 +9,7 @@ import publish from '../../utils/publish'
 import {GQLContext} from '../graphql'
 import PokerResetDimensionPayload from '../types/PokerResetDimensionPayload'
 import sendPokerMeetingRevoteToSegment from './helpers/sendPokerMeetingRevoteToSegment'
+import getPhase from '../../utils/getPhase'
 
 const pokerResetDimension = {
   type: GraphQLNonNull(PokerResetDimensionPayload),
@@ -61,7 +61,7 @@ const pokerResetDimension = {
     }
 
     // VALIDATION
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')! as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     const {stages} = estimatePhase
     const stage = stages.find((stage) => stage.id === stageId)
     if (!stage) {

--- a/packages/server/graphql/mutations/pokerRevealVotes.ts
+++ b/packages/server/graphql/mutations/pokerRevealVotes.ts
@@ -1,7 +1,7 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {PokerCards, SubscriptionChannel} from 'parabol-client/types/constEnums'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
-import EstimatePhase from '../../database/types/EstimatePhase'
+import getPhase from '../../utils/getPhase'
 import EstimateUserScore from '../../database/types/EstimateUserScore'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import updateStage from '../../database/updateStage'
@@ -66,7 +66,7 @@ const pokerRevealVotes = {
     }
 
     // VALIDATION
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')! as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     const {stages} = estimatePhase
     const stage = stages.find((stage) => stage.id === stageId)
     if (!stage) {

--- a/packages/server/graphql/mutations/pokerSetFinalScore.ts
+++ b/packages/server/graphql/mutations/pokerSetFinalScore.ts
@@ -3,9 +3,9 @@ import {SprintPokerDefaults, SubscriptionChannel} from 'parabol-client/types/con
 import makeAppURL from 'parabol-client/utils/makeAppURL'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
 import JiraServiceTaskId from '../../../client/shared/gqlIds/JiraServiceTaskId'
+import getPhase from '../../utils/getPhase'
 import appOrigin from '../../appOrigin'
 import getRethink from '../../database/rethinkDriver'
-import EstimatePhase from '../../database/types/EstimatePhase'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import {TaskServiceEnum} from '../../database/types/Task'
 import updateStage from '../../database/updateStage'
@@ -81,7 +81,7 @@ const pokerSetFinalScore = {
     }
 
     // VALIDATION
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')! as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     const {stages} = estimatePhase
     const stage = stages.find((stage) => stage.id === stageId)
     if (!stage) {

--- a/packages/server/graphql/mutations/setPhaseFocus.ts
+++ b/packages/server/graphql/mutations/setPhaseFocus.ts
@@ -1,9 +1,9 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {GROUP, REFLECT} from 'parabol-client/utils/constants'
+import {GROUP} from 'parabol-client/utils/constants'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import ReflectPhase from '../../database/types/ReflectPhase'
 import {getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -46,14 +46,14 @@ const setPhaseFocus = {
     if (facilitatorUserId !== viewerId) {
       return standardError(new Error('Not meeting facilitator'), {userId: viewerId})
     }
-    const phase = meeting.phases.find((phase) => phase.phaseType === REFLECT) as ReflectPhase
-    if (!phase) {
+    const reflectPhase = getPhase(meeting.phases, 'reflect')
+    if (!reflectPhase) {
       return standardError(new Error('Meeting not found'), {userId: viewerId})
     }
 
     // RESOLUTION
     // mutative
-    phase.focusedPromptId = focusedPromptId || null
+    reflectPhase.focusedPromptId = focusedPromptId || null
     await r
       .table('NewMeeting')
       .get(meetingId)

--- a/packages/server/graphql/mutations/updateAgendaItem.ts
+++ b/packages/server/graphql/mutations/updateAgendaItem.ts
@@ -1,9 +1,8 @@
 import {GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {AGENDA_ITEMS} from 'parabol-client/utils/constants'
 import makeUpdateAgendaItemSchema from 'parabol-client/validation/makeUpdateAgendaItemSchema'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import AgendaItemsPhase from '../../database/types/AgendaItemsPhase'
 import AgendaItemsStage from '../../database/types/AgendaItemsStage'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
@@ -65,9 +64,7 @@ export default {
     const meetingId = actionMeeting?.id ?? null
     if (actionMeeting) {
       const {id: meetingId, phases} = actionMeeting
-      const agendaItemPhase = phases.find(
-        (phase) => phase.phaseType === AGENDA_ITEMS
-      )! as AgendaItemsPhase
+      const agendaItemPhase = getPhase(phases, 'agendaitems')
       const {stages} = agendaItemPhase
       const agendaItems = await dataLoader.get('agendaItemsByTeamId').load(teamId)
       const getSortOrder = (stage: AgendaItemsStage) => {

--- a/packages/server/graphql/mutations/updateNewCheckInQuestion.ts
+++ b/packages/server/graphql/mutations/updateNewCheckInQuestion.ts
@@ -1,11 +1,10 @@
 import {GraphQLID, GraphQLNonNull, GraphQLString} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {CHECKIN} from 'parabol-client/utils/constants'
 import convertToTaskContent from 'parabol-client/utils/draftjs/convertToTaskContent'
 import {makeCheckinQuestion} from 'parabol-client/utils/makeCheckinGreeting'
 import normalizeRawDraftJS from 'parabol-client/validation/normalizeRawDraftJS'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import CheckInPhase from '../../database/types/CheckInPhase'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -52,7 +51,7 @@ export default {
       : convertToTaskContent(makeCheckinQuestion(Math.floor(Math.random() * 1000), teamId))
 
     // RESOLUTION
-    const checkInPhase = phases.find((phase) => phase.phaseType === CHECKIN) as CheckInPhase
+    const checkInPhase = getPhase(phases, 'checkin')
 
     // mutative
     checkInPhase.checkInQuestion = normalizedCheckInQuestion

--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -1,8 +1,8 @@
 import {GraphQLID, GraphQLList, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel, Threshold} from 'parabol-client/types/constEnums'
 import JiraServiceTaskId from '../../../client/shared/gqlIds/JiraServiceTaskId'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import EstimatePhase from '../../database/types/EstimatePhase'
 import EstimateStage from '../../database/types/EstimateStage'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import getTemplateRefById from '../../postgres/queries/getTemplateRefById'
@@ -83,7 +83,7 @@ const updatePokerScope = {
       issueKey: string
       dimensionName: string
     }[]
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE') as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     let stages = estimatePhase.stages
     const templateRef = await getTemplateRefById(templateRefId)
 

--- a/packages/server/graphql/mutations/voteForPokerStory.ts
+++ b/packages/server/graphql/mutations/voteForPokerStory.ts
@@ -1,8 +1,8 @@
 import {GraphQLID, GraphQLNonNull, GraphQLString} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
+import getPhase from '../../utils/getPhase'
 import getRethink from '../../database/rethinkDriver'
-import EstimatePhase from '../../database/types/EstimatePhase'
 import EstimateUserScore from '../../database/types/EstimateUserScore'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import updateStage from '../../database/updateStage'
@@ -92,7 +92,7 @@ const voteForPokerStory = {
     }
 
     // VALIDATION
-    const estimatePhase = phases.find((phase) => phase.phaseType === 'ESTIMATE')! as EstimatePhase
+    const estimatePhase = getPhase(phases, 'ESTIMATE')
     const {stages} = estimatePhase
     const stage = stages.find((stage) => stage.id === stageId)
     if (!stage) {

--- a/packages/server/graphql/types/PokerMeeting.ts
+++ b/packages/server/graphql/types/PokerMeeting.ts
@@ -1,7 +1,7 @@
 import {GraphQLID, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import JiraServiceTaskId from '../../../client/shared/gqlIds/JiraServiceTaskId'
-import EstimatePhase from '../../database/types/EstimatePhase'
+import getPhase from '../../utils/getPhase'
 import {getUserId} from '../../utils/authorization'
 import {GQLContext} from '../graphql'
 import NewMeeting, {newMeetingFields} from './NewMeeting'
@@ -48,9 +48,7 @@ const PokerMeeting = new GraphQLObjectType<any, GQLContext>({
         }
       },
       resolve: async ({phases, teamId}, {storyId: serviceTaskId}, {dataLoader}) => {
-        const estimatePhase = phases.find(
-          (phase) => phase.phaseType === 'ESTIMATE'
-        ) as EstimatePhase
+        const estimatePhase = getPhase(phases, 'ESTIMATE')
         const {stages} = estimatePhase
         const stage = stages.find((stage) => stage.serviceTaskId === serviceTaskId)
         if (!stage) return null

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -8,10 +8,10 @@ import {
   GraphQLObjectType
 } from 'graphql'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
-import DiscussPhase from '../../database/types/DiscussPhase'
 import RetroMeetingMember from '../../database/types/RetroMeetingMember'
 import {getUserId} from '../../utils/authorization'
 import filterTasksByMeeting from '../../utils/filterTasksByMeeting'
+import getPhase from '../../utils/getPhase'
 import {GQLContext} from '../graphql'
 import {resolveForSU} from '../resolvers'
 import NewMeeting, {newMeetingFields} from './NewMeeting'
@@ -102,7 +102,7 @@ const RetrospectiveMeeting = new GraphQLObjectType<any, GQLContext>({
         } else if (sortBy === 'stageOrder') {
           const meeting = await dataLoader.get('newMeetings').load(meetingId)
           const {phases} = meeting
-          const discussPhase = phases.find((phase) => phase.phaseType === 'discuss') as DiscussPhase
+          const discussPhase = getPhase(phases, 'discuss')
           if (!discussPhase) return reflectionGroups
           const {stages} = discussPhase
           // for early terminations the stages may not exist

--- a/packages/server/graphql/types/TimelineEventPokerComplete.ts
+++ b/packages/server/graphql/types/TimelineEventPokerComplete.ts
@@ -1,5 +1,5 @@
 import {GraphQLID, GraphQLNonNull, GraphQLObjectType} from 'graphql'
-import RetrospectiveMeeting from './RetrospectiveMeeting'
+import PokerMeeting from './PokerMeeting'
 import Team from './Team'
 import TimelineEvent, {timelineEventInterfaceFields} from './TimelineEvent'
 
@@ -11,7 +11,7 @@ const TimelineEventPokerComplete = new GraphQLObjectType<any>({
   fields: () => ({
     ...timelineEventInterfaceFields(),
     meeting: {
-      type: new GraphQLNonNull(RetrospectiveMeeting),
+      type: new GraphQLNonNull(PokerMeeting),
       description: 'The meeting that was completed',
       resolve: ({meetingId}, _args, {dataLoader}) => {
         return dataLoader.get('newMeetings').load(meetingId)

--- a/packages/server/utils/getPhase.ts
+++ b/packages/server/utils/getPhase.ts
@@ -1,0 +1,22 @@
+import GenericMeetingPhase from '../database/types/GenericMeetingPhase'
+import EstimatePhase from '../database/types/EstimatePhase'
+import AgendaItemsPhase from '../database/types/AgendaItemsPhase'
+import CheckInPhase from '../database/types/CheckInPhase'
+import DiscussPhase from '../database/types/DiscussPhase'
+import ReflectPhase from '../database/types/ReflectPhase'
+import UpdatesPhase from '../database/types/UpdatesPhase'
+
+interface PhaseTypeLookup {
+  agendaitems: AgendaItemsPhase
+  checkin: CheckInPhase
+  discuss: DiscussPhase
+  ESTIMATE: EstimatePhase
+  reflect: ReflectPhase
+  updates: UpdatesPhase
+}
+
+const getPhase = <T extends keyof PhaseTypeLookup>(phases: GenericMeetingPhase[], phaseType: T) => {
+  return phases.find((phase) => phase.phaseType === phaseType) as PhaseTypeLookup[T]
+}
+
+export default getPhase


### PR DESCRIPTION
PR to resolve issue #4983 

This PR saves the story count and comment count to the db when a poker meeting ends. It also adds a migration to update previous meeting stats.

### AC:

- [ ] The story count and comment count for a Poker meeting in the timeline feed are accurate
- [ ] Story count and comment count are accurate in Slack notifications