### PR TITLE
Fix dashboard padding

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
-import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
 import {PALETTE} from '../../styles/paletteV3'
-import {AppBar, Breakpoint, NavSidebar} from '../../types/constEnums'
+import {NavSidebar} from '../../types/constEnums'
 import {DashSidebar_viewer} from '../../__generated__/DashSidebar_viewer.graphql'
 import DashNavList from '../DashNavList/DashNavList'
 import LeftDashNavItem from './LeftDashNavItem'
@@ -19,13 +18,7 @@ const Nav = styled('nav')<{isOpen: boolean}>(({isOpen}) => ({
   userSelect: 'none',
   transition: `all 300ms`,
   transform: isOpen ? undefined : `translateX(-${NavSidebar.WIDTH}px)`,
-  width: isOpen ? NavSidebar.WIDTH : 0,
-  [makeMinWidthMediaQuery(Breakpoint.DASH_BREAKPOINT_WIDEST)]: {
-    bottom: 0,
-    left: 0,
-    top: AppBar.HEIGHT,
-    zIndex: 2
-  }
+  width: isOpen ? NavSidebar.WIDTH : 0
 }))
 
 const Contents = styled('div')({

--- a/packages/client/components/TimelineRightDrawer.tsx
+++ b/packages/client/components/TimelineRightDrawer.tsx
@@ -7,7 +7,7 @@ import ErrorBoundary from './ErrorBoundary'
 import TimelinePriorityTasks from './TimelinePriorityTasks'
 import {PALETTE} from '../styles/paletteV3'
 import TimelineNewFeature from './TimelineNewFeature'
-import {Breakpoint, DashTimeline, NavSidebar} from '../types/constEnums'
+import {DashTimeline, NavSidebar} from '../types/constEnums'
 import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
 
 interface Props {
@@ -29,12 +29,6 @@ export const RightDrawer = styled('div')({
   padding: 16,
   [makeMinWidthMediaQuery(MIN_WIDTH)]: {
     display: 'block'
-  },
-  [makeMinWidthMediaQuery(Breakpoint.DASH_BREAKPOINT_WIDEST)]: {
-    bottom: 0,
-    position: 'fixed',
-    right: 0,
-    top: 56
   }
 })
 

--- a/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled'
 
 import useDocumentTitle from '../../../../hooks/useDocumentTitle'
 import {desktopSidebarShadow, navDrawerShadow} from '../../../../styles/elevation'
-import {AppBar, Breakpoint, NavSidebar, RightSidebar, ZIndex} from '../../../../types/constEnums'
+import {AppBar, Breakpoint, RightSidebar, ZIndex} from '../../../../types/constEnums'
 import TeamColumnsContainer from '../../containers/TeamColumns/TeamColumnsContainer'
 import TeamTasksHeaderContainer from '../../containers/TeamTasksHeader/TeamTasksHeaderContainer'
 import AgendaListAndInput from '../AgendaListAndInput/AgendaListAndInput'
@@ -32,7 +32,6 @@ const TasksMain = styled('div')({
   height: '100%',
   overflow: 'auto',
   [desktopDashWidestMediaQuery]: {
-    paddingLeft: NavSidebar.WIDTH,
     paddingRight: RightSidebar.WIDTH
   }
 })


### PR DESCRIPTION
PR to resolve issue: #5117 

Issue was caused by removing `position: fixed` [here](https://github.com/ParabolInc/parabol/blob/c8d057bc6861eaa9d102e8a53966fb79e55a3272/packages/client/components/Dashboard/DashSidebar.tsx#L23) in #4975. 

However, it looks like the [DashMain](https://github.com/ParabolInc/parabol/blob/bdbb60c65d52f48698268aed46f9e095947ee3f3/packages/client/components/Dashboard.tsx#L114) div previously included the nav sidebar on large screens and we adjusted the content of `DashMain` with padding. 

Instead, by removing `position: fixed` and removing the extra padding, we can correctly centre the dashboards and the `DashMain` div won't include the sidebar.

### AC:

- [ ] dashboards look beautiful on all screensizes 