### PR TITLE
Bug/null user

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -11,9 +11,12 @@ import {
   CacheConfig,
   Environment,
   FetchFunction,
+  fetchQuery,
   GraphQLResponse,
+  GraphQLTaggedNode,
   Network,
   Observable,
+  OperationType,
   RecordSource,
   RelayFeatureFlags,
   RequestParameters,
@@ -287,6 +290,20 @@ export default class Atmosphere extends Environment {
     })
   }
 
+  fetchQuery = async <T extends OperationType>(
+    taggedNode: GraphQLTaggedNode,
+    variables: Variables = {}
+  ) => {
+    let res: T['response']
+    try {
+      res = await fetchQuery<T>(this, taggedNode, variables, {
+        fetchPolicy: 'store-or-network'
+      }).toPromise()
+    } catch (e) {
+      return null
+    }
+    return res
+  }
   getAuthToken = (global: Window) => {
     if (!global) return
     const authToken = global.localStorage.getItem(LocalStorageKey.APP_TOKEN_KEY)

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -1,10 +1,9 @@
 /// <reference types="@types/segment-analytics" />
 
 import * as Sentry from '@sentry/browser'
-import LogRocket from 'logrocket'
 import graphql from 'babel-plugin-relay/macro'
+import ms from 'ms'
 import {useEffect, useRef} from 'react'
-import {fetchQuery} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {LocalStorageKey} from '~/types/constEnums'
 import safeIdentify from '~/utils/safeIdentify'
@@ -12,11 +11,12 @@ import {AnalyticsPageQuery} from '~/__generated__/AnalyticsPageQuery.graphql'
 import useScript from '../hooks/useScript'
 import getAnonymousId from '../utils/getAnonymousId'
 import makeHref from '../utils/makeHref'
-import ms from 'ms'
+import safeInitLogRocket from '../utils/safeInitLogRocket'
 
 const query = graphql`
   query AnalyticsPageQuery {
     viewer {
+      id
       email
       isWatched
     }
@@ -74,29 +74,23 @@ const AnalyticsPage = () => {
 
   const initLogRocket = async () => {
     const logRocketId = window.__ACTION__.logRocket
-    const errorProneAt = window.localStorage.getItem(LocalStorageKey.ERROR_PRONE_AT)
-    const expiredErrorProne =
-      errorProneAt && new Date(parseInt(errorProneAt)) < new Date(Date.now() - ms('14d'))
-    const email = window.localStorage.getItem(LocalStorageKey.EMAIL)
-    const res = await fetchQuery<AnalyticsPageQuery>(atmosphere, query, {}).toPromise()
-    const isWatched = res?.viewer?.isWatched
-    if (expiredErrorProne && !isWatched) {
+    if (!logRocketId) return
+    const errorProneAtStr = window.localStorage.getItem(LocalStorageKey.ERROR_PRONE_AT)
+    const errorProneAtDate = new Date(errorProneAtStr!)
+    const isErrorProne = errorProneAtDate.toJSON() === errorProneAtStr && errorProneAtDate > new Date(Date.now() - ms('14d'))
+    if (!isErrorProne) {
       window.localStorage.removeItem(LocalStorageKey.ERROR_PRONE_AT)
-    } else if (logRocketId && (errorProneAt || isWatched)) {
-      LogRocket.init(logRocketId, {
-        release: __APP_VERSION__,
-        network: {
-          requestSanitizer: (request) => {
-            const body = request?.body?.toLowerCase()
-            if (body?.includes('password')) return null
-            return request
-          }
-        }
-      })
-      if (email) {
-        LogRocket.identify(atmosphere.viewerId, {
-          email
-        })
+    }
+    const res = await atmosphere.fetchQuery<AnalyticsPageQuery>(query)
+    if (!res) {
+      if (isErrorProne) {
+        safeInitLogRocket()
+      }
+    } else {
+      const {viewer} = res
+      const {isWatched, email, id: viewerId} = viewer
+      if (isErrorProne || isWatched) {
+        safeInitLogRocket(viewerId, email)
       }
     }
   }
@@ -115,11 +109,13 @@ const AnalyticsPage = () => {
       return
     }
     const cacheEmail = async () => {
-      const res = await fetchQuery<AnalyticsPageQuery>(atmosphere, query, {}).toPromise()
-      const nextEmail = res?.viewer?.email
-      if (!nextEmail) return
-      window.localStorage.setItem(LocalStorageKey.EMAIL, nextEmail)
-      safeIdentify(atmosphere.viewerId, nextEmail)
+      const res = await atmosphere.fetchQuery<AnalyticsPageQuery>(query)
+      if (!res) return
+      const {viewer} = res
+      const {email} = viewer
+      if (!email) return
+      window.localStorage.setItem(LocalStorageKey.EMAIL, email)
+      safeIdentify(atmosphere.viewerId, email)
     }
     cacheEmail().catch()
   }, [isSegmentLoaded])

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -108,7 +108,7 @@ const Dashboard = (props: Props) => {
     queryRef,
     {UNSTABLE_renderPolicy: 'full'}
   )
-  const viewer = data.viewer!
+  const {viewer} = data
   const {teams} = viewer
   const activeMeetings = teams.flatMap((team) => team.activeMeetings).filter(Boolean)
   const {isOpen, toggle, handleMenuClick} = useSidebar()

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -73,7 +73,7 @@ const DiscussionThread = (props: Props) => {
     queryRef,
     {UNSTABLE_renderPolicy: 'full'}
   )
-  const viewer = data.viewer!
+  const {viewer} = data
   const isExpanded =
     useCoverable(
       'threads',

--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -1,31 +1,31 @@
-import React, {forwardRef, useEffect, useImperativeHandle, useState} from 'react'
 import styled from '@emotion/styled'
-import ErrorAlert from './ErrorAlert/ErrorAlert'
-import PrimaryButton from './PrimaryButton'
-import RaisedButton from './RaisedButton'
-import {CREATE_ACCOUNT_BUTTON_LABEL, SIGNIN_LABEL} from '../utils/constants'
-import {emailRegex} from '../validation/regex'
-import Legitity from '../validation/Legitity'
-import EmailInputField from './EmailInputField'
-import PasswordInputField from './PasswordInputField'
-import getSAMLIdP from '../utils/getSAMLIdP'
-import getValidRedirectParam from '../utils/getValidRedirectParam'
-import {LocalStorageKey} from '../types/constEnums'
-import StyledTip from './StyledTip'
-import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
-import getTokenFromSSO from '../utils/getTokenFromSSO'
-import PlainButton from './PlainButton/PlainButton'
-import {PALETTE} from '../styles/paletteV3'
-import getSSODomainFromEmail from '../utils/getSSODomainFromEmail'
+import React, {forwardRef, useEffect, useImperativeHandle, useState} from 'react'
 import Atmosphere from '../Atmosphere'
-import useMutationProps from '../hooks/useMutationProps'
-import useForm from '../hooks/useForm'
 import useAtmosphere from '../hooks/useAtmosphere'
+import useForm from '../hooks/useForm'
+import useMutationProps from '../hooks/useMutationProps'
 import useRouter from '../hooks/useRouter'
-import getAnonymousId from '../utils/getAnonymousId'
+import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import LoginWithPasswordMutation from '../mutations/LoginWithPasswordMutation'
 import SignUpWithPasswordMutation from '../mutations/SignUpWithPasswordMutation'
+import {PALETTE} from '../styles/paletteV3'
+import {LocalStorageKey} from '../types/constEnums'
+import {CREATE_ACCOUNT_BUTTON_LABEL, SIGNIN_LABEL} from '../utils/constants'
+import getAnonymousId from '../utils/getAnonymousId'
+import getSAMLIdP from '../utils/getSAMLIdP'
+import getSSODomainFromEmail from '../utils/getSSODomainFromEmail'
+import getTokenFromSSO from '../utils/getTokenFromSSO'
+import getValidRedirectParam from '../utils/getValidRedirectParam'
+import Legitity from '../validation/Legitity'
+import {emailRegex} from '../validation/regex'
+import EmailInputField from './EmailInputField'
+import ErrorAlert from './ErrorAlert/ErrorAlert'
 import {AuthPageSlug} from './GenericAuthentication'
+import PasswordInputField from './PasswordInputField'
+import PlainButton from './PlainButton/PlainButton'
+import PrimaryButton from './PrimaryButton'
+import RaisedButton from './RaisedButton'
+import StyledTip from './StyledTip'
 
 interface Props {
   email: string
@@ -125,7 +125,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
         setPendingDomain(domain)
         const url = await getSSOUrl(atmosphere, email)
         setSSODomain(domain)
-        setSSOURL(url)
+        setSSOURL(url || '')
       }
     }
   }

--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/browser'
-import React, {Component, ErrorInfo, ReactNode} from 'react'
-import ErrorComponent from './ErrorComponent/ErrorComponent'
-import withAtmosphere, {WithAtmosphereProps} from '~/decorators/withAtmosphere/withAtmosphere'
 import LogRocket from 'logrocket'
+import React, {Component, ErrorInfo, ReactNode} from 'react'
+import withAtmosphere, {WithAtmosphereProps} from '~/decorators/withAtmosphere/withAtmosphere'
 import {LocalStorageKey} from '~/types/constEnums'
+import ErrorComponent from './ErrorComponent/ErrorComponent'
+import safeInitLogRocket from '../utils/safeInitLogRocket'
 
 interface Props extends WithAtmosphereProps {
   fallback?: (error: Error, eventId: string) => ReactNode
@@ -35,22 +36,8 @@ class ErrorBoundary extends Component<Props, State> {
     }
     const logRocketId = window.__ACTION__.logRocket
     if (logRocketId) {
-      LogRocket.init(logRocketId, {
-        release: __APP_VERSION__,
-        network: {
-          requestSanitizer: (request) => {
-            const body = request?.body?.toLowerCase()
-            if (body?.includes('password')) return null
-            return request
-          }
-        }
-      })
-      if (email) {
-        LogRocket.identify(viewerId, {
-          email
-        })
-      }
-      window.localStorage.setItem(LocalStorageKey.ERROR_PRONE_AT, `${new Date().getTime()}`)
+      safeInitLogRocket(viewerId, email)
+      window.localStorage.setItem(LocalStorageKey.ERROR_PRONE_AT, new Date().toJSON())
       LogRocket.captureException(error)
       LogRocket.track('Fatal error')
     }

--- a/packages/client/components/MeetingSelector.tsx
+++ b/packages/client/components/MeetingSelector.tsx
@@ -42,7 +42,7 @@ const MeetingSelector = (props: Props) => {
     {UNSTABLE_renderPolicy: 'full'}
   )
 
-  const viewer = data.viewer!
+  const {viewer} = data
   const {isConnected, meeting} = viewer
   useEffect(() => {
     if (!meeting) {

--- a/packages/client/components/MyDashboardTasksAndHeader.tsx
+++ b/packages/client/components/MyDashboardTasksAndHeader.tsx
@@ -23,7 +23,7 @@ const MyDashboardTasksAndHeader = (props: Props) => {
     queryRef,
     {UNSTABLE_renderPolicy: 'full'}
   )
-  const viewer = data.viewer!
+  const {viewer} = data
   return (
     <>
       <UserTasksHeader viewerRef={viewer} />

--- a/packages/client/components/MyDashboardTimeline.tsx
+++ b/packages/client/components/MyDashboardTimeline.tsx
@@ -53,7 +53,7 @@ const MyDashboardTimeline = (props: Props) => {
       UNSTABLE_renderPolicy: 'full'
     }
   )
-  const viewer = data.viewer!
+  const {viewer} = data
   useDocumentTitle('My Timeline | Parabol', 'Timeline')
   return (
     <FeedAndDrawer>

--- a/packages/client/hooks/useAllIntegrations.ts
+++ b/packages/client/hooks/useAllIntegrations.ts
@@ -1,6 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useEffect, useMemo, useRef, useState} from 'react'
-import {fetchQuery} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
 import {
   useAllIntegrationsQuery,
@@ -64,11 +63,11 @@ const useAllIntegrations = (
   useEffect(() => {
     isMountedRef.current = true
     const fetchIntegrations = async () => {
-      const res = await fetchQuery<useAllIntegrationsQuery>(atmosphere, gqlQuery, {
+      const res = await atmosphere.fetchQuery<useAllIntegrationsQuery>(gqlQuery, {
         teamId,
         userId
-      }).toPromise()
-      if (!res?.viewer?.teamMember) {
+      })
+      if (!res?.viewer.teamMember) {
         if (isMountedRef.current) {
           setStatus('error')
         }

--- a/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
@@ -8,7 +8,6 @@ import extractTextFromDraftString from 'parabol-client/utils/draftjs/extractText
 import withMutationProps, {WithMutationProps} from 'parabol-client/utils/relay/withMutationProps'
 import {ExportToCSVQuery} from 'parabol-client/__generated__/ExportToCSVQuery.graphql'
 import React, {Component} from 'react'
-import {fetchQuery} from 'react-relay'
 import {ExternalLinks, PokerCards} from '../../../../types/constEnums'
 import AnchorIfEmail from './MeetingSummaryEmail/AnchorIfEmail'
 import EmailBorderBottom from './MeetingSummaryEmail/EmailBorderBottom'
@@ -316,11 +315,10 @@ class ExportToCSV extends Component<Props> {
     const {atmosphere, meetingId, submitMutation, submitting, onCompleted} = this.props
     if (submitting) return
     submitMutation()
-    const data = await fetchQuery<ExportToCSVQuery>(atmosphere, query, {meetingId}).toPromise()
+    const data = await atmosphere.fetchQuery<ExportToCSVQuery>(query, {meetingId})
     onCompleted()
     if (!data) return
     const {viewer} = data
-    if (!viewer) return
     const {newMeeting} = viewer
     if (!newMeeting) return
     const rows = this.getRows(newMeeting)

--- a/packages/client/modules/newTeam/NewTeam.tsx
+++ b/packages/client/modules/newTeam/NewTeam.tsx
@@ -83,7 +83,7 @@ const NewTeam = (props: Props) => {
     queryRef,
     {UNSTABLE_renderPolicy: 'full'}
   )
-  const viewer = data.viewer!
+  const {viewer} = data
   const {organizations} = viewer
 
   return (

--- a/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaAndTasks/AgendaAndTasks.tsx
@@ -124,7 +124,7 @@ const AgendaAndTasks = (props: Props) => {
     {UNSTABLE_renderPolicy: 'full'}
   )
 
-  const viewer = data.viewer!
+  const {viewer} = data
   const {dashSearch} = viewer
   const team = viewer.team!
   const teamMember = viewer.teamMember!

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -140,7 +140,7 @@ const TeamArchive = (props: Props) => {
     viewerRef
   )
 
-  const viewer = data.viewer!
+  const {viewer} = data
   const team = useFragment(
     graphql`
       fragment TeamArchive_team on Team {

--- a/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
@@ -45,7 +45,7 @@ const TeamContainer = (props: Props) => {
     queryRef,
     {UNSTABLE_renderPolicy: 'full'}
   )
-  const viewer = data.viewer!
+  const {viewer} = data
   const {team} = viewer
   const {history, match} = useRouter()
   const {location} = window

--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -44332,12 +44332,12 @@ export interface IPageInfoDateCursor {
   /**
    * When paginating backwards, the cursor to continue.
    */
-  startCursor: string | null;
+  startCursor: any | null;
 
   /**
    * When paginating forwards, the cursor to continue.
    */
-  endCursor: string | null;
+  endCursor: any | null;
 }
 
 /**
@@ -50247,7 +50247,7 @@ export interface IComment {
 
 export interface IQuery {
   __typename: 'Query';
-  viewer: IUser | null;
+  viewer: IUser;
   getDemoEntities: IGetDemoEntitiesPayload;
   massInvitation: IMassInvitationPayload;
   verifiedInvitation: IVerifiedInvitationPayload;

--- a/packages/client/utils/getSAMLIdP.ts
+++ b/packages/client/utils/getSAMLIdP.ts
@@ -1,5 +1,4 @@
 import graphql from 'babel-plugin-relay/macro'
-import {fetchQuery} from 'react-relay'
 import Atmosphere from '../Atmosphere'
 import {getSAMLIdPQuery, getSAMLIdPQueryVariables} from '../__generated__/getSAMLIdPQuery.graphql'
 
@@ -10,14 +9,8 @@ const query = graphql`
 `
 
 const getSAMLIdP = async (atmosphere: Atmosphere, variables: getSAMLIdPQueryVariables) => {
-  let res
-  try {
-    res = await fetchQuery<getSAMLIdPQuery>(atmosphere, query, variables).toPromise()
-  } catch (e) {
-    // server error, probably rate limited
-    return null
-  }
-  return res && res.SAMLIdP
+  const res = await atmosphere.fetchQuery<getSAMLIdPQuery>(query, variables)
+  return res?.SAMLIdP ?? null
 }
 
 export default getSAMLIdP

--- a/packages/client/utils/handleSuccessfulLogin.ts
+++ b/packages/client/utils/handleSuccessfulLogin.ts
@@ -1,6 +1,6 @@
 import {LocalStorageKey} from '~/types/constEnums'
 import safeIdentify from './safeIdentify'
-import LogRocket from 'logrocket'
+import safeInitLogRocket from './safeInitLogRocket'
 
 interface Payload {
   user?: {
@@ -15,9 +15,7 @@ const handleSuccessfulLogin = (payload: Payload) => {
   if (!email || !userId) return
   window.localStorage.setItem(LocalStorageKey.EMAIL, email)
   safeIdentify(userId, email)
-  LogRocket.identify(userId, {
-    email
-  })
+  safeInitLogRocket(userId, email)
 }
 
 export default handleSuccessfulLogin

--- a/packages/client/utils/safeInitLogRocket.ts
+++ b/packages/client/utils/safeInitLogRocket.ts
@@ -1,0 +1,23 @@
+import LogRocket from 'logrocket'
+
+const safeInitLogRocket = (viewerId?: string, email?: string) => {
+  const logRocketId = window.__ACTION__.logRocket
+  if (!logRocketId) return
+  LogRocket.init(logRocketId, {
+    release: __APP_VERSION__,
+    network: {
+      requestSanitizer: (request) => {
+        const body = request?.body?.toLowerCase()
+        if (body?.includes('password')) return null
+        return request
+      }
+    }
+  })
+  if (email && viewerId) {
+    LogRocket.identify(viewerId, {
+      email
+    })
+  }
+}
+
+export default safeInitLogRocket

--- a/packages/server/graphql/rootQuery.ts
+++ b/packages/server/graphql/rootQuery.ts
@@ -1,4 +1,4 @@
-import {GraphQLObjectType} from 'graphql'
+import {GraphQLNonNull, GraphQLObjectType} from 'graphql'
 import {getUserId} from '../utils/authorization'
 import {GQLContext} from './graphql'
 import getDemoEntities from './queries/getDemoEntitites'
@@ -6,26 +6,15 @@ import massInvitation from './queries/massInvitation'
 import SAMLIdP from './queries/SAMLIdP'
 import verifiedInvitation from './queries/verifiedInvitation'
 import User from './types/User'
-import * as Sentry from '@sentry/browser'
-import LogRocket from 'logrocket'
 
 export default new GraphQLObjectType<any, GQLContext>({
   name: 'Query',
   fields: () => ({
     viewer: {
-      type: User,
+      type: GraphQLNonNull(User),
       resolve: async (_source, _args, {authToken, dataLoader}) => {
         const viewerId = getUserId(authToken)
-        if (!viewerId) {
-          const error = new Error(
-            `viewerId is null in User query. authToken: ${JSON.stringify(
-              authToken
-            )}. Timestamp: ${Math.floor(new Date().getTime() / 1000)}`
-          )
-          Sentry.captureException(error)
-          LogRocket.captureException(error)
-          return null
-        }
+        if (!viewerId) throw new Error('401 Please log in')
         return dataLoader.get('users').load(viewerId)
       }
     },


### PR DESCRIPTION
Predecessor: #5294

The nasty invitation bug was caused because `viewer: null` was stored in our cache.
`viewer: null` was set because `fetchQuery` was called before the user was logged in the logrocket init script

This is no one's fault, it's a sharp edge that needs to be softened.
To fix, I've done the following:
- make `viewer` non-null on the server. Now, if someone tries to query the viewer without being logged in, the server returns an error instead of quietly setting `viewer: null`
- created `Atmosphere.fetchQuery` to be used instead of `fetchQuery(atmosphere).toPromise()`. The latter would require a try/catch block. The former will just return null, so it should be safer for other developers. Also include store-or-network fetchPolicy to eliminate unnecessary fetches.
- rewrote the logrocket init code. now all init/identify calls happen in 1 area. ErrorProneAt is stored as ISO8601 string. We still allow for error tracking before login if the user is error prone.