### PR TITLE
Fix source returning to kanban & 2 column error

### DIFF
--- a/packages/client/components/SpotlightModal.tsx
+++ b/packages/client/components/SpotlightModal.tsx
@@ -192,6 +192,7 @@ const SpotlightModal = (props: Props) => {
               reflectionGroup={spotlightGroup}
               meeting={meeting}
               reflectionIdsToHide={reflectionIdsToHideRef.current}
+              expandedReflectionGroupPortalParentId='spotlight'
             />
           )}
         </Source>

--- a/packages/client/hooks/useGroupMatrix.ts
+++ b/packages/client/hooks/useGroupMatrix.ts
@@ -19,9 +19,10 @@ const useGroupMatrix = (
     const width = el?.clientWidth
     if (!width) return null
     let colCount = 1
+    const currentMaxColumns = Math.min(resultsGroups.length, MAX_SPOTLIGHT_COLUMNS)
     const getNextWidth = (count: number) =>
       ElementWidth.MEETING_CARD * count + ElementWidth.MEETING_CARD_MARGIN * (count - 1)
-    while (getNextWidth(colCount + 1) < width && colCount + 1 <= MAX_SPOTLIGHT_COLUMNS) {
+    while (getNextWidth(colCount + 1) < width && colCount + 1 <= currentMaxColumns) {
       colCount++
     }
     return colCount

--- a/packages/client/hooks/useSpotlightSimulatedDrag.tsx
+++ b/packages/client/hooks/useSpotlightSimulatedDrag.tsx
@@ -54,9 +54,6 @@ const useSpotlightSimulatedDrag = (
       const meetingProxy = store.get(meetingId)
       meetingProxy?.setValue(null, 'spotlightGroup')
       meetingProxy?.setValue(null, 'spotlightReflectionId')
-      const reflection = store.get(reflectionId)
-      // set isDropping to true so that the source is added back to its original position in kanban
-      reflection?.setValue(true, 'isDropping')
     })
     dragIdRef.current = undefined
     reflectionIdRef.current = undefined

--- a/packages/client/mutations/handlers/handleUpdateSpotlightResults.ts
+++ b/packages/client/mutations/handlers/handleUpdateSpotlightResults.ts
@@ -30,7 +30,7 @@ const handleUpdateSpotlightResults = (
   const reflectionGroupId = reflectionGroup.getValue('id')
   const groupsIds = similarReflectionGroups
     .map((group) => group.getValue('id'))
-    .concat(reflectionGroupId)
+    .concat(spotlightGroupId)
   const isInSpotlight = groupsIds.includes(reflectionGroupId)
   const wasInSpotlight = groupsIds.includes(oldReflectionGroupId)
   // added to another group. Remove old reflection group

--- a/packages/client/mutations/handlers/handleUpdateSpotlightResults.ts
+++ b/packages/client/mutations/handlers/handleUpdateSpotlightResults.ts
@@ -34,7 +34,7 @@ const handleUpdateSpotlightResults = (
   const isInSpotlight = groupsIds.includes(reflectionGroupId)
   const wasInSpotlight = groupsIds.includes(oldReflectionGroupId)
   // added to another group. Remove old reflection group
-  if (isOldGroupEmpty) {
+  if (isOldGroupEmpty && wasInSpotlight) {
     safeRemoveNodeFromArray(oldReflectionGroupId, viewer, 'similarReflectionGroups', {
       storageKeyArgs: {
         reflectionGroupId: spotlightGroupId,
@@ -43,7 +43,9 @@ const handleUpdateSpotlightResults = (
     })
   }
   // ungrouping created a new group or was added to a group in the kanban
-  if ((reflectionsCount === 1 && wasInSpotlight) || (isOldGroupEmpty && !isInSpotlight)) {
+  // reflectionsCount is undefined when ungrouping
+  // don't use else if: when a result is added to a kanban group, remove old empty group and add new one
+  if (!isInSpotlight && reflectionsCount !== undefined && wasInSpotlight) {
     addNodeToArray(reflectionGroup, viewer, 'similarReflectionGroups', 'sortOrder', {
       storageKeyArgs: {
         reflectionGroupId: spotlightGroupId,


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/5625 and https://github.com/ParabolInc/parabol/issues/5622

### To test

- [ ] When closing the Spotlight, the source animation is immediately returned to the kanban, i.e. there's no 500ms wait for it to return
- [ ] Can open the Spotlight if there's only 3 reflections in the kanban
- [ ] After dropping a result reflection on the source, the reflection isn't briefly added back to the results group
- [ ] After grouping a result reflection into the source and clicking on the source group to open the expanded reflection stack, closing the expanded reflection stack modal does not close the Spotlight modal