### PR TITLE
Filter Parabol domain from watchlist

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -78,11 +78,12 @@ const AnalyticsPage = () => {
     const expiredErrorProne =
       errorProneAt && new Date(parseInt(errorProneAt)) < new Date(Date.now() - ms('14d'))
     const email = window.localStorage.getItem(LocalStorageKey.EMAIL)
+    const isParabolDomain = email?.includes('parabol.co')
     const res = await fetchQuery<AnalyticsPageQuery>(atmosphere, query, {})
     const isWatched = res?.viewer?.isWatched
     if (expiredErrorProne && !isWatched) {
       window.localStorage.removeItem(LocalStorageKey.ERROR_PRONE_AT)
-    } else if (logRocketId && (errorProneAt || isWatched)) {
+    } else if (logRocketId && !isParabolDomain && (errorProneAt || isWatched)) {
       LogRocket.init(logRocketId, {
         release: __APP_VERSION__,
         network: {


### PR DESCRIPTION
While it might be helpful to record Parabol sessions for debugging, I think it's probably best if we don't record them to avoid snooping. Plus, as we're power users, this will free up some extra sessions. 