### PR TITLE
Implement RedisLockQueue

### DIFF
--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -11,7 +11,7 @@ import ensureJiraDimensionField from '../../utils/ensureJiraDimensionField'
 import getPhase from '../../utils/getPhase'
 import getRedis from '../../utils/getRedis'
 import publish from '../../utils/publish'
-import RedisLock from '../../utils/RedisLock'
+import RedisLockQueue from '../../utils/RedisLockQueue'
 import {GQLContext} from '../graphql'
 import UpdatePokerScopeItemInput from '../types/UpdatePokerScopeItemInput'
 import UpdatePokerScopePayload from '../types/UpdatePokerScopePayload'
@@ -68,7 +68,7 @@ const updatePokerScope = {
     }
 
     // lock the meeting while the scope is updating
-    const redisLock = new RedisLock(`meeting:${meetingId}`, 3000)
+    const redisLock = new RedisLockQueue(`meeting:${meetingId}`, 3000)
     await redisLock.lock(10000)
 
     // RESOLUTION

--- a/packages/server/utils/RedisLockQueue.ts
+++ b/packages/server/utils/RedisLockQueue.ts
@@ -33,10 +33,8 @@ export default class RedisLockQueue {
         .exec()
       this.queued = true
       const resultingListLength = res[0][1]
-      if (resultingListLength === 1) {
-        // If the resulting LIST length is 1, we're already first on the list, return no lock
-        return false
-      }
+      // If the resulting LIST length is 1, we're already first on the list, return no lock
+      return resultingListLength !== 1
     }
     // Checking if we are the first on the list
     const head = await this.redis.lindex(this.queueKey, 0)

--- a/packages/server/utils/RedisLockQueue.ts
+++ b/packages/server/utils/RedisLockQueue.ts
@@ -32,7 +32,7 @@ export default class RedisLockQueue {
   }
 
   private markTaskAsRunning = async () => {
-    // Append timestamp to a key and replace the head
+    // Append a timestamp to uid and replace the head
     this.uidWithTimestamp = `${this.uid}::${Date.now()}`
     return this.redis.lset(this.queueKey, 0, this.uidWithTimestamp)
   }

--- a/packages/server/utils/RedisLockQueue.ts
+++ b/packages/server/utils/RedisLockQueue.ts
@@ -1,0 +1,74 @@
+import sleep from '../../client/utils/sleep'
+import generateUID from '../generateUID'
+import getRedis from './getRedis'
+
+export default class RedisLockQueue {
+  uid = generateUID()
+  queueKey: string
+  waitTime: number
+  ttl: number
+  queued = false
+  redis = getRedis()
+
+  constructor(key: string, ttl: number) {
+    this.queueKey = `lock:queue:${key}`
+    this.ttl = ttl
+    this.waitTime = 0
+  }
+
+  unlock = async () => {
+    // Remove all occurrences of the event from the list
+    return this.redis.lrem(this.queueKey, 0, this.uid)
+  }
+
+  checkLock = async () => {
+    // Add an event to the queue only once
+    if (!this.queued) {
+      const resultingListLength = await this.redis.rpush(this.queueKey, this.uid)
+      this.queued = true
+      // If the resulting LIST length is 1, we're already first on the list
+      if (resultingListLength === 1) {
+        // No lock
+        return false
+      }
+    }
+    // Checking if we are the first on the list
+    const head = await this.redis.lindex(this.queueKey, 0)
+    if (head == null) {
+      // If no head element exists, the queue was removed for some reason
+      // Now we cannot guarantee the correct order of the event
+      throw new Error(`Could not achieve lock for ${this.queueKey}. Queue does not exists`)
+    }
+    if (head === this.uid) {
+      // We are the first on the list, no lock
+      return false
+    }
+    return true
+  }
+
+  lock = async (maxWait: number) => {
+    // Check lock every 100 ms
+    const checkAfterMs = 100
+    // "Infinity" loop
+    for (let i = 0; i < 1000; i++) {
+      const hasLock = await this.checkLock()
+      if (!hasLock) {
+        // Refresh or set TTL on the list before running the event
+        const ttl = await this.redis.pexpire(this.queueKey, this.ttl)
+        if (ttl === 0) {
+          // TTL was not set, because queue is not exists for some reason
+          throw new Error(`Could not achieve lock for ${this.queueKey}. Unable to set TTL`)
+        }
+        return
+      } else {
+        await sleep(checkAfterMs)
+        this.waitTime += checkAfterMs
+        if (this.waitTime > maxWait) {
+          // Remove event from the queue
+          await this.unlock()
+          throw new Error(`Could not achieve lock for ${this.queueKey} after ${maxWait}ms`)
+        }
+      }
+    }
+  }
+}

--- a/packages/server/utils/RedisLockQueue.ts
+++ b/packages/server/utils/RedisLockQueue.ts
@@ -51,9 +51,9 @@ export default class RedisLockQueue {
     // Checking if we are the first on the list
     const head = await this.redis.lindex(this.queueKey, 0)
     if (head === null) {
-      // If no head element exists, the queue was removed for some reason
-      // Now we cannot guarantee the correct order of the event
-      throw new Error(`Could not achieve lock for ${this.queueKey}. Queue does not exists`)
+      // Queue disappeared for some reason, try again
+      this.queued = false
+      return true
     }
 
     const [, headTimestamp] = head.split(RedisLockQueue.timestampDelimiter)


### PR DESCRIPTION
#5268

In this PR I add `RedisLockQueue` which is a lock that put tasks in a queue and execute them in serial in the order that they were queued.

**It works as follows:**

- Instead of setting a single key, we use a LIST to push a request UID into it.
- Each request periodically checks if it is the first in the LIST. And if so, it is executed.
- After successful execution, the request calls `unlock` function which removes its UID from the LIST.
- Now, another request is able to find its UID in the LIST and execute

**Handling errors:**

It is theoretically possible that some of the events are failed and stuck in a queue. To handle this situations we use the following approach:
- When event starts, we append a timestamp to its UID. Each process checks if timestamp of the first event in a queue is too old or the event didn't event start. If so, it removes that event from the queue.
- If an event waits too long for its turn, it will fail with maxtime error and remove itself from the queue

