### PR TITLE
support prod build locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.23.2 2021-Aug-19
+
+### Fixed
+
+- Support debugging production mode locally (#5284)
+- Remove logRocket from SSR client keys (#5284)
+
 ## 6.23.1 2021-Jul-30
 
 ### Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "6.23.1",
+  "version": "6.23.2",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.23.1",
+  "version": "6.23.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.23.0",
+  "version": "6.23.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/packages/client/utils/getMassInvitationUrl.ts
+++ b/packages/client/utils/getMassInvitationUrl.ts
@@ -1,9 +1,9 @@
 import makeHref from './makeHref'
 
 const getMassInvitationUrl = (token: string) => {
-    return __PRODUCTION__
-      ? `https://${window.__ACTION__.prblIn}/${token}`
-      : makeHref(`/invitation-link/${token}`)
-  }
+  const {prblIn} = window.__ACTION__
+  const protocol = prblIn.startsWith('localhost') ? 'http:' : 'https:'
+  return __PRODUCTION__ ? `${protocol}//${prblIn}/${token}` : makeHref(`/invitation-link/${token}`)
+}
 
-  export default getMassInvitationUrl
+export default getMassInvitationUrl

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.23.0",
+  "version": "6.23.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"
@@ -58,6 +58,6 @@
   "dependencies": {
     "dotenv": "8.0.0",
     "dotenv-expand": "5.1.0",
-    "parabol-client": "^6.23.0"
+    "parabol-client": "^6.23.2"
   }
 }

--- a/packages/gql-executor/package.json
+++ b/packages/gql-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-executor",
-  "version": "6.23.1",
+  "version": "6.23.2",
   "description": "A Stateless GraphQL Executor",
   "author": "Matt Krick <matt.krick@gmail.com>",
   "homepage": "https://github.com/ParabolInc/parabol/tree/master/packages/gqlExecutor#readme",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "dd-trace": "^0.31.4",
-    "parabol-client": "^6.23.0",
-    "parabol-server": "^6.23.1"
+    "parabol-client": "^6.23.2",
+    "parabol-server": "^6.23.2"
   }
 }

--- a/packages/server/createSSR.ts
+++ b/packages/server/createSSR.ts
@@ -12,7 +12,6 @@ export const getClientKeys = () => {
     atlassian: process.env.ATLASSIAN_CLIENT_ID,
     github: process.env.GITHUB_CLIENT_ID,
     google: process.env.GOOGLE_OAUTH_CLIENT_ID,
-    logRocket: process.env.LOG_ROCKET,
     segment: process.env.SEGMENT_WRITE_KEY,
     sentry: process.env.SENTRY_DSN,
     slack: process.env.SLACK_CLIENT_ID,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.23.1",
+  "version": "6.23.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"
@@ -126,7 +126,7 @@
     "node-fetch": "^2.6.1",
     "node-pg-migrate": "^5.9.0",
     "nodemailer": "^6.4.6",
-    "parabol-client": "^6.23.0",
+    "parabol-client": "^6.23.2",
     "pg": "^8.5.1",
     "pm2": "^4.4.1",
     "react": "^16.12.0",

--- a/packages/server/utils/getReqAuth.ts
+++ b/packages/server/utils/getReqAuth.ts
@@ -2,7 +2,9 @@ import {HttpRequest} from 'uWebSockets.js'
 import getVerifiedAuthToken from './getVerifiedAuthToken'
 
 const getReqAuth = (req: HttpRequest) => {
-  const authHeader = req.getHeader('authorization')
+  const hasReverseProxy = req.getHeader('x-forwarded-for')
+  const authorizationHeaderName = hasReverseProxy ? 'authorization' : 'x-application-authorization'
+  const authHeader = req.getHeader(authorizationHeaderName)
   const token = authHeader.slice(7)
   return getVerifiedAuthToken(token)
 }

--- a/packages/sfu/package.json
+++ b/packages/sfu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parabol-sfu",
-  "version": "6.23.1",
+  "version": "6.23.2",
   "description": "A signaling and relay server for forwarding media streams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "homepage": "https://github.com/ParabolInc/parabol/tree/master/packages/gqlExecutor#readme",
@@ -28,8 +28,8 @@
     "awaitqueue": "^2.1.1",
     "express": "^4.17.1",
     "mediasoup": "^3.6.21",
-    "parabol-client": "^6.23.0",
-    "parabol-server": "^6.23.1",
+    "parabol-client": "^6.23.2",
+    "parabol-server": "^6.23.2",
     "protoo-server": "^4.0.4"
   }
 }


### PR DESCRIPTION
fix #5282 

- Removes logRocket from the client keys, disabling it entirely (I think we'll probably want to move to datadog client in the future...)
- uses http proto when the invitation link starts with localhost
- server checks for a reverse proxy (x-forwarded-for header) and if not present uses x-application-authorization header