### PR TITLE
Run prettier after pg:build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "pm2-runtime start pm2.config.js",
     "heroku-postbuild": "echo 'Skipping build'",
     "build": "node scripts/prod.js",
-    "pg:build": "pgtyped -c ./packages/server/postgres/pgtypedConfig.js",
+    "pg:build": "pgtyped -c ./packages/server/postgres/pgtypedConfig.js && prettier --write 'packages/server/postgres/queries/generated/*.ts'",
     "pg:migrate": "node-pg-migrate -f ./packages/server/postgres/pgmConfig.js",
     "pg:postmigrate": "node-pg-migrate -f ./packages/server/postgres/pgmPostDeployConfig.js",
     "db:start": "docker-compose -f docker/dev.yml up -d",

--- a/packages/server/postgres/queries/generated/backupUserQuery.ts
+++ b/packages/server/postgres/queries/generated/backupUserQuery.ts
@@ -1,7 +1,7 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/backupUserQuery.sql" */
 import {PreparedQuery} from '@pgtyped/query'
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise'
 
 export type AuthTokenRole = 'su'
 

--- a/packages/server/postgres/queries/generated/getTeamsByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getTeamsByIdQuery.ts
@@ -1,9 +1,9 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getTeamsByIdQuery.sql" */
 import {PreparedQuery} from '@pgtyped/query'
 
-export type MeetingTypeEnum = 'poker' | 'retrospective' | 'action'
+export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker'
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise'
 
 export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
 
@@ -26,7 +26,6 @@ export interface IGetTeamsByIdQueryResult {
   orgId: string
   isOnboardTeam: boolean
   updatedAt: Date
-  eqChecked: Date
   lockMessageHTML: string | null
 }
 

--- a/packages/server/postgres/queries/generated/getUsersByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getUsersByIdQuery.ts
@@ -1,7 +1,7 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getUsersByIdQuery.sql" */
 import {PreparedQuery} from '@pgtyped/query'
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise'
 
 export type AuthTokenRole = 'su'
 
@@ -36,7 +36,6 @@ export interface IGetUsersByIdQueryResult {
   reasonRemoved: string | null
   rol: AuthTokenRole | null
   payLaterClickCount: number
-  eqChecked: Date
   isWatched: boolean
 }
 

--- a/packages/server/postgres/queries/generated/insertOrgUserAuditQuery.ts
+++ b/packages/server/postgres/queries/generated/insertOrgUserAuditQuery.ts
@@ -1,28 +1,46 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertOrgUserAuditQuery.sql" */
-import { PreparedQuery } from '@pgtyped/query';
+import {PreparedQuery} from '@pgtyped/query'
 
-export type OrganizationUserAuditEventTypeEnum = 'added' | 'activated' | 'inactivated' | 'removed';
+export type OrganizationUserAuditEventTypeEnum = 'added' | 'activated' | 'inactivated' | 'removed'
 
 /** 'InsertOrgUserAuditQuery' parameters type */
 export interface IInsertOrgUserAuditQueryParams {
   auditRows: Array<{
-    orgId: string | null | void,
-    userId: string | null | void,
-    eventDate: Date | null | void,
+    orgId: string | null | void
+    userId: string | null | void
+    eventDate: Date | null | void
     eventType: OrganizationUserAuditEventTypeEnum | null | void
-  }>;
+  }>
 }
 
 /** 'InsertOrgUserAuditQuery' return type */
-export type IInsertOrgUserAuditQueryResult = void;
+export type IInsertOrgUserAuditQueryResult = void
 
 /** 'InsertOrgUserAuditQuery' query type */
 export interface IInsertOrgUserAuditQueryQuery {
-  params: IInsertOrgUserAuditQueryParams;
-  result: IInsertOrgUserAuditQueryResult;
+  params: IInsertOrgUserAuditQueryParams
+  result: IInsertOrgUserAuditQueryResult
 }
 
-const insertOrgUserAuditQueryIR: any = {"name":"insertOrgUserAuditQuery","params":[{"name":"auditRows","codeRefs":{"defined":{"a":45,"b":53,"line":3,"col":9},"used":[{"a":204,"b":212,"line":10,"col":10}]},"transform":{"type":"pick_array_spread","keys":["orgId","userId","eventDate","eventType"]}}],"usedParamSet":{"auditRows":true},"statement":{"body":"INSERT INTO \"OrganizationUserAudit\" (\n  \"orgId\",\n  \"userId\",\n  \"eventDate\",\n  \"eventType\"\n) VALUES :auditRows","loc":{"a":104,"b":212,"line":5,"col":0}}};
+const insertOrgUserAuditQueryIR: any = {
+  name: 'insertOrgUserAuditQuery',
+  params: [
+    {
+      name: 'auditRows',
+      codeRefs: {
+        defined: {a: 45, b: 53, line: 3, col: 9},
+        used: [{a: 204, b: 212, line: 10, col: 10}]
+      },
+      transform: {type: 'pick_array_spread', keys: ['orgId', 'userId', 'eventDate', 'eventType']}
+    }
+  ],
+  usedParamSet: {auditRows: true},
+  statement: {
+    body:
+      'INSERT INTO "OrganizationUserAudit" (\n  "orgId",\n  "userId",\n  "eventDate",\n  "eventType"\n) VALUES :auditRows',
+    loc: {a: 104, b: 212, line: 5, col: 0}
+  }
+}
 
 /**
  * Query generated from SQL:
@@ -35,6 +53,7 @@ const insertOrgUserAuditQueryIR: any = {"name":"insertOrgUserAuditQuery","params
  * ) VALUES :auditRows
  * ```
  */
-export const insertOrgUserAuditQuery = new PreparedQuery<IInsertOrgUserAuditQueryParams,IInsertOrgUserAuditQueryResult>(insertOrgUserAuditQueryIR);
-
-
+export const insertOrgUserAuditQuery = new PreparedQuery<
+  IInsertOrgUserAuditQueryParams,
+  IInsertOrgUserAuditQueryResult
+>(insertOrgUserAuditQueryIR)

--- a/packages/server/postgres/queries/generated/insertUserQuery.ts
+++ b/packages/server/postgres/queries/generated/insertUserQuery.ts
@@ -1,7 +1,7 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertUserQuery.sql" */
 import {PreparedQuery} from '@pgtyped/query'
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise'
 
 export type stringArray = string[]
 

--- a/packages/server/postgres/queries/generated/updateUserQuery.ts
+++ b/packages/server/postgres/queries/generated/updateUserQuery.ts
@@ -1,7 +1,7 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateUserQuery.sql" */
 import {PreparedQuery} from '@pgtyped/query'
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise'
 
 export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
 


### PR DESCRIPTION
Having all generated files in the wrong format is distracting during
development. Also format files which weren't correctly formatted.