### PR TITLE
turn existing jira stages into tasks and estimates

### DIFF
--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -48385,6 +48385,11 @@ export interface IEstimateStage {
   scores: Array<IEstimateUserScore>;
 
   /**
+   * The task referenced in the stage, as it exists in Parabol. null if the task was deleted
+   */
+  task: ITask | null;
+
+  /**
    * the story referenced in the stage. Either a Parabol Task or something similar from an integration. Null if fetching from service failed
    */
   story: Story | null;

--- a/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
+++ b/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
@@ -25,7 +25,11 @@ export const up = async function (r: R) {
             phase.merge({
               stages: phase('stages').map((stage) =>
                 stage.merge({
-                  taskId: r(stageIdTaskIdLookup)(stage('id')).default(stage('serviceTaskId'))
+                  taskId: r.branch(
+                    stage('taskId'),
+                    stage('taskId'),
+                    r(stageIdTaskIdLookup)(stage('id')).default(stage('serviceTaskId'))
+                  )
                 })
               )
             }),

--- a/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
+++ b/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
@@ -7,7 +7,7 @@ import getTemplateRefById from '../../postgres/queries/getTemplateRefById'
 import insertTaskEstimate from '../../postgres/queries/insertTaskEstimate'
 import EstimatePhase from '../types/EstimatePhase'
 
-export const up = async function(r: R) {
+export const up = async function (r: R) {
   const BATCH_SIZE = 1000
   const plaintextContent = `Task imported from jira`
   const content = convertToTaskContent(plaintextContent)
@@ -58,6 +58,7 @@ export const up = async function(r: R) {
       const {stages} = phase
       const stageIdToTaskId = {} as Record<string, string>
       stages.forEach((stage) => {
+        if (stage.taskId) return
         const {
           id: stageId,
           service,
@@ -142,6 +143,6 @@ export const up = async function(r: R) {
   }
 }
 
-export const down = async function() {
+export const down = async function () {
   // noop. it's just a taskId field & there's no way to discriminate between old vs new
 }

--- a/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
+++ b/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
@@ -83,6 +83,7 @@ export const up = async function(r: R) {
             meetingId,
             sortOrder: dndNoise(),
             status: 'future',
+            tags: ['archived'],
             teamId,
             integrationHash: serviceTaskId,
             integration: {

--- a/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
+++ b/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
@@ -7,7 +7,7 @@ import getTemplateRefById from '../../postgres/queries/getTemplateRefById'
 import insertTaskEstimate from '../../postgres/queries/insertTaskEstimate'
 import EstimatePhase from '../types/EstimatePhase'
 
-export const up = async function (r: R) {
+export const up = async function(r: R) {
   const BATCH_SIZE = 1000
   const plaintextContent = `Task imported from jira`
   const content = convertToTaskContent(plaintextContent)
@@ -92,6 +92,7 @@ export const up = async function (r: R) {
             teamId,
             integrationHash: serviceTaskId,
             integration: {
+              service: 'jira',
               cloudId,
               issueKey,
               projectKey,
@@ -147,6 +148,6 @@ export const up = async function (r: R) {
   }
 }
 
-export const down = async function () {
+export const down = async function() {
   // noop. it's just a taskId field & there's no way to discriminate between old vs new
 }

--- a/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
+++ b/packages/server/database/migrations/20210726140543-estimate-stage-tasks.ts
@@ -1,0 +1,146 @@
+import JiraIssueId from 'parabol-client/shared/gqlIds/JiraIssueId'
+import {R} from 'rethinkdb-ts'
+import dndNoise from '../../../client/utils/dndNoise'
+import convertToTaskContent from '../../../client/utils/draftjs/convertToTaskContent'
+import generateUID from '../../generateUID'
+import getTemplateRefById from '../../postgres/queries/getTemplateRefById'
+import insertTaskEstimate from '../../postgres/queries/insertTaskEstimate'
+import EstimatePhase from '../types/EstimatePhase'
+
+export const up = async function(r: R) {
+  const BATCH_SIZE = 1000
+  const plaintextContent = `Task imported from jira`
+  const content = convertToTaskContent(plaintextContent)
+  const updateStagesWithTaskIds = (
+    meetingId: string,
+    stageIdTaskIdLookup: Record<string, string>
+  ) => {
+    return r
+      .table('NewMeeting')
+      .get(meetingId)
+      .update((meeting) => ({
+        phases: meeting('phases').map((phase) =>
+          r.branch(
+            phase('phaseType').eq('ESTIMATE'),
+            phase.merge({
+              stages: phase('stages').map((stage) =>
+                stage.merge({
+                  taskId: r(stageIdTaskIdLookup)(stage('id')).default(stage('serviceTaskId'))
+                })
+              )
+            }),
+            phase
+          )
+        )
+      }))
+      .run()
+  }
+
+  for (let i = 0; i < 1e6; i++) {
+    const skip = i * BATCH_SIZE
+    console.log('migrating meeting #', skip)
+    const curMeetings = await r
+      .table('NewMeeting')
+      .filter({meetingType: 'poker'})
+      .orderBy('createdAt')
+      .skip(skip)
+      .limit(BATCH_SIZE)
+      .run()
+    if (curMeetings.length < 1) break
+    //
+    const tasksToInsert = []
+    const estimatesToInsert = []
+    const stageUpdates = curMeetings.map(async (meeting) => {
+      const {id: meetingId, teamId, phases, templateRefId} = meeting
+      const templateRef = await getTemplateRefById(templateRefId)
+      const phase = phases.find((phase) => phase.phaseType === 'ESTIMATE') as EstimatePhase
+      if (!phase) return
+      const {stages} = phase
+      const stageIdToTaskId = {} as Record<string, string>
+      stages.forEach((stage) => {
+        const {
+          id: stageId,
+          service,
+          serviceTaskId,
+          creatorUserId,
+          finalScore,
+          startAt,
+          dimensionRefIdx,
+          discussionId
+        } = stage
+        // in case there was a hiccup with pg
+        const dimensionName = templateRef?.dimensions?.[dimensionRefIdx]?.name ?? 'Story Points'
+        let taskId = serviceTaskId
+        if (service === 'jira') {
+          const {cloudId, issueKey, projectKey} = JiraIssueId.split(serviceTaskId)
+          taskId = generateUID()
+          // turn it into a parabol task
+          const task = {
+            content,
+            plaintextContent,
+            createdAt: new Date(),
+            createdBy: creatorUserId,
+            meetingId,
+            sortOrder: dndNoise(),
+            status: 'future',
+            teamId,
+            integrationHash: serviceTaskId,
+            integration: {
+              cloudId,
+              issueKey,
+              projectKey,
+              accessUserId: creatorUserId
+            },
+            userId: creatorUserId,
+            id: taskId,
+            updatedAt: new Date()
+          }
+          tasksToInsert.push(task)
+          stageIdToTaskId[stageId] = taskId
+        }
+        if (finalScore !== null && finalScore !== undefined) {
+          const estimate = {
+            changeSource: 'meeting',
+            createdAt: startAt || meeting.createdAt,
+            name: dimensionName,
+            label: finalScore,
+            taskId,
+            userId: creatorUserId,
+            meetingId,
+            stageId,
+            discussionId,
+            jiraFieldId: null
+          }
+          estimatesToInsert.push(estimate)
+        }
+      })
+      return updateStagesWithTaskIds(meetingId, stageIdToTaskId)
+    })
+    try {
+      await Promise.all(stageUpdates)
+    } catch (e) {
+      console.log('error updating stage taskId', e)
+    }
+    console.log({taskCount: tasksToInsert.length, estimateCount: estimatesToInsert.length})
+    try {
+      if (tasksToInsert.length > 0) {
+        await r
+          .table('Task')
+          .insert(tasksToInsert)
+          .run()
+      }
+    } catch (e) {
+      console.log('error inserting tasks', e)
+    }
+
+    try {
+      await Promise.all(estimatesToInsert.map((estimate) => insertTaskEstimate(estimate)))
+    } catch (e) {
+      console.log('error inserting tasks', e)
+    }
+  }
+}
+
+export const down = async function() {
+  // noop. it's just a taskId field & there's no way to discriminate between old vs new
+}

--- a/packages/server/graphql/types/EstimateStage.ts
+++ b/packages/server/graphql/types/EstimateStage.ts
@@ -21,6 +21,7 @@ import EstimateUserScore from './EstimateUserScore'
 import NewMeetingStage, {newMeetingStageFields} from './NewMeetingStage'
 import ServiceField from './ServiceField'
 import Story from './Story'
+import Task from './Task'
 import TaskServiceEnum from './TaskServiceEnum'
 import TemplateDimensionRef from './TemplateDimensionRef'
 import User from './User'
@@ -184,6 +185,14 @@ const EstimateStage = new GraphQLObjectType<any, GQLContext>({
           ...score,
           stageId
         }))
+      }
+    },
+    task: {
+      type: Task,
+      description:
+        'The task referenced in the stage, as it exists in Parabol. null if the task was deleted',
+      resolve: async ({taskId}, _args, {dataLoader}) => {
+        return dataLoader.get('tasks').load(taskId)
       }
     },
     story: {

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -13,8 +13,8 @@ const PROJECT_ROOT = getProjectRoot()
 const TOOLBOX_ROOT = path.join(PROJECT_ROOT, 'scripts', 'toolbox')
 const pgMigrate = require('node-pg-migrate').default
 const cliPgmConfig = require('../packages/server/postgres/pgmConfig')
-const {generate} = require('@graphql-codegen/cli')
-const codegenSchema = require('../codegen.json')
+// const {generate} = require('@graphql-codegen/cli')
+// const codegenSchema = require('../codegen.json')
 
 const compileToolbox = () => {
   return new Promise((resolve) => {
@@ -44,7 +44,8 @@ const dev = async (maybeInit) => {
     console.log('👋👋👋      Welcome to Parabol!      👋👋👋')
     await Promise.all([removeArtifacts()])
   }
-  await generate(codegenSchema)
+  // Enable this if you're creating new github schemas
+  // await generate(codegenSchema)
   const buildDLL = require('./buildDll')()
   const clearRedis = redis.flushall()
   const migrateRethinkDB = require('./migrate')()


### PR DESCRIPTION
### DO NOT MERGE UNTIL v6.23.0 IS IN PRODUCTION
 
fix #5161
For all new poker meetings, a task is created for imported stories.
This migrates all old meetings to guarantee that each imported story has a linked task.
It also turns the stage's finalScore into a TaskEstimate so we can reference the task's story points outside of the meeting

TEST
- [x] from v6.22.0, complete 1 poker meeting. have 1 poker meeting in progress. Both have jira integrations & parabol tasks. The meeting in progress has 1 incomplete jira stage, 1 complete jira stage. 1 incomplete parabol stage. 1 complete parabol stage.
- [x] pull branch, run migration
- [x] the jira stages now have corresponding tasks that are archived
- [x] the parabol stages are unchanged
- [x] each completed stage's task has a matching TaskEstimate that is visible in the meeting