### PR TITLE
Fixed summary review not working properly

### DIFF
--- a/packages/client/components/RetroReflectPhase/PhaseItemColumn.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemColumn.tsx
@@ -142,7 +142,7 @@ interface Props {
 const PhaseItemColumn = (props: Props) => {
   const {idx, meeting, phaseRef, prompt, isDesktop} = props
   const {id: promptId, editorIds, question, groupColor, description} = prompt
-  const {id: meetingId, facilitatorUserId, localPhase, phases, reflectionGroups} = meeting
+  const {id: meetingId, facilitatorUserId, localPhase, phases, reflectionGroups, endedAt} = meeting
   const {id: phaseId, focusedPromptId} = localPhase
   const groupPhase = phases.find((phase) => phase.phaseType === 'group')!
   const {stages: groupStages} = groupPhase
@@ -229,6 +229,7 @@ const PhaseItemColumn = (props: Props) => {
                   forceUpdateColumn={forceUpdateColumn}
                   promptId={promptId}
                   stackTopRef={stackTopRef}
+                  readOnly={!!endedAt}
                 />
               </EditorAndStatus>
             </EditorSection>
@@ -271,6 +272,7 @@ export default createFragmentContainer(PhaseItemColumn, {
       ...ReflectionStack_meeting
       facilitatorUserId
       id
+      endedAt
       localPhase {
         id
         phaseType

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -33,6 +33,7 @@ interface Props {
   promptId: string
   stackTopRef: RefObject<HTMLDivElement>
   dataCy: string
+  readOnly?: boolean
 }
 
 const PhaseItemEditor = (props: Props) => {
@@ -44,7 +45,8 @@ const PhaseItemEditor = (props: Props) => {
     stackTopRef,
     cardsInFlightRef,
     forceUpdateColumn,
-    dataCy
+    dataCy,
+    readOnly
   } = props
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation} = useMutationProps()
@@ -180,6 +182,7 @@ const PhaseItemEditor = (props: Props) => {
           keyBindingFn={ensureEditing}
           placeholder='My reflection… (press enter to add)'
           setEditorState={setEditorState}
+          readOnly={readOnly}
         />
       </ReflectionCardRoot>
       {portal(

--- a/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
@@ -304,6 +304,7 @@ class ExportToCSV extends Component<Props> {
     const {newMeeting} = viewer
     if (!newMeeting) return
     const rows = this.getRows(newMeeting)
+    if (rows.length === 0) return
     const {endedAt, team, meetingType} = newMeeting
     const {name: teamName} = team
     const label = meetingType[0].toUpperCase() + meetingType.slice(1)

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
@@ -40,27 +40,35 @@ const RetroTopics = (props: Props) => {
           {plural(stages.length, RETRO_TOPIC_LABEL)}
         </td>
       </tr>
-      {stages.map((stage, idx) => {
-        const topicUrlPath = `/meet/${meetingId}/discuss/${idx + 1}`
-        const topicUrl = isEmail
-          ? makeAppURL(appOrigin, topicUrlPath, {
-              searchParams: {
-                utm_source: 'summary email',
-                utm_medium: 'email',
-                utm_campaign: 'after-meeting'
-              }
-            })
-          : topicUrlPath
-        return (
-          <RetroTopic
-            key={stage.id}
-            isDemo={isDemo}
-            isEmail={isEmail}
-            stage={stage}
-            to={topicUrl}
-          />
-        )
-      })}
+      {stages.length ? (
+        stages.map((stage, idx) => {
+          const topicUrlPath = `/meet/${meetingId}/discuss/${idx + 1}`
+          const topicUrl = isEmail
+            ? makeAppURL(appOrigin, topicUrlPath, {
+                searchParams: {
+                  utm_source: 'summary email',
+                  utm_medium: 'email',
+                  utm_campaign: 'after-meeting'
+                }
+              })
+            : topicUrlPath
+          return (
+            <RetroTopic
+              key={stage.id}
+              isDemo={isDemo}
+              isEmail={isEmail}
+              stage={stage}
+              to={topicUrl}
+            />
+          )
+        })
+      ) : (
+        <tr>
+          <td align='center' style={{paddingTop: 20}}>
+            No new topics...
+          </td>
+        </tr>
+      )}
       <EmailBorderBottom />
     </>
   )

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -47691,7 +47691,7 @@ export interface IRetroDiscussStage {
   discussionId: string;
 
   /**
-   * The discussion about the stage or a dummy data when there is no disscussion id
+   * The discussion about the stage or a dummy data when there is no disscussion
    */
   discussion: IDiscussion;
 

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -47691,7 +47691,7 @@ export interface IRetroDiscussStage {
   discussionId: string;
 
   /**
-   * The discussion about the stage
+   * The discussion about the stage or a dummy data when there is no disscussion id
    */
   discussion: IDiscussion;
 

--- a/packages/server/graphql/types/RetroDiscussStage.ts
+++ b/packages/server/graphql/types/RetroDiscussStage.ts
@@ -7,8 +7,8 @@ import DiscussionThreadStage, {discussionThreadStageFields} from './DiscussionTh
 import NewMeetingStage, {newMeetingStageFields} from './NewMeetingStage'
 import RetroReflectionGroup from './RetroReflectionGroup'
 
-const createEmptyDiscussion = (id) => ({
-  id,
+const DUMMY_DISCUSSION = {
+  id: 'dummy-discussion-id',
   teamId: '',
   meetingId: '',
   createdAt: '',
@@ -18,7 +18,7 @@ const createEmptyDiscussion = (id) => ({
   thread: {
     edges: []
   }
-})
+}
 
 const RetroDiscussStage = new GraphQLObjectType<any, GQLContext>({
   name: 'RetroDiscussStage',
@@ -31,9 +31,9 @@ const RetroDiscussStage = new GraphQLObjectType<any, GQLContext>({
     discussion: {
       type: GraphQLNonNull(Discussion),
       description: 'The discussion about the stage or a dummy data when there is no disscussion',
-      resolve: async ({discussionId}, _args, {dataLoader}) => {
-        const discussion = await dataLoader.get('discussions').load(discussionId)
-        return discussion ?? createEmptyDiscussion(discussionId)
+      resolve: async ({discussionId, reflectionGroupId}, _args, {dataLoader}) => {
+        const isDummy = reflectionGroupId === ''
+        return isDummy ? DUMMY_DISCUSSION : dataLoader.get('discussions').load(discussionId)
       }
     },
     reflectionGroupId: {

--- a/packages/server/graphql/types/RetroDiscussStage.ts
+++ b/packages/server/graphql/types/RetroDiscussStage.ts
@@ -2,9 +2,23 @@ import {GraphQLFloat, GraphQLID, GraphQLNonNull, GraphQLObjectType} from 'graphq
 import {NewMeetingPhaseTypeEnum} from '../../database/types/GenericMeetingPhase'
 import ReflectionGroup from '../../database/types/ReflectionGroup'
 import {GQLContext} from '../graphql'
+import Discussion from './Discussion'
 import DiscussionThreadStage, {discussionThreadStageFields} from './DiscussionThreadStage'
 import NewMeetingStage, {newMeetingStageFields} from './NewMeetingStage'
 import RetroReflectionGroup from './RetroReflectionGroup'
+
+const createEmptyDiscussion = (id) => ({
+  id,
+  teamId: '',
+  meetingId: '',
+  createdAt: '',
+  discussionTopicId: '',
+  discussionTopicType: '',
+  commentCount: 0,
+  thread: {
+    edges: []
+  }
+})
 
 const RetroDiscussStage = new GraphQLObjectType<any, GQLContext>({
   name: 'RetroDiscussStage',
@@ -14,6 +28,14 @@ const RetroDiscussStage = new GraphQLObjectType<any, GQLContext>({
   fields: () => ({
     ...newMeetingStageFields(),
     ...discussionThreadStageFields(),
+    discussion: {
+      type: GraphQLNonNull(Discussion),
+      description: 'The discussion about the stage or a dummy data when there is no disscussion',
+      resolve: async ({discussionId}, _args, {dataLoader}) => {
+        const discussion = await dataLoader.get('discussions').load(discussionId)
+        return discussion ?? createEmptyDiscussion(discussionId)
+      }
+    },
     reflectionGroupId: {
       type: GraphQLNonNull(GraphQLID),
       description: 'foreign key. use reflectionGroup'


### PR DESCRIPTION
Related issue: https://github.com/ParabolInc/parabol/issues/5099

I've noticed one more thing though. If the meeting ends before going to the discussion phase, the reflections fetched in the meeting summary will be an empty array. I'm investigating this but if someone has any quick fixes for that, please let me know! For now, I've added a check for empty data in CSV export to prevent it from crashing.

AC:
* Meeting summary works when there's no discussion