### PR TITLE
Do not format generated files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+**/__generated__/
+**/generated/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,10 @@
 		}
 	],
 	"npm.packageManager": "yarn",
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+	},
 	"javascript.format.semicolons": "remove",
 	"javascript.preferences.quoteStyle": "single",
 	"javascript.preferences.useAliasesForRenames": false,

--- a/packages/server/.prettierignore
+++ b/packages/server/.prettierignore
@@ -1,0 +1,2 @@
+**/__generated__/
+**/generated/

--- a/packages/server/postgres/queries/generated/addUserNewFeatureQuery.ts
+++ b/packages/server/postgres/queries/generated/addUserNewFeatureQuery.ts
@@ -1,35 +1,21 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/addUserNewFeatureQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'AddUserNewFeatureQuery' parameters type */
 export interface IAddUserNewFeatureQueryParams {
-  newFeatureId: string | null | void
+  newFeatureId: string | null | void;
 }
 
 /** 'AddUserNewFeatureQuery' return type */
-export type IAddUserNewFeatureQueryResult = void
+export type IAddUserNewFeatureQueryResult = void;
 
 /** 'AddUserNewFeatureQuery' query type */
 export interface IAddUserNewFeatureQueryQuery {
-  params: IAddUserNewFeatureQueryParams
-  result: IAddUserNewFeatureQueryResult
+  params: IAddUserNewFeatureQueryParams;
+  result: IAddUserNewFeatureQueryResult;
 }
 
-const addUserNewFeatureQueryIR: any = {
-  name: 'addUserNewFeatureQuery',
-  params: [
-    {
-      name: 'newFeatureId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 75, b: 86, line: 5, col: 20}]}
-    }
-  ],
-  usedParamSet: {newFeatureId: true},
-  statement: {
-    body: 'UPDATE "User" SET\n  "newFeatureId" = :newFeatureId',
-    loc: {a: 37, b: 86, line: 4, col: 0}
-  }
-}
+const addUserNewFeatureQueryIR: any = {"name":"addUserNewFeatureQuery","params":[{"name":"newFeatureId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":75,"b":86,"line":5,"col":20}]}}],"usedParamSet":{"newFeatureId":true},"statement":{"body":"UPDATE \"User\" SET\n  \"newFeatureId\" = :newFeatureId","loc":{"a":37,"b":86,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -38,7 +24,6 @@ const addUserNewFeatureQueryIR: any = {
  *   "newFeatureId" = :newFeatureId
  * ```
  */
-export const addUserNewFeatureQuery = new PreparedQuery<
-  IAddUserNewFeatureQueryParams,
-  IAddUserNewFeatureQueryResult
->(addUserNewFeatureQueryIR)
+export const addUserNewFeatureQuery = new PreparedQuery<IAddUserNewFeatureQueryParams,IAddUserNewFeatureQueryResult>(addUserNewFeatureQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/appendUserFeatureFlagsQuery.ts
+++ b/packages/server/postgres/queries/generated/appendUserFeatureFlagsQuery.ts
@@ -1,45 +1,22 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/appendUserFeatureFlagsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'AppendUserFeatureFlagsQuery' parameters type */
 export interface IAppendUserFeatureFlagsQueryParams {
-  ids: Array<string | null | void>
-  flag: string | null | void
+  ids: Array<string | null | void>;
+  flag: string | null | void;
 }
 
 /** 'AppendUserFeatureFlagsQuery' return type */
-export type IAppendUserFeatureFlagsQueryResult = void
+export type IAppendUserFeatureFlagsQueryResult = void;
 
 /** 'AppendUserFeatureFlagsQuery' query type */
 export interface IAppendUserFeatureFlagsQueryQuery {
-  params: IAppendUserFeatureFlagsQueryParams
-  result: IAppendUserFeatureFlagsQueryResult
+  params: IAppendUserFeatureFlagsQueryParams;
+  result: IAppendUserFeatureFlagsQueryResult;
 }
 
-const appendUserFeatureFlagsQueryIR: any = {
-  name: 'appendUserFeatureFlagsQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 48, b: 50, line: 3, col: 9},
-        used: [{a: 153, b: 155, line: 7, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    },
-    {
-      name: 'flag',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 134, b: 137, line: 6, col: 52}]}
-    }
-  ],
-  usedParamSet: {flag: true, ids: true},
-  statement: {
-    body:
-      'UPDATE "User" SET\n  "featureFlags" = arr_append_uniq("featureFlags", :flag)\nWHERE id IN :ids',
-    loc: {a: 64, b: 155, line: 5, col: 0}
-  }
-}
+const appendUserFeatureFlagsQueryIR: any = {"name":"appendUserFeatureFlagsQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":48,"b":50,"line":3,"col":9},"used":[{"a":153,"b":155,"line":7,"col":13}]},"transform":{"type":"array_spread"}},{"name":"flag","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":134,"b":137,"line":6,"col":52}]}}],"usedParamSet":{"flag":true,"ids":true},"statement":{"body":"UPDATE \"User\" SET\n  \"featureFlags\" = arr_append_uniq(\"featureFlags\", :flag)\nWHERE id IN :ids","loc":{"a":64,"b":155,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -49,7 +26,6 @@ const appendUserFeatureFlagsQueryIR: any = {
  * WHERE id IN :ids
  * ```
  */
-export const appendUserFeatureFlagsQuery = new PreparedQuery<
-  IAppendUserFeatureFlagsQueryParams,
-  IAppendUserFeatureFlagsQueryResult
->(appendUserFeatureFlagsQueryIR)
+export const appendUserFeatureFlagsQuery = new PreparedQuery<IAppendUserFeatureFlagsQueryParams,IAppendUserFeatureFlagsQueryResult>(appendUserFeatureFlagsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/appendUserTmsQuery.ts
+++ b/packages/server/postgres/queries/generated/appendUserTmsQuery.ts
@@ -1,41 +1,22 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/appendUserTmsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'AppendUserTmsQuery' parameters type */
 export interface IAppendUserTmsQueryParams {
-  teamId: string | null | void
-  id: string | null | void
+  teamId: string | null | void;
+  id: string | null | void;
 }
 
 /** 'AppendUserTmsQuery' return type */
-export type IAppendUserTmsQueryResult = void
+export type IAppendUserTmsQueryResult = void;
 
 /** 'AppendUserTmsQuery' query type */
 export interface IAppendUserTmsQueryQuery {
-  params: IAppendUserTmsQueryParams
-  result: IAppendUserTmsQueryResult
+  params: IAppendUserTmsQueryParams;
+  result: IAppendUserTmsQueryResult;
 }
 
-const appendUserTmsQueryIR: any = {
-  name: 'appendUserTmsQuery',
-  params: [
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 81, b: 86, line: 5, col: 30}]}
-    },
-    {
-      name: 'id',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 101, b: 102, line: 6, col: 12}]}
-    }
-  ],
-  usedParamSet: {teamId: true, id: true},
-  statement: {
-    body: 'UPDATE "User" SET\n  tms = arr_append_uniq(tms, :teamId)\nWHERE id = :id',
-    loc: {a: 33, b: 102, line: 4, col: 0}
-  }
-}
+const appendUserTmsQueryIR: any = {"name":"appendUserTmsQuery","params":[{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":81,"b":86,"line":5,"col":30}]}},{"name":"id","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":101,"b":102,"line":6,"col":12}]}}],"usedParamSet":{"teamId":true,"id":true},"statement":{"body":"UPDATE \"User\" SET\n  tms = arr_append_uniq(tms, :teamId)\nWHERE id = :id","loc":{"a":33,"b":102,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -45,7 +26,6 @@ const appendUserTmsQueryIR: any = {
  * WHERE id = :id
  * ```
  */
-export const appendUserTmsQuery = new PreparedQuery<
-  IAppendUserTmsQueryParams,
-  IAppendUserTmsQueryResult
->(appendUserTmsQueryIR)
+export const appendUserTmsQuery = new PreparedQuery<IAppendUserTmsQueryParams,IAppendUserTmsQueryResult>(appendUserTmsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/backfillSegmentIdQuery.ts
+++ b/packages/server/postgres/queries/generated/backfillSegmentIdQuery.ts
@@ -1,53 +1,34 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/backfillSegmentIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'BackfillSegmentIdQuery' parameters type */
 export interface IBackfillSegmentIdQueryParams {
   users: Array<{
-    segmentId: string | null | void
+    segmentId: string | null | void,
     id: string | null | void
-  }>
+  }>;
 }
 
 /** 'BackfillSegmentIdQuery' return type */
-export type IBackfillSegmentIdQueryResult = void
+export type IBackfillSegmentIdQueryResult = void;
 
 /** 'BackfillSegmentIdQuery' query type */
 export interface IBackfillSegmentIdQueryQuery {
-  params: IBackfillSegmentIdQueryParams
-  result: IBackfillSegmentIdQueryResult
+  params: IBackfillSegmentIdQueryParams;
+  result: IBackfillSegmentIdQueryResult;
 }
 
-const backfillSegmentIdQueryIR: any = {
-  name: 'backfillSegmentIdQuery',
-  params: [
-    {
-      name: 'users',
-      codeRefs: {
-        defined: {a: 43, b: 47, line: 3, col: 9},
-        used: [{a: 143, b: 147, line: 7, col: 14}]
-      },
-      transform: {type: 'pick_array_spread', keys: ['segmentId', 'id']}
-    }
-  ],
-  usedParamSet: {users: true},
-  statement: {
-    body:
-      'UPDATE "User" AS u SET\n  "segmentId" = c."segmentId"\nFROM (VALUES :users) AS c("segmentId", "id") \nWHERE c."id" = u."id"',
-    loc: {a: 76, b: 195, line: 5, col: 0}
-  }
-}
+const backfillSegmentIdQueryIR: any = {"name":"backfillSegmentIdQuery","params":[{"name":"users","codeRefs":{"defined":{"a":43,"b":47,"line":3,"col":9},"used":[{"a":143,"b":147,"line":7,"col":14}]},"transform":{"type":"pick_array_spread","keys":["segmentId","id"]}}],"usedParamSet":{"users":true},"statement":{"body":"UPDATE \"User\" AS u SET\n  \"segmentId\" = c.\"segmentId\"\nFROM (VALUES :users) AS c(\"segmentId\", \"id\") \nWHERE c.\"id\" = u.\"id\"","loc":{"a":76,"b":195,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
  * ```
  * UPDATE "User" AS u SET
  *   "segmentId" = c."segmentId"
- * FROM (VALUES :users) AS c("segmentId", "id")
+ * FROM (VALUES :users) AS c("segmentId", "id") 
  * WHERE c."id" = u."id"
  * ```
  */
-export const backfillSegmentIdQuery = new PreparedQuery<
-  IBackfillSegmentIdQueryParams,
-  IBackfillSegmentIdQueryResult
->(backfillSegmentIdQueryIR)
+export const backfillSegmentIdQuery = new PreparedQuery<IBackfillSegmentIdQueryParams,IBackfillSegmentIdQueryResult>(backfillSegmentIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/backupTeamQuery.ts
+++ b/packages/server/postgres/queries/generated/backupTeamQuery.ts
@@ -1,74 +1,40 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/backupTeamQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker'
+export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker';
 
-export type TierEnum = 'personal' | 'pro' | 'enterprise'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'BackupTeamQuery' parameters type */
 export interface IBackupTeamQueryParams {
   teams: Array<{
-    id: string | null | void
-    name: string | null | void
-    createdAt: Date | null | void
-    createdBy: string | null | void
-    isArchived: boolean | null | void
-    isPaid: boolean | null | void
-    jiraDimensionFields: JsonArray | null | void
-    lastMeetingType: MeetingTypeEnum | null | void
-    tier: TierEnum | null | void
-    orgId: string | null | void
-    isOnboardTeam: boolean | null | void
+    id: string | null | void,
+    name: string | null | void,
+    createdAt: Date | null | void,
+    createdBy: string | null | void,
+    isArchived: boolean | null | void,
+    isPaid: boolean | null | void,
+    jiraDimensionFields: JsonArray | null | void,
+    lastMeetingType: MeetingTypeEnum | null | void,
+    tier: TierEnum | null | void,
+    orgId: string | null | void,
+    isOnboardTeam: boolean | null | void,
     updatedAt: Date | null | void
-  }>
+  }>;
 }
 
 /** 'BackupTeamQuery' return type */
-export type IBackupTeamQueryResult = void
+export type IBackupTeamQueryResult = void;
 
 /** 'BackupTeamQuery' query type */
 export interface IBackupTeamQueryQuery {
-  params: IBackupTeamQueryParams
-  result: IBackupTeamQueryResult
+  params: IBackupTeamQueryParams;
+  result: IBackupTeamQueryResult;
 }
 
-const backupTeamQueryIR: any = {
-  name: 'backupTeamQuery',
-  params: [
-    {
-      name: 'teams',
-      codeRefs: {
-        defined: {a: 36, b: 40, line: 3, col: 9},
-        used: [{a: 466, b: 470, line: 31, col: 10}]
-      },
-      transform: {
-        type: 'pick_array_spread',
-        keys: [
-          'id',
-          'name',
-          'createdAt',
-          'createdBy',
-          'isArchived',
-          'isPaid',
-          'jiraDimensionFields',
-          'lastMeetingType',
-          'tier',
-          'orgId',
-          'isOnboardTeam',
-          'updatedAt'
-        ]
-      }
-    }
-  ],
-  usedParamSet: {teams: true},
-  statement: {
-    body:
-      'INSERT INTO "Team" (\n    "id",\n    "name",\n    "createdAt",\n    "createdBy",\n    "isArchived",\n    "isPaid",\n    "jiraDimensionFields",\n    "lastMeetingType",\n    "tier",\n    "orgId",\n    "isOnboardTeam",\n    "updatedAt"\n) VALUES :teams\nON CONFLICT (id) DO UPDATE SET\n  "id" = EXCLUDED."id",\n  "name" = EXCLUDED."name",\n  "createdAt" = EXCLUDED."createdAt",\n  "createdBy" = EXCLUDED."createdBy",\n  "isArchived" = EXCLUDED."isArchived",\n  "isPaid" = EXCLUDED."isPaid",\n  "jiraDimensionFields" = EXCLUDED."jiraDimensionFields",\n  "lastMeetingType" = EXCLUDED."lastMeetingType",\n  "tier" = EXCLUDED."tier",\n  "orgId" = EXCLUDED."orgId",\n  "isOnboardTeam" = EXCLUDED."isOnboardTeam",\n  "updatedAt" = EXCLUDED."updatedAt"',
-    loc: {a: 235, b: 950, line: 18, col: 0}
-  }
-}
+const backupTeamQueryIR: any = {"name":"backupTeamQuery","params":[{"name":"teams","codeRefs":{"defined":{"a":36,"b":40,"line":3,"col":9},"used":[{"a":466,"b":470,"line":31,"col":10}]},"transform":{"type":"pick_array_spread","keys":["id","name","createdAt","createdBy","isArchived","isPaid","jiraDimensionFields","lastMeetingType","tier","orgId","isOnboardTeam","updatedAt"]}}],"usedParamSet":{"teams":true},"statement":{"body":"INSERT INTO \"Team\" (\n    \"id\",\n    \"name\",\n    \"createdAt\",\n    \"createdBy\",\n    \"isArchived\",\n    \"isPaid\",\n    \"jiraDimensionFields\",\n    \"lastMeetingType\",\n    \"tier\",\n    \"orgId\",\n    \"isOnboardTeam\",\n    \"updatedAt\"\n) VALUES :teams\nON CONFLICT (id) DO UPDATE SET\n  \"id\" = EXCLUDED.\"id\",\n  \"name\" = EXCLUDED.\"name\",\n  \"createdAt\" = EXCLUDED.\"createdAt\",\n  \"createdBy\" = EXCLUDED.\"createdBy\",\n  \"isArchived\" = EXCLUDED.\"isArchived\",\n  \"isPaid\" = EXCLUDED.\"isPaid\",\n  \"jiraDimensionFields\" = EXCLUDED.\"jiraDimensionFields\",\n  \"lastMeetingType\" = EXCLUDED.\"lastMeetingType\",\n  \"tier\" = EXCLUDED.\"tier\",\n  \"orgId\" = EXCLUDED.\"orgId\",\n  \"isOnboardTeam\" = EXCLUDED.\"isOnboardTeam\",\n  \"updatedAt\" = EXCLUDED.\"updatedAt\"","loc":{"a":235,"b":950,"line":18,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -102,6 +68,6 @@ const backupTeamQueryIR: any = {
  *   "updatedAt" = EXCLUDED."updatedAt"
  * ```
  */
-export const backupTeamQuery = new PreparedQuery<IBackupTeamQueryParams, IBackupTeamQueryResult>(
-  backupTeamQueryIR
-)
+export const backupTeamQuery = new PreparedQuery<IBackupTeamQueryParams,IBackupTeamQueryResult>(backupTeamQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/backupUserQuery.ts
+++ b/packages/server/postgres/queries/generated/backupUserQuery.ts
@@ -1,100 +1,58 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/backupUserQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type AuthTokenRole = 'su'
+export type AuthTokenRole = 'su';
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'BackupUserQuery' parameters type */
 export interface IBackupUserQueryParams {
   users: Array<{
-    id: string | null | void
-    email: string | null | void
-    createdAt: Date | null | void
-    updatedAt: Date | null | void
-    inactive: boolean | null | void
-    lastSeenAt: Date | null | void
-    preferredName: string | null | void
-    tier: TierEnum | null | void
-    picture: string | null | void
-    tms: stringArray | null | void
-    featureFlags: stringArray | null | void
-    lastSeenAtURLs: stringArray | null | void
-    identities: JsonArray | null | void
-    segmentId: string | null | void
-    newFeatureId: string | null | void
-    overLimitCopy: string | null | void
-    isRemoved: boolean | null | void
-    reasonRemoved: string | null | void
-    rol: AuthTokenRole | null | void
+    id: string | null | void,
+    email: string | null | void,
+    createdAt: Date | null | void,
+    updatedAt: Date | null | void,
+    inactive: boolean | null | void,
+    lastSeenAt: Date | null | void,
+    preferredName: string | null | void,
+    tier: TierEnum | null | void,
+    picture: string | null | void,
+    tms: stringArray | null | void,
+    featureFlags: stringArray | null | void,
+    lastSeenAtURLs: stringArray | null | void,
+    identities: JsonArray | null | void,
+    segmentId: string | null | void,
+    newFeatureId: string | null | void,
+    overLimitCopy: string | null | void,
+    isRemoved: boolean | null | void,
+    reasonRemoved: string | null | void,
+    rol: AuthTokenRole | null | void,
     payLaterClickCount: number | null | void
-  }>
+  }>;
 }
 
 /** 'BackupUserQuery' return type */
-export type IBackupUserQueryResult = void
+export type IBackupUserQueryResult = void;
 
 /** 'BackupUserQuery' query type */
 export interface IBackupUserQueryQuery {
-  params: IBackupUserQueryParams
-  result: IBackupUserQueryResult
+  params: IBackupUserQueryParams;
+  result: IBackupUserQueryResult;
 }
 
-const backupUserQueryIR: any = {
-  name: 'backupUserQuery',
-  params: [
-    {
-      name: 'users',
-      codeRefs: {
-        defined: {a: 36, b: 40, line: 3, col: 9},
-        used: [{a: 740, b: 744, line: 47, col: 12}]
-      },
-      transform: {
-        type: 'pick_array_spread',
-        keys: [
-          'id',
-          'email',
-          'createdAt',
-          'updatedAt',
-          'inactive',
-          'lastSeenAt',
-          'preferredName',
-          'tier',
-          'picture',
-          'tms',
-          'featureFlags',
-          'lastSeenAtURLs',
-          'identities',
-          'segmentId',
-          'newFeatureId',
-          'overLimitCopy',
-          'isRemoved',
-          'reasonRemoved',
-          'rol',
-          'payLaterClickCount'
-        ]
-      }
-    }
-  ],
-  usedParamSet: {users: true},
-  statement: {
-    body:
-      'INSERT INTO "User" ( \n    "id",\n    "email",\n    "createdAt", \n    "updatedAt",\n    "inactive",\n    "lastSeenAt",\n    "preferredName",\n    "tier",\n    "picture",\n    "tms",\n    "featureFlags",\n    "lastSeenAtURLs",\n    "identities",\n    "segmentId",\n    "newFeatureId",\n    "overLimitCopy",\n    "isRemoved",\n    "reasonRemoved",\n    "rol",\n    "payLaterClickCount"\n  ) VALUES :users\n  ON CONFLICT (id) DO UPDATE SET\n    email = EXCLUDED."email",\n    "createdAt" = EXCLUDED."createdAt",\n    "updatedAt" = EXCLUDED."updatedAt",\n    inactive = EXCLUDED."inactive",\n    "lastSeenAt" = EXCLUDED."lastSeenAt",\n    "preferredName" = EXCLUDED."preferredName",\n    tier = EXCLUDED."tier",\n    picture = EXCLUDED."picture",\n    tms = EXCLUDED."tms",\n    "featureFlags" = EXCLUDED."featureFlags",\n    "lastSeenAtURLs" = EXCLUDED."lastSeenAtURLs",\n    identities = EXCLUDED."identities",\n    "segmentId" = EXCLUDED."segmentId",\n    "newFeatureId" = EXCLUDED."newFeatureId",\n    "overLimitCopy" = EXCLUDED."overLimitCopy",\n    "isRemoved" = EXCLUDED."isRemoved",\n    "reasonRemoved" = EXCLUDED."reasonRemoved",\n    rol = EXCLUDED."rol",\n    "payLaterClickCount" = EXCLUDED."payLaterClickCount"',
-    loc: {a: 363, b: 1542, line: 26, col: 2}
-  }
-}
+const backupUserQueryIR: any = {"name":"backupUserQuery","params":[{"name":"users","codeRefs":{"defined":{"a":36,"b":40,"line":3,"col":9},"used":[{"a":740,"b":744,"line":47,"col":12}]},"transform":{"type":"pick_array_spread","keys":["id","email","createdAt","updatedAt","inactive","lastSeenAt","preferredName","tier","picture","tms","featureFlags","lastSeenAtURLs","identities","segmentId","newFeatureId","overLimitCopy","isRemoved","reasonRemoved","rol","payLaterClickCount"]}}],"usedParamSet":{"users":true},"statement":{"body":"INSERT INTO \"User\" ( \n    \"id\",\n    \"email\",\n    \"createdAt\", \n    \"updatedAt\",\n    \"inactive\",\n    \"lastSeenAt\",\n    \"preferredName\",\n    \"tier\",\n    \"picture\",\n    \"tms\",\n    \"featureFlags\",\n    \"lastSeenAtURLs\",\n    \"identities\",\n    \"segmentId\",\n    \"newFeatureId\",\n    \"overLimitCopy\",\n    \"isRemoved\",\n    \"reasonRemoved\",\n    \"rol\",\n    \"payLaterClickCount\"\n  ) VALUES :users\n  ON CONFLICT (id) DO UPDATE SET\n    email = EXCLUDED.\"email\",\n    \"createdAt\" = EXCLUDED.\"createdAt\",\n    \"updatedAt\" = EXCLUDED.\"updatedAt\",\n    inactive = EXCLUDED.\"inactive\",\n    \"lastSeenAt\" = EXCLUDED.\"lastSeenAt\",\n    \"preferredName\" = EXCLUDED.\"preferredName\",\n    tier = EXCLUDED.\"tier\",\n    picture = EXCLUDED.\"picture\",\n    tms = EXCLUDED.\"tms\",\n    \"featureFlags\" = EXCLUDED.\"featureFlags\",\n    \"lastSeenAtURLs\" = EXCLUDED.\"lastSeenAtURLs\",\n    identities = EXCLUDED.\"identities\",\n    \"segmentId\" = EXCLUDED.\"segmentId\",\n    \"newFeatureId\" = EXCLUDED.\"newFeatureId\",\n    \"overLimitCopy\" = EXCLUDED.\"overLimitCopy\",\n    \"isRemoved\" = EXCLUDED.\"isRemoved\",\n    \"reasonRemoved\" = EXCLUDED.\"reasonRemoved\",\n    rol = EXCLUDED.\"rol\",\n    \"payLaterClickCount\" = EXCLUDED.\"payLaterClickCount\"","loc":{"a":363,"b":1542,"line":26,"col":2}}};
 
 /**
  * Query generated from SQL:
  * ```
- * INSERT INTO "User" (
+ * INSERT INTO "User" ( 
  *     "id",
  *     "email",
- *     "createdAt",
+ *     "createdAt", 
  *     "updatedAt",
  *     "inactive",
  *     "lastSeenAt",
@@ -135,6 +93,6 @@ const backupUserQueryIR: any = {
  *     "payLaterClickCount" = EXCLUDED."payLaterClickCount"
  * ```
  */
-export const backupUserQuery = new PreparedQuery<IBackupUserQueryParams, IBackupUserQueryResult>(
-  backupUserQueryIR
-)
+export const backupUserQuery = new PreparedQuery<IBackupUserQueryParams,IBackupUserQueryResult>(backupUserQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/dismissNewFeatureQuery.ts
+++ b/packages/server/postgres/queries/generated/dismissNewFeatureQuery.ts
@@ -1,38 +1,21 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/dismissNewFeatureQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'DismissNewFeatureQuery' parameters type */
 export interface IDismissNewFeatureQueryParams {
-  ids: Array<string | null | void>
+  ids: Array<string | null | void>;
 }
 
 /** 'DismissNewFeatureQuery' return type */
-export type IDismissNewFeatureQueryResult = void
+export type IDismissNewFeatureQueryResult = void;
 
 /** 'DismissNewFeatureQuery' query type */
 export interface IDismissNewFeatureQueryQuery {
-  params: IDismissNewFeatureQueryParams
-  result: IDismissNewFeatureQueryResult
+  params: IDismissNewFeatureQueryParams;
+  result: IDismissNewFeatureQueryResult;
 }
 
-const dismissNewFeatureQueryIR: any = {
-  name: 'dismissNewFeatureQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 43, b: 45, line: 3, col: 9},
-        used: [{a: 114, b: 116, line: 7, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {ids: true},
-  statement: {
-    body: 'UPDATE "User" SET\n  "newFeatureId" = NULL\nWHERE id IN :ids',
-    loc: {a: 59, b: 116, line: 5, col: 0}
-  }
-}
+const dismissNewFeatureQueryIR: any = {"name":"dismissNewFeatureQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":43,"b":45,"line":3,"col":9},"used":[{"a":114,"b":116,"line":7,"col":13}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"ids":true},"statement":{"body":"UPDATE \"User\" SET\n  \"newFeatureId\" = NULL\nWHERE id IN :ids","loc":{"a":59,"b":116,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -42,7 +25,6 @@ const dismissNewFeatureQueryIR: any = {
  * WHERE id IN :ids
  * ```
  */
-export const dismissNewFeatureQuery = new PreparedQuery<
-  IDismissNewFeatureQueryParams,
-  IDismissNewFeatureQueryResult
->(dismissNewFeatureQueryIR)
+export const dismissNewFeatureQuery = new PreparedQuery<IDismissNewFeatureQueryParams,IDismissNewFeatureQueryResult>(dismissNewFeatureQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getAtlassianAuthByUserIdTeamIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getAtlassianAuthByUserIdTeamIdQuery.ts
@@ -1,58 +1,38 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getAtlassianAuthByUserIdTeamIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
 /** 'GetAtlassianAuthByUserIdTeamIdQuery' parameters type */
 export interface IGetAtlassianAuthByUserIdTeamIdQueryParams {
-  userId: string | null | void
-  teamId: string | null | void
+  userId: string | null | void;
+  teamId: string | null | void;
 }
 
 /** 'GetAtlassianAuthByUserIdTeamIdQuery' return type */
 export interface IGetAtlassianAuthByUserIdTeamIdQueryResult {
-  accessToken: string
-  refreshToken: string
-  createdAt: Date
-  updatedAt: Date
-  isActive: boolean
-  jiraSearchQueries: JsonArray
-  cloudIds: stringArray
-  scope: string
-  accountId: string
-  teamId: string
-  userId: string
+  accessToken: string;
+  refreshToken: string;
+  createdAt: Date;
+  updatedAt: Date;
+  isActive: boolean;
+  jiraSearchQueries: JsonArray;
+  cloudIds: stringArray;
+  scope: string;
+  accountId: string;
+  teamId: string;
+  userId: string;
 }
 
 /** 'GetAtlassianAuthByUserIdTeamIdQuery' query type */
 export interface IGetAtlassianAuthByUserIdTeamIdQueryQuery {
-  params: IGetAtlassianAuthByUserIdTeamIdQueryParams
-  result: IGetAtlassianAuthByUserIdTeamIdQueryResult
+  params: IGetAtlassianAuthByUserIdTeamIdQueryParams;
+  result: IGetAtlassianAuthByUserIdTeamIdQueryResult;
 }
 
-const getAtlassianAuthByUserIdTeamIdQueryIR: any = {
-  name: 'getAtlassianAuthByUserIdTeamIdQuery',
-  params: [
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 98, b: 103, line: 5, col: 18}]}
-    },
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 121, b: 126, line: 5, col: 41}]}
-    }
-  ],
-  usedParamSet: {userId: true, teamId: true},
-  statement: {
-    body:
-      'SELECT * from "AtlassianAuth"\nWHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE',
-    loc: {a: 50, b: 148, line: 4, col: 0}
-  }
-}
+const getAtlassianAuthByUserIdTeamIdQueryIR: any = {"name":"getAtlassianAuthByUserIdTeamIdQuery","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":98,"b":103,"line":5,"col":18}]}},{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":121,"b":126,"line":5,"col":41}]}}],"usedParamSet":{"userId":true,"teamId":true},"statement":{"body":"SELECT * from \"AtlassianAuth\"\nWHERE \"userId\" = :userId AND \"teamId\" = :teamId AND \"isActive\" = TRUE","loc":{"a":50,"b":148,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -61,7 +41,6 @@ const getAtlassianAuthByUserIdTeamIdQueryIR: any = {
  * WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE
  * ```
  */
-export const getAtlassianAuthByUserIdTeamIdQuery = new PreparedQuery<
-  IGetAtlassianAuthByUserIdTeamIdQueryParams,
-  IGetAtlassianAuthByUserIdTeamIdQueryResult
->(getAtlassianAuthByUserIdTeamIdQueryIR)
+export const getAtlassianAuthByUserIdTeamIdQuery = new PreparedQuery<IGetAtlassianAuthByUserIdTeamIdQueryParams,IGetAtlassianAuthByUserIdTeamIdQueryResult>(getAtlassianAuthByUserIdTeamIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getDiscussionsByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getDiscussionsByIdQuery.ts
@@ -1,52 +1,30 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getDiscussionsByIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type DiscussionTopicTypeEnum =
-  | 'agendaItem'
-  | 'reflectionGroup'
-  | 'task'
-  | 'githubIssue'
-  | 'jiraIssue'
+export type DiscussionTopicTypeEnum = 'agendaItem' | 'reflectionGroup' | 'task' | 'githubIssue' | 'jiraIssue';
 
 /** 'GetDiscussionsByIdQuery' parameters type */
 export interface IGetDiscussionsByIdQueryParams {
-  ids: Array<string | null | void>
+  ids: Array<string | null | void>;
 }
 
 /** 'GetDiscussionsByIdQuery' return type */
 export interface IGetDiscussionsByIdQueryResult {
-  id: string
-  createdAt: Date
-  teamId: string
-  meetingId: string
-  discussionTopicId: string
-  discussionTopicType: DiscussionTopicTypeEnum
+  id: string;
+  createdAt: Date;
+  teamId: string;
+  meetingId: string;
+  discussionTopicId: string;
+  discussionTopicType: DiscussionTopicTypeEnum;
 }
 
 /** 'GetDiscussionsByIdQuery' query type */
 export interface IGetDiscussionsByIdQueryQuery {
-  params: IGetDiscussionsByIdQueryParams
-  result: IGetDiscussionsByIdQueryResult
+  params: IGetDiscussionsByIdQueryParams;
+  result: IGetDiscussionsByIdQueryResult;
 }
 
-const getDiscussionsByIdQueryIR: any = {
-  name: 'getDiscussionsByIdQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 44, b: 46, line: 3, col: 9},
-        used: [{a: 100, b: 102, line: 6, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {ids: true},
-  statement: {
-    body: 'SELECT * FROM "Discussion"\nWHERE id in :ids',
-    loc: {a: 60, b: 102, line: 5, col: 0}
-  }
-}
+const getDiscussionsByIdQueryIR: any = {"name":"getDiscussionsByIdQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":44,"b":46,"line":3,"col":9},"used":[{"a":100,"b":102,"line":6,"col":13}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"ids":true},"statement":{"body":"SELECT * FROM \"Discussion\"\nWHERE id in :ids","loc":{"a":60,"b":102,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -55,7 +33,6 @@ const getDiscussionsByIdQueryIR: any = {
  * WHERE id in :ids
  * ```
  */
-export const getDiscussionsByIdQuery = new PreparedQuery<
-  IGetDiscussionsByIdQueryParams,
-  IGetDiscussionsByIdQueryResult
->(getDiscussionsByIdQueryIR)
+export const getDiscussionsByIdQuery = new PreparedQuery<IGetDiscussionsByIdQueryParams,IGetDiscussionsByIdQueryResult>(getDiscussionsByIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getGitHubAuthByUserIdTeamIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getGitHubAuthByUserIdTeamIdQuery.ts
@@ -1,54 +1,34 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getGitHubAuthByUserIdTeamIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'GetGitHubAuthByUserIdTeamIdQuery' parameters type */
 export interface IGetGitHubAuthByUserIdTeamIdQueryParams {
-  userId: string | null | void
-  teamId: string | null | void
+  userId: string | null | void;
+  teamId: string | null | void;
 }
 
 /** 'GetGitHubAuthByUserIdTeamIdQuery' return type */
 export interface IGetGitHubAuthByUserIdTeamIdQueryResult {
-  accessToken: string
-  createdAt: Date
-  updatedAt: Date
-  isActive: boolean
-  login: string
-  teamId: string
-  userId: string
-  githubSearchQueries: JsonArray
-  scope: string
+  accessToken: string;
+  createdAt: Date;
+  updatedAt: Date;
+  isActive: boolean;
+  login: string;
+  teamId: string;
+  userId: string;
+  githubSearchQueries: JsonArray;
+  scope: string;
 }
 
 /** 'GetGitHubAuthByUserIdTeamIdQuery' query type */
 export interface IGetGitHubAuthByUserIdTeamIdQueryQuery {
-  params: IGetGitHubAuthByUserIdTeamIdQueryParams
-  result: IGetGitHubAuthByUserIdTeamIdQueryResult
+  params: IGetGitHubAuthByUserIdTeamIdQueryParams;
+  result: IGetGitHubAuthByUserIdTeamIdQueryResult;
 }
 
-const getGitHubAuthByUserIdTeamIdQueryIR: any = {
-  name: 'getGitHubAuthByUserIdTeamIdQuery',
-  params: [
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 92, b: 97, line: 5, col: 18}]}
-    },
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 115, b: 120, line: 5, col: 41}]}
-    }
-  ],
-  usedParamSet: {userId: true, teamId: true},
-  statement: {
-    body:
-      'SELECT * from "GitHubAuth"\nWHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE',
-    loc: {a: 47, b: 142, line: 4, col: 0}
-  }
-}
+const getGitHubAuthByUserIdTeamIdQueryIR: any = {"name":"getGitHubAuthByUserIdTeamIdQuery","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":92,"b":97,"line":5,"col":18}]}},{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":115,"b":120,"line":5,"col":41}]}}],"usedParamSet":{"userId":true,"teamId":true},"statement":{"body":"SELECT * from \"GitHubAuth\"\nWHERE \"userId\" = :userId AND \"teamId\" = :teamId AND \"isActive\" = TRUE","loc":{"a":47,"b":142,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -57,7 +37,6 @@ const getGitHubAuthByUserIdTeamIdQueryIR: any = {
  * WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE
  * ```
  */
-export const getGitHubAuthByUserIdTeamIdQuery = new PreparedQuery<
-  IGetGitHubAuthByUserIdTeamIdQueryParams,
-  IGetGitHubAuthByUserIdTeamIdQueryResult
->(getGitHubAuthByUserIdTeamIdQueryIR)
+export const getGitHubAuthByUserIdTeamIdQuery = new PreparedQuery<IGetGitHubAuthByUserIdTeamIdQueryParams,IGetGitHubAuthByUserIdTeamIdQueryResult>(getGitHubAuthByUserIdTeamIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getLatestTaskEstimatesQuery.ts
+++ b/packages/server/postgres/queries/generated/getLatestTaskEstimatesQuery.ts
@@ -1,53 +1,35 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getLatestTaskEstimatesQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type ChangeSourceEnum = 'meeting' | 'task' | 'external'
+export type ChangeSourceEnum = 'meeting' | 'task' | 'external';
 
 /** 'GetLatestTaskEstimatesQuery' parameters type */
 export interface IGetLatestTaskEstimatesQueryParams {
-  taskIds: Array<string | null | void>
+  taskIds: Array<string | null | void>;
 }
 
 /** 'GetLatestTaskEstimatesQuery' return type */
 export interface IGetLatestTaskEstimatesQueryResult {
-  id: number
-  createdAt: Date
-  changeSource: ChangeSourceEnum
-  name: string
-  label: string
-  taskId: string
-  userId: string
-  meetingId: string | null
-  stageId: string | null
-  discussionId: string | null
-  jiraFieldId: string | null
+  id: number;
+  createdAt: Date;
+  changeSource: ChangeSourceEnum;
+  name: string;
+  label: string;
+  taskId: string;
+  userId: string;
+  meetingId: string | null;
+  stageId: string | null;
+  discussionId: string | null;
+  jiraFieldId: string | null;
 }
 
 /** 'GetLatestTaskEstimatesQuery' query type */
 export interface IGetLatestTaskEstimatesQueryQuery {
-  params: IGetLatestTaskEstimatesQueryParams
-  result: IGetLatestTaskEstimatesQueryResult
+  params: IGetLatestTaskEstimatesQueryParams;
+  result: IGetLatestTaskEstimatesQueryResult;
 }
 
-const getLatestTaskEstimatesQueryIR: any = {
-  name: 'getLatestTaskEstimatesQuery',
-  params: [
-    {
-      name: 'taskIds',
-      codeRefs: {
-        defined: {a: 48, b: 54, line: 3, col: 9},
-        used: [{a: 146, b: 152, line: 6, col: 19}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {taskIds: true},
-  statement: {
-    body:
-      'SELECT DISTINCT ON("taskId", "name") * From "TaskEstimate"\nWHERE "taskId" in :taskIds\nORDER BY "taskId", "name", "createdAt" desc',
-    loc: {a: 68, b: 196, line: 5, col: 0}
-  }
-}
+const getLatestTaskEstimatesQueryIR: any = {"name":"getLatestTaskEstimatesQuery","params":[{"name":"taskIds","codeRefs":{"defined":{"a":48,"b":54,"line":3,"col":9},"used":[{"a":146,"b":152,"line":6,"col":19}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"taskIds":true},"statement":{"body":"SELECT DISTINCT ON(\"taskId\", \"name\") * From \"TaskEstimate\"\nWHERE \"taskId\" in :taskIds\nORDER BY \"taskId\", \"name\", \"createdAt\" desc","loc":{"a":68,"b":196,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -57,7 +39,6 @@ const getLatestTaskEstimatesQueryIR: any = {
  * ORDER BY "taskId", "name", "createdAt" desc
  * ```
  */
-export const getLatestTaskEstimatesQuery = new PreparedQuery<
-  IGetLatestTaskEstimatesQueryParams,
-  IGetLatestTaskEstimatesQueryResult
->(getLatestTaskEstimatesQueryIR)
+export const getLatestTaskEstimatesQuery = new PreparedQuery<IGetLatestTaskEstimatesQueryParams,IGetLatestTaskEstimatesQueryResult>(getLatestTaskEstimatesQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getMeetingTaskEstimatesQuery.ts
+++ b/packages/server/postgres/queries/generated/getMeetingTaskEstimatesQuery.ts
@@ -1,62 +1,36 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getMeetingTaskEstimatesQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type ChangeSourceEnum = 'meeting' | 'task' | 'external'
+export type ChangeSourceEnum = 'meeting' | 'task' | 'external';
 
 /** 'GetMeetingTaskEstimatesQuery' parameters type */
 export interface IGetMeetingTaskEstimatesQueryParams {
-  taskIds: Array<string | null | void>
-  meetingIds: Array<string | null | void>
+  taskIds: Array<string | null | void>;
+  meetingIds: Array<string | null | void>;
 }
 
 /** 'GetMeetingTaskEstimatesQuery' return type */
 export interface IGetMeetingTaskEstimatesQueryResult {
-  id: number
-  createdAt: Date
-  changeSource: ChangeSourceEnum
-  name: string
-  label: string
-  taskId: string
-  userId: string
-  meetingId: string | null
-  stageId: string | null
-  discussionId: string | null
-  jiraFieldId: string | null
+  id: number;
+  createdAt: Date;
+  changeSource: ChangeSourceEnum;
+  name: string;
+  label: string;
+  taskId: string;
+  userId: string;
+  meetingId: string | null;
+  stageId: string | null;
+  discussionId: string | null;
+  jiraFieldId: string | null;
 }
 
 /** 'GetMeetingTaskEstimatesQuery' query type */
 export interface IGetMeetingTaskEstimatesQueryQuery {
-  params: IGetMeetingTaskEstimatesQueryParams
-  result: IGetMeetingTaskEstimatesQueryResult
+  params: IGetMeetingTaskEstimatesQueryParams;
+  result: IGetMeetingTaskEstimatesQueryResult;
 }
 
-const getMeetingTaskEstimatesQueryIR: any = {
-  name: 'getMeetingTaskEstimatesQuery',
-  params: [
-    {
-      name: 'taskIds',
-      codeRefs: {
-        defined: {a: 49, b: 55, line: 3, col: 9},
-        used: [{a: 207, b: 213, line: 8, col: 17}]
-      },
-      transform: {type: 'array_spread'}
-    },
-    {
-      name: 'meetingIds',
-      codeRefs: {
-        defined: {a: 75, b: 84, line: 4, col: 9},
-        used: [{a: 179, b: 188, line: 7, col: 22}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {meetingIds: true, taskIds: true},
-  statement: {
-    body:
-      'SELECT DISTINCT ON("taskId", "name") * From "TaskEstimate"\nWHERE "meetingId" in :meetingIds\nAND "taskId" in :taskIds\nORDER BY "taskId", "name", "createdAt" desc',
-    loc: {a: 98, b: 257, line: 6, col: 0}
-  }
-}
+const getMeetingTaskEstimatesQueryIR: any = {"name":"getMeetingTaskEstimatesQuery","params":[{"name":"taskIds","codeRefs":{"defined":{"a":49,"b":55,"line":3,"col":9},"used":[{"a":207,"b":213,"line":8,"col":17}]},"transform":{"type":"array_spread"}},{"name":"meetingIds","codeRefs":{"defined":{"a":75,"b":84,"line":4,"col":9},"used":[{"a":179,"b":188,"line":7,"col":22}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"meetingIds":true,"taskIds":true},"statement":{"body":"SELECT DISTINCT ON(\"taskId\", \"name\") * From \"TaskEstimate\"\nWHERE \"meetingId\" in :meetingIds\nAND \"taskId\" in :taskIds\nORDER BY \"taskId\", \"name\", \"createdAt\" desc","loc":{"a":98,"b":257,"line":6,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -67,7 +41,6 @@ const getMeetingTaskEstimatesQueryIR: any = {
  * ORDER BY "taskId", "name", "createdAt" desc
  * ```
  */
-export const getMeetingTaskEstimatesQuery = new PreparedQuery<
-  IGetMeetingTaskEstimatesQueryParams,
-  IGetMeetingTaskEstimatesQueryResult
->(getMeetingTaskEstimatesQueryIR)
+export const getMeetingTaskEstimatesQuery = new PreparedQuery<IGetMeetingTaskEstimatesQueryParams,IGetMeetingTaskEstimatesQueryResult>(getMeetingTaskEstimatesQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getTeamsByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getTeamsByIdQuery.ts
@@ -1,56 +1,41 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getTeamsByIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type MeetingTypeEnum = 'poker' | 'retrospective' | 'action'
+export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker';
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'GetTeamsByIdQuery' parameters type */
 export interface IGetTeamsByIdQueryParams {
-  ids: Array<string | null | void>
+  ids: Array<string | null | void>;
 }
 
 /** 'GetTeamsByIdQuery' return type */
 export interface IGetTeamsByIdQueryResult {
-  id: string
-  name: string
-  createdAt: Date
-  createdBy: string | null
-  isArchived: boolean
-  isPaid: boolean
-  jiraDimensionFields: JsonArray
-  lastMeetingType: MeetingTypeEnum
-  tier: TierEnum
-  orgId: string
-  isOnboardTeam: boolean
-  updatedAt: Date
-  eqChecked: Date
-  lockMessageHTML: string | null
+  id: string;
+  name: string;
+  createdAt: Date;
+  createdBy: string | null;
+  isArchived: boolean;
+  isPaid: boolean;
+  jiraDimensionFields: JsonArray;
+  lastMeetingType: MeetingTypeEnum;
+  tier: TierEnum;
+  orgId: string;
+  isOnboardTeam: boolean;
+  updatedAt: Date;
+  lockMessageHTML: string | null;
 }
 
 /** 'GetTeamsByIdQuery' query type */
 export interface IGetTeamsByIdQueryQuery {
-  params: IGetTeamsByIdQueryParams
-  result: IGetTeamsByIdQueryResult
+  params: IGetTeamsByIdQueryParams;
+  result: IGetTeamsByIdQueryResult;
 }
 
-const getTeamsByIdQueryIR: any = {
-  name: 'getTeamsByIdQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 38, b: 40, line: 3, col: 9},
-        used: [{a: 88, b: 90, line: 6, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {ids: true},
-  statement: {body: 'SELECT * FROM "Team"\nWHERE id IN :ids', loc: {a: 54, b: 90, line: 5, col: 0}}
-}
+const getTeamsByIdQueryIR: any = {"name":"getTeamsByIdQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":38,"b":40,"line":3,"col":9},"used":[{"a":88,"b":90,"line":6,"col":13}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"ids":true},"statement":{"body":"SELECT * FROM \"Team\"\nWHERE id IN :ids","loc":{"a":54,"b":90,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -59,7 +44,6 @@ const getTeamsByIdQueryIR: any = {
  * WHERE id IN :ids
  * ```
  */
-export const getTeamsByIdQuery = new PreparedQuery<
-  IGetTeamsByIdQueryParams,
-  IGetTeamsByIdQueryResult
->(getTeamsByIdQueryIR)
+export const getTeamsByIdQuery = new PreparedQuery<IGetTeamsByIdQueryParams,IGetTeamsByIdQueryResult>(getTeamsByIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getTemplateRefsByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getTemplateRefsByIdQuery.ts
@@ -1,46 +1,28 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getTemplateRefsByIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type Json = null | boolean | number | string | Json[] | {[key: string]: Json}
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 /** 'GetTemplateRefsByIdQuery' parameters type */
 export interface IGetTemplateRefsByIdQueryParams {
-  refIds: Array<string | null | void>
+  refIds: Array<string | null | void>;
 }
 
 /** 'GetTemplateRefsByIdQuery' return type */
 export interface IGetTemplateRefsByIdQueryResult {
-  id: string
-  createdAt: Date | null
-  name: string | null
-  dimensions: Json | null
+  id: string;
+  createdAt: Date | null;
+  name: string | null;
+  dimensions: Json | null;
 }
 
 /** 'GetTemplateRefsByIdQuery' query type */
 export interface IGetTemplateRefsByIdQueryQuery {
-  params: IGetTemplateRefsByIdQueryParams
-  result: IGetTemplateRefsByIdQueryResult
+  params: IGetTemplateRefsByIdQueryParams;
+  result: IGetTemplateRefsByIdQueryResult;
 }
 
-const getTemplateRefsByIdQueryIR: any = {
-  name: 'getTemplateRefsByIdQuery',
-  params: [
-    {
-      name: 'refIds',
-      codeRefs: {
-        defined: {a: 45, b: 50, line: 3, col: 9},
-        used: [{a: 228, b: 233, line: 7, col: 17}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {refIds: true},
-  statement: {
-    body:
-      'SELECT t."id", t."createdAt", s."name", s."dimensions"\nFROM "TemplateRef" as t, jsonb_to_record(t."template") as s("name" text, "dimensions" json)\nWHERE t."id" in :refIds',
-    loc: {a: 64, b: 233, line: 5, col: 0}
-  }
-}
+const getTemplateRefsByIdQueryIR: any = {"name":"getTemplateRefsByIdQuery","params":[{"name":"refIds","codeRefs":{"defined":{"a":45,"b":50,"line":3,"col":9},"used":[{"a":228,"b":233,"line":7,"col":17}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"refIds":true},"statement":{"body":"SELECT t.\"id\", t.\"createdAt\", s.\"name\", s.\"dimensions\"\nFROM \"TemplateRef\" as t, jsonb_to_record(t.\"template\") as s(\"name\" text, \"dimensions\" json)\nWHERE t.\"id\" in :refIds","loc":{"a":64,"b":233,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -50,7 +32,6 @@ const getTemplateRefsByIdQueryIR: any = {
  * WHERE t."id" in :refIds
  * ```
  */
-export const getTemplateRefsByIdQuery = new PreparedQuery<
-  IGetTemplateRefsByIdQueryParams,
-  IGetTemplateRefsByIdQueryResult
->(getTemplateRefsByIdQueryIR)
+export const getTemplateRefsByIdQuery = new PreparedQuery<IGetTemplateRefsByIdQueryParams,IGetTemplateRefsByIdQueryResult>(getTemplateRefsByIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getTemplateScaleRefByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getTemplateScaleRefByIdQuery.ts
@@ -1,43 +1,28 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getTemplateScaleRefByIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type Json = null | boolean | number | string | Json[] | {[key: string]: Json}
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 /** 'GetTemplateScaleRefByIdQuery' parameters type */
 export interface IGetTemplateScaleRefByIdQueryParams {
-  scaleRefId: string | null | void
+  scaleRefId: string | null | void;
 }
 
 /** 'GetTemplateScaleRefByIdQuery' return type */
 export interface IGetTemplateScaleRefByIdQueryResult {
-  id: string
-  createdAt: Date | null
-  name: string | null
-  values: Json | null
+  id: string;
+  createdAt: Date | null;
+  name: string | null;
+  values: Json | null;
 }
 
 /** 'GetTemplateScaleRefByIdQuery' query type */
 export interface IGetTemplateScaleRefByIdQueryQuery {
-  params: IGetTemplateScaleRefByIdQueryParams
-  result: IGetTemplateScaleRefByIdQueryResult
+  params: IGetTemplateScaleRefByIdQueryParams;
+  result: IGetTemplateScaleRefByIdQueryResult;
 }
 
-const getTemplateScaleRefByIdQueryIR: any = {
-  name: 'getTemplateScaleRefByIdQuery',
-  params: [
-    {
-      name: 'scaleRefId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 198, b: 207, line: 6, col: 14}]}
-    }
-  ],
-  usedParamSet: {scaleRefId: true},
-  statement: {
-    body:
-      'SELECT t."id", t."createdAt", s."name", s."values"\nFROM "TemplateScaleRef" as t, jsonb_to_record(t."scale") as s("name" text, "values" json)\nWHERE "id" = :scaleRefId',
-    loc: {a: 43, b: 207, line: 4, col: 0}
-  }
-}
+const getTemplateScaleRefByIdQueryIR: any = {"name":"getTemplateScaleRefByIdQuery","params":[{"name":"scaleRefId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":198,"b":207,"line":6,"col":14}]}}],"usedParamSet":{"scaleRefId":true},"statement":{"body":"SELECT t.\"id\", t.\"createdAt\", s.\"name\", s.\"values\"\nFROM \"TemplateScaleRef\" as t, jsonb_to_record(t.\"scale\") as s(\"name\" text, \"values\" json)\nWHERE \"id\" = :scaleRefId","loc":{"a":43,"b":207,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -47,7 +32,6 @@ const getTemplateScaleRefByIdQueryIR: any = {
  * WHERE "id" = :scaleRefId
  * ```
  */
-export const getTemplateScaleRefByIdQuery = new PreparedQuery<
-  IGetTemplateScaleRefByIdQueryParams,
-  IGetTemplateScaleRefByIdQueryResult
->(getTemplateScaleRefByIdQueryIR)
+export const getTemplateScaleRefByIdQuery = new PreparedQuery<IGetTemplateScaleRefByIdQueryParams,IGetTemplateScaleRefByIdQueryResult>(getTemplateScaleRefByIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/getUsersByIdQuery.ts
+++ b/packages/server/postgres/queries/generated/getUsersByIdQuery.ts
@@ -1,66 +1,51 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/getUsersByIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type AuthTokenRole = 'su'
+export type AuthTokenRole = 'su';
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'GetUsersByIdQuery' parameters type */
 export interface IGetUsersByIdQueryParams {
-  ids: Array<string | null | void>
+  ids: Array<string | null | void>;
 }
 
 /** 'GetUsersByIdQuery' return type */
 export interface IGetUsersByIdQueryResult {
-  id: string
-  email: string
-  createdAt: Date
-  updatedAt: Date
-  inactive: boolean
-  lastSeenAt: Date | null
-  preferredName: string
-  tier: TierEnum
-  picture: string
-  tms: stringArray
-  featureFlags: stringArray
-  identities: JsonArray
-  lastSeenAtURLs: stringArray | null
-  segmentId: string | null
-  newFeatureId: string | null
-  overLimitCopy: string | null
-  isRemoved: boolean
-  reasonRemoved: string | null
-  rol: AuthTokenRole | null
-  payLaterClickCount: number
-  eqChecked: Date
-  isWatched: boolean
+  id: string;
+  email: string;
+  createdAt: Date;
+  updatedAt: Date;
+  inactive: boolean;
+  lastSeenAt: Date | null;
+  preferredName: string;
+  tier: TierEnum;
+  picture: string;
+  tms: stringArray;
+  featureFlags: stringArray;
+  identities: JsonArray;
+  lastSeenAtURLs: stringArray | null;
+  segmentId: string | null;
+  newFeatureId: string | null;
+  overLimitCopy: string | null;
+  isRemoved: boolean;
+  reasonRemoved: string | null;
+  rol: AuthTokenRole | null;
+  payLaterClickCount: number;
+  isWatched: boolean;
 }
 
 /** 'GetUsersByIdQuery' query type */
 export interface IGetUsersByIdQueryQuery {
-  params: IGetUsersByIdQueryParams
-  result: IGetUsersByIdQueryResult
+  params: IGetUsersByIdQueryParams;
+  result: IGetUsersByIdQueryResult;
 }
 
-const getUsersByIdQueryIR: any = {
-  name: 'getUsersByIdQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 38, b: 40, line: 3, col: 9},
-        used: [{a: 88, b: 90, line: 6, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    }
-  ],
-  usedParamSet: {ids: true},
-  statement: {body: 'SELECT * FROM "User"\nWHERE id in :ids', loc: {a: 54, b: 90, line: 5, col: 0}}
-}
+const getUsersByIdQueryIR: any = {"name":"getUsersByIdQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":38,"b":40,"line":3,"col":9},"used":[{"a":88,"b":90,"line":6,"col":13}]},"transform":{"type":"array_spread"}}],"usedParamSet":{"ids":true},"statement":{"body":"SELECT * FROM \"User\"\nWHERE id in :ids","loc":{"a":54,"b":90,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -69,7 +54,6 @@ const getUsersByIdQueryIR: any = {
  * WHERE id in :ids
  * ```
  */
-export const getUsersByIdQuery = new PreparedQuery<
-  IGetUsersByIdQueryParams,
-  IGetUsersByIdQueryResult
->(getUsersByIdQueryIR)
+export const getUsersByIdQuery = new PreparedQuery<IGetUsersByIdQueryParams,IGetUsersByIdQueryResult>(getUsersByIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/incrementUserPayLaterClickCountQuery.ts
+++ b/packages/server/postgres/queries/generated/incrementUserPayLaterClickCountQuery.ts
@@ -1,35 +1,21 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/incrementUserPayLaterClickCountQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'IncrementUserPayLaterClickCountQuery' parameters type */
 export interface IIncrementUserPayLaterClickCountQueryParams {
-  id: string | null | void
+  id: string | null | void;
 }
 
 /** 'IncrementUserPayLaterClickCountQuery' return type */
-export type IIncrementUserPayLaterClickCountQueryResult = void
+export type IIncrementUserPayLaterClickCountQueryResult = void;
 
 /** 'IncrementUserPayLaterClickCountQuery' query type */
 export interface IIncrementUserPayLaterClickCountQueryQuery {
-  params: IIncrementUserPayLaterClickCountQueryParams
-  result: IIncrementUserPayLaterClickCountQueryResult
+  params: IIncrementUserPayLaterClickCountQueryParams;
+  result: IIncrementUserPayLaterClickCountQueryResult;
 }
 
-const incrementUserPayLaterClickCountQueryIR: any = {
-  name: 'incrementUserPayLaterClickCountQuery',
-  params: [
-    {
-      name: 'id',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 132, b: 133, line: 7, col: 12}]}
-    }
-  ],
-  usedParamSet: {id: true},
-  statement: {
-    body: 'UPDATE "User" SET\n  "payLaterClickCount" = "payLaterClickCount" + 1\nWHERE id = :id',
-    loc: {a: 52, b: 133, line: 5, col: 0}
-  }
-}
+const incrementUserPayLaterClickCountQueryIR: any = {"name":"incrementUserPayLaterClickCountQuery","params":[{"name":"id","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":132,"b":133,"line":7,"col":12}]}}],"usedParamSet":{"id":true},"statement":{"body":"UPDATE \"User\" SET\n  \"payLaterClickCount\" = \"payLaterClickCount\" + 1\nWHERE id = :id","loc":{"a":52,"b":133,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -39,7 +25,6 @@ const incrementUserPayLaterClickCountQueryIR: any = {
  * WHERE id = :id
  * ```
  */
-export const incrementUserPayLaterClickCountQuery = new PreparedQuery<
-  IIncrementUserPayLaterClickCountQueryParams,
-  IIncrementUserPayLaterClickCountQueryResult
->(incrementUserPayLaterClickCountQueryIR)
+export const incrementUserPayLaterClickCountQuery = new PreparedQuery<IIncrementUserPayLaterClickCountQueryParams,IIncrementUserPayLaterClickCountQueryResult>(incrementUserPayLaterClickCountQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertAtlassianAuthsQuery.ts
+++ b/packages/server/postgres/queries/generated/insertAtlassianAuthsQuery.ts
@@ -1,70 +1,37 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertAtlassianAuthsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
 /** 'InsertAtlassianAuthsQuery' parameters type */
 export interface IInsertAtlassianAuthsQueryParams {
   auths: Array<{
-    accessToken: string | null | void
-    refreshToken: string | null | void
-    createdAt: Date | null | void
-    updatedAt: Date | null | void
-    isActive: boolean | null | void
-    jiraSearchQueries: JsonArray | null | void
-    cloudIds: stringArray | null | void
-    scope: string | null | void
-    accountId: string | null | void
-    teamId: string | null | void
+    accessToken: string | null | void,
+    refreshToken: string | null | void,
+    createdAt: Date | null | void,
+    updatedAt: Date | null | void,
+    isActive: boolean | null | void,
+    jiraSearchQueries: JsonArray | null | void,
+    cloudIds: stringArray | null | void,
+    scope: string | null | void,
+    accountId: string | null | void,
+    teamId: string | null | void,
     userId: string | null | void
-  }>
+  }>;
 }
 
 /** 'InsertAtlassianAuthsQuery' return type */
-export type IInsertAtlassianAuthsQueryResult = void
+export type IInsertAtlassianAuthsQueryResult = void;
 
 /** 'InsertAtlassianAuthsQuery' query type */
 export interface IInsertAtlassianAuthsQueryQuery {
-  params: IInsertAtlassianAuthsQueryParams
-  result: IInsertAtlassianAuthsQueryResult
+  params: IInsertAtlassianAuthsQueryParams;
+  result: IInsertAtlassianAuthsQueryResult;
 }
 
-const insertAtlassianAuthsQueryIR: any = {
-  name: 'insertAtlassianAuthsQuery',
-  params: [
-    {
-      name: 'auths',
-      codeRefs: {
-        defined: {a: 46, b: 50, line: 3, col: 9},
-        used: [{a: 367, b: 371, line: 6, col: 8}]
-      },
-      transform: {
-        type: 'pick_array_spread',
-        keys: [
-          'accessToken',
-          'refreshToken',
-          'createdAt',
-          'updatedAt',
-          'isActive',
-          'jiraSearchQueries',
-          'cloudIds',
-          'scope',
-          'accountId',
-          'teamId',
-          'userId'
-        ]
-      }
-    }
-  ],
-  usedParamSet: {auths: true},
-  statement: {
-    body:
-      'INSERT INTO "AtlassianAuth" ("accessToken", "refreshToken", "createdAt", "updatedAt", "isActive", "jiraSearchQueries", "cloudIds", "scope", "accountId", "teamId", "userId")\nVALUES :auths',
-    loc: {a: 186, b: 371, line: 5, col: 0}
-  }
-}
+const insertAtlassianAuthsQueryIR: any = {"name":"insertAtlassianAuthsQuery","params":[{"name":"auths","codeRefs":{"defined":{"a":46,"b":50,"line":3,"col":9},"used":[{"a":367,"b":371,"line":6,"col":8}]},"transform":{"type":"pick_array_spread","keys":["accessToken","refreshToken","createdAt","updatedAt","isActive","jiraSearchQueries","cloudIds","scope","accountId","teamId","userId"]}}],"usedParamSet":{"auths":true},"statement":{"body":"INSERT INTO \"AtlassianAuth\" (\"accessToken\", \"refreshToken\", \"createdAt\", \"updatedAt\", \"isActive\", \"jiraSearchQueries\", \"cloudIds\", \"scope\", \"accountId\", \"teamId\", \"userId\")\nVALUES :auths","loc":{"a":186,"b":371,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -73,7 +40,6 @@ const insertAtlassianAuthsQueryIR: any = {
  * VALUES :auths
  * ```
  */
-export const insertAtlassianAuthsQuery = new PreparedQuery<
-  IInsertAtlassianAuthsQueryParams,
-  IInsertAtlassianAuthsQueryResult
->(insertAtlassianAuthsQueryIR)
+export const insertAtlassianAuthsQuery = new PreparedQuery<IInsertAtlassianAuthsQueryParams,IInsertAtlassianAuthsQueryResult>(insertAtlassianAuthsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertDiscussionsQuery.ts
+++ b/packages/server/postgres/queries/generated/insertDiscussionsQuery.ts
@@ -1,55 +1,29 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertDiscussionsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type DiscussionTopicTypeEnum =
-  | 'agendaItem'
-  | 'reflectionGroup'
-  | 'task'
-  | 'githubIssue'
-  | 'jiraIssue'
+export type DiscussionTopicTypeEnum = 'agendaItem' | 'reflectionGroup' | 'task' | 'githubIssue' | 'jiraIssue';
 
 /** 'InsertDiscussionsQuery' parameters type */
 export interface IInsertDiscussionsQueryParams {
   discussions: Array<{
-    id: string | null | void
-    teamId: string | null | void
-    meetingId: string | null | void
-    discussionTopicId: string | null | void
+    id: string | null | void,
+    teamId: string | null | void,
+    meetingId: string | null | void,
+    discussionTopicId: string | null | void,
     discussionTopicType: DiscussionTopicTypeEnum | null | void
-  }>
+  }>;
 }
 
 /** 'InsertDiscussionsQuery' return type */
-export type IInsertDiscussionsQueryResult = void
+export type IInsertDiscussionsQueryResult = void;
 
 /** 'InsertDiscussionsQuery' query type */
 export interface IInsertDiscussionsQueryQuery {
-  params: IInsertDiscussionsQueryParams
-  result: IInsertDiscussionsQueryResult
+  params: IInsertDiscussionsQueryParams;
+  result: IInsertDiscussionsQueryResult;
 }
 
-const insertDiscussionsQueryIR: any = {
-  name: 'insertDiscussionsQuery',
-  params: [
-    {
-      name: 'discussions',
-      codeRefs: {
-        defined: {a: 43, b: 53, line: 3, col: 9},
-        used: [{a: 237, b: 247, line: 6, col: 8}]
-      },
-      transform: {
-        type: 'pick_array_spread',
-        keys: ['id', 'teamId', 'meetingId', 'discussionTopicId', 'discussionTopicType']
-      }
-    }
-  ],
-  usedParamSet: {discussions: true},
-  statement: {
-    body:
-      'INSERT INTO "Discussion" ("id", "teamId", "meetingId", "discussionTopicId", "discussionTopicType")\nVALUES :discussions',
-    loc: {a: 130, b: 247, line: 5, col: 0}
-  }
-}
+const insertDiscussionsQueryIR: any = {"name":"insertDiscussionsQuery","params":[{"name":"discussions","codeRefs":{"defined":{"a":43,"b":53,"line":3,"col":9},"used":[{"a":237,"b":247,"line":6,"col":8}]},"transform":{"type":"pick_array_spread","keys":["id","teamId","meetingId","discussionTopicId","discussionTopicType"]}}],"usedParamSet":{"discussions":true},"statement":{"body":"INSERT INTO \"Discussion\" (\"id\", \"teamId\", \"meetingId\", \"discussionTopicId\", \"discussionTopicType\")\nVALUES :discussions","loc":{"a":130,"b":247,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -58,7 +32,6 @@ const insertDiscussionsQueryIR: any = {
  * VALUES :discussions
  * ```
  */
-export const insertDiscussionsQuery = new PreparedQuery<
-  IInsertDiscussionsQueryParams,
-  IInsertDiscussionsQueryResult
->(insertDiscussionsQueryIR)
+export const insertDiscussionsQuery = new PreparedQuery<IInsertDiscussionsQueryParams,IInsertDiscussionsQueryResult>(insertDiscussionsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertGitHubAuthsQuery.ts
+++ b/packages/server/postgres/queries/generated/insertGitHubAuthsQuery.ts
@@ -1,50 +1,29 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertGitHubAuthsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'InsertGitHubAuthsQuery' parameters type */
 export interface IInsertGitHubAuthsQueryParams {
   auths: Array<{
-    accessToken: string | null | void
-    createdAt: Date | null | void
-    updatedAt: Date | null | void
-    isActive: boolean | null | void
-    login: string | null | void
-    teamId: string | null | void
+    accessToken: string | null | void,
+    createdAt: Date | null | void,
+    updatedAt: Date | null | void,
+    isActive: boolean | null | void,
+    login: string | null | void,
+    teamId: string | null | void,
     userId: string | null | void
-  }>
+  }>;
 }
 
 /** 'InsertGitHubAuthsQuery' return type */
-export type IInsertGitHubAuthsQueryResult = void
+export type IInsertGitHubAuthsQueryResult = void;
 
 /** 'InsertGitHubAuthsQuery' query type */
 export interface IInsertGitHubAuthsQueryQuery {
-  params: IInsertGitHubAuthsQueryParams
-  result: IInsertGitHubAuthsQueryResult
+  params: IInsertGitHubAuthsQueryParams;
+  result: IInsertGitHubAuthsQueryResult;
 }
 
-const insertGitHubAuthsQueryIR: any = {
-  name: 'insertGitHubAuthsQuery',
-  params: [
-    {
-      name: 'auths',
-      codeRefs: {
-        defined: {a: 43, b: 47, line: 3, col: 9},
-        used: [{a: 245, b: 249, line: 6, col: 8}]
-      },
-      transform: {
-        type: 'pick_array_spread',
-        keys: ['accessToken', 'createdAt', 'updatedAt', 'isActive', 'login', 'teamId', 'userId']
-      }
-    }
-  ],
-  usedParamSet: {auths: true},
-  statement: {
-    body:
-      'INSERT INTO "GitHubAuth" ("accessToken", "createdAt", "updatedAt", "isActive", "login", "teamId", "userId")\nVALUES :auths',
-    loc: {a: 129, b: 249, line: 5, col: 0}
-  }
-}
+const insertGitHubAuthsQueryIR: any = {"name":"insertGitHubAuthsQuery","params":[{"name":"auths","codeRefs":{"defined":{"a":43,"b":47,"line":3,"col":9},"used":[{"a":245,"b":249,"line":6,"col":8}]},"transform":{"type":"pick_array_spread","keys":["accessToken","createdAt","updatedAt","isActive","login","teamId","userId"]}}],"usedParamSet":{"auths":true},"statement":{"body":"INSERT INTO \"GitHubAuth\" (\"accessToken\", \"createdAt\", \"updatedAt\", \"isActive\", \"login\", \"teamId\", \"userId\")\nVALUES :auths","loc":{"a":129,"b":249,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -53,7 +32,6 @@ const insertGitHubAuthsQueryIR: any = {
  * VALUES :auths
  * ```
  */
-export const insertGitHubAuthsQuery = new PreparedQuery<
-  IInsertGitHubAuthsQueryParams,
-  IInsertGitHubAuthsQueryResult
->(insertGitHubAuthsQueryIR)
+export const insertGitHubAuthsQuery = new PreparedQuery<IInsertGitHubAuthsQueryParams,IInsertGitHubAuthsQueryResult>(insertGitHubAuthsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertTaskEstimateQuery.ts
+++ b/packages/server/postgres/queries/generated/insertTaskEstimateQuery.ts
@@ -1,96 +1,31 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertTaskEstimateQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type ChangeSourceEnum = 'meeting' | 'task' | 'external'
+export type ChangeSourceEnum = 'meeting' | 'task' | 'external';
 
 /** 'InsertTaskEstimateQuery' parameters type */
 export interface IInsertTaskEstimateQueryParams {
-  changeSource: ChangeSourceEnum | null | void
-  name: string | null | void
-  label: string | null | void
-  taskId: string | null | void
-  userId: string | null | void
-  meetingId: string | null | void
-  stageId: string | null | void
-  discussionId: string | null | void
-  jiraFieldId: string | null | void
+  changeSource: ChangeSourceEnum | null | void;
+  name: string | null | void;
+  label: string | null | void;
+  taskId: string | null | void;
+  userId: string | null | void;
+  meetingId: string | null | void;
+  stageId: string | null | void;
+  discussionId: string | null | void;
+  jiraFieldId: string | null | void;
 }
 
 /** 'InsertTaskEstimateQuery' return type */
-export type IInsertTaskEstimateQueryResult = void
+export type IInsertTaskEstimateQueryResult = void;
 
 /** 'InsertTaskEstimateQuery' query type */
 export interface IInsertTaskEstimateQueryQuery {
-  params: IInsertTaskEstimateQueryParams
-  result: IInsertTaskEstimateQueryResult
+  params: IInsertTaskEstimateQueryParams;
+  result: IInsertTaskEstimateQueryResult;
 }
 
-const insertTaskEstimateQueryIR: any = {
-  name: 'insertTaskEstimateQuery',
-  params: [
-    {
-      name: 'changeSource',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 206, b: 217, line: 15, col: 3}]}
-    },
-    {
-      name: 'name',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 223, b: 226, line: 16, col: 3}]}
-    },
-    {
-      name: 'label',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 232, b: 236, line: 17, col: 3}]}
-    },
-    {
-      name: 'taskId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 242, b: 247, line: 18, col: 3}]}
-    },
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 253, b: 258, line: 19, col: 3}]}
-    },
-    {
-      name: 'meetingId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 264, b: 272, line: 20, col: 3}]}
-    },
-    {
-      name: 'stageId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 278, b: 284, line: 21, col: 3}]}
-    },
-    {
-      name: 'discussionId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 290, b: 301, line: 22, col: 3}]}
-    },
-    {
-      name: 'jiraFieldId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 307, b: 317, line: 23, col: 3}]}
-    }
-  ],
-  usedParamSet: {
-    changeSource: true,
-    name: true,
-    label: true,
-    taskId: true,
-    userId: true,
-    meetingId: true,
-    stageId: true,
-    discussionId: true,
-    jiraFieldId: true
-  },
-  statement: {
-    body:
-      'INSERT INTO "TaskEstimate" (\n  "changeSource",\n  "name",\n  "label",\n  "taskId",\n  "userId",\n  "meetingId",\n  "stageId",\n  "discussionId",\n  "jiraFieldId"\n) VALUES (\n  :changeSource,\n  :name,\n  :label,\n  :taskId,\n  :userId,\n  :meetingId,\n  :stageId,\n  :discussionId,\n  :jiraFieldId\n)',
-    loc: {a: 38, b: 319, line: 4, col: 0}
-  }
-}
+const insertTaskEstimateQueryIR: any = {"name":"insertTaskEstimateQuery","params":[{"name":"changeSource","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":206,"b":217,"line":15,"col":3}]}},{"name":"name","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":223,"b":226,"line":16,"col":3}]}},{"name":"label","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":232,"b":236,"line":17,"col":3}]}},{"name":"taskId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":242,"b":247,"line":18,"col":3}]}},{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":253,"b":258,"line":19,"col":3}]}},{"name":"meetingId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":264,"b":272,"line":20,"col":3}]}},{"name":"stageId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":278,"b":284,"line":21,"col":3}]}},{"name":"discussionId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":290,"b":301,"line":22,"col":3}]}},{"name":"jiraFieldId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":307,"b":317,"line":23,"col":3}]}}],"usedParamSet":{"changeSource":true,"name":true,"label":true,"taskId":true,"userId":true,"meetingId":true,"stageId":true,"discussionId":true,"jiraFieldId":true},"statement":{"body":"INSERT INTO \"TaskEstimate\" (\n  \"changeSource\",\n  \"name\",\n  \"label\",\n  \"taskId\",\n  \"userId\",\n  \"meetingId\",\n  \"stageId\",\n  \"discussionId\",\n  \"jiraFieldId\"\n) VALUES (\n  :changeSource,\n  :name,\n  :label,\n  :taskId,\n  :userId,\n  :meetingId,\n  :stageId,\n  :discussionId,\n  :jiraFieldId\n)","loc":{"a":38,"b":319,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -118,7 +53,6 @@ const insertTaskEstimateQueryIR: any = {
  * )
  * ```
  */
-export const insertTaskEstimateQuery = new PreparedQuery<
-  IInsertTaskEstimateQueryParams,
-  IInsertTaskEstimateQueryResult
->(insertTaskEstimateQueryIR)
+export const insertTaskEstimateQuery = new PreparedQuery<IInsertTaskEstimateQueryParams,IInsertTaskEstimateQueryResult>(insertTaskEstimateQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertTeamQuery.ts
+++ b/packages/server/postgres/queries/generated/insertTeamQuery.ts
@@ -1,112 +1,35 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertTeamQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker'
+export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker';
 
-export type TierEnum = 'personal' | 'pro' | 'enterprise'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
 /** 'InsertTeamQuery' parameters type */
 export interface IInsertTeamQueryParams {
-  id: string | null | void
-  name: string | null | void
-  createdAt: Date | null | void
-  createdBy: string | null | void
-  isArchived: boolean | null | void
-  isPaid: boolean | null | void
-  lastMeetingType: MeetingTypeEnum | null | void
-  tier: TierEnum | null | void
-  orgId: string | null | void
-  isOnboardTeam: boolean | null | void
-  updatedAt: Date | null | void
+  id: string | null | void;
+  name: string | null | void;
+  createdAt: Date | null | void;
+  createdBy: string | null | void;
+  isArchived: boolean | null | void;
+  isPaid: boolean | null | void;
+  lastMeetingType: MeetingTypeEnum | null | void;
+  tier: TierEnum | null | void;
+  orgId: string | null | void;
+  isOnboardTeam: boolean | null | void;
+  updatedAt: Date | null | void;
 }
 
 /** 'InsertTeamQuery' return type */
-export type IInsertTeamQueryResult = void
+export type IInsertTeamQueryResult = void;
 
 /** 'InsertTeamQuery' query type */
 export interface IInsertTeamQueryQuery {
-  params: IInsertTeamQueryParams
-  result: IInsertTeamQueryResult
+  params: IInsertTeamQueryParams;
+  result: IInsertTeamQueryResult;
 }
 
-const insertTeamQueryIR: any = {
-  name: 'insertTeamQuery',
-  params: [
-    {
-      name: 'id',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 216, b: 217, line: 17, col: 3}]}
-    },
-    {
-      name: 'name',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 223, b: 226, line: 18, col: 3}]}
-    },
-    {
-      name: 'createdAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 232, b: 240, line: 19, col: 3}]}
-    },
-    {
-      name: 'createdBy',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 246, b: 254, line: 20, col: 3}]}
-    },
-    {
-      name: 'isArchived',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 260, b: 269, line: 21, col: 3}]}
-    },
-    {
-      name: 'isPaid',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 275, b: 280, line: 22, col: 3}]}
-    },
-    {
-      name: 'lastMeetingType',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 286, b: 300, line: 23, col: 3}]}
-    },
-    {
-      name: 'tier',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 306, b: 309, line: 24, col: 3}]}
-    },
-    {
-      name: 'orgId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 315, b: 319, line: 25, col: 3}]}
-    },
-    {
-      name: 'isOnboardTeam',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 325, b: 337, line: 26, col: 3}]}
-    },
-    {
-      name: 'updatedAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 343, b: 351, line: 27, col: 3}]}
-    }
-  ],
-  usedParamSet: {
-    id: true,
-    name: true,
-    createdAt: true,
-    createdBy: true,
-    isArchived: true,
-    isPaid: true,
-    lastMeetingType: true,
-    tier: true,
-    orgId: true,
-    isOnboardTeam: true,
-    updatedAt: true
-  },
-  statement: {
-    body:
-      'INSERT INTO "Team" (\n  "id",\n  "name",\n  "createdAt",\n  "createdBy",\n  "isArchived",\n  "isPaid",\n  "lastMeetingType",\n  "tier",\n  "orgId",\n  "isOnboardTeam",\n  "updatedAt"\n) VALUES (\n  :id,\n  :name,\n  :createdAt,\n  :createdBy,\n  :isArchived,\n  :isPaid,\n  :lastMeetingType,\n  :tier,\n  :orgId,\n  :isOnboardTeam,\n  :updatedAt\n)',
-    loc: {a: 30, b: 353, line: 4, col: 0}
-  }
-}
+const insertTeamQueryIR: any = {"name":"insertTeamQuery","params":[{"name":"id","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":216,"b":217,"line":17,"col":3}]}},{"name":"name","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":223,"b":226,"line":18,"col":3}]}},{"name":"createdAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":232,"b":240,"line":19,"col":3}]}},{"name":"createdBy","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":246,"b":254,"line":20,"col":3}]}},{"name":"isArchived","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":260,"b":269,"line":21,"col":3}]}},{"name":"isPaid","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":275,"b":280,"line":22,"col":3}]}},{"name":"lastMeetingType","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":286,"b":300,"line":23,"col":3}]}},{"name":"tier","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":306,"b":309,"line":24,"col":3}]}},{"name":"orgId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":315,"b":319,"line":25,"col":3}]}},{"name":"isOnboardTeam","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":325,"b":337,"line":26,"col":3}]}},{"name":"updatedAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":343,"b":351,"line":27,"col":3}]}}],"usedParamSet":{"id":true,"name":true,"createdAt":true,"createdBy":true,"isArchived":true,"isPaid":true,"lastMeetingType":true,"tier":true,"orgId":true,"isOnboardTeam":true,"updatedAt":true},"statement":{"body":"INSERT INTO \"Team\" (\n  \"id\",\n  \"name\",\n  \"createdAt\",\n  \"createdBy\",\n  \"isArchived\",\n  \"isPaid\",\n  \"lastMeetingType\",\n  \"tier\",\n  \"orgId\",\n  \"isOnboardTeam\",\n  \"updatedAt\"\n) VALUES (\n  :id,\n  :name,\n  :createdAt,\n  :createdBy,\n  :isArchived,\n  :isPaid,\n  :lastMeetingType,\n  :tier,\n  :orgId,\n  :isOnboardTeam,\n  :updatedAt\n)","loc":{"a":30,"b":353,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -138,6 +61,6 @@ const insertTeamQueryIR: any = {
  * )
  * ```
  */
-export const insertTeamQuery = new PreparedQuery<IInsertTeamQueryParams, IInsertTeamQueryResult>(
-  insertTeamQueryIR
-)
+export const insertTeamQuery = new PreparedQuery<IInsertTeamQueryParams,IInsertTeamQueryResult>(insertTeamQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertTemplateRefQuery.ts
+++ b/packages/server/postgres/queries/generated/insertTemplateRefQuery.ts
@@ -1,44 +1,26 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertTemplateRefQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type Json = null | boolean | number | string | Json[] | {[key: string]: Json}
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 /** 'InsertTemplateRefQuery' parameters type */
 export interface IInsertTemplateRefQueryParams {
   ref: {
-    id: string | null | void
+    id: string | null | void,
     template: Json | null | void
-  }
+  };
 }
 
 /** 'InsertTemplateRefQuery' return type */
-export type IInsertTemplateRefQueryResult = void
+export type IInsertTemplateRefQueryResult = void;
 
 /** 'InsertTemplateRefQuery' query type */
 export interface IInsertTemplateRefQueryQuery {
-  params: IInsertTemplateRefQueryParams
-  result: IInsertTemplateRefQueryResult
+  params: IInsertTemplateRefQueryParams;
+  result: IInsertTemplateRefQueryResult;
 }
 
-const insertTemplateRefQueryIR: any = {
-  name: 'insertTemplateRefQuery',
-  params: [
-    {
-      name: 'ref',
-      codeRefs: {
-        defined: {a: 43, b: 45, line: 3, col: 9},
-        used: [{a: 127, b: 129, line: 9, col: 8}]
-      },
-      transform: {type: 'pick_tuple', keys: ['id', 'template']}
-    }
-  ],
-  usedParamSet: {ref: true},
-  statement: {
-    body:
-      'INSERT INTO "TemplateRef" (\n  "id",\n  "template"\n)\nVALUES :ref\nON CONFLICT (id)\nDO NOTHING',
-    loc: {a: 68, b: 157, line: 5, col: 0}
-  }
-}
+const insertTemplateRefQueryIR: any = {"name":"insertTemplateRefQuery","params":[{"name":"ref","codeRefs":{"defined":{"a":43,"b":45,"line":3,"col":9},"used":[{"a":127,"b":129,"line":9,"col":8}]},"transform":{"type":"pick_tuple","keys":["id","template"]}}],"usedParamSet":{"ref":true},"statement":{"body":"INSERT INTO \"TemplateRef\" (\n  \"id\",\n  \"template\"\n)\nVALUES :ref\nON CONFLICT (id)\nDO NOTHING","loc":{"a":68,"b":157,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -52,7 +34,6 @@ const insertTemplateRefQueryIR: any = {
  * DO NOTHING
  * ```
  */
-export const insertTemplateRefQuery = new PreparedQuery<
-  IInsertTemplateRefQueryParams,
-  IInsertTemplateRefQueryResult
->(insertTemplateRefQueryIR)
+export const insertTemplateRefQuery = new PreparedQuery<IInsertTemplateRefQueryParams,IInsertTemplateRefQueryResult>(insertTemplateRefQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertTemplateScaleRefQuery.ts
+++ b/packages/server/postgres/queries/generated/insertTemplateScaleRefQuery.ts
@@ -1,44 +1,26 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertTemplateScaleRefQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type Json = null | boolean | number | string | Json[] | {[key: string]: Json}
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
 
 /** 'InsertTemplateScaleRefQuery' parameters type */
 export interface IInsertTemplateScaleRefQueryParams {
   templateScales: Array<{
-    id: string | null | void
+    id: string | null | void,
     scale: Json | null | void
-  }>
+  }>;
 }
 
 /** 'InsertTemplateScaleRefQuery' return type */
-export type IInsertTemplateScaleRefQueryResult = void
+export type IInsertTemplateScaleRefQueryResult = void;
 
 /** 'InsertTemplateScaleRefQuery' query type */
 export interface IInsertTemplateScaleRefQueryQuery {
-  params: IInsertTemplateScaleRefQueryParams
-  result: IInsertTemplateScaleRefQueryResult
+  params: IInsertTemplateScaleRefQueryParams;
+  result: IInsertTemplateScaleRefQueryResult;
 }
 
-const insertTemplateScaleRefQueryIR: any = {
-  name: 'insertTemplateScaleRefQuery',
-  params: [
-    {
-      name: 'templateScales',
-      codeRefs: {
-        defined: {a: 48, b: 61, line: 3, col: 9},
-        used: [{a: 147, b: 160, line: 9, col: 8}]
-      },
-      transform: {type: 'pick_array_spread', keys: ['id', 'scale']}
-    }
-  ],
-  usedParamSet: {templateScales: true},
-  statement: {
-    body:
-      'INSERT INTO "TemplateScaleRef" (\n  "id",\n  "scale"\n)\nVALUES :templateScales\nON CONFLICT (id)\nDO NOTHING',
-    loc: {a: 86, b: 188, line: 5, col: 0}
-  }
-}
+const insertTemplateScaleRefQueryIR: any = {"name":"insertTemplateScaleRefQuery","params":[{"name":"templateScales","codeRefs":{"defined":{"a":48,"b":61,"line":3,"col":9},"used":[{"a":147,"b":160,"line":9,"col":8}]},"transform":{"type":"pick_array_spread","keys":["id","scale"]}}],"usedParamSet":{"templateScales":true},"statement":{"body":"INSERT INTO \"TemplateScaleRef\" (\n  \"id\",\n  \"scale\"\n)\nVALUES :templateScales\nON CONFLICT (id)\nDO NOTHING","loc":{"a":86,"b":188,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -52,7 +34,6 @@ const insertTemplateScaleRefQueryIR: any = {
  * DO NOTHING
  * ```
  */
-export const insertTemplateScaleRefQuery = new PreparedQuery<
-  IInsertTemplateScaleRefQueryParams,
-  IInsertTemplateScaleRefQueryResult
->(insertTemplateScaleRefQueryIR)
+export const insertTemplateScaleRefQuery = new PreparedQuery<IInsertTemplateScaleRefQueryParams,IInsertTemplateScaleRefQueryResult>(insertTemplateScaleRefQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/insertUserQuery.ts
+++ b/packages/server/postgres/queries/generated/insertUserQuery.ts
@@ -1,135 +1,40 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/insertUserQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'InsertUserQuery' parameters type */
 export interface IInsertUserQueryParams {
-  id: string | null | void
-  email: string | null | void
-  createdAt: Date | null | void
-  updatedAt: Date | null | void
-  inactive: boolean | null | void
-  lastSeenAt: Date | null | void
-  preferredName: string | null | void
-  tier: TierEnum | null | void
-  picture: string | null | void
-  tms: stringArray | null | void
-  featureFlags: stringArray | null | void
-  lastSeenAtURLs: stringArray | null | void
-  segmentId: string | null | void
-  identities: JsonArray | null | void
+  id: string | null | void;
+  email: string | null | void;
+  createdAt: Date | null | void;
+  updatedAt: Date | null | void;
+  inactive: boolean | null | void;
+  lastSeenAt: Date | null | void;
+  preferredName: string | null | void;
+  tier: TierEnum | null | void;
+  picture: string | null | void;
+  tms: stringArray | null | void;
+  featureFlags: stringArray | null | void;
+  lastSeenAtURLs: stringArray | null | void;
+  segmentId: string | null | void;
+  identities: JsonArray | null | void;
 }
 
 /** 'InsertUserQuery' return type */
-export type IInsertUserQueryResult = void
+export type IInsertUserQueryResult = void;
 
 /** 'InsertUserQuery' query type */
 export interface IInsertUserQueryQuery {
-  params: IInsertUserQueryParams
-  result: IInsertUserQueryResult
+  params: IInsertUserQueryParams;
+  result: IInsertUserQueryResult;
 }
 
-const insertUserQueryIR: any = {
-  name: 'insertUserQuery',
-  params: [
-    {
-      name: 'id',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 264, b: 265, line: 20, col: 3}]}
-    },
-    {
-      name: 'email',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 271, b: 275, line: 21, col: 3}]}
-    },
-    {
-      name: 'createdAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 281, b: 289, line: 22, col: 3}]}
-    },
-    {
-      name: 'updatedAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 295, b: 303, line: 23, col: 3}]}
-    },
-    {
-      name: 'inactive',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 309, b: 316, line: 24, col: 3}]}
-    },
-    {
-      name: 'lastSeenAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 322, b: 331, line: 25, col: 3}]}
-    },
-    {
-      name: 'preferredName',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 337, b: 349, line: 26, col: 3}]}
-    },
-    {
-      name: 'tier',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 355, b: 358, line: 27, col: 3}]}
-    },
-    {
-      name: 'picture',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 364, b: 370, line: 28, col: 3}]}
-    },
-    {
-      name: 'tms',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 376, b: 378, line: 29, col: 3}]}
-    },
-    {
-      name: 'featureFlags',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 384, b: 395, line: 30, col: 3}]}
-    },
-    {
-      name: 'lastSeenAtURLs',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 401, b: 414, line: 31, col: 3}]}
-    },
-    {
-      name: 'segmentId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 420, b: 428, line: 32, col: 3}]}
-    },
-    {
-      name: 'identities',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 434, b: 443, line: 33, col: 3}]}
-    }
-  ],
-  usedParamSet: {
-    id: true,
-    email: true,
-    createdAt: true,
-    updatedAt: true,
-    inactive: true,
-    lastSeenAt: true,
-    preferredName: true,
-    tier: true,
-    picture: true,
-    tms: true,
-    featureFlags: true,
-    lastSeenAtURLs: true,
-    segmentId: true,
-    identities: true
-  },
-  statement: {
-    body:
-      'INSERT INTO "User" (\n  "id",\n  "email",\n  "createdAt", \n  "updatedAt",\n  "inactive",\n  "lastSeenAt",\n  "preferredName",\n  "tier",\n  "picture",\n  "tms",\n  "featureFlags",\n  "lastSeenAtURLs",\n  "segmentId",\n  "identities"\n) VALUES (\n  :id,\n  :email,\n  :createdAt,\n  :updatedAt,\n  :inactive,\n  :lastSeenAt,\n  :preferredName,\n  :tier,\n  :picture,\n  :tms,\n  :featureFlags,\n  :lastSeenAtURLs,\n  :segmentId,\n  :identities\n)',
-    loc: {a: 30, b: 445, line: 4, col: 0}
-  }
-}
+const insertUserQueryIR: any = {"name":"insertUserQuery","params":[{"name":"id","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":264,"b":265,"line":20,"col":3}]}},{"name":"email","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":271,"b":275,"line":21,"col":3}]}},{"name":"createdAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":281,"b":289,"line":22,"col":3}]}},{"name":"updatedAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":295,"b":303,"line":23,"col":3}]}},{"name":"inactive","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":309,"b":316,"line":24,"col":3}]}},{"name":"lastSeenAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":322,"b":331,"line":25,"col":3}]}},{"name":"preferredName","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":337,"b":349,"line":26,"col":3}]}},{"name":"tier","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":355,"b":358,"line":27,"col":3}]}},{"name":"picture","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":364,"b":370,"line":28,"col":3}]}},{"name":"tms","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":376,"b":378,"line":29,"col":3}]}},{"name":"featureFlags","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":384,"b":395,"line":30,"col":3}]}},{"name":"lastSeenAtURLs","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":401,"b":414,"line":31,"col":3}]}},{"name":"segmentId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":420,"b":428,"line":32,"col":3}]}},{"name":"identities","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":434,"b":443,"line":33,"col":3}]}}],"usedParamSet":{"id":true,"email":true,"createdAt":true,"updatedAt":true,"inactive":true,"lastSeenAt":true,"preferredName":true,"tier":true,"picture":true,"tms":true,"featureFlags":true,"lastSeenAtURLs":true,"segmentId":true,"identities":true},"statement":{"body":"INSERT INTO \"User\" (\n  \"id\",\n  \"email\",\n  \"createdAt\", \n  \"updatedAt\",\n  \"inactive\",\n  \"lastSeenAt\",\n  \"preferredName\",\n  \"tier\",\n  \"picture\",\n  \"tms\",\n  \"featureFlags\",\n  \"lastSeenAtURLs\",\n  \"segmentId\",\n  \"identities\"\n) VALUES (\n  :id,\n  :email,\n  :createdAt,\n  :updatedAt,\n  :inactive,\n  :lastSeenAt,\n  :preferredName,\n  :tier,\n  :picture,\n  :tms,\n  :featureFlags,\n  :lastSeenAtURLs,\n  :segmentId,\n  :identities\n)","loc":{"a":30,"b":445,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -137,7 +42,7 @@ const insertUserQueryIR: any = {
  * INSERT INTO "User" (
  *   "id",
  *   "email",
- *   "createdAt",
+ *   "createdAt", 
  *   "updatedAt",
  *   "inactive",
  *   "lastSeenAt",
@@ -167,6 +72,6 @@ const insertUserQueryIR: any = {
  * )
  * ```
  */
-export const insertUserQuery = new PreparedQuery<IInsertUserQueryParams, IInsertUserQueryResult>(
-  insertUserQueryIR
-)
+export const insertUserQuery = new PreparedQuery<IInsertUserQueryParams,IInsertUserQueryResult>(insertUserQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/mergeTeamJiraDimensionFieldsQuery.ts
+++ b/packages/server/postgres/queries/generated/mergeTeamJiraDimensionFieldsQuery.ts
@@ -1,44 +1,24 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/mergeTeamJiraDimensionFieldsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'MergeTeamJiraDimensionFieldsQuery' parameters type */
 export interface IMergeTeamJiraDimensionFieldsQueryParams {
-  jiraDimensionFields: JsonArray | null | void
-  id: string | null | void
+  jiraDimensionFields: JsonArray | null | void;
+  id: string | null | void;
 }
 
 /** 'MergeTeamJiraDimensionFieldsQuery' return type */
-export type IMergeTeamJiraDimensionFieldsQueryResult = void
+export type IMergeTeamJiraDimensionFieldsQueryResult = void;
 
 /** 'MergeTeamJiraDimensionFieldsQuery' query type */
 export interface IMergeTeamJiraDimensionFieldsQueryQuery {
-  params: IMergeTeamJiraDimensionFieldsQueryParams
-  result: IMergeTeamJiraDimensionFieldsQueryResult
+  params: IMergeTeamJiraDimensionFieldsQueryParams;
+  result: IMergeTeamJiraDimensionFieldsQueryResult;
 }
 
-const mergeTeamJiraDimensionFieldsQueryIR: any = {
-  name: 'mergeTeamJiraDimensionFieldsQuery',
-  params: [
-    {
-      name: 'jiraDimensionFields',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 126, b: 144, line: 5, col: 60}]}
-    },
-    {
-      name: 'id',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 161, b: 162, line: 6, col: 14}]}
-    }
-  ],
-  usedParamSet: {jiraDimensionFields: true, id: true},
-  statement: {
-    body:
-      'UPDATE "Team" SET\n  "jiraDimensionFields" = arr_merge("jiraDimensionFields", :jiraDimensionFields)\nWHERE "id" = :id',
-    loc: {a: 48, b: 162, line: 4, col: 0}
-  }
-}
+const mergeTeamJiraDimensionFieldsQueryIR: any = {"name":"mergeTeamJiraDimensionFieldsQuery","params":[{"name":"jiraDimensionFields","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":126,"b":144,"line":5,"col":60}]}},{"name":"id","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":161,"b":162,"line":6,"col":14}]}}],"usedParamSet":{"jiraDimensionFields":true,"id":true},"statement":{"body":"UPDATE \"Team\" SET\n  \"jiraDimensionFields\" = arr_merge(\"jiraDimensionFields\", :jiraDimensionFields)\nWHERE \"id\" = :id","loc":{"a":48,"b":162,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -48,7 +28,6 @@ const mergeTeamJiraDimensionFieldsQueryIR: any = {
  * WHERE "id" = :id
  * ```
  */
-export const mergeTeamJiraDimensionFieldsQuery = new PreparedQuery<
-  IMergeTeamJiraDimensionFieldsQueryParams,
-  IMergeTeamJiraDimensionFieldsQueryResult
->(mergeTeamJiraDimensionFieldsQueryIR)
+export const mergeTeamJiraDimensionFieldsQuery = new PreparedQuery<IMergeTeamJiraDimensionFieldsQueryParams,IMergeTeamJiraDimensionFieldsQueryResult>(mergeTeamJiraDimensionFieldsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/removeAtlassianAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/removeAtlassianAuthQuery.ts
@@ -1,42 +1,22 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/removeAtlassianAuthQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'RemoveAtlassianAuthQuery' parameters type */
 export interface IRemoveAtlassianAuthQueryParams {
-  userId: string | null | void
-  teamId: string | null | void
+  userId: string | null | void;
+  teamId: string | null | void;
 }
 
 /** 'RemoveAtlassianAuthQuery' return type */
-export type IRemoveAtlassianAuthQueryResult = void
+export type IRemoveAtlassianAuthQueryResult = void;
 
 /** 'RemoveAtlassianAuthQuery' query type */
 export interface IRemoveAtlassianAuthQueryQuery {
-  params: IRemoveAtlassianAuthQueryParams
-  result: IRemoveAtlassianAuthQueryResult
+  params: IRemoveAtlassianAuthQueryParams;
+  result: IRemoveAtlassianAuthQueryResult;
 }
 
-const removeAtlassianAuthQueryIR: any = {
-  name: 'removeAtlassianAuthQuery',
-  params: [
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 136, b: 141, line: 6, col: 18}]}
-    },
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 159, b: 164, line: 6, col: 41}]}
-    }
-  ],
-  usedParamSet: {userId: true, teamId: true},
-  statement: {
-    body:
-      'UPDATE "AtlassianAuth"\nSET "isActive" = FALSE, "updatedAt" = CURRENT_TIMESTAMP\nWHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE',
-    loc: {a: 39, b: 186, line: 4, col: 0}
-  }
-}
+const removeAtlassianAuthQueryIR: any = {"name":"removeAtlassianAuthQuery","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":136,"b":141,"line":6,"col":18}]}},{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":159,"b":164,"line":6,"col":41}]}}],"usedParamSet":{"userId":true,"teamId":true},"statement":{"body":"UPDATE \"AtlassianAuth\"\nSET \"isActive\" = FALSE, \"updatedAt\" = CURRENT_TIMESTAMP\nWHERE \"userId\" = :userId AND \"teamId\" = :teamId AND \"isActive\" = TRUE","loc":{"a":39,"b":186,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -46,7 +26,6 @@ const removeAtlassianAuthQueryIR: any = {
  * WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE
  * ```
  */
-export const removeAtlassianAuthQuery = new PreparedQuery<
-  IRemoveAtlassianAuthQueryParams,
-  IRemoveAtlassianAuthQueryResult
->(removeAtlassianAuthQueryIR)
+export const removeAtlassianAuthQuery = new PreparedQuery<IRemoveAtlassianAuthQueryParams,IRemoveAtlassianAuthQueryResult>(removeAtlassianAuthQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/removeGitHubAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/removeGitHubAuthQuery.ts
@@ -1,42 +1,22 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/removeGitHubAuthQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'RemoveGitHubAuthQuery' parameters type */
 export interface IRemoveGitHubAuthQueryParams {
-  userId: string | null | void
-  teamId: string | null | void
+  userId: string | null | void;
+  teamId: string | null | void;
 }
 
 /** 'RemoveGitHubAuthQuery' return type */
-export type IRemoveGitHubAuthQueryResult = void
+export type IRemoveGitHubAuthQueryResult = void;
 
 /** 'RemoveGitHubAuthQuery' query type */
 export interface IRemoveGitHubAuthQueryQuery {
-  params: IRemoveGitHubAuthQueryParams
-  result: IRemoveGitHubAuthQueryResult
+  params: IRemoveGitHubAuthQueryParams;
+  result: IRemoveGitHubAuthQueryResult;
 }
 
-const removeGitHubAuthQueryIR: any = {
-  name: 'removeGitHubAuthQuery',
-  params: [
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 130, b: 135, line: 6, col: 18}]}
-    },
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 153, b: 158, line: 6, col: 41}]}
-    }
-  ],
-  usedParamSet: {userId: true, teamId: true},
-  statement: {
-    body:
-      'UPDATE "GitHubAuth"\nSET "isActive" = FALSE, "updatedAt" = CURRENT_TIMESTAMP\nWHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE',
-    loc: {a: 36, b: 180, line: 4, col: 0}
-  }
-}
+const removeGitHubAuthQueryIR: any = {"name":"removeGitHubAuthQuery","params":[{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":130,"b":135,"line":6,"col":18}]}},{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":153,"b":158,"line":6,"col":41}]}}],"usedParamSet":{"userId":true,"teamId":true},"statement":{"body":"UPDATE \"GitHubAuth\"\nSET \"isActive\" = FALSE, \"updatedAt\" = CURRENT_TIMESTAMP\nWHERE \"userId\" = :userId AND \"teamId\" = :teamId AND \"isActive\" = TRUE","loc":{"a":36,"b":180,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -46,7 +26,6 @@ const removeGitHubAuthQueryIR: any = {
  * WHERE "userId" = :userId AND "teamId" = :teamId AND "isActive" = TRUE
  * ```
  */
-export const removeGitHubAuthQuery = new PreparedQuery<
-  IRemoveGitHubAuthQueryParams,
-  IRemoveGitHubAuthQueryResult
->(removeGitHubAuthQueryIR)
+export const removeGitHubAuthQuery = new PreparedQuery<IRemoveGitHubAuthQueryParams,IRemoveGitHubAuthQueryResult>(removeGitHubAuthQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/removeMeetingTaskEstimatesQuery.ts
+++ b/packages/server/postgres/queries/generated/removeMeetingTaskEstimatesQuery.ts
@@ -1,35 +1,21 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/removeMeetingTaskEstimatesQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'RemoveMeetingTaskEstimatesQuery' parameters type */
 export interface IRemoveMeetingTaskEstimatesQueryParams {
-  meetingId: string | null | void
+  meetingId: string | null | void;
 }
 
 /** 'RemoveMeetingTaskEstimatesQuery' return type */
-export type IRemoveMeetingTaskEstimatesQueryResult = void
+export type IRemoveMeetingTaskEstimatesQueryResult = void;
 
 /** 'RemoveMeetingTaskEstimatesQuery' query type */
 export interface IRemoveMeetingTaskEstimatesQueryQuery {
-  params: IRemoveMeetingTaskEstimatesQueryParams
-  result: IRemoveMeetingTaskEstimatesQueryResult
+  params: IRemoveMeetingTaskEstimatesQueryParams;
+  result: IRemoveMeetingTaskEstimatesQueryResult;
 }
 
-const removeMeetingTaskEstimatesQueryIR: any = {
-  name: 'removeMeetingTaskEstimatesQuery',
-  params: [
-    {
-      name: 'meetingId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 94, b: 102, line: 5, col: 21}]}
-    }
-  ],
-  usedParamSet: {meetingId: true},
-  statement: {
-    body: 'DELETE FROM "TaskEstimate"\nWHERE "meetingId" = :meetingId',
-    loc: {a: 46, b: 102, line: 4, col: 0}
-  }
-}
+const removeMeetingTaskEstimatesQueryIR: any = {"name":"removeMeetingTaskEstimatesQuery","params":[{"name":"meetingId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":94,"b":102,"line":5,"col":21}]}}],"usedParamSet":{"meetingId":true},"statement":{"body":"DELETE FROM \"TaskEstimate\"\nWHERE \"meetingId\" = :meetingId","loc":{"a":46,"b":102,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -38,7 +24,6 @@ const removeMeetingTaskEstimatesQueryIR: any = {
  * WHERE "meetingId" = :meetingId
  * ```
  */
-export const removeMeetingTaskEstimatesQuery = new PreparedQuery<
-  IRemoveMeetingTaskEstimatesQueryParams,
-  IRemoveMeetingTaskEstimatesQueryResult
->(removeMeetingTaskEstimatesQueryIR)
+export const removeMeetingTaskEstimatesQuery = new PreparedQuery<IRemoveMeetingTaskEstimatesQueryParams,IRemoveMeetingTaskEstimatesQueryResult>(removeMeetingTaskEstimatesQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/removeUserTmsQuery.ts
+++ b/packages/server/postgres/queries/generated/removeUserTmsQuery.ts
@@ -1,46 +1,24 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/removeUserTmsQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
 /** 'RemoveUserTmsQuery' parameters type */
 export interface IRemoveUserTmsQueryParams {
-  ids: Array<string | null | void>
-  teamIds: stringArray | null | void
+  ids: Array<string | null | void>;
+  teamIds: stringArray | null | void;
 }
 
 /** 'RemoveUserTmsQuery' return type */
-export type IRemoveUserTmsQueryResult = void
+export type IRemoveUserTmsQueryResult = void;
 
 /** 'RemoveUserTmsQuery' query type */
 export interface IRemoveUserTmsQueryQuery {
-  params: IRemoveUserTmsQueryParams
-  result: IRemoveUserTmsQueryResult
+  params: IRemoveUserTmsQueryParams;
+  result: IRemoveUserTmsQueryResult;
 }
 
-const removeUserTmsQueryIR: any = {
-  name: 'removeUserTmsQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 39, b: 41, line: 3, col: 9},
-        used: [{a: 118, b: 120, line: 7, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    },
-    {
-      name: 'teamIds',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 96, b: 102, line: 6, col: 23}]}
-    }
-  ],
-  usedParamSet: {teamIds: true, ids: true},
-  statement: {
-    body: 'UPDATE "User" SET\n  tms = arr_diff(tms, :teamIds)\nWHERE id IN :ids',
-    loc: {a: 55, b: 120, line: 5, col: 0}
-  }
-}
+const removeUserTmsQueryIR: any = {"name":"removeUserTmsQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":39,"b":41,"line":3,"col":9},"used":[{"a":118,"b":120,"line":7,"col":13}]},"transform":{"type":"array_spread"}},{"name":"teamIds","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":96,"b":102,"line":6,"col":23}]}}],"usedParamSet":{"teamIds":true,"ids":true},"statement":{"body":"UPDATE \"User\" SET\n  tms = arr_diff(tms, :teamIds)\nWHERE id IN :ids","loc":{"a":55,"b":120,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -50,7 +28,6 @@ const removeUserTmsQueryIR: any = {
  * WHERE id IN :ids
  * ```
  */
-export const removeUserTmsQuery = new PreparedQuery<
-  IRemoveUserTmsQueryParams,
-  IRemoveUserTmsQueryResult
->(removeUserTmsQueryIR)
+export const removeUserTmsQuery = new PreparedQuery<IRemoveUserTmsQueryParams,IRemoveUserTmsQueryResult>(removeUserTmsQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/updateGitHubSearchQueriesQuery.ts
+++ b/packages/server/postgres/queries/generated/updateGitHubSearchQueriesQuery.ts
@@ -1,50 +1,25 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateGitHubSearchQueriesQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'UpdateGitHubSearchQueriesQuery' parameters type */
 export interface IUpdateGitHubSearchQueriesQueryParams {
-  githubSearchQueries: JsonArray | null | void
-  teamId: string | null | void
-  userId: string | null | void
+  githubSearchQueries: JsonArray | null | void;
+  teamId: string | null | void;
+  userId: string | null | void;
 }
 
 /** 'UpdateGitHubSearchQueriesQuery' return type */
-export type IUpdateGitHubSearchQueriesQueryResult = void
+export type IUpdateGitHubSearchQueriesQueryResult = void;
 
 /** 'UpdateGitHubSearchQueriesQuery' query type */
 export interface IUpdateGitHubSearchQueriesQueryQuery {
-  params: IUpdateGitHubSearchQueriesQueryParams
-  result: IUpdateGitHubSearchQueriesQueryResult
+  params: IUpdateGitHubSearchQueriesQueryParams;
+  result: IUpdateGitHubSearchQueriesQueryResult;
 }
 
-const updateGitHubSearchQueriesQueryIR: any = {
-  name: 'updateGitHubSearchQueriesQuery',
-  params: [
-    {
-      name: 'githubSearchQueries',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 97, b: 115, line: 6, col: 27}]}
-    },
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 135, b: 140, line: 7, col: 18}]}
-    },
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 158, b: 163, line: 7, col: 41}]}
-    }
-  ],
-  usedParamSet: {githubSearchQueries: true, teamId: true, userId: true},
-  statement: {
-    body:
-      'UPDATE "GitHubAuth" SET\n  "githubSearchQueries" = :githubSearchQueries\nWHERE "teamId" = :teamId AND "userId" = :userId',
-    loc: {a: 46, b: 163, line: 5, col: 0}
-  }
-}
+const updateGitHubSearchQueriesQueryIR: any = {"name":"updateGitHubSearchQueriesQuery","params":[{"name":"githubSearchQueries","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":97,"b":115,"line":6,"col":27}]}},{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":135,"b":140,"line":7,"col":18}]}},{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":158,"b":163,"line":7,"col":41}]}}],"usedParamSet":{"githubSearchQueries":true,"teamId":true,"userId":true},"statement":{"body":"UPDATE \"GitHubAuth\" SET\n  \"githubSearchQueries\" = :githubSearchQueries\nWHERE \"teamId\" = :teamId AND \"userId\" = :userId","loc":{"a":46,"b":163,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -54,7 +29,6 @@ const updateGitHubSearchQueriesQueryIR: any = {
  * WHERE "teamId" = :teamId AND "userId" = :userId
  * ```
  */
-export const updateGitHubSearchQueriesQuery = new PreparedQuery<
-  IUpdateGitHubSearchQueriesQueryParams,
-  IUpdateGitHubSearchQueriesQueryResult
->(updateGitHubSearchQueriesQueryIR)
+export const updateGitHubSearchQueriesQuery = new PreparedQuery<IUpdateGitHubSearchQueriesQueryParams,IUpdateGitHubSearchQueriesQueryResult>(updateGitHubSearchQueriesQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/updateJiraSearchQueriesQuery.ts
+++ b/packages/server/postgres/queries/generated/updateJiraSearchQueriesQuery.ts
@@ -1,50 +1,25 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateJiraSearchQueriesQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'UpdateJiraSearchQueriesQuery' parameters type */
 export interface IUpdateJiraSearchQueriesQueryParams {
-  jiraSearchQueries: JsonArray | null | void
-  teamId: string | null | void
-  userId: string | null | void
+  jiraSearchQueries: JsonArray | null | void;
+  teamId: string | null | void;
+  userId: string | null | void;
 }
 
 /** 'UpdateJiraSearchQueriesQuery' return type */
-export type IUpdateJiraSearchQueriesQueryResult = void
+export type IUpdateJiraSearchQueriesQueryResult = void;
 
 /** 'UpdateJiraSearchQueriesQuery' query type */
 export interface IUpdateJiraSearchQueriesQueryQuery {
-  params: IUpdateJiraSearchQueriesQueryParams
-  result: IUpdateJiraSearchQueriesQueryResult
+  params: IUpdateJiraSearchQueriesQueryParams;
+  result: IUpdateJiraSearchQueriesQueryResult;
 }
 
-const updateJiraSearchQueriesQueryIR: any = {
-  name: 'updateJiraSearchQueriesQuery',
-  params: [
-    {
-      name: 'jiraSearchQueries',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 96, b: 112, line: 6, col: 25}]}
-    },
-    {
-      name: 'teamId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 132, b: 137, line: 7, col: 18}]}
-    },
-    {
-      name: 'userId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 155, b: 160, line: 7, col: 41}]}
-    }
-  ],
-  usedParamSet: {jiraSearchQueries: true, teamId: true, userId: true},
-  statement: {
-    body:
-      'UPDATE "AtlassianAuth" SET\n  "jiraSearchQueries" = :jiraSearchQueries\nWHERE "teamId" = :teamId AND "userId" = :userId',
-    loc: {a: 44, b: 160, line: 5, col: 0}
-  }
-}
+const updateJiraSearchQueriesQueryIR: any = {"name":"updateJiraSearchQueriesQuery","params":[{"name":"jiraSearchQueries","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":96,"b":112,"line":6,"col":25}]}},{"name":"teamId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":132,"b":137,"line":7,"col":18}]}},{"name":"userId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":155,"b":160,"line":7,"col":41}]}}],"usedParamSet":{"jiraSearchQueries":true,"teamId":true,"userId":true},"statement":{"body":"UPDATE \"AtlassianAuth\" SET\n  \"jiraSearchQueries\" = :jiraSearchQueries\nWHERE \"teamId\" = :teamId AND \"userId\" = :userId","loc":{"a":44,"b":160,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -54,7 +29,6 @@ const updateJiraSearchQueriesQueryIR: any = {
  * WHERE "teamId" = :teamId AND "userId" = :userId
  * ```
  */
-export const updateJiraSearchQueriesQuery = new PreparedQuery<
-  IUpdateJiraSearchQueriesQueryParams,
-  IUpdateJiraSearchQueriesQueryResult
->(updateJiraSearchQueriesQueryIR)
+export const updateJiraSearchQueriesQuery = new PreparedQuery<IUpdateJiraSearchQueriesQueryParams,IUpdateJiraSearchQueriesQueryResult>(updateJiraSearchQueriesQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/updateTeamByOrgIdQuery.ts
+++ b/packages/server/postgres/queries/generated/updateTeamByOrgIdQuery.ts
@@ -1,98 +1,34 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateTeamByOrgIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker'
+export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker';
 
-export type TierEnum = 'personal' | 'pro' | 'enterprise'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'UpdateTeamByOrgIdQuery' parameters type */
 export interface IUpdateTeamByOrgIdQueryParams {
-  name: string | null | void
-  isArchived: boolean | null | void
-  isPaid: boolean | null | void
-  jiraDimensionFields: JsonArray | null | void
-  lastMeetingType: MeetingTypeEnum | null | void
-  tier: TierEnum | null | void
-  orgId: string | null | void
-  updatedAt: Date | null | void
+  name: string | null | void;
+  isArchived: boolean | null | void;
+  isPaid: boolean | null | void;
+  jiraDimensionFields: JsonArray | null | void;
+  lastMeetingType: MeetingTypeEnum | null | void;
+  tier: TierEnum | null | void;
+  orgId: string | null | void;
+  updatedAt: Date | null | void;
 }
 
 /** 'UpdateTeamByOrgIdQuery' return type */
-export type IUpdateTeamByOrgIdQueryResult = void
+export type IUpdateTeamByOrgIdQueryResult = void;
 
 /** 'UpdateTeamByOrgIdQuery' query type */
 export interface IUpdateTeamByOrgIdQueryQuery {
-  params: IUpdateTeamByOrgIdQueryParams
-  result: IUpdateTeamByOrgIdQueryResult
+  params: IUpdateTeamByOrgIdQueryParams;
+  result: IUpdateTeamByOrgIdQueryResult;
 }
 
-const updateTeamByOrgIdQueryIR: any = {
-  name: 'updateTeamByOrgIdQuery',
-  params: [
-    {
-      name: 'name',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 76, b: 79, line: 5, col: 21}]}
-    },
-    {
-      name: 'isArchived',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 118, b: 127, line: 6, col: 27}]}
-    },
-    {
-      name: 'isPaid',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 168, b: 173, line: 7, col: 23}]}
-    },
-    {
-      name: 'jiraDimensionFields',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 223, b: 241, line: 8, col: 36}]}
-    },
-    {
-      name: 'lastMeetingType',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 300, b: 314, line: 9, col: 32}]}
-    },
-    {
-      name: 'tier',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 358, b: 361, line: 10, col: 21}]}
-    },
-    {
-      name: 'orgId',
-      transform: {type: 'scalar'},
-      codeRefs: {
-        used: [
-          {a: 395, b: 399, line: 11, col: 22},
-          {a: 479, b: 483, line: 13, col: 17}
-        ]
-      }
-    },
-    {
-      name: 'updatedAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 438, b: 446, line: 12, col: 26}]}
-    }
-  ],
-  usedParamSet: {
-    name: true,
-    isArchived: true,
-    isPaid: true,
-    jiraDimensionFields: true,
-    lastMeetingType: true,
-    tier: true,
-    orgId: true,
-    updatedAt: true
-  },
-  statement: {
-    body:
-      'UPDATE "Team" SET\n  "name" = COALESCE(:name, "name"),\n  "isArchived" = COALESCE(:isArchived, "isArchived"),\n  "isPaid" = COALESCE(:isPaid, "isPaid"),\n  "jiraDimensionFields" = COALESCE(:jiraDimensionFields, "jiraDimensionFields"),\n  "lastMeetingType" = COALESCE(:lastMeetingType, "lastMeetingType"),\n  "tier" = COALESCE(:tier, "tier"),\n  "orgId" = COALESCE(:orgId, "orgId"),\n  "updatedAt" = COALESCE(:updatedAt, "updatedAt")\nWHERE "orgId" = :orgId',
-    loc: {a: 37, b: 483, line: 4, col: 0}
-  }
-}
+const updateTeamByOrgIdQueryIR: any = {"name":"updateTeamByOrgIdQuery","params":[{"name":"name","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":76,"b":79,"line":5,"col":21}]}},{"name":"isArchived","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":118,"b":127,"line":6,"col":27}]}},{"name":"isPaid","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":168,"b":173,"line":7,"col":23}]}},{"name":"jiraDimensionFields","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":223,"b":241,"line":8,"col":36}]}},{"name":"lastMeetingType","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":300,"b":314,"line":9,"col":32}]}},{"name":"tier","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":358,"b":361,"line":10,"col":21}]}},{"name":"orgId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":395,"b":399,"line":11,"col":22},{"a":479,"b":483,"line":13,"col":17}]}},{"name":"updatedAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":438,"b":446,"line":12,"col":26}]}}],"usedParamSet":{"name":true,"isArchived":true,"isPaid":true,"jiraDimensionFields":true,"lastMeetingType":true,"tier":true,"orgId":true,"updatedAt":true},"statement":{"body":"UPDATE \"Team\" SET\n  \"name\" = COALESCE(:name, \"name\"),\n  \"isArchived\" = COALESCE(:isArchived, \"isArchived\"),\n  \"isPaid\" = COALESCE(:isPaid, \"isPaid\"),\n  \"jiraDimensionFields\" = COALESCE(:jiraDimensionFields, \"jiraDimensionFields\"),\n  \"lastMeetingType\" = COALESCE(:lastMeetingType, \"lastMeetingType\"),\n  \"tier\" = COALESCE(:tier, \"tier\"),\n  \"orgId\" = COALESCE(:orgId, \"orgId\"),\n  \"updatedAt\" = COALESCE(:updatedAt, \"updatedAt\")\nWHERE \"orgId\" = :orgId","loc":{"a":37,"b":483,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -109,7 +45,6 @@ const updateTeamByOrgIdQueryIR: any = {
  * WHERE "orgId" = :orgId
  * ```
  */
-export const updateTeamByOrgIdQuery = new PreparedQuery<
-  IUpdateTeamByOrgIdQueryParams,
-  IUpdateTeamByOrgIdQueryResult
->(updateTeamByOrgIdQueryIR)
+export const updateTeamByOrgIdQuery = new PreparedQuery<IUpdateTeamByOrgIdQueryParams,IUpdateTeamByOrgIdQueryResult>(updateTeamByOrgIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/updateTeamByTeamIdQuery.ts
+++ b/packages/server/postgres/queries/generated/updateTeamByTeamIdQuery.ts
@@ -1,110 +1,36 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateTeamByTeamIdQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker'
+export type MeetingTypeEnum = 'action' | 'retrospective' | 'poker';
 
-export type TierEnum = 'personal' | 'pro' | 'enterprise'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'UpdateTeamByTeamIdQuery' parameters type */
 export interface IUpdateTeamByTeamIdQueryParams {
-  ids: Array<string | null | void>
-  name: string | null | void
-  isArchived: boolean | null | void
-  isPaid: boolean | null | void
-  jiraDimensionFields: JsonArray | null | void
-  lastMeetingType: MeetingTypeEnum | null | void
-  tier: TierEnum | null | void
-  orgId: string | null | void
-  updatedAt: Date | null | void
-  lockMessageHTML: string | null | void
+  ids: Array<string | null | void>;
+  name: string | null | void;
+  isArchived: boolean | null | void;
+  isPaid: boolean | null | void;
+  jiraDimensionFields: JsonArray | null | void;
+  lastMeetingType: MeetingTypeEnum | null | void;
+  tier: TierEnum | null | void;
+  orgId: string | null | void;
+  updatedAt: Date | null | void;
+  lockMessageHTML: string | null | void;
 }
 
 /** 'UpdateTeamByTeamIdQuery' return type */
-export type IUpdateTeamByTeamIdQueryResult = void
+export type IUpdateTeamByTeamIdQueryResult = void;
 
 /** 'UpdateTeamByTeamIdQuery' query type */
 export interface IUpdateTeamByTeamIdQueryQuery {
-  params: IUpdateTeamByTeamIdQueryParams
-  result: IUpdateTeamByTeamIdQueryResult
+  params: IUpdateTeamByTeamIdQueryParams;
+  result: IUpdateTeamByTeamIdQueryResult;
 }
 
-const updateTeamByTeamIdQueryIR: any = {
-  name: 'updateTeamByTeamIdQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 44, b: 46, line: 3, col: 9},
-        used: [{a: 567, b: 569, line: 15, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    },
-    {
-      name: 'name',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 99, b: 102, line: 6, col: 21}]}
-    },
-    {
-      name: 'isArchived',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 141, b: 150, line: 7, col: 27}]}
-    },
-    {
-      name: 'isPaid',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 191, b: 196, line: 8, col: 23}]}
-    },
-    {
-      name: 'jiraDimensionFields',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 246, b: 264, line: 9, col: 36}]}
-    },
-    {
-      name: 'lastMeetingType',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 323, b: 337, line: 10, col: 32}]}
-    },
-    {
-      name: 'tier',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 381, b: 384, line: 11, col: 21}]}
-    },
-    {
-      name: 'orgId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 418, b: 422, line: 12, col: 22}]}
-    },
-    {
-      name: 'updatedAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 461, b: 469, line: 13, col: 26}]}
-    },
-    {
-      name: 'lockMessageHTML',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 518, b: 532, line: 14, col: 32}]}
-    }
-  ],
-  usedParamSet: {
-    name: true,
-    isArchived: true,
-    isPaid: true,
-    jiraDimensionFields: true,
-    lastMeetingType: true,
-    tier: true,
-    orgId: true,
-    updatedAt: true,
-    lockMessageHTML: true,
-    ids: true
-  },
-  statement: {
-    body:
-      'UPDATE "Team" SET\n  "name" = COALESCE(:name, "name"),\n  "isArchived" = COALESCE(:isArchived, "isArchived"),\n  "isPaid" = COALESCE(:isPaid, "isPaid"),\n  "jiraDimensionFields" = COALESCE(:jiraDimensionFields, "jiraDimensionFields"),\n  "lastMeetingType" = COALESCE(:lastMeetingType, "lastMeetingType"),\n  "tier" = COALESCE(:tier, "tier"),\n  "orgId" = COALESCE(:orgId, "orgId"),\n  "updatedAt" = COALESCE(:updatedAt, "updatedAt"),\n  "lockMessageHTML" = COALESCE(:lockMessageHTML, "lockMessageHTML")\nWHERE id IN :ids',
-    loc: {a: 60, b: 569, line: 5, col: 0}
-  }
-}
+const updateTeamByTeamIdQueryIR: any = {"name":"updateTeamByTeamIdQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":44,"b":46,"line":3,"col":9},"used":[{"a":567,"b":569,"line":15,"col":13}]},"transform":{"type":"array_spread"}},{"name":"name","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":99,"b":102,"line":6,"col":21}]}},{"name":"isArchived","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":141,"b":150,"line":7,"col":27}]}},{"name":"isPaid","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":191,"b":196,"line":8,"col":23}]}},{"name":"jiraDimensionFields","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":246,"b":264,"line":9,"col":36}]}},{"name":"lastMeetingType","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":323,"b":337,"line":10,"col":32}]}},{"name":"tier","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":381,"b":384,"line":11,"col":21}]}},{"name":"orgId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":418,"b":422,"line":12,"col":22}]}},{"name":"updatedAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":461,"b":469,"line":13,"col":26}]}},{"name":"lockMessageHTML","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":518,"b":532,"line":14,"col":32}]}}],"usedParamSet":{"name":true,"isArchived":true,"isPaid":true,"jiraDimensionFields":true,"lastMeetingType":true,"tier":true,"orgId":true,"updatedAt":true,"lockMessageHTML":true,"ids":true},"statement":{"body":"UPDATE \"Team\" SET\n  \"name\" = COALESCE(:name, \"name\"),\n  \"isArchived\" = COALESCE(:isArchived, \"isArchived\"),\n  \"isPaid\" = COALESCE(:isPaid, \"isPaid\"),\n  \"jiraDimensionFields\" = COALESCE(:jiraDimensionFields, \"jiraDimensionFields\"),\n  \"lastMeetingType\" = COALESCE(:lastMeetingType, \"lastMeetingType\"),\n  \"tier\" = COALESCE(:tier, \"tier\"),\n  \"orgId\" = COALESCE(:orgId, \"orgId\"),\n  \"updatedAt\" = COALESCE(:updatedAt, \"updatedAt\"),\n  \"lockMessageHTML\" = COALESCE(:lockMessageHTML, \"lockMessageHTML\")\nWHERE id IN :ids","loc":{"a":60,"b":569,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -122,7 +48,6 @@ const updateTeamByTeamIdQueryIR: any = {
  * WHERE id IN :ids
  * ```
  */
-export const updateTeamByTeamIdQuery = new PreparedQuery<
-  IUpdateTeamByTeamIdQueryParams,
-  IUpdateTeamByTeamIdQueryResult
->(updateTeamByTeamIdQueryIR)
+export const updateTeamByTeamIdQuery = new PreparedQuery<IUpdateTeamByTeamIdQueryParams,IUpdateTeamByTeamIdQueryResult>(updateTeamByTeamIdQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/updateUserQuery.ts
+++ b/packages/server/postgres/queries/generated/updateUserQuery.ts
@@ -1,143 +1,39 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateUserQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type TierEnum = 'enterprise' | 'pro' | 'personal'
+export type TierEnum = 'personal' | 'pro' | 'enterprise';
 
-export type JsonArray = (null | boolean | number | string | Json[] | {[key: string]: Json})[]
+export type JsonArray = (null | boolean | number | string | Json[] | { [key: string]: Json })[];
 
 /** 'UpdateUserQuery' parameters type */
 export interface IUpdateUserQueryParams {
-  ids: Array<string | null | void>
-  email: string | null | void
-  updatedAt: Date | null | void
-  inactive: boolean | null | void
-  lastSeenAt: Date | null | void
-  preferredName: string | null | void
-  tier: TierEnum | null | void
-  picture: string | null | void
-  segmentId: string | null | void
-  isRemoved: boolean | null | void
-  isWatched: boolean | null | void
-  reasonRemoved: string | null | void
-  newFeatureId: string | null | void
-  identities: JsonArray | null | void
-  overLimitCopy: string | null | void
+  ids: Array<string | null | void>;
+  email: string | null | void;
+  updatedAt: Date | null | void;
+  inactive: boolean | null | void;
+  lastSeenAt: Date | null | void;
+  preferredName: string | null | void;
+  tier: TierEnum | null | void;
+  picture: string | null | void;
+  segmentId: string | null | void;
+  isRemoved: boolean | null | void;
+  isWatched: boolean | null | void;
+  reasonRemoved: string | null | void;
+  newFeatureId: string | null | void;
+  identities: JsonArray | null | void;
+  overLimitCopy: string | null | void;
 }
 
 /** 'UpdateUserQuery' return type */
-export type IUpdateUserQueryResult = void
+export type IUpdateUserQueryResult = void;
 
 /** 'UpdateUserQuery' query type */
 export interface IUpdateUserQueryQuery {
-  params: IUpdateUserQueryParams
-  result: IUpdateUserQueryResult
+  params: IUpdateUserQueryParams;
+  result: IUpdateUserQueryResult;
 }
 
-const updateUserQueryIR: any = {
-  name: 'updateUserQuery',
-  params: [
-    {
-      name: 'ids',
-      codeRefs: {
-        defined: {a: 36, b: 38, line: 3, col: 9},
-        used: [{a: 827, b: 829, line: 20, col: 13}]
-      },
-      transform: {type: 'array_spread'}
-    },
-    {
-      name: 'email',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 90, b: 94, line: 6, col: 20}]}
-    },
-    {
-      name: 'updatedAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 133, b: 141, line: 7, col: 26}]}
-    },
-    {
-      name: 'inactive',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 181, b: 188, line: 8, col: 23}]}
-    },
-    {
-      name: 'lastSeenAt',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 254, b: 263, line: 9, col: 50}]}
-    },
-    {
-      name: 'preferredName',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 312, b: 324, line: 10, col: 30}]}
-    },
-    {
-      name: 'tier',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 364, b: 367, line: 11, col: 19}]}
-    },
-    {
-      name: 'picture',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 401, b: 407, line: 12, col: 22}]}
-    },
-    {
-      name: 'segmentId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 448, b: 456, line: 13, col: 26}]}
-    },
-    {
-      name: 'isRemoved',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 499, b: 507, line: 14, col: 26}]}
-    },
-    {
-      name: 'isWatched',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 550, b: 558, line: 15, col: 26}]}
-    },
-    {
-      name: 'reasonRemoved',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 605, b: 617, line: 16, col: 30}]}
-    },
-    {
-      name: 'newFeatureId',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 667, b: 678, line: 17, col: 29}]}
-    },
-    {
-      name: 'identities',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 725, b: 734, line: 18, col: 27}]}
-    },
-    {
-      name: 'overLimitCopy',
-      transform: {type: 'scalar'},
-      codeRefs: {used: [{a: 782, b: 794, line: 19, col: 30}]}
-    }
-  ],
-  usedParamSet: {
-    email: true,
-    updatedAt: true,
-    inactive: true,
-    lastSeenAt: true,
-    preferredName: true,
-    tier: true,
-    picture: true,
-    segmentId: true,
-    isRemoved: true,
-    isWatched: true,
-    reasonRemoved: true,
-    newFeatureId: true,
-    identities: true,
-    overLimitCopy: true,
-    ids: true
-  },
-  statement: {
-    body:
-      'UPDATE "User" SET\n  email = COALESCE(:email, "email"),\n  "updatedAt" = COALESCE(:updatedAt, "updatedAt"),\n  inactive = COALESCE(:inactive, "inactive"),\n  "lastSeenAt" = GREATEST("lastSeenAt", COALESCE(:lastSeenAt, "lastSeenAt")),\n  "preferredName" = COALESCE(:preferredName, "preferredName"),\n  tier = COALESCE(:tier, "tier"),\n  picture = COALESCE(:picture, "picture"),\n  "segmentId" = COALESCE(:segmentId, "segmentId"),\n  "isRemoved" = COALESCE(:isRemoved, "isRemoved"),\n  "isWatched" = COALESCE(:isWatched, "isWatched"),\n  "reasonRemoved" = COALESCE(:reasonRemoved, "reasonRemoved"),\n  "newFeatureId" = COALESCE(:newFeatureId, "newFeatureId"),\n  "identities" = COALESCE(:identities, "identities"),\n  "overLimitCopy" = COALESCE(:overLimitCopy, "overLimitCopy")\nWHERE id IN :ids',
-    loc: {a: 52, b: 829, line: 5, col: 0}
-  }
-}
+const updateUserQueryIR: any = {"name":"updateUserQuery","params":[{"name":"ids","codeRefs":{"defined":{"a":36,"b":38,"line":3,"col":9},"used":[{"a":827,"b":829,"line":20,"col":13}]},"transform":{"type":"array_spread"}},{"name":"email","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":90,"b":94,"line":6,"col":20}]}},{"name":"updatedAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":133,"b":141,"line":7,"col":26}]}},{"name":"inactive","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":181,"b":188,"line":8,"col":23}]}},{"name":"lastSeenAt","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":254,"b":263,"line":9,"col":50}]}},{"name":"preferredName","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":312,"b":324,"line":10,"col":30}]}},{"name":"tier","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":364,"b":367,"line":11,"col":19}]}},{"name":"picture","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":401,"b":407,"line":12,"col":22}]}},{"name":"segmentId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":448,"b":456,"line":13,"col":26}]}},{"name":"isRemoved","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":499,"b":507,"line":14,"col":26}]}},{"name":"isWatched","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":550,"b":558,"line":15,"col":26}]}},{"name":"reasonRemoved","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":605,"b":617,"line":16,"col":30}]}},{"name":"newFeatureId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":667,"b":678,"line":17,"col":29}]}},{"name":"identities","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":725,"b":734,"line":18,"col":27}]}},{"name":"overLimitCopy","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":782,"b":794,"line":19,"col":30}]}}],"usedParamSet":{"email":true,"updatedAt":true,"inactive":true,"lastSeenAt":true,"preferredName":true,"tier":true,"picture":true,"segmentId":true,"isRemoved":true,"isWatched":true,"reasonRemoved":true,"newFeatureId":true,"identities":true,"overLimitCopy":true,"ids":true},"statement":{"body":"UPDATE \"User\" SET\n  email = COALESCE(:email, \"email\"),\n  \"updatedAt\" = COALESCE(:updatedAt, \"updatedAt\"),\n  inactive = COALESCE(:inactive, \"inactive\"),\n  \"lastSeenAt\" = GREATEST(\"lastSeenAt\", COALESCE(:lastSeenAt, \"lastSeenAt\")),\n  \"preferredName\" = COALESCE(:preferredName, \"preferredName\"),\n  tier = COALESCE(:tier, \"tier\"),\n  picture = COALESCE(:picture, \"picture\"),\n  \"segmentId\" = COALESCE(:segmentId, \"segmentId\"),\n  \"isRemoved\" = COALESCE(:isRemoved, \"isRemoved\"),\n  \"isWatched\" = COALESCE(:isWatched, \"isWatched\"),\n  \"reasonRemoved\" = COALESCE(:reasonRemoved, \"reasonRemoved\"),\n  \"newFeatureId\" = COALESCE(:newFeatureId, \"newFeatureId\"),\n  \"identities\" = COALESCE(:identities, \"identities\"),\n  \"overLimitCopy\" = COALESCE(:overLimitCopy, \"overLimitCopy\")\nWHERE id IN :ids","loc":{"a":52,"b":829,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -160,6 +56,6 @@ const updateUserQueryIR: any = {
  * WHERE id IN :ids
  * ```
  */
-export const updateUserQuery = new PreparedQuery<IUpdateUserQueryParams, IUpdateUserQueryResult>(
-  updateUserQueryIR
-)
+export const updateUserQuery = new PreparedQuery<IUpdateUserQueryParams,IUpdateUserQueryResult>(updateUserQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/updateUserTiersQuery.ts
+++ b/packages/server/postgres/queries/generated/updateUserTiersQuery.ts
@@ -1,53 +1,34 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/updateUserTiersQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'UpdateUserTiersQuery' parameters type */
 export interface IUpdateUserTiersQueryParams {
   users: Array<{
-    tier: string | null | void
+    tier: string | null | void,
     id: string | null | void
-  }>
+  }>;
 }
 
 /** 'UpdateUserTiersQuery' return type */
-export type IUpdateUserTiersQueryResult = void
+export type IUpdateUserTiersQueryResult = void;
 
 /** 'UpdateUserTiersQuery' query type */
 export interface IUpdateUserTiersQueryQuery {
-  params: IUpdateUserTiersQueryParams
-  result: IUpdateUserTiersQueryResult
+  params: IUpdateUserTiersQueryParams;
+  result: IUpdateUserTiersQueryResult;
 }
 
-const updateUserTiersQueryIR: any = {
-  name: 'updateUserTiersQuery',
-  params: [
-    {
-      name: 'users',
-      codeRefs: {
-        defined: {a: 41, b: 45, line: 3, col: 9},
-        used: [{a: 138, b: 142, line: 7, col: 14}]
-      },
-      transform: {type: 'pick_array_spread', keys: ['tier', 'id']}
-    }
-  ],
-  usedParamSet: {users: true},
-  statement: {
-    body:
-      'UPDATE "User" AS u SET\n  "tier" = c."tier"::"TierEnum"\nFROM (VALUES :users) AS c("tier", "id") \nWHERE c."id" = u."id"',
-    loc: {a: 69, b: 185, line: 5, col: 0}
-  }
-}
+const updateUserTiersQueryIR: any = {"name":"updateUserTiersQuery","params":[{"name":"users","codeRefs":{"defined":{"a":41,"b":45,"line":3,"col":9},"used":[{"a":138,"b":142,"line":7,"col":14}]},"transform":{"type":"pick_array_spread","keys":["tier","id"]}}],"usedParamSet":{"users":true},"statement":{"body":"UPDATE \"User\" AS u SET\n  \"tier\" = c.\"tier\"::\"TierEnum\"\nFROM (VALUES :users) AS c(\"tier\", \"id\") \nWHERE c.\"id\" = u.\"id\"","loc":{"a":69,"b":185,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
  * ```
  * UPDATE "User" AS u SET
  *   "tier" = c."tier"::"TierEnum"
- * FROM (VALUES :users) AS c("tier", "id")
+ * FROM (VALUES :users) AS c("tier", "id") 
  * WHERE c."id" = u."id"
  * ```
  */
-export const updateUserTiersQuery = new PreparedQuery<
-  IUpdateUserTiersQueryParams,
-  IUpdateUserTiersQueryResult
->(updateUserTiersQueryIR)
+export const updateUserTiersQuery = new PreparedQuery<IUpdateUserTiersQueryParams,IUpdateUserTiersQueryResult>(updateUserTiersQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/upsertAtlassianAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/upsertAtlassianAuthQuery.ts
@@ -1,52 +1,31 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/upsertAtlassianAuthQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
-export type stringArray = string[]
+export type stringArray = (string)[];
 
 /** 'UpsertAtlassianAuthQuery' parameters type */
 export interface IUpsertAtlassianAuthQueryParams {
   auth: {
-    accessToken: string | null | void
-    refreshToken: string | null | void
-    cloudIds: stringArray | null | void
-    scope: string | null | void
-    accountId: string | null | void
-    teamId: string | null | void
+    accessToken: string | null | void,
+    refreshToken: string | null | void,
+    cloudIds: stringArray | null | void,
+    scope: string | null | void,
+    accountId: string | null | void,
+    teamId: string | null | void,
     userId: string | null | void
-  }
+  };
 }
 
 /** 'UpsertAtlassianAuthQuery' return type */
-export type IUpsertAtlassianAuthQueryResult = void
+export type IUpsertAtlassianAuthQueryResult = void;
 
 /** 'UpsertAtlassianAuthQuery' query type */
 export interface IUpsertAtlassianAuthQueryQuery {
-  params: IUpsertAtlassianAuthQueryParams
-  result: IUpsertAtlassianAuthQueryResult
+  params: IUpsertAtlassianAuthQueryParams;
+  result: IUpsertAtlassianAuthQueryResult;
 }
 
-const upsertAtlassianAuthQueryIR: any = {
-  name: 'upsertAtlassianAuthQuery',
-  params: [
-    {
-      name: 'auth',
-      codeRefs: {
-        defined: {a: 43, b: 46, line: 3, col: 8},
-        used: [{a: 281, b: 284, line: 14, col: 8}]
-      },
-      transform: {
-        type: 'pick_tuple',
-        keys: ['accessToken', 'refreshToken', 'cloudIds', 'scope', 'accountId', 'teamId', 'userId']
-      }
-    }
-  ],
-  usedParamSet: {auth: true},
-  statement: {
-    body:
-      'INSERT INTO "AtlassianAuth" (\n    "accessToken",\n    "refreshToken",\n    "cloudIds",\n    "scope",\n    "accountId",\n    "teamId",\n    "userId"\n  )\nVALUES :auth ON CONFLICT ("userId", "teamId") DO\nUPDATE\nSET (\n    "isActive",\n    "updatedAt",\n    "accessToken",\n    "refreshToken",\n    "cloudIds",\n    "scope",\n    "accountId",\n    "teamId",\n    "userId"\n  ) = (\n    TRUE,\n    CURRENT_TIMESTAMP,\n    EXCLUDED."accessToken",\n    EXCLUDED."refreshToken",\n    EXCLUDED."cloudIds",\n    EXCLUDED."scope",\n    EXCLUDED."accountId",\n    EXCLUDED."teamId",\n    EXCLUDED."userId"\n  )',
-    loc: {a: 127, b: 698, line: 5, col: 0}
-  }
-}
+const upsertAtlassianAuthQueryIR: any = {"name":"upsertAtlassianAuthQuery","params":[{"name":"auth","codeRefs":{"defined":{"a":43,"b":46,"line":3,"col":8},"used":[{"a":281,"b":284,"line":14,"col":8}]},"transform":{"type":"pick_tuple","keys":["accessToken","refreshToken","cloudIds","scope","accountId","teamId","userId"]}}],"usedParamSet":{"auth":true},"statement":{"body":"INSERT INTO \"AtlassianAuth\" (\n    \"accessToken\",\n    \"refreshToken\",\n    \"cloudIds\",\n    \"scope\",\n    \"accountId\",\n    \"teamId\",\n    \"userId\"\n  )\nVALUES :auth ON CONFLICT (\"userId\", \"teamId\") DO\nUPDATE\nSET (\n    \"isActive\",\n    \"updatedAt\",\n    \"accessToken\",\n    \"refreshToken\",\n    \"cloudIds\",\n    \"scope\",\n    \"accountId\",\n    \"teamId\",\n    \"userId\"\n  ) = (\n    TRUE,\n    CURRENT_TIMESTAMP,\n    EXCLUDED.\"accessToken\",\n    EXCLUDED.\"refreshToken\",\n    EXCLUDED.\"cloudIds\",\n    EXCLUDED.\"scope\",\n    EXCLUDED.\"accountId\",\n    EXCLUDED.\"teamId\",\n    EXCLUDED.\"userId\"\n  )","loc":{"a":127,"b":698,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -85,7 +64,6 @@ const upsertAtlassianAuthQueryIR: any = {
  *   )
  * ```
  */
-export const upsertAtlassianAuthQuery = new PreparedQuery<
-  IUpsertAtlassianAuthQueryParams,
-  IUpsertAtlassianAuthQueryResult
->(upsertAtlassianAuthQueryIR)
+export const upsertAtlassianAuthQuery = new PreparedQuery<IUpsertAtlassianAuthQueryParams,IUpsertAtlassianAuthQueryResult>(upsertAtlassianAuthQueryIR);
+
+

--- a/packages/server/postgres/queries/generated/upsertGitHubAuthQuery.ts
+++ b/packages/server/postgres/queries/generated/upsertGitHubAuthQuery.ts
@@ -1,45 +1,27 @@
 /** Types generated for queries found in "packages/server/postgres/queries/src/upsertGitHubAuthQuery.sql" */
-import {PreparedQuery} from '@pgtyped/query'
+import { PreparedQuery } from '@pgtyped/query';
 
 /** 'UpsertGitHubAuthQuery' parameters type */
 export interface IUpsertGitHubAuthQueryParams {
   auth: {
-    accessToken: string | null | void
-    login: string | null | void
-    teamId: string | null | void
-    userId: string | null | void
+    accessToken: string | null | void,
+    login: string | null | void,
+    teamId: string | null | void,
+    userId: string | null | void,
     scope: string | null | void
-  }
+  };
 }
 
 /** 'UpsertGitHubAuthQuery' return type */
-export type IUpsertGitHubAuthQueryResult = void
+export type IUpsertGitHubAuthQueryResult = void;
 
 /** 'UpsertGitHubAuthQuery' query type */
 export interface IUpsertGitHubAuthQueryQuery {
-  params: IUpsertGitHubAuthQueryParams
-  result: IUpsertGitHubAuthQueryResult
+  params: IUpsertGitHubAuthQueryParams;
+  result: IUpsertGitHubAuthQueryResult;
 }
 
-const upsertGitHubAuthQueryIR: any = {
-  name: 'upsertGitHubAuthQuery',
-  params: [
-    {
-      name: 'auth',
-      codeRefs: {
-        defined: {a: 42, b: 45, line: 3, col: 9},
-        used: [{a: 184, b: 187, line: 6, col: 8}]
-      },
-      transform: {type: 'pick_tuple', keys: ['accessToken', 'login', 'teamId', 'userId', 'scope']}
-    }
-  ],
-  usedParamSet: {auth: true},
-  statement: {
-    body:
-      'INSERT INTO "GitHubAuth" ("accessToken", "login", "teamId", "userId", "scope")\nVALUES :auth\nON CONFLICT ("userId", "teamId")\nDO UPDATE\nSET ("accessToken", "updatedAt", "isActive", "login", "scope") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login, EXCLUDED.scope)',
-    loc: {a: 97, b: 377, line: 5, col: 0}
-  }
-}
+const upsertGitHubAuthQueryIR: any = {"name":"upsertGitHubAuthQuery","params":[{"name":"auth","codeRefs":{"defined":{"a":42,"b":45,"line":3,"col":9},"used":[{"a":184,"b":187,"line":6,"col":8}]},"transform":{"type":"pick_tuple","keys":["accessToken","login","teamId","userId","scope"]}}],"usedParamSet":{"auth":true},"statement":{"body":"INSERT INTO \"GitHubAuth\" (\"accessToken\", \"login\", \"teamId\", \"userId\", \"scope\")\nVALUES :auth\nON CONFLICT (\"userId\", \"teamId\")\nDO UPDATE\nSET (\"accessToken\", \"updatedAt\", \"isActive\", \"login\", \"scope\") = (EXCLUDED.\"accessToken\", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login, EXCLUDED.scope)","loc":{"a":97,"b":377,"line":5,"col":0}}};
 
 /**
  * Query generated from SQL:
@@ -51,7 +33,6 @@ const upsertGitHubAuthQueryIR: any = {
  * SET ("accessToken", "updatedAt", "isActive", "login", "scope") = (EXCLUDED."accessToken", CURRENT_TIMESTAMP, TRUE, EXCLUDED.login, EXCLUDED.scope)
  * ```
  */
-export const upsertGitHubAuthQuery = new PreparedQuery<
-  IUpsertGitHubAuthQueryParams,
-  IUpsertGitHubAuthQueryResult
->(upsertGitHubAuthQueryIR)
+export const upsertGitHubAuthQuery = new PreparedQuery<IUpsertGitHubAuthQueryParams,IUpsertGitHubAuthQueryResult>(upsertGitHubAuthQueryIR);
+
+


### PR DESCRIPTION
Commit pg:build files in unformatted form.
For VSCode users switch from builtin formatter to prettier extension
one. The builtin one formats different from prettier anyways.
Add the extension as recommendation.
There are two .prettierignore files added since VSCode extension looks
in the root directory while git commit hooks check the package.