### PR TITLE
support new m1 pro architecture

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,13 @@
   "singleQuote": true,
   "jsxSingleQuote": true,
   "semi": false,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "overrides": [
+    {
+      "files": "*.yml",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -1,8 +1,8 @@
-
 version: "3.7"
 
 services:
   db:
+    platform: linux/x86_64
     image: rethinkdb:latest
     restart: unless-stopped
     ports:
@@ -33,13 +33,14 @@ services:
       - postgres
     env_file: ../.env
     volumes:
-       - "pgadmin-data:/var/lib/pgadmin"
+      - "pgadmin-data:/var/lib/pgadmin"
     ports:
       - "5050:80"
     networks:
       - parabol-network
     restart: unless-stopped
   redis:
+    platform: linux/x86_64
     image: redis:latest
     restart: unless-stopped
     ports:

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -7,7 +7,7 @@ const {promisify} = require('util')
 const webpack = require('webpack')
 const getProjectRoot = require('./webpack/utils/getProjectRoot')
 const Redis = require('ioredis')
-const rmdir = promisify(fs.rmdir)
+const rm = promisify(fs.rm)
 const unlink = promisify(fs.unlink)
 const PROJECT_ROOT = getProjectRoot()
 const TOOLBOX_ROOT = path.join(PROJECT_ROOT, 'scripts', 'toolbox')
@@ -30,7 +30,7 @@ const removeArtifacts = async () => {
   const generated = path.join(PROJECT_ROOT, 'packages/client/__generated__')
   const queryMap = path.join(PROJECT_ROOT, 'queryMap.json')
   try {
-    await Promise.all([rmdir(generated, {recursive: true}), unlink(schemaPath), unlink(queryMap)])
+    await Promise.all([rm(generated, {recursive: true}), unlink(schemaPath), unlink(queryMap)])
   } catch (_) {
     // probably didn't exist, noop
   }


### PR DESCRIPTION
redis & rethinkdb don't have M1 architectures yet so we have to emulate them.
Also noticed some deprecation warnings on node v16.9.1, so fixed that up.
an explicit x86_64 should work just fine for intel architectures, too.


 