### PR TITLE
Fix ending meeting without open phases

### DIFF
--- a/packages/client/utils/getMeetingPhase.ts
+++ b/packages/client/utils/getMeetingPhase.ts
@@ -5,9 +5,9 @@ interface Phase {
 }
 
 const getMeetingPhase = <T extends Phase>(phases: readonly T[]) => {
-  return (phases.find((phase) => {
+  return phases.find((phase) => {
     return !phase.stages.every((stage) => stage.isComplete)
-  }) as unknown) as T
+  })
 }
 
 export default getMeetingPhase

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -279,7 +279,7 @@ export default {
     const data = {
       meetingId,
       teamId,
-      isKill: ![AGENDA_ITEMS, LAST_CALL].includes(phase.phaseType),
+      isKill: phase && ![AGENDA_ITEMS, LAST_CALL].includes(phase.phaseType),
       updatedTaskIds,
       removedTaskIds,
       timelineEventId

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -173,7 +173,7 @@ export default {
     const data = {
       meetingId,
       teamId,
-      isKill: phase.phaseType !== DISCUSS,
+      isKill: phase && phase.phaseType !== DISCUSS,
       removedTaskIds,
       timelineEventId
     }

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -108,7 +108,7 @@ export default {
     ])
     endSlackMeeting(meetingId, teamId, dataLoader).catch(console.log)
     sendMeetingEndToSegment(completedMeeting, meetingMembers as MeetingMember[], template)
-    const isKill = phase.phaseType !== 'ESTIMATE'
+    const isKill = phase && phase.phaseType !== 'ESTIMATE'
     if (!isKill) {
       sendNewMeetingSummary(completedMeeting, context).catch(console.log)
     }


### PR DESCRIPTION
With the right sequence of events it is possible to end up with a
complete (no open phases) meeting which did not end yet. This should not
throw.

Relates-To: #5243 