### PR TITLE
Fix bug where reflections missing if meeting not advance to discuss phase

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
@@ -29,6 +29,19 @@ const query = graphql`
           name
         }
         endedAt
+        ... on RetrospectiveMeeting {
+          reflectionGroups(sortBy: voteCount) {
+            title
+            voteCount
+            reflections {
+              content
+              createdAt
+              prompt {
+                question
+              }
+            }
+          }
+        }
         phases {
           phaseType
           stages {
@@ -43,13 +56,6 @@ const query = graphql`
               reflectionGroup {
                 title
                 voteCount
-                reflections {
-                  content
-                  createdAt
-                  prompt {
-                    question
-                  }
-                }
               }
             }
             ... on EstimateStage {
@@ -196,13 +202,14 @@ class ExportToCSV extends Component<Props> {
     return rows
   }
   handleRetroMeeting(newMeeting: Meeting) {
-    const {phases} = newMeeting
+    const {phases, reflectionGroups} = newMeeting
     const discussPhase = phases.find((phase) => phase.phaseType === 'discuss')!
     const {stages} = discussPhase
     const rows = [] as CSVRetroRow[]
-    stages.forEach((stage) => {
-      const {reflectionGroup, discussion} = stage
-      const {reflections, title, voteCount: votes} = reflectionGroup!
+
+    if (!reflectionGroups) return rows
+    reflectionGroups.forEach((reflectionGroup) => {
+      const {reflections, title, voteCount: votes} = reflectionGroup
       reflections.forEach((reflection) => {
         const {prompt, content} = reflection
         const createdAt = reflection.createdAt!
@@ -218,6 +225,11 @@ class ExportToCSV extends Component<Props> {
           content: extractTextFromDraftString(content)
         })
       })
+    })
+
+    stages.forEach((stage) => {
+      const {reflectionGroup, discussion} = stage
+      const {title, voteCount: votes} = reflectionGroup!
       if (!discussion) return
       const {thread} = discussion
       const {edges} = thread

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
@@ -89,7 +89,7 @@ const RetroTopics = (props: Props) => {
           const {reflections, title} = reflectionGroup
           const grid = useEmailItemGrid(reflections, 3)
           return (
-            <>
+            <React.Fragment key={reflectionGroup.id}>
               <tr>
                 <td align='center' style={{paddingTop: 20}}>
                   <AnchorIfEmail href={meetingUrl} isDemo={isDemo} isEmail={isEmail} style={stageThemeHeading}>
@@ -104,7 +104,7 @@ const RetroTopics = (props: Props) => {
                   ))}
                 </td>
               </tr>
-            </>
+            </React.Fragment>
           )
         }
       )}


### PR DESCRIPTION
Fixes #5191 .

Test:

Starts a retro meeting, fill in some reflections. End the meeting before discussion phase. Verify:

*   [x] reflection cards are shown in meeting summary page, and within correct reflection groups is there are any
*   [x] export to CSV button works and reflection texts are in the CSV file