### PR TITLE
Reset retro meeting to group phase without creating all the new phases

### DIFF
--- a/packages/client/components/StageTimerDisplay.tsx
+++ b/packages/client/components/StageTimerDisplay.tsx
@@ -50,7 +50,7 @@ const StageTimerDisplay = (props: Props) => {
       {isPhaseComplete
         ? <PhaseCompleteWrapper>
           <PhaseCompleteTag isComplete={isPhaseComplete} />
-          {canUndoGroupPhase ? <UndoableGroupPhaseControl meetingId={meeting.id} resetToStageId={localStage.id} /> : null}
+          {canUndoGroupPhase ? <UndoableGroupPhaseControl meetingId={meeting.id} /> : null}
         </PhaseCompleteWrapper>
         : null}
     </DisplayRow>

--- a/packages/client/components/UndoableGroupPhaseControl.tsx
+++ b/packages/client/components/UndoableGroupPhaseControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ResetMeetingToStageMutation from '~/mutations/ResetMeetingToStageMutation'
+import ResetRetroMeetingToGroupStageMutation from '~/mutations/ResetRetroMeetingToGroupStageMutation'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useHotkey from '~/hooks/useHotkey'
 import useModal from '~/hooks/useModal'
@@ -34,7 +34,7 @@ const UndoableGroupPhaseControl = (props: Props) => {
   const atmosphere = useAtmosphere()
   useHotkey('i d i d n t m e a n t o', () => {
     console.log('didntmean')
-    ResetMeetingToStageMutation(atmosphere, {meetingId, stageId: resetToStageId})
+    ResetRetroMeetingToGroupStageMutation(atmosphere, {meetingId, stageId: resetToStageId})
   })
   return (
     <>

--- a/packages/client/components/UndoableGroupPhaseControl.tsx
+++ b/packages/client/components/UndoableGroupPhaseControl.tsx
@@ -10,7 +10,6 @@ import Icon from '~/components/Icon'
 
 interface Props {
   meetingId: string
-  resetToStageId: string
 }
 
 const StyledButton = styled(FlatButton)({
@@ -29,17 +28,17 @@ const UndoableGroupPhaseDialog = lazyPreload(() =>
 )
 
 const UndoableGroupPhaseControl = (props: Props) => {
-  const {meetingId, resetToStageId} = props
+  const {meetingId} = props
   const {togglePortal: toggleModal, closePortal: closeModal, modalPortal} = useModal()
   const atmosphere = useAtmosphere()
   useHotkey('i d i d n t m e a n t o', () => {
     console.log('didntmean')
-    ResetRetroMeetingToGroupStageMutation(atmosphere, {meetingId, stageId: resetToStageId})
+    ResetRetroMeetingToGroupStageMutation(atmosphere, {meetingId})
   })
   return (
     <>
       <StyledButton onClick={toggleModal} palette={'blue'}><StyledIcon>edit</StyledIcon>{' Edit Groups'}</StyledButton>
-      {modalPortal(<UndoableGroupPhaseDialog closePortal={closeModal} meetingId={meetingId} resetToStageId={resetToStageId} />)}
+      {modalPortal(<UndoableGroupPhaseDialog closePortal={closeModal} meetingId={meetingId} />)}
     </>
   )
 }

--- a/packages/client/components/UndoableGroupPhaseDialog.tsx
+++ b/packages/client/components/UndoableGroupPhaseDialog.tsx
@@ -12,7 +12,6 @@ import {PALETTE} from '~/styles/paletteV3'
 interface Props {
   closePortal: () => void
   meetingId: string
-  resetToStageId: string
 }
 
 const ButtonGroup = styled('div')({
@@ -29,10 +28,10 @@ const StyledButton = styled(FlatButton)({
 })
 
 const UndoableGroupPhaseDialog = (props: Props) => {
-  const {closePortal, meetingId, resetToStageId} = props
+  const {closePortal, meetingId} = props
   const atmosphere = useAtmosphere()
   const handleConfirm = () => {
-    ResetRetroMeetingToGroupStageMutation(atmosphere, {meetingId, stageId: resetToStageId}) && closePortal()
+    ResetRetroMeetingToGroupStageMutation(atmosphere, {meetingId}) && closePortal()
   }
   return (
     <DialogContainer>

--- a/packages/client/components/UndoableGroupPhaseDialog.tsx
+++ b/packages/client/components/UndoableGroupPhaseDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import ResetMeetingToStageMutation from '~/mutations/ResetMeetingToStageMutation'
+import ResetRetroMeetingToGroupStageMutation from '~/mutations/ResetRetroMeetingToGroupStageMutation'
 import DialogContainer from '~/components/DialogContainer'
 import DialogContent from '~/components/DialogContent'
 import DialogTitle from '~/components/DialogTitle'
@@ -32,7 +32,7 @@ const UndoableGroupPhaseDialog = (props: Props) => {
   const {closePortal, meetingId, resetToStageId} = props
   const atmosphere = useAtmosphere()
   const handleConfirm = () => {
-    ResetMeetingToStageMutation(atmosphere, {meetingId, stageId: resetToStageId}) && closePortal()
+    ResetRetroMeetingToGroupStageMutation(atmosphere, {meetingId, stageId: resetToStageId}) && closePortal()
   }
   return (
     <DialogContainer>

--- a/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
+++ b/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
@@ -38,8 +38,8 @@ graphql`
 `
 
 const mutation = graphql`
-  mutation ResetRetroMeetingToGroupStageMutation($meetingId: ID!, $stageId: ID!) {
-    resetRetroMeetingToGroupStage(meetingId: $meetingId, stageId: $stageId) {
+  mutation ResetRetroMeetingToGroupStageMutation($meetingId: ID!) {
+    resetRetroMeetingToGroupStage(meetingId: $meetingId) {
       error {
         message
       }

--- a/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
+++ b/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
@@ -3,13 +3,13 @@ import {commitMutation} from 'react-relay'
 import Atmosphere from '~/Atmosphere'
 import {SimpleMutation} from '../types/relayMutations'
 import {
-  ResetMeetingToStageMutation as TResetMeetingToStageMutation,
-  ResetMeetingToStageMutationVariables
-} from '../__generated__/ResetMeetingToStageMutation.graphql'
+  ResetRetroMeetingToGroupStageMutation as TResetRetroMeetingToGroupStageMutation,
+  ResetRetroMeetingToGroupStageMutationVariables
+} from '../__generated__/ResetRetroMeetingToGroupStageMutation.graphql'
 import getDiscussionThreadConn from './connections/getDiscussionThreadConn'
 
 graphql`
-  fragment ResetMeetingToStageMutation_meeting on ResetMeetingToStagePayload {
+  fragment ResetRetroMeetingToGroupStageMutation_meeting on ResetRetroMeetingToGroupStagePayload {
     meeting {
       id
       phases {
@@ -38,17 +38,17 @@ graphql`
 `
 
 const mutation = graphql`
-  mutation ResetMeetingToStageMutation($meetingId: ID!, $stageId: ID!) {
-    resetMeetingToStage(meetingId: $meetingId, stageId: $stageId) {
+  mutation ResetRetroMeetingToGroupStageMutation($meetingId: ID!, $stageId: ID!) {
+    resetRetroMeetingToGroupStage(meetingId: $meetingId, stageId: $stageId) {
       error {
         message
       }
-      ...ResetMeetingToStageMutation_meeting @relay(mask: false)
+      ...ResetRetroMeetingToGroupStageMutation_meeting @relay(mask: false)
     }
   }
 `
 
-export const resetMeetingToStageUpdater = (payload, {store}) => {
+export const resetRetroMeetingToGroupStageUpdater = (payload, {store}) => {
   const meeting = payload.getLinkedRecord('meeting')
   const phases = meeting.getLinkedRecords('phases')
   const discussPhase = phases.find((phase) => phase?.getValue('phaseType') === 'discuss')
@@ -61,19 +61,19 @@ export const resetMeetingToStageUpdater = (payload, {store}) => {
   })
 }
 
-const ResetMeetingToStageMutation: SimpleMutation<TResetMeetingToStageMutation> = (
+const ResetRetroMeetingToGroupStageMutation: SimpleMutation<TResetRetroMeetingToGroupStageMutation> = (
   atmosphere: Atmosphere,
-  variables: ResetMeetingToStageMutationVariables
+  variables: ResetRetroMeetingToGroupStageMutationVariables
 ) => {
-  return commitMutation<TResetMeetingToStageMutation>(atmosphere, {
+  return commitMutation<TResetRetroMeetingToGroupStageMutation>(atmosphere, {
     mutation,
     updater: (store) => {
-      const payload = store.getRootField('resetMeetingToStage')
+      const payload = store.getRootField('resetRetroMeetingToGroupStage')
       if (!payload) return
-      resetMeetingToStageUpdater(payload, {store})
+      resetRetroMeetingToGroupStageUpdater(payload, {store})
     },
     variables
   })
 }
 
-export default ResetMeetingToStageMutation
+export default ResetRetroMeetingToGroupStageMutation

--- a/packages/client/subscriptions/MeetingSubscription.ts
+++ b/packages/client/subscriptions/MeetingSubscription.ts
@@ -15,7 +15,7 @@ import {
 import {pokerAnnounceDeckHoverMeetingUpdater} from '../mutations/PokerAnnounceDeckHoverMutation'
 import {promoteNewMeetingFacilitatorMeetingOnNext} from '../mutations/PromoteNewMeetingFacilitatorMutation'
 import {removeReflectionMeetingUpdater} from '../mutations/RemoveReflectionMutation'
-import {resetMeetingToStageUpdater} from '../mutations/ResetMeetingToStageMutation'
+import {resetRetroMeetingToGroupStageUpdater} from '../mutations/ResetRetroMeetingToGroupStageMutation'
 import {setStageTimerMeetingUpdater} from '../mutations/SetStageTimerMutation'
 import {startDraggingReflectionMeetingUpdater} from '../mutations/StartDraggingReflectionMutation'
 
@@ -41,7 +41,7 @@ const subscription = graphql`
       ...FlagReadyToAdvanceMutation_meeting @relay(mask: false)
       ...PromoteNewMeetingFacilitatorMutation_meeting @relay(mask: false)
       ...RemoveReflectionMutation_meeting @relay(mask: false)
-      ...ResetMeetingToStageMutation_meeting @relay(mask: false)
+      ...ResetRetroMeetingToGroupStageMutation_meeting @relay(mask: false)
       ...SetPhaseFocusMutation_meeting @relay(mask: false)
       ...SetStageTimerMutation_meeting @relay(mask: false)
       ...StartDraggingReflectionMutation_meeting @relay(mask: false)
@@ -71,7 +71,7 @@ const updateHandlers = {
   EndDraggingReflectionPayload: endDraggingReflectionMeetingUpdater,
   RemoveReflectionPayload: removeReflectionMeetingUpdater,
   SetStageTimerPayload: setStageTimerMeetingUpdater,
-  ResetMeetingToStagePayload: resetMeetingToStageUpdater,
+  ResetRetroMeetingToGroupStagePayload: resetRetroMeetingToGroupStageUpdater,
   StartDraggingReflectionPayload: startDraggingReflectionMeetingUpdater,
   PokerAnnounceDeckHoverSuccess: pokerAnnounceDeckHoverMeetingUpdater
 }

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -50823,14 +50823,14 @@ export interface IMutation {
   removeTeamMember: IRemoveTeamMemberPayload | null;
 
   /**
-   * Reset a retro meeting to group stage
-   */
-  resetMeetingToStage: IResetMeetingToStagePayload;
-
-  /**
    * Reset the password for an account
    */
   resetPassword: IResetPasswordPayload;
+
+  /**
+   * Reset a retro meeting to group stage
+   */
+  resetRetroMeetingToGroupStage: IResetRetroMeetingToGroupStagePayload;
 
   /**
    * track an event in segment, like when errors are hit
@@ -51745,11 +51745,6 @@ export interface IRemoveTeamMemberOnMutationArguments {
   teamMemberId: string;
 }
 
-export interface IResetMeetingToStageOnMutationArguments {
-  meetingId: string;
-  stageId: string;
-}
-
 export interface IResetPasswordOnMutationArguments {
   /**
    * the password reset token
@@ -51760,6 +51755,11 @@ export interface IResetPasswordOnMutationArguments {
    * The new password for the account
    */
   newPassword: string;
+}
+
+export interface IResetRetroMeetingToGroupStageOnMutationArguments {
+  meetingId: string;
+  stageId: string;
 }
 
 export interface ISegmentEventTrackOnMutationArguments {
@@ -53791,12 +53791,6 @@ export interface IRemoveTeamMemberPayload {
   kickOutNotification: INotifyKickedOut | null;
 }
 
-export interface IResetMeetingToStagePayload {
-  __typename: 'ResetMeetingToStagePayload';
-  error: IStandardMutationError | null;
-  meeting: NewMeeting | null;
-}
-
 export interface IResetPasswordPayload {
   __typename: 'ResetPasswordPayload';
   error: IStandardMutationError | null;
@@ -53811,6 +53805,12 @@ export interface IResetPasswordPayload {
    * the user that changed their password
    */
   user: IUser | null;
+}
+
+export interface IResetRetroMeetingToGroupStagePayload {
+  __typename: 'ResetRetroMeetingToGroupStagePayload';
+  error: IStandardMutationError | null;
+  meeting: NewMeeting | null;
 }
 
 export interface ISegmentEventTrackOptions {
@@ -54592,7 +54592,7 @@ export type MeetingSubscriptionPayload =
   | INewMeetingCheckInPayload
   | IPromoteNewMeetingFacilitatorPayload
   | IRemoveReflectionPayload
-  | IResetMeetingToStagePayload
+  | IResetRetroMeetingToGroupStagePayload
   | ISetPhaseFocusPayload
   | ISetStageTimerPayload
   | IStartDraggingReflectionPayload

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -50823,7 +50823,7 @@ export interface IMutation {
   removeTeamMember: IRemoveTeamMemberPayload | null;
 
   /**
-   * Reset meeting to a previously completed stage
+   * Reset a retro meeting to group stage
    */
   resetMeetingToStage: IResetMeetingToStagePayload;
 

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -51759,7 +51759,6 @@ export interface IResetPasswordOnMutationArguments {
 
 export interface IResetRetroMeetingToGroupStageOnMutationArguments {
   meetingId: string;
-  stageId: string;
 }
 
 export interface ISegmentEventTrackOnMutationArguments {

--- a/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
+++ b/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
@@ -13,7 +13,7 @@ import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import {getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
-import ResetMeetingToStagePayload from '../types/ResetMeetingToStagePayload'
+import ResetRetroMeetingToGroupStagePayload from '../types/ResetRetroMeetingToGroupStagePayload'
 import {primePhases} from './helpers/createNewMeetingPhases'
 
 const resetMeetingPhase = (phase: GenericMeetingPhase) => {
@@ -28,8 +28,8 @@ const resetMeetingPhase = (phase: GenericMeetingPhase) => {
   phase.stages = newStages
 }
 
-const resetMeetingToStage = {
-  type: GraphQLNonNull(ResetMeetingToStagePayload),
+const resetRetroMeetingToGroupStage = {
+  type: GraphQLNonNull(ResetRetroMeetingToGroupStagePayload),
   description: `Reset a retro meeting to group stage`,
   args: {
     meetingId: {
@@ -136,9 +136,15 @@ const resetMeetingToStage = {
     const data = {
       meetingId
     }
-    publish(SubscriptionChannel.MEETING, meetingId, 'ResetMeetingToStagePayload', data, subOptions)
+    publish(
+      SubscriptionChannel.MEETING,
+      meetingId,
+      'ResetRetroMeetingToGroupStagePayload',
+      data,
+      subOptions
+    )
     return data
   }
 }
 
-export default resetMeetingToStage
+export default resetRetroMeetingToGroupStage

--- a/packages/server/graphql/rootMutation.ts
+++ b/packages/server/graphql/rootMutation.ts
@@ -90,7 +90,7 @@ import renameMeetingTemplate from './mutations/renameMeetingTemplate'
 import renamePokerTemplateDimension from './mutations/renamePokerTemplateDimension'
 import renamePokerTemplateScale from './mutations/renamePokerTemplateScale'
 import renameReflectTemplatePrompt from './mutations/renameReflectTemplatePrompt'
-import resetMeetingToStage from './mutations/resetMeetingToStage'
+import resetRetroMeetingToGroupStage from './mutations/resetRetroMeetingToGroupStage'
 import resetPassword from './mutations/resetPassword'
 import segmentEventTrack from './mutations/segmentEventTrack'
 import selectTemplate from './mutations/selectTemplate'
@@ -223,8 +223,8 @@ export default new GraphQLObjectType<any, Context>({
       removeReflection,
       removeSlackAuth,
       removeTeamMember,
-      resetMeetingToStage,
       resetPassword,
+      resetRetroMeetingToGroupStage,
       segmentEventTrack,
       selectTemplate,
       setAppLocation,

--- a/packages/server/graphql/types/MeetingSubscriptionPayload.ts
+++ b/packages/server/graphql/types/MeetingSubscriptionPayload.ts
@@ -20,7 +20,7 @@ import {PokerRevealVotesSuccess} from './PokerRevealVotesPayload'
 import {PokerSetFinalScoreSuccess} from './PokerSetFinalScorePayload'
 import PromoteNewMeetingFacilitatorPayload from './PromoteNewMeetingFacilitatorPayload'
 import RemoveReflectionPayload from './RemoveReflectionPayload'
-import ResetMeetingToStagePayload from './ResetMeetingToStagePayload'
+import ResetRetroMeetingToGroupStagePayload from './ResetRetroMeetingToGroupStagePayload'
 import SetPhaseFocusPayload from './SetPhaseFocusPayload'
 import {SetPokerSpectateSuccess} from './SetPokerSpectatePayload'
 import SetStageTimerPayload from './SetStageTimerPayload'
@@ -52,7 +52,7 @@ const types = [
   NewMeetingCheckInPayload,
   PromoteNewMeetingFacilitatorPayload,
   RemoveReflectionPayload,
-  ResetMeetingToStagePayload,
+  ResetRetroMeetingToGroupStagePayload,
   SetPhaseFocusPayload,
   SetStageTimerPayload,
   StartDraggingReflectionPayload,

--- a/packages/server/graphql/types/ResetRetroMeetingToGroupStagePayload.ts
+++ b/packages/server/graphql/types/ResetRetroMeetingToGroupStagePayload.ts
@@ -4,8 +4,8 @@ import {resolveNewMeeting} from '../resolvers'
 import StandardMutationError from './StandardMutationError'
 import {GQLContext} from '../graphql'
 
-const ResetMeetingToStagePayload = new GraphQLObjectType<any, GQLContext>({
-  name: 'ResetMeetingToStagePayload',
+const ResetRetroMeetingToGroupStagePayload = new GraphQLObjectType<any, GQLContext>({
+  name: 'ResetRetroMeetingToGroupStagePayload',
   fields: () => ({
     error: {
       type: StandardMutationError
@@ -17,4 +17,4 @@ const ResetMeetingToStagePayload = new GraphQLObjectType<any, GQLContext>({
   })
 })
 
-export default ResetMeetingToStagePayload
+export default ResetRetroMeetingToGroupStagePayload


### PR DESCRIPTION
Fixes #5249

### Changes
1. Updates existing `resetMeetingToStage` to only works for resetting to group stage for a retro meeting. This is to ensure that we don't need to create dummy phases/stages for the meeting beforehand, hence we no longer rely on the `meetingSettings` which could change during the meeting period. See discussion in #5249 and [this thread](https://parabol.slack.com/archives/C836NA350/p1628885677080400?thread_ts=1628639020.029800&cid=C836NA350).
2. Due to the above changes, rename the mutation to `resetRetroMeetingToGroupStage` across the board, to avoid confusion.

### Tests

- [x] User can reset a retro meeting back to group phase ...
  - [x] from vote phase when voting has not begun
  - [x] from vote phase when voting has begun (verify that all vote counts have been reset)
  - [x] from discuss phase when there's only 1 discussion topic (verify that discussion agenda items have been cleared)
  - [x] from discuss phase when there are multiple discussion topics (verify that discussion agenda items have been cleared)
  - [x] any number of times freely
- [x] User can properly reset a retro meeting with icebreakers to group phase, even when there's a second retro meeting running without icebreaker (i.e., the reproduction step described in #5249)