### PR TITLE
Add emails and domain to updateWatchlist

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/updateWatchlist.ts
+++ b/packages/server/graphql/intranetSchema/mutations/updateWatchlist.ts
@@ -1,25 +1,38 @@
-import {GraphQLBoolean, GraphQLID, GraphQLNonNull} from 'graphql'
+import {User} from '@sentry/node'
+import {GraphQLBoolean, GraphQLList, GraphQLString, GraphQLNonNull} from 'graphql'
 import getRethink from '../../../database/rethinkDriver'
 import updateUser from '../../../postgres/queries/updateUser'
 import {requireSU} from '../../../utils/authorization'
+import db from '../../../db'
+import UpdateWatchlistPayload from '../../types/UpdateWatchlistPayload'
 
 const updateWatchlist = {
-  type: GraphQLBoolean,
-  description: 'add a user to the LogRocket watchlist so that their sessions are recorded',
+  type: GraphQLNonNull(UpdateWatchlistPayload),
+  description:
+    'add/remove user(s) to/from the LogRocket watchlist so that we start/stop recording their sessions',
   args: {
-    userId: {
-      type: new GraphQLNonNull(GraphQLID),
-      description: 'The id of the user to be added to the watchlist'
+    emails: {
+      type: GraphQLList(GraphQLNonNull(GraphQLString)),
+      description: `a list of the email addresses of users whose sessions we want to start/stop recording in LogRocket`
+    },
+    domain: {
+      type: GraphQLString,
+      description:
+        'add/remove the entire domain to/from the LogRocket watchlist. The part of the email after the @'
     },
     includeInWatchlist: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      description: 'True if the user should be added to the watchlist, false if not'
+      description: 'true if the user should be added to the watchlist, false if not'
     }
   },
   resolve: async (
     _source,
-    {includeInWatchlist, userId}: {includeInWatchlist: boolean; userId: string},
-    {authToken, dataLoader}
+    {
+      includeInWatchlist,
+      emails,
+      domain
+    }: {includeInWatchlist: boolean; emails: string[]; domain: string},
+    {authToken}
   ) => {
     const r = await getRethink()
     const now = new Date()
@@ -27,22 +40,38 @@ const updateWatchlist = {
     // AUTH
     requireSU(authToken)
 
-    // VALIDATION
-    const user = await dataLoader.get('users').load(userId)
-    if (!user) throw new Error(`User doesn't exist`)
-
     // RESOLUTION
+    const users = [] as User[]
+    if (emails) {
+      const usersByEmail = await r
+        .table('User')
+        .getAll(r.args(emails), {index: 'email'})
+        .run()
+      users.push(...usersByEmail)
+    }
+    if (domain) {
+      const usersByDomain = await r
+        .table('User')
+        .filter((doc) => (doc as any)('email').match(domain))
+        .run()
+      users.push(...usersByDomain)
+    }
+    await db.prime('User', users)
+    const userIds = users.map(({id}) => id).filter((id): id is string => !!id)
+    if (users.length === 0) {
+      return {error: {message: 'No users found matching the email or domain'}}
+    }
     const update = {isWatched: includeInWatchlist, updatedAt: now}
     await Promise.all([
       r
         .table('User')
-        .get(userId)
+        .getAll(r.args(userIds))
         .update(update)
         .run(),
-      updateUser(update, userId)
+      updateUser(update, userIds)
     ])
 
-    return true
+    return {success: true}
   }
 }
 

--- a/packages/server/graphql/types/UpdateWatchlistPayload.ts
+++ b/packages/server/graphql/types/UpdateWatchlistPayload.ts
@@ -1,0 +1,17 @@
+import {GraphQLBoolean, GraphQLObjectType} from 'graphql'
+import {GQLContext} from '../graphql'
+import makeMutationPayload from './makeMutationPayload'
+
+const UpdateWatchlistSuccess = new GraphQLObjectType<any, GQLContext>({
+  name: 'UpdateWatchlistSuccess',
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      description: 'true if the mutation was successfully executed'
+    }
+  })
+})
+
+const UpdateWatchlistPayload = makeMutationPayload('UpdateWatchlistPayload', UpdateWatchlistSuccess)
+
+export default UpdateWatchlistPayload


### PR DESCRIPTION
PR to implement Matt's suggestion here: https://github.com/ParabolInc/parabol/pull/5127#discussion_r670037068

With this update, super users can add a list of emails or a domain that they want to start/stop recording in LogRocket.