### PR TITLE
Adds empty alt property to meeting card images for a11y

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -173,7 +173,7 @@ const MeetingCard = (props: Props) => {
       <MeetingImgWrapper>
         <MeetingTypeLabel>{MEETING_TYPE_LABEL[meetingType]}</MeetingTypeLabel>
         <Link to={`/meet/${meetingId}`}>
-          <MeetingImg src={ILLUSTRATIONS[meetingType]} />
+          <MeetingImg src={ILLUSTRATIONS[meetingType]} alt='' />
         </Link>
       </MeetingImgWrapper>
       <MeetingInfo>


### PR DESCRIPTION
This tiny little PR adds an empty `alt` property (`alt=''`) to the meeting card images in the meeting view. This is important for folks using assistive technology, such as screen readers, as it tells the software to ignore the image.

I've chosen to ignore the images because they are purely decorative and don't provide any critical meaning to the user. For a screen reader user, the meeting type is already indicated by the meeting type label in the meeting card.

Credit also goes to @acressall for the help 🙌