### PR TITLE
fix migration from silent rethinkdb fail when stage has no taskId

### DIFF
--- a/packages/server/database/migrations/20211025134235-estimateStageTaskIdBackfill.ts
+++ b/packages/server/database/migrations/20211025134235-estimateStageTaskIdBackfill.ts
@@ -1,0 +1,153 @@
+import JiraIssueId from 'parabol-client/shared/gqlIds/JiraIssueId'
+import {R} from 'rethinkdb-ts'
+import dndNoise from '../../../client/utils/dndNoise'
+import convertToTaskContent from '../../../client/utils/draftjs/convertToTaskContent'
+import generateUID from '../../generateUID'
+import getTemplateRefsById from '../../postgres/queries/getTemplateRefsById'
+import insertTaskEstimate from '../../postgres/queries/insertTaskEstimate'
+import EstimatePhase from '../types/EstimatePhase'
+
+export const up = async function(r: R) {
+  const BATCH_SIZE = 1000
+  const plaintextContent = `Task imported from jira`
+  const content = convertToTaskContent(plaintextContent)
+  const updateStagesWithTaskIds = (
+    meetingId: string,
+    stageIdTaskIdLookup: Record<string, string>
+  ) => {
+    return r
+      .table('NewMeeting')
+      .get(meetingId)
+      .update((meeting) => ({
+        phases: meeting('phases').map((phase) =>
+          r.branch(
+            phase('phaseType').eq('ESTIMATE'),
+            phase.merge({
+              stages: phase('stages').map((stage) =>
+                r.branch(
+                  stage.hasFields('taskId').not(),
+                  stage.merge({
+                    taskId: r(stageIdTaskIdLookup)(stage('id')).default(stage('serviceTaskId'))
+                  }),
+                  stage
+                )
+              )
+            }),
+            phase
+          )
+        )
+      }))
+      .run()
+  }
+
+  for (let i = 0; i < 1e6; i++) {
+    const skip = i * BATCH_SIZE
+    console.log('migrating meeting #', skip)
+    const curMeetings = await r
+      .table('NewMeeting')
+      .filter({meetingType: 'poker'})
+      .orderBy('createdAt')
+      .skip(skip)
+      .limit(BATCH_SIZE)
+      .run()
+    if (curMeetings.length < 1) break
+    //
+    const tasksToInsert = []
+    const estimatesToInsert = []
+    const stageUpdates = curMeetings.map(async (meeting) => {
+      const {id: meetingId, teamId, phases, templateRefId} = meeting
+      const [templateRef] = await getTemplateRefsById([templateRefId])
+      const phase = phases.find((phase) => phase.phaseType === 'ESTIMATE') as EstimatePhase
+      if (!phase) return
+      const {stages} = phase
+      const stageIdToTaskId = {} as Record<string, string>
+      stages.forEach((stage) => {
+        if (stage.taskId) return
+        const {
+          id: stageId,
+          service,
+          serviceTaskId,
+          creatorUserId,
+          finalScore,
+          startAt,
+          dimensionRefIdx,
+          discussionId
+        } = stage
+        // in case there was a hiccup with pg
+        const dimensionName = templateRef?.dimensions?.[dimensionRefIdx]?.name ?? 'Story Points'
+        let taskId = serviceTaskId
+        if (service === 'jira') {
+          const {cloudId, issueKey, projectKey} = JiraIssueId.split(serviceTaskId)
+          taskId = generateUID()
+          // turn it into a parabol task
+          const task = {
+            content,
+            plaintextContent,
+            createdAt: new Date(),
+            createdBy: creatorUserId,
+            meetingId,
+            sortOrder: dndNoise(),
+            status: 'future',
+            tags: ['archived'],
+            teamId,
+            integrationHash: serviceTaskId,
+            integration: {
+              service: 'jira',
+              cloudId,
+              issueKey,
+              projectKey,
+              accessUserId: creatorUserId
+            },
+            userId: creatorUserId,
+            id: taskId,
+            updatedAt: new Date()
+          }
+          tasksToInsert.push(task)
+          stageIdToTaskId[stageId] = taskId
+        }
+        if (finalScore !== null && finalScore !== undefined) {
+          const estimate = {
+            changeSource: 'meeting',
+            createdAt: startAt || meeting.createdAt,
+            name: dimensionName,
+            label: finalScore,
+            taskId,
+            userId: creatorUserId,
+            meetingId,
+            stageId,
+            discussionId,
+            jiraFieldId: null
+          }
+          estimatesToInsert.push(estimate)
+        }
+      })
+      return updateStagesWithTaskIds(meetingId, stageIdToTaskId)
+    })
+    try {
+      await Promise.all(stageUpdates)
+    } catch (e) {
+      console.log('error updating stage taskId', e)
+    }
+    console.log({taskCount: tasksToInsert.length, estimateCount: estimatesToInsert.length})
+    try {
+      if (tasksToInsert.length > 0) {
+        await r
+          .table('Task')
+          .insert(tasksToInsert)
+          .run()
+      }
+    } catch (e) {
+      console.log('error inserting tasks', e)
+    }
+
+    try {
+      await Promise.all(estimatesToInsert.map((estimate) => insertTaskEstimate(estimate)))
+    } catch (e) {
+      console.log('error inserting tasks', e)
+    }
+  }
+}
+
+export const down = async function() {
+  // noop. it's just a taskId field & there's no way to discriminate between old vs new
+}


### PR DESCRIPTION
Resolves #5558

When this migration runs in staging or production, the user from #5424 and any others similarly affected should be able to access their ended meetings on the timeline with no errors.

Solves the following silent error from rethinkdb, which was surfaced during development using `returnChanges`.

```
{
  changes: [],
  deleted: 0,
  errors: 1,
  first_error: 'No attribute `taskId` in object:\n' +
    '{\n' +
    '\t"endAt":\t{\n' +
    '\t\t"$reql_type$":\t"TIME",\n' +
    '\t\t"epoch_time":\t1632431013.443,\n' +
    '\t\t"timezone":\t"+00:00"\n' +
    '\t},\n' +
    '\t"finalScore":\tnull,\n' +
    '\t"id":\t"4E7aaI8kec",\n' +
    '\t"isComplete":\ttrue,\n' +
    '\t"isNavigable":\ttrue,\n' +
    '\t"isNavigableByFacilitator":\ttrue,\n' +
    '\t"isVoting":\ttrue,\n' +
    '\t"phaseType":\t"ESTIMATE",\n' +
    '\t"readyToAdvance":\t[],\n' +
    '\t"scores":\t[],\n' +
    '\t"service":\t"PARABOL",\n' +
    '\t"sortOrder":\t0,\n' +
    '\t"startAt":\t{\n' +
    '\t\t"$reql_type$":\t"TIME",\n' +
    '\t\t"epoch_time":\t1624457446.957,\n' +
    '\t\t"timezone":\t"+00:00"\n' +
    '\t},\n' +
    '\t"viewCount":\t1\n' +
    '}',
  inserted: 0,
  replaced: 0,
  skipped: 0,
  unchanged: 0
}
```