### PR TITLE
Center align kanban columns on safari

### DIFF
--- a/packages/client/components/RetroReflectPhase/ReflectWrapperDesktop.tsx
+++ b/packages/client/components/RetroReflectPhase/ReflectWrapperDesktop.tsx
@@ -6,13 +6,13 @@ const DesktopWrapper = styled('div')({
   height: '100%',
   // if the viewport is wide enough for 2+ columns, let them scroll
   overflowX: 'auto',
-  width: '100%',
+  width: '100%'
 })
 
 const Inner = styled('div')({
   display: 'flex',
   margin: '0 auto',
-  
+  justifyContent: 'center'
 })
 
 interface Props {
@@ -22,7 +22,7 @@ interface Props {
 const ReflectWrapperDesktop = forwardRef((props: Props, ref: Ref<HTMLDivElement>) => {
   const {children} = props
   return (
-    <DesktopWrapper >
+    <DesktopWrapper>
       <Inner ref={ref}>{children}</Inner>
     </DesktopWrapper>
   )


### PR DESCRIPTION
PR to resolve issue #5263 

This PR center aligns the kanban columns on Safari to be consistent with Chrome.

@enriquesanchez mind reviewing this one? It's a tiny change so if you're happy it, I think we can merge it without a second code review