### PR TITLE
Deprecate prompt title

### DIFF
--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -45686,11 +45686,6 @@ export interface IReflectPrompt {
   template: IReflectTemplate;
 
   /**
-   * The title of the phase of the retrospective. Often a short version of the question
-   */
-  title: string;
-
-  /**
    * The question to answer during the phase of the retrospective (eg What went well?)
    */
   question: string;

--- a/packages/server/database/migrations/20210708185500-removePromptTitle.ts
+++ b/packages/server/database/migrations/20210708185500-removePromptTitle.ts
@@ -1,0 +1,22 @@
+import {R} from 'rethinkdb-ts'
+export const up = async function(r: R) {
+  try {
+    await r
+      .table('ReflectPrompt')
+      .replace(r.row.without('title'))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function(r: R) {
+  try {
+    await r
+      .table('ReflectPrompt')
+      .update((row) => ({title: row('question')}))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/types/RetrospectivePrompt.ts
+++ b/packages/server/database/types/RetrospectivePrompt.ts
@@ -8,7 +8,6 @@ interface Input {
   description: string
   groupColor: string
   removedAt: Date | null
-  title?: string
   parentPromptId?: string
 }
 
@@ -22,7 +21,6 @@ export default class RetrospectivePrompt {
   templateId: string
   question: string
   removedAt: Date | null
-  title: string
   updatedAt = new Date()
   parentPromptId?: string
 
@@ -35,7 +33,6 @@ export default class RetrospectivePrompt {
       description,
       groupColor,
       removedAt,
-      title,
       parentPromptId
     } = input
     this.id = generateUID()
@@ -46,7 +43,6 @@ export default class RetrospectivePrompt {
     this.description = description || ''
     this.groupColor = groupColor
     this.removedAt = removedAt
-    this.title = title || question
     this.parentPromptId = parentPromptId
   }
 }

--- a/packages/server/graphql/mutations/helpers/makeRetroTemplates.ts
+++ b/packages/server/graphql/mutations/helpers/makeRetroTemplates.ts
@@ -5,7 +5,6 @@ interface TemplatePrompt {
   description: string
   groupColor: string
   question: string
-  title?: string
   scope?: string
 }
 
@@ -30,7 +29,6 @@ const makeRetroTemplates = (teamId: string, orgId: string, templateObj: Template
           question: prompt.question,
           description: prompt.description,
           groupColor: prompt.groupColor,
-          title: prompt.title,
           removedAt: null
         })
     )

--- a/packages/server/graphql/types/ReflectPrompt.ts
+++ b/packages/server/graphql/types/ReflectPrompt.ts
@@ -44,11 +44,6 @@ const ReflectPrompt = new GraphQLObjectType<any, GQLContext>({
         return dataLoader.get('meetingTemplates').load(templateId)
       }
     },
-    title: {
-      type: new GraphQLNonNull(GraphQLString),
-      description:
-        'The title of the phase of the retrospective. Often a short version of the question'
-    },
     question: {
       description:
         'The question to answer during the phase of the retrospective (eg What went well?)',


### PR DESCRIPTION
PR to resolve issue #5009 

I know that [we sometimes](https://github.com/ParabolInc/parabol/blob/db45e3b5a4c27e917dcc267d33175bae8a04970b/packages/server/graphql/types/RetroReflectionGroup.ts#L32) keep the field with a deprecation reason. I assume we do this when deprecating a previously important field and we want to be careful in case we break something? The prompt title isn't being used anywhere so I assume it's safe to remove it entirely.