### PR TITLE
Fixed atlassian auth migration

### DIFF
--- a/packages/server/graphql/mutations/addAtlassianAuth.ts
+++ b/packages/server/graphql/mutations/addAtlassianAuth.ts
@@ -50,7 +50,7 @@ export default {
       refreshToken,
       cloudIds,
       teamId,
-      scope: AtlassianServerManager.SCOPE
+      scope: AtlassianServerManager.SCOPE.join(' ')
     })
 
     segmentIo.track({

--- a/packages/server/postgres/migrations/1624862201216_addAtlassianAuthTable.ts
+++ b/packages/server/postgres/migrations/1624862201216_addAtlassianAuthTable.ts
@@ -69,7 +69,7 @@ export async function up(): Promise<void> {
       userId,
       jiraSearchQueries: jiraSearchQueries || [],
       cloudIds,
-      scope: AtlassianManager.SCOPE
+      scope: AtlassianManager.SCOPE.join(' ')
     })
   )
   if (auths.length) {


### PR DESCRIPTION
After merging https://github.com/ParabolInc/parabol/pull/4880 `scope` is no longer kept as a string but as an array of strings to allow easier manipulation. This PR fixes the migration which assumed it was a string. 

I've also added an improvement to existing functionality: https://github.com/ParabolInc/parabol/issues/5134 