### PR TITLE
Read autopauseUsers user from PG

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/autopauseUsers.ts
+++ b/packages/server/graphql/intranetSchema/mutations/autopauseUsers.ts
@@ -3,6 +3,7 @@ import {InvoiceItemType, Threshold} from 'parabol-client/types/constEnums'
 import adjustUserCount from '../../../billing/helpers/adjustUserCount'
 import getRethink from '../../../database/rethinkDriver'
 import {requireSU} from '../../../utils/authorization'
+import getUserIdsToPause from '../../../postgres/queries/getUserIdsToPause'
 
 const autopauseUsers = {
   type: GraphQLInt,
@@ -16,13 +17,7 @@ const autopauseUsers = {
 
     // RESOLUTION
     const activeThresh = new Date(Date.now() - Threshold.AUTO_PAUSE)
-    const userIdsToPause = await r
-      .table('User')
-      .filter((user) => user('lastSeenAt').le(activeThresh))
-      .filter({
-        inactive: false
-      })('id')
-      .run()
+    const userIdsToPause = await getUserIdsToPause(activeThresh)
 
     const BATCH_SIZE = 100
     for (let i = 0; i < 1e5; i++) {

--- a/packages/server/postgres/queries/generated/getUserIdsToPauseQuery.ts
+++ b/packages/server/postgres/queries/generated/getUserIdsToPauseQuery.ts
@@ -1,0 +1,47 @@
+/** Types generated for queries found in "packages/server/postgres/queries/src/getUserIdsToPauseQuery.sql" */
+import {PreparedQuery} from '@pgtyped/query'
+
+/** 'GetUserIdsToPauseQuery' parameters type */
+export interface IGetUserIdsToPauseQueryParams {
+  activeThreshold: Date | null | void
+}
+
+/** 'GetUserIdsToPauseQuery' return type */
+export interface IGetUserIdsToPauseQueryResult {
+  id: string
+}
+
+/** 'GetUserIdsToPauseQuery' query type */
+export interface IGetUserIdsToPauseQueryQuery {
+  params: IGetUserIdsToPauseQueryParams
+  result: IGetUserIdsToPauseQueryResult
+}
+
+const getUserIdsToPauseQueryIR: any = {
+  name: 'getUserIdsToPauseQuery',
+  params: [
+    {
+      name: 'activeThreshold',
+      transform: {type: 'scalar'},
+      codeRefs: {used: [{a: 128, b: 142, line: 5, col: 69}]}
+    }
+  ],
+  usedParamSet: {activeThreshold: true},
+  statement: {
+    body:
+      'SELECT id FROM "User"\nWHERE inactive = false AND ("lastSeenAt" IS NULL OR "lastSeenAt" <= :activeThreshold)',
+    loc: {a: 37, b: 143, line: 4, col: 0}
+  }
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT id FROM "User"
+ * WHERE inactive = false AND ("lastSeenAt" IS NULL OR "lastSeenAt" <= :activeThreshold)
+ * ```
+ */
+export const getUserIdsToPauseQuery = new PreparedQuery<
+  IGetUserIdsToPauseQueryParams,
+  IGetUserIdsToPauseQueryResult
+>(getUserIdsToPauseQueryIR)

--- a/packages/server/postgres/queries/getUserIdsToPause.ts
+++ b/packages/server/postgres/queries/getUserIdsToPause.ts
@@ -1,0 +1,13 @@
+import {getUserIdsToPauseQuery} from './generated/getUserIdsToPauseQuery'
+import getPg from '../getPg'
+import catchAndLog from '../utils/catchAndLog'
+
+const getUserIdsToPause = async (activeThreshold: Date): Promise<string[]> => {
+  return (
+    (await catchAndLog(async () =>
+      (await getUserIdsToPauseQuery.run({activeThreshold}, getPg())).map((user) => user.id)
+    )) ?? []
+  )
+}
+
+export default getUserIdsToPause

--- a/packages/server/postgres/queries/src/getUserIdsToPauseQuery.sql
+++ b/packages/server/postgres/queries/src/getUserIdsToPauseQuery.sql
@@ -1,0 +1,5 @@
+/*
+  @name getUserIdsToPauseQuery
+*/
+SELECT id FROM "User"
+WHERE inactive = false AND ("lastSeenAt" IS NULL OR "lastSeenAt" <= :activeThreshold);


### PR DESCRIPTION
First step to replace User reads from RethinkDB with reads from Postgres.

This is a separate PR as it's independent and easy to test.

Relates-To: #4867