### PR TITLE
make sort team members query case insensitive

### DIFF
--- a/packages/server/graphql/types/Team.ts
+++ b/packages/server/graphql/types/Team.ts
@@ -292,7 +292,12 @@ const Team = new GraphQLObjectType<ITeam, GQLContext>({
       async resolve({id: teamId}, {sortBy = 'preferredName'}, {authToken, dataLoader}) {
         if (!isTeamMember(authToken, teamId)) return []
         const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)
-        teamMembers.sort((a, b) => (a[sortBy] > b[sortBy] ? 1 : -1))
+        teamMembers.sort((a, b) => {
+          let [aProp, bProp] = [a[sortBy], b[sortBy]]
+          aProp = aProp?.toLowerCase ? aProp.toLowerCase() : aProp
+          bProp = bProp?.toLowerCase ? bProp.toLowerCase() : bProp
+          return aProp > bProp ? 1 : -1
+        })
         return teamMembers
       }
     },


### PR DESCRIPTION
Resolves https://github.com/ParabolInc/parabol/issues/5169

**AC:**
- [ ] make a new user with name such as "alfred" and invite to your team
- [ ] go to team page and on zoom in on a task on the kanban board
- [ ] click the avatar on bottom left hand corner to assign the task to a teammate
- [ ] observe that "afred" will be listed first instead of list in the dropdown