### PR TITLE
Fetch user by email from PG

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/intranetSchema/mutations/draftEnterpriseInvoice.ts
@@ -12,6 +12,7 @@ import hideConversionModal from '../../mutations/helpers/hideConversionModal'
 import setTierForOrgUsers from '../../../utils/setTierForOrgUsers'
 import DraftEnterpriseInvoicePayload from '../types/DraftEnterpriseInvoicePayload'
 import updateTeamByOrgId from '../../../postgres/queries/updateTeamByOrgId'
+import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
 
 const getBillingLeaderUser = async (
   email: string | null,
@@ -20,12 +21,7 @@ const getBillingLeaderUser = async (
 ) => {
   const r = await getRethink()
   if (email) {
-    const user = await r
-      .table('User')
-      .getAll(email, {index: 'email'})
-      .nth(0)
-      .default(null)
-      .run()
+    const user = await getUserByEmail(email)
     if (!user) {
       throw new Error('User for email not found')
     }

--- a/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
+++ b/packages/server/graphql/intranetSchema/mutations/loginSAML.ts
@@ -4,6 +4,7 @@ import {GraphQLID, GraphQLNonNull, GraphQLString} from 'graphql'
 import getSSODomainFromEmail from 'parabol-client/utils/getSSODomainFromEmail'
 import querystring from 'querystring'
 import * as samlify from 'samlify'
+import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
 import getRethink from '../../../database/rethinkDriver'
 import AuthToken from '../../../database/types/AuthToken'
 import User from '../../../database/types/User'
@@ -88,15 +89,12 @@ const loginSAML = {
       return {error: {message: `${email} does not belong to ${domains.join(', ')}`}}
     }
 
-    const user = await r
-      .table('User')
-      .getAll(email, {index: 'email'})
-      .nth(0)
-      .default(null)
-      .run()
+    const user = await getUserByEmail(email)
     if (user) {
       return {
-        authToken: encodeAuthToken(new AuthToken({sub: user.id, tms: user.tms, rol: user.rol}))
+        authToken: encodeAuthToken(
+          new AuthToken({sub: user.id, tms: user.tms, rol: user.rol ?? undefined})
+        )
       }
     }
 

--- a/packages/server/graphql/intranetSchema/mutations/updateWatchlist.ts
+++ b/packages/server/graphql/intranetSchema/mutations/updateWatchlist.ts
@@ -5,6 +5,7 @@ import updateUser from '../../../postgres/queries/updateUser'
 import {requireSU} from '../../../utils/authorization'
 import db from '../../../db'
 import UpdateWatchlistPayload from '../../types/UpdateWatchlistPayload'
+import {getUsersByEmails} from '../../../postgres/queries/getUsersByEmails'
 
 const updateWatchlist = {
   type: GraphQLNonNull(UpdateWatchlistPayload),
@@ -43,10 +44,7 @@ const updateWatchlist = {
     // RESOLUTION
     const users = [] as User[]
     if (emails) {
-      const usersByEmail = await r
-        .table('User')
-        .getAll(r.args(emails), {index: 'email'})
-        .run()
+      const usersByEmail = await getUsersByEmails(emails)
       users.push(...usersByEmail)
     }
     if (domain) {

--- a/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
+++ b/packages/server/graphql/intranetSchema/queries/dailyPulse.ts
@@ -7,6 +7,7 @@ import SlackServerManager from '../../../utils/SlackServerManager'
 import GraphQLISO8601Type from '../../types/GraphQLISO8601Type'
 import authCountByDomain from './helpers/authCountByDomain'
 import {makeSection} from '../../mutations/helpers/makeSlackBlocks'
+import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
 
 interface TypeField {
   type: 'mrkdwn'
@@ -90,12 +91,7 @@ const dailyPulse = {
   async resolve(_source, {after, email, channelId}, {authToken}) {
     requireSU(authToken)
     const r = await getRethink()
-    const user = await r
-      .table('User')
-      .getAll(email, {index: 'email'})
-      .nth(0)
-      .default(null)
-      .run()
+    const user = await getUserByEmail(email)
     if (!user) throw new Error('Bad user')
     const {id: userId} = user
     const slackAuth = await r

--- a/packages/server/graphql/intranetSchema/queries/user.ts
+++ b/packages/server/graphql/intranetSchema/queries/user.ts
@@ -1,5 +1,5 @@
 import {GraphQLID, GraphQLString} from 'graphql'
-import getRethink from '../../../database/rethinkDriver'
+import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
 import db from '../../../db'
 import {requireSU} from '../../../utils/authorization'
 import User from '../../types/User'
@@ -17,16 +17,10 @@ const user = {
     }
   },
   description: 'Dig into a user by providing the email or userId',
-  async resolve(_source, {email, userId}, {authToken}) {
+  async resolve(_source, {email, userId}: {email: string; userId: string}, {authToken}) {
     requireSU(authToken)
-    const r = await getRethink()
     if (email) {
-      return r
-        .table('User')
-        .getAll(email, {index: 'email'})
-        .nth(0)
-        .default(null)
-        .run()
+      return getUserByEmail(email)
     }
     return db.read('User', userId)
   }

--- a/packages/server/graphql/mutations/helpers/attemptLogin.ts
+++ b/packages/server/graphql/mutations/helpers/attemptLogin.ts
@@ -7,7 +7,7 @@ import getRethink from '../../../database/rethinkDriver'
 import AuthIdentityLocal from '../../../database/types/AuthIdentityLocal'
 import AuthToken from '../../../database/types/AuthToken'
 import FailedAuthRequest from '../../../database/types/FailedAuthRequest'
-import User from '../../../database/types/User'
+import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
 
 const logFailedLogin = async (ip: string, email: string) => {
   const r = await getRethink()
@@ -24,12 +24,9 @@ const attemptLogin = async (denormEmail: string, password: string, ip = '') => {
   const r = await getRethink()
   const yesterday = new Date(Date.now() - ms('1d'))
   const email = denormEmail.toLowerCase().trim()
-  const {existingUser, failOnAccount, failOnTime} = await r({
-    existingUser: (r
-      .table('User')
-      .getAll(email, {index: 'email'})
-      .nth(0)
-      .default(null) as unknown) as User,
+
+  const existingUser = await getUserByEmail(email)
+  const {failOnAccount, failOnTime} = await r({
     failOnAccount: (r
       .table('FailedAuthRequest')
       .getAll(ip, {index: 'ip'})

--- a/packages/server/graphql/mutations/resetPassword.ts
+++ b/packages/server/graphql/mutations/resetPassword.ts
@@ -14,6 +14,7 @@ import {GQLContext} from '../graphql'
 import rateLimit from '../rateLimit'
 import ResetPasswordPayload from '../types/ResetPasswordPayload'
 import updateUser from '../../postgres/queries/updateUser'
+import {getUserByEmail} from '../../postgres/queries/getUsersByEmails'
 
 const resetPassword = {
   type: new GraphQLNonNull(ResetPasswordPayload),
@@ -49,12 +50,7 @@ const resetPassword = {
       }
 
       // token is legit, let's invalidate it & set the new password
-      const user = await r
-        .table('User')
-        .getAll(email, {index: 'email'})
-        .nth(0)
-        .default(null)
-        .run()
+      const user = await getUserByEmail(email)
       if (!user) {
         return standardError(new Error(`User ${email} does not exist for password reset`))
       }

--- a/packages/server/graphql/mutations/verifyEmail.ts
+++ b/packages/server/graphql/mutations/verifyEmail.ts
@@ -4,7 +4,6 @@ import getRethink from '../../database/rethinkDriver'
 import AuthIdentityLocal from '../../database/types/AuthIdentityLocal'
 import AuthToken from '../../database/types/AuthToken'
 import EmailVerification from '../../database/types/EmailVerification'
-import User from '../../database/types/User'
 import db from '../../db'
 import createNewLocalUser from '../../utils/createNewLocalUser'
 import encodeAuthToken from '../../utils/encodeAuthToken'
@@ -12,6 +11,7 @@ import rateLimit from '../rateLimit'
 import VerifyEmailPayload from '../types/VerifyEmailPayload'
 import bootstrapNewUser from './helpers/bootstrapNewUser'
 import updateUser from '../../postgres/queries/updateUser'
+import {getUserByEmail} from '../../postgres/queries/getUsersByEmails'
 
 export default {
   type: GraphQLNonNull(VerifyEmailPayload),
@@ -44,12 +44,7 @@ export default {
       return {error: {message: 'Verification token expired'}}
     }
 
-    const user = (await r
-      .table('User')
-      .getAll(email, {index: 'email'})
-      .nth(0)
-      .default(null)
-      .run()) as User
+    const user = await getUserByEmail(email)
 
     if (user) {
       const {id: userId, identities, rol, tms} = user

--- a/packages/server/graphql/queries/verifiedInvitation.ts
+++ b/packages/server/graphql/queries/verifiedInvitation.ts
@@ -2,6 +2,7 @@ import dns, {MxRecord} from 'dns'
 import promisify from 'es6-promisify'
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {InvitationTokenError} from 'parabol-client/types/constEnums'
+import {getUserByEmail} from '../../postgres/queries/getUsersByEmails'
 import {AuthIdentityTypeEnum} from '../../../client/types/constEnums'
 import getRethink from '../../database/rethinkDriver'
 import User from '../../database/types/User'
@@ -90,12 +91,7 @@ export default {
         }
       }
 
-      const viewer = (await r
-        .table('User')
-        .getAll(email, {index: 'email'})
-        .nth(0)
-        .default(null)
-        .run()) as User | null
+      const viewer = await getUserByEmail(email)
       const userId = viewer?.id ?? null
       const ssoURL = await getSAMLURLFromEmail(email, true)
       const isGoogle = await getIsGoogleProvider(viewer, email)

--- a/packages/server/hubspot/backfillHubSpot.ts
+++ b/packages/server/hubspot/backfillHubSpot.ts
@@ -1,7 +1,7 @@
 // call with yarn sucrase-node hubspot/backfillHubSpot.ts
 import fetch from 'node-fetch'
+import {getUsersByEmails} from '../postgres/queries/getUsersByEmails'
 import '../../../scripts/webpack/utils/dotenv'
-import getRethink from '../database/rethinkDriver'
 
 const contactKeys = {
   lastMetAt: 'last_met_at',
@@ -56,11 +56,7 @@ const upsertHubspotContact = async (
 
 const backfillHubSpot = async () => {
   const emails = process.argv.slice(2)
-  const r = await getRethink()
-  const users = await r
-    .table('User')
-    .getAll(r.args(emails), {index: 'email'})
-    .run()
+  const users = await getUsersByEmails(emails)
 
   await Promise.all(
     users.map(async ({email, id, tier}) => {

--- a/packages/server/postgres/queries/generated/getUserIdsToPauseQuery.ts
+++ b/packages/server/postgres/queries/generated/getUserIdsToPauseQuery.ts
@@ -1,38 +1,23 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getUserIdsToPauseQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'GetUserIdsToPauseQuery' parameters type */
 export interface IGetUserIdsToPauseQueryParams {
-  activeThreshold: Date | null | void
+  activeThreshold: Date | null | void;
 }
 
 /** 'GetUserIdsToPauseQuery' return type */
 export interface IGetUserIdsToPauseQueryResult {
-  id: string
+  id: string;
 }
 
 /** 'GetUserIdsToPauseQuery' query type */
 export interface IGetUserIdsToPauseQueryQuery {
-  params: IGetUserIdsToPauseQueryParams
-  result: IGetUserIdsToPauseQueryResult
+  params: IGetUserIdsToPauseQueryParams;
+  result: IGetUserIdsToPauseQueryResult;
 }
 
-const getUserIdsToPauseQueryIR: any = {
-  name: 'getUserIdsToPauseQuery',
-  params: [
-    {
-      name: 'activeThreshold',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 128, b: 142, line: 5, col: 69}]}
-    }
-  ],
-  usedParamSet: {activeThreshold: true},
-  statement: {
-    body:
-      'SELECT id FROM "User"\nWHERE inactive = false AND ("lastSeenAt" IS NULL OR "lastSeenAt" <= :activeThreshold)',
-    loc: {a: 37, b: 143, line: 4, col: 0}
-  }
-}
+const getUserIdsToPauseQueryIR: any = {"name":"getUserIdsToPauseQuery","params":[{"name":"activeThreshold","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":128,"b":142,"line":5,"col":69}]}}],"usedParamSet":{"activeThreshold":true},"statement":{"body":"SELECT id FROM \"User\"\nWHERE inactive = false AND (\"lastSeenAt\" IS NULL OR \"lastSeenAt\" <= :activeThreshold)","loc":{"a":37,"b":143,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -41,7 +26,6 @@ const getUserIdsToPauseQueryIR: any = {
  * WHERE inactive = false AND ("lastSeenAt" IS NULL OR "lastSeenAt" <= :activeThreshold)
  * ```
  */
-export const getUserIdsToPauseQuery = new PreparedQuery<
-  IGetUserIdsToPauseQueryParams,
-  IGetUserIdsToPauseQueryResult
->(getUserIdsToPauseQueryIR)
+export const getUserIdsToPauseQuery = new PreparedQuery<IGetUserIdsToPauseQueryParams,IGetUserIdsToPauseQueryResult>(getUserIdsToPauseQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getUsersByEmailsQuery.ts
+++ b/packages/server/postgres/queries/generated/getUsersByEmailsQuery.ts
@@ -1,0 +1,59 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/getUsersByEmailsQuery.sql" */
+import { PreparedQuery } from '@pgtyped/query';
+
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
+
+export type AuthTokenRole = 'su';
+
+export type stringArray = (string)[];
+
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
+
+/** 'GetUsersByEmailsQuery' parameters type */
+export interface IGetUsersByEmailsQueryParams {
+  emails: Array<string | null | void>;
+}
+
+/** 'GetUsersByEmailsQuery' return type */
+export interface IGetUsersByEmailsQueryResult {
+  id: string;
+  email: string;
+  createdAt: Date;
+  updatedAt: Date;
+  inactive: boolean;
+  lastSeenAt: Date | null;
+  preferredName: string;
+  tier: TierEnum;
+  picture: string;
+  tms: stringArray;
+  featureFlags: stringArray;
+  identities: JsonArray;
+  lastSeenAtURLs: stringArray | null;
+  segmentId: string | null;
+  newFeatureId: string | null;
+  overLimitCopy: string | null;
+  isRemoved: boolean;
+  reasonRemoved: string | null;
+  rol: AuthTokenRole | null;
+  payLaterClickCount: number;
+  isWatched: boolean;
+}
+
+/** 'GetUsersByEmailsQuery' query type */
+export interface IGetUsersByEmailsQueryQuery {
+  params: IGetUsersByEmailsQueryParams;
+  result: IGetUsersByEmailsQueryResult;
+}
+
+const getUsersByEmailsQueryIR: any = {"name":"getUsersByEmailsQuery","params":[{"name":"emails","codeRefs":{"defined":{"a":42,"b":47,"line":3,"col":9},"used":[{"a":98,"b":103,"line":6,"col":16}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"emails":true},"statement":{"body":"SELECT * FROM \"User\"\nWHERE email in :emails","loc":{"a":61,"b":103,"line":5,"col":0}}};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * FROM "User"
+ * WHERE email in :emails
+ * ```
+ */
+export const getUsersByEmailsQuery = new PreparedQuery<IGetUsersByEmailsQueryParams,IGetUsersByEmailsQueryResult>(getUsersByEmailsQueryIR);
+
+

--- a/packages/server/postgres/queries/getUsersByEmails.ts
+++ b/packages/server/postgres/queries/getUsersByEmails.ts
@@ -1,0 +1,24 @@
+import {getUsersByEmailsQuery} from './generated/getUsersByEmailsQuery'
+import getPg from '../getPg'
+import AuthIdentity from '../../database/types/AuthIdentity'
+import User from '../../database/types/User'
+import {AuthTokenRole} from 'parabol-client/types/constEnums'
+
+export const getUsersByEmails = async (emails: string[]): Promise<User[]> => {
+  const users = await getUsersByEmailsQuery.run({emails}, getPg())
+  return (
+    // TODO #5372 remove conversion to User
+    users?.map((user) => ({
+      ...user,
+      segmentId: user.segmentId ?? undefined,
+      reasonRemoved: user.reasonRemoved ?? undefined,
+      rol: user.rol === 'su' ? AuthTokenRole.SUPER_USER : undefined,
+      identities: (user.identities as unknown) as AuthIdentity[]
+    })) ?? []
+  )
+}
+
+export const getUserByEmail = async (email: string): Promise<User | null> => {
+  const users = await getUsersByEmails([email])
+  return users[0] ?? null
+}

--- a/packages/server/postgres/queries/src/getUsersByEmailsQuery.sql
+++ b/packages/server/postgres/queries/src/getUsersByEmailsQuery.sql
@@ -1,0 +1,6 @@
+/*
+  @name getUsersByEmailsQuery
+  @param emails -> (...)
+*/
+SELECT * FROM "User"
+WHERE email in :emails;


### PR DESCRIPTION
Fetch users by email from Postgres. Split query into two versions (1 user, multiple users) to avoid accidentally indexing the promise due to wrong parenthesis since it happened to me multiple times.

Resolves: #5373

## queries/mutations to test
### private:

* [x] draftEnterpriseInvoice
* [x] loginSAML
* [x] updateEmail
* [x] updateWatchlist
* [x] dailyPulse
* [x] user

### public
* [x] deleteUser
* [x] emailPasswordReset
* [x] attemptLogin
* [x] inviteToTeam
* [x] loginWithGoogle
* [x] resetPassword
* [x] verifyEmail
* [x] verifiedInvitation

### scripts
* [ ] backfillHubSpot
