### PR TITLE
Remove promptTemplateId field from reflect stage

### DIFF
--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -88,10 +88,7 @@ export type DemoReflectionGroup = Omit<ReflectionGroup, 'team' | 'createdAt' | '
   voterIds: any
 }
 
-export type IDiscussPhase = Omit<
-  DiscussPhase,
-  'readyToAdvance' | 'endAt' | 'startAt' | 'promptTemplateId'
-> & {
+export type IDiscussPhase = Omit<DiscussPhase, 'readyToAdvance' | 'endAt' | 'startAt'> & {
   readyToAdvance: any
   startAt: string | Date
   endAt: string | Date

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -47422,11 +47422,6 @@ export interface IReflectPhase {
   focusedPrompt: IReflectPrompt | null;
 
   /**
-   * FK. The ID of the template used during the reflect phase
-   */
-  promptTemplateId: string;
-
-  /**
    * The prompts used during the reflect phase
    */
   reflectPrompts: Array<IReflectPrompt>;

--- a/packages/server/database/migrations/20210817223727-removePromptTemplateId.ts
+++ b/packages/server/database/migrations/20210817223727-removePromptTemplateId.ts
@@ -1,0 +1,33 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function(r: R) {
+  try {
+    await r
+      .table('NewMeeting')
+      .filter({meetingType: 'retrospective'})
+      .update((row) => ({
+        phases: row('phases').without('promptTemplateId')
+      }))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function(r: R) {
+  try {
+    await r
+      .table('NewMeeting')
+      .filter({meetingType: 'retrospective'})
+      .update((meeting) => ({
+        phases: meeting('phases').map((phase) =>
+          phase('phaseType')
+            .eq('reflect')
+            .branch(phase.merge({promptTemplateId: meeting('templateId')}), phase)
+        )
+      }))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/types/ReflectPhase.ts
+++ b/packages/server/database/types/ReflectPhase.ts
@@ -6,11 +6,7 @@ export default class ReflectPhase extends GenericMeetingPhase {
   stages: GenericMeetingStage[]
   focusedPromptId?: string
 
-  constructor(
-    public teamId: string,
-    public promptTemplateId: string,
-    durations: number[] | undefined
-  ) {
+  constructor(public teamId: string, durations: number[] | undefined) {
     super('reflect')
     this.stages = [new GenericMeetingStage({phaseType: REFLECT, durations})]
   }

--- a/packages/server/graphql/mutations/startRetrospective.ts
+++ b/packages/server/graphql/mutations/startRetrospective.ts
@@ -85,10 +85,14 @@ export default {
     })
 
     const template = await dataLoader.get('meetingTemplates').load(selectedTemplateId)
-    await r
-      .table('NewMeeting')
-      .insert(meeting)
-      .run()
+    const now = new Date()
+    await r({
+      template: r
+        .table('MeetingTemplate')
+        .get(selectedTemplateId)
+        .update({lastUsedAt: now}),
+      meeting: r.table('NewMeeting').insert(meeting)
+    }).run()
 
     // Disallow accidental starts (2 meetings within 2 seconds)
     const newActiveMeetings = await dataLoader.get('activeMeetingsByTeamId').load(teamId)

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -119,11 +119,14 @@ export default {
     })
 
     const template = await dataLoader.get('meetingTemplates').load(selectedTemplateId)
-
-    await r
-      .table('NewMeeting')
-      .insert(meeting)
-      .run()
+    const now = new Date()
+    await r({
+      template: r
+        .table('MeetingTemplate')
+        .get(selectedTemplateId)
+        .update({lastUsedAt: now}),
+      meeting: r.table('NewMeeting').insert(meeting)
+    }).run()
 
     // Disallow accidental starts (2 meetings within 2 seconds)
     const newActiveMeetings = await dataLoader.get('activeMeetingsByTeamId').load(teamId)

--- a/packages/server/graphql/types/ReflectPhase.ts
+++ b/packages/server/graphql/types/ReflectPhase.ts
@@ -22,16 +22,12 @@ const ReflectPhase = new GraphQLObjectType<any, GQLContext>({
         return dataLoader.get('reflectPrompts').load(focusedPromptId)
       }
     },
-    promptTemplateId: {
-      type: new GraphQLNonNull(GraphQLID),
-      description: 'FK. The ID of the template used during the reflect phase'
-    },
     reflectPrompts: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ReflectPrompt))),
       description: 'The prompts used during the reflect phase',
-      resolve: async ({meetingId, promptTemplateId}, _args, {dataLoader}) => {
+      resolve: async ({meetingId}, _args, {dataLoader}) => {
         const meeting = await dataLoader.get('newMeetings').load(meetingId)
-        const prompts = await dataLoader.get('reflectPromptsByTemplateId').load(promptTemplateId)
+        const prompts = await dataLoader.get('reflectPromptsByTemplateId').load(meeting.templateId)
         // only show prompts that were created before the meeting and
         // either have not been removed or they were removed after the meeting was created
         return prompts.filter(


### PR DESCRIPTION
Remove the field from the meeting stage. The template is now not
connected to the stage anymore so update the template timestamp where it
is used when starting the meeting.

Resolves: #3949