### PR TITLE
Handle slow responding gql executor

### DIFF
--- a/packages/server/graphql/handleGraphQLTrebuchetRequest.ts
+++ b/packages/server/graphql/handleGraphQLTrebuchetRequest.ts
@@ -57,6 +57,17 @@ const handleGraphQLTrebuchetRequest = async (
       const messageType = result.data ? 'complete' : 'error'
       return {type: messageType, id: opId, payload: safeResult} as const
     } catch (e) {
+      if (e?.message === 'TIMEOUT') {
+        sendToSentry(new Error('GQL executor took too long to respond'), {
+          tags: {
+            authToken: JSON.stringify(authToken),
+            docId: docId || '',
+            query: query || '',
+            variables: JSON.stringify(variables)
+          }
+        })
+        return {data: null, errors: [{message: 'The request took too long'}]}
+      }
       const viewerId = getUserId(authToken)
       sendToSentry(e, {userId: viewerId})
     }

--- a/packages/server/utils/PubSubPromise.ts
+++ b/packages/server/utils/PubSubPromise.ts
@@ -1,5 +1,4 @@
 import Redis from 'ioredis'
-import {GQLRequest} from '../graphql/executeGraphQL'
 import numToBase64 from './numToBase64'
 import sendToSentry from './sendToSentry'
 
@@ -10,7 +9,6 @@ interface Job {
 }
 
 const {SERVER_ID, REDIS_URL} = process.env
-
 export default class PubSubPromise<Request, Response> {
   jobs = {} as {[jobId: string]: Job}
   publisher = new Redis(REDIS_URL)
@@ -39,27 +37,12 @@ export default class PubSubPromise<Request, Response> {
   }
 
   publish = (request: Request) => {
-    return new Promise<Response>((resolve) => {
+    return new Promise<Response>((resolve, reject) => {
       const nextJob = numToBase64(this.jobCounter++)
       const jobId = `${SERVER_ID}:${nextJob}`
       const timeoutId = setTimeout(() => {
         delete this.jobs[jobId]
-        const errorMessage = `GQL Executor took more than ${MAX_TIMEOUT}ms to respond`
-        const {
-          authToken,
-          query = '',
-          variables = '',
-          docId = ''
-        } = (request as unknown) as GQLRequest
-        sendToSentry(new Error(errorMessage), {
-          tags: {
-            authToken: JSON.stringify(authToken),
-            query,
-            variables: JSON.stringify(variables),
-            docId
-          }
-        })
-        return {data: null, errors: [{message: errorMessage}]}
+        reject(new Error('TIMEOUT'))
       }, MAX_TIMEOUT)
       const previousJob = this.jobs[jobId]
       if (previousJob) {


### PR DESCRIPTION
PR to resolve issue #5189 

With these changes, the app shows the loading icon rather than crashes when the GQL Executor doesn't respond within the timeout limit. 