### PR TITLE
templateDimension dataloader should only return non removed dimensions

### DIFF
--- a/packages/server/dataloader/foreignLoaderMakers.ts
+++ b/packages/server/dataloader/foreignLoaderMakers.ts
@@ -265,7 +265,6 @@ export const templateDimensionsByTemplateId = new LoaderMakerForeign(
         .getAll(r.args(templateIds), {index: 'templateId'})
         // NOTE: isActive must be false so we can see meetings in the past that use a now-inactive template
         // .filter({isActive: true})
-        .filter(row => row.hasFields('removedAt').not())
         .orderBy('sortOrder')
         .run()
     )

--- a/packages/server/dataloader/foreignLoaderMakers.ts
+++ b/packages/server/dataloader/foreignLoaderMakers.ts
@@ -265,6 +265,7 @@ export const templateDimensionsByTemplateId = new LoaderMakerForeign(
         .getAll(r.args(templateIds), {index: 'templateId'})
         // NOTE: isActive must be false so we can see meetings in the past that use a now-inactive template
         // .filter({isActive: true})
+        .filter(row => row.hasFields('removedAt').not())
         .orderBy('sortOrder')
         .run()
     )

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -26,8 +26,9 @@ const freezeTemplateAsRef = async (templateId: string, dataLoader: DataLoaderWor
     dataLoader.get('meetingTemplates').load(templateId),
     dataLoader.get('templateDimensionsByTemplateId').load(templateId)
   ])
+  const activeDimensions = dimensions.filter(({removedAt}) => !removedAt)
   const {name: templateName} = template
-  const uniqueScaleIds = Array.from(new Set(dimensions.map(({scaleId}) => scaleId)))
+  const uniqueScaleIds = Array.from(new Set(activeDimensions.map(({scaleId}) => scaleId)))
   const uniqueScales = await dataLoader.get('templateScales').loadMany(uniqueScaleIds)
   const templateScales = uniqueScales.map(({name, values}) => {
     const scale = {name, values}
@@ -37,7 +38,7 @@ const freezeTemplateAsRef = async (templateId: string, dataLoader: DataLoaderWor
 
   const templateRef = {
     name: templateName,
-    dimensions: dimensions.map((dimension) => {
+    dimensions: activeDimensions.map((dimension) => {
       const {name, scaleId} = dimension
       const scaleIdx = uniqueScales.findIndex((scale) => scale.id === scaleId)
       const templateScale = templateScales[scaleIdx]


### PR DESCRIPTION
Resolves https://github.com/ParabolInc/parabol/issues/5126

**AC:**
- [ ] before starting a sprint poker meeting, clone a parabol template and add a custom dimension to the team template copy
- [ ] remove the new custom dimension from the team template
- [ ] start the sprint poker meeting, add some items to scoping phase, advance to estimate and observe that the removed dimension no longer shows up in the meeting