### PR TITLE
Backfill email field for deleted users in RethinkDB to match with PG

### DIFF
--- a/packages/server/database/migrations/20210719161718-deletedUserEmailBackfill.ts
+++ b/packages/server/database/migrations/20210719161718-deletedUserEmailBackfill.ts
@@ -1,0 +1,21 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
+  await r
+    .table('User')
+    .filter({isRemoved: true})
+    .update((user) => ({
+      email: r.expr('DELETED:').add(user('id').add(':1626360264029'))
+    }))
+    .run()
+}
+
+export const down = async function(r: R) {
+  await r
+    .table('User')
+    .filter({isRemoved: true})
+    .update({
+      email: 'DELETED'
+    })
+    .run()
+}


### PR DESCRIPTION
Deleted users in PG have their emails look like this:

```
parabol-saas=> SELECT "email" FROM "User" WHERE "email" LIKE 'DELETED%' LIMIT 5;
                           email
-----------------------------------------------------------
 DELETED:google-oauth2|110945899376117816083:1626360264029
 DELETED:google-oauth2|116562409957802979935:1626360264029
 DELETED:local|4myp2jiFe:1626360264029
 DELETED:google-oauth2|104006359267253995684:1626360264029
 DELETED:local|ZCVtnN3APd:1626360264029
(5 rows)
```

There are 1,275 deleted users:
```
parabol-saas=> SELECT COUNT(1) FROM "User" WHERE "email" LIKE 'DELETED%';
 count
-------
  1275
(1 row)
```

We need to backfill RethinkDB to match with the format so the equality checker won't complain.