### PR TITLE
Fix undefined phaseType bug

### DIFF
--- a/packages/client/components/ActionSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/ActionSidebarPhaseListItemChildren.tsx
@@ -44,9 +44,6 @@ export default createFragmentContainer(ActionSidebarPhaseListItemChildren, {
   meeting: graphql`
     fragment ActionSidebarPhaseListItemChildren_meeting on ActionMeeting {
       ...MeetingSidebarTeamMemberStageItems_meeting
-      localPhase {
-        phaseType
-      }
       ...ActionSidebarAgendaItemsSection_meeting
     }
   `

--- a/packages/client/components/MeetingSidebarTeamMemberStageItems.tsx
+++ b/packages/client/components/MeetingSidebarTeamMemberStageItems.tsx
@@ -36,23 +36,25 @@ interface Props {
 const MeetingSidebarTeamMemberStageItems = (props: Props) => {
   const {gotoStageId, handleMenuClick, meeting, phaseType} = props
   const {facilitatorStageId, facilitatorUserId, localPhase, localStage, phases} = meeting
-  const sidebarPhase = phases.find((phase) => phase.phaseType === phaseType)!
+  const sidebarPhase = phases.find((phase) => phase.phaseType === phaseType)
   const localStageId = (localStage && localStage.id) || ''
   const gotoStage = (teamMemberId) => () => {
-    const teamMemberStage = sidebarPhase.stages.find((stage) => stage.teamMemberId === teamMemberId)
+    const teamMemberStage =
+      sidebarPhase && sidebarPhase.stages.find((stage) => stage.teamMemberId === teamMemberId)
     const teamMemberStageId = (teamMemberStage && teamMemberStage.id) || ''
     gotoStageId(teamMemberStageId).catch()
     handleMenuClick()
   }
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
-  const isActive = localPhase.phaseType === sidebarPhase.phaseType
+  const isActive = !!(localPhase && localPhase.phaseType === sidebarPhase?.phaseType)
   const isViewerFacilitator = viewerId === facilitatorUserId
-  const {height, ref} = useAnimatedPhaseListChildren(isActive, sidebarPhase.stages.length)
+  const childItemCount = sidebarPhase ? sidebarPhase.stages.length : 0
+  const {height, ref} = useAnimatedPhaseListChildren(isActive, childItemCount)
   return (
     <MeetingSidebarPhaseItemChild minHeight={height} height={height}>
       <ScrollStageItems isActive={isActive} ref={ref}>
-        {sidebarPhase.stages.map((stage) => {
+        {sidebarPhase?.stages.map((stage) => {
           const {
             id: stageId,
             isComplete,


### PR DESCRIPTION
Fixes #5307 

We [previously checked](https://github.com/ParabolInc/parabol/blob/8c68bf771a350b31c7948e6bd11c5c110e30c977/packages/client/components/ActionSidebarPhaseListItemChildren.tsx#L27) whether the `localPhase` type equaled the `phaseType` before rendering the component.

We now need to always render the `MeetingSidebarTeamMemberStageItems` component during the check-in and updates phases so that the sidebar transition can work.

Checking whether `localPhase` exists in `MeetingSidebarTeamMemberStageItems` does the trick as the `useAnimatedPhaseListChildren` will return a height of 0 if it doesn't exist.

While the `sidebarPhase` should always exist, I've removed the bang operator and added additional checks, just to be extra cautious. 

I'm not sure why the `localPhase` can be null, however. Our client schema shows `localPhase` as non-nullable.

This is a p1 bug and the ship is scheduled today so I'll go straight to maintainer reviewer. 