### PR TITLE
Fixed agenda items sorting and deleting

### DIFF
--- a/packages/client/mutations/UpdateAgendaItemMutation.ts
+++ b/packages/client/mutations/UpdateAgendaItemMutation.ts
@@ -7,6 +7,7 @@ import updateProxyRecord from '../utils/relay/updateProxyRecord'
 import {UpdateAgendaItemMutation as TUpdateAgendaItemMutation} from '../__generated__/UpdateAgendaItemMutation.graphql'
 import {UpdateAgendaItemMutation_team} from '~/__generated__/UpdateAgendaItemMutation_team.graphql'
 import {ActionMeeting_meeting} from '~/__generated__/ActionMeeting_meeting.graphql'
+import {AgendaItem_agendaItem} from '../__generated__/AgendaItem_agendaItem.graphql'
 
 graphql`
   fragment UpdateAgendaItemMutation_team on UpdateAgendaItemPayload {
@@ -43,8 +44,8 @@ const handleUpdateAgendaPhase = (
       phase ? phase.getValue('phaseType') === 'agendaitems' : false
     )
     if (!agendaPhase) return
-    const getSortOrder = (stage) => {
-      const agendaItem = stage.getLinkedRecord('agendaItem')
+    const getSortOrder = (stage: RecordProxy) => {
+      const agendaItem = stage.getLinkedRecord<AgendaItem_agendaItem>('agendaItem')
       if (!agendaItem) return 0
       return agendaItem.getValue('sortOrder')
     }

--- a/packages/client/mutations/UpdateAgendaItemMutation.ts
+++ b/packages/client/mutations/UpdateAgendaItemMutation.ts
@@ -7,7 +7,7 @@ import updateProxyRecord from '../utils/relay/updateProxyRecord'
 import {UpdateAgendaItemMutation as TUpdateAgendaItemMutation} from '../__generated__/UpdateAgendaItemMutation.graphql'
 import {UpdateAgendaItemMutation_team} from '~/__generated__/UpdateAgendaItemMutation_team.graphql'
 import {ActionMeeting_meeting} from '~/__generated__/ActionMeeting_meeting.graphql'
-import {AgendaItem_agendaItem} from '../__generated__/AgendaItem_agendaItem.graphql'
+import {AgendaItem_agendaItem} from '~/__generated__/AgendaItem_agendaItem.graphql'
 
 graphql`
   fragment UpdateAgendaItemMutation_team on UpdateAgendaItemPayload {

--- a/packages/client/mutations/UpdateAgendaItemMutation.ts
+++ b/packages/client/mutations/UpdateAgendaItemMutation.ts
@@ -7,7 +7,6 @@ import updateProxyRecord from '../utils/relay/updateProxyRecord'
 import {UpdateAgendaItemMutation as TUpdateAgendaItemMutation} from '../__generated__/UpdateAgendaItemMutation.graphql'
 import {UpdateAgendaItemMutation_team} from '~/__generated__/UpdateAgendaItemMutation_team.graphql'
 import {ActionMeeting_meeting} from '~/__generated__/ActionMeeting_meeting.graphql'
-import {AgendaItem_agendaItem} from '~/__generated__/AgendaItem_agendaItem.graphql'
 
 graphql`
   fragment UpdateAgendaItemMutation_team on UpdateAgendaItemPayload {
@@ -45,8 +44,7 @@ const handleUpdateAgendaPhase = (
     )
     if (!agendaPhase) return
     const getSortOrder = (stage) => {
-      const agendaItemId = stage.getValue('agendaItemId')
-      const agendaItem = store.get<AgendaItem_agendaItem>(agendaItemId)
+      const agendaItem = stage.getLinkedRecord('agendaItem')
       if (!agendaItem) return 0
       return agendaItem.getValue('sortOrder')
     }

--- a/packages/client/mutations/handlers/handleRemoveAgendaItems.ts
+++ b/packages/client/mutations/handlers/handleRemoveAgendaItems.ts
@@ -24,7 +24,8 @@ const handleRemoveAgendaItem = (
     const stages = agendaItemPhase.getLinkedRecords('stages')
     if (!stages) return
     const stageToRemove = stages.find(
-      (stage) => stage.getLinkedRecord('agendaItem')?.getValue('id') === agendaItemId
+      (stage) =>
+        stage.getLinkedRecord<AgendaItem_agendaItem>('agendaItem')?.getValue('id') === agendaItemId
     )
     if (!stageToRemove) return
     const stageId = stageToRemove.getValue('id') as string

--- a/packages/client/mutations/handlers/handleRemoveAgendaItems.ts
+++ b/packages/client/mutations/handlers/handleRemoveAgendaItems.ts
@@ -23,7 +23,9 @@ const handleRemoveAgendaItem = (
     if (!agendaItemPhase) return
     const stages = agendaItemPhase.getLinkedRecords('stages')
     if (!stages) return
-    const stageToRemove = stages.find((stage) => stage.getValue('agendaItemId') === agendaItemId)
+    const stageToRemove = stages.find(
+      (stage) => stage.getLinkedRecord('agendaItem')?.getValue('id') === agendaItemId
+    )
     if (!stageToRemove) return
     const stageId = stageToRemove.getValue('id') as string
     if (!stageId) return

--- a/packages/server/graphql/mutations/removeAgendaItem.ts
+++ b/packages/server/graphql/mutations/removeAgendaItem.ts
@@ -44,10 +44,8 @@ export default {
       return standardError(new Error('Agenda item not found'), {userId: viewerId})
     }
     const filterFn = (stage: AgendaItemsStage) => stage.agendaItemId === agendaItemId
-    const meetingIds = await removeStagesFromMeetings(filterFn, teamId, dataLoader)
-    // safe to do so because we guarantee only 1 action meeting at the same time
-    const [meetingId] = meetingIds
-    const data = {agendaItem, meetingId}
+    await removeStagesFromMeetings(filterFn, teamId, dataLoader)
+    const data = {agendaItem, meetingId: agendaItem.meetingId}
     publish(SubscriptionChannel.TEAM, teamId, 'RemoveAgendaItemPayload', data, subOptions)
     return data
   }


### PR DESCRIPTION
Related issue: https://github.com/ParabolInc/parabol/issues/5056 

Agenda items related relay store updaters were broken because they were reading non-exsiting `agendaItemId` property from `AgendaItemsStage`. 
![Screenshot 2021-06-24 at 18 11 29](https://user-images.githubusercontent.com/1017620/123297265-b609ed00-d517-11eb-8f23-2135be0850a5.png)
 
Now, both sorting and deletion work without any issues (currently, on prod sorting and deletion are broken). 