### PR TITLE
Fix collapsed reflections 

### DIFF
--- a/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
+++ b/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
@@ -109,10 +109,16 @@ const DraggableReflectionCard = (props: Props) => {
   const {viewer} = spotlightSearchResults
   const {similarReflectionGroups} = viewer
   const isReflectionIdInSpotlight = useMemo(() => {
-    const resultReflectionIdsInSpotlight =
-      similarReflectionGroups?.flatMap(({reflections}) => reflections.map(({id}) => id)) || []
-    return [...resultReflectionIdsInSpotlight, spotlightReflectionId].includes(reflectionId)
-  }, [similarReflectionGroups, reflectionId])
+    return (
+      reflectionId === spotlightReflectionId ||
+      !!(
+        reflectionId &&
+        similarReflectionGroups?.find(({reflections}) =>
+          reflections.find(({id}) => id === reflectionId)
+        )
+      )
+    )
+  }, [similarReflectionGroups, reflectionId, spotlightReflectionId])
 
   const {onMouseDown} = useDraggableReflectionCard(
     meeting,

--- a/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
+++ b/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useEffect, useState} from 'react'
+import React, {useEffect, useMemo, useState} from 'react'
 import {createFragmentContainer, useLazyLoadQuery} from 'react-relay'
 import useDraggableReflectionCard from '../../hooks/useDraggableReflectionCard'
 import {DraggableReflectionCardLocalQuery} from '../../__generated__/DraggableReflectionCardLocalQuery.graphql'
@@ -78,9 +78,9 @@ const DraggableReflectionCard = (props: Props) => {
     swipeColumn,
     dataCy
   } = props
-  const {id: meetingId, teamId, localStage, spotlightGroup} = meeting
+  const {id: meetingId, teamId, localStage, spotlightGroup, spotlightReflectionId} = meeting
   const {isComplete, phaseType} = localStage
-  const {isDropping, isEditing, reflectionGroupId, remoteDrag} = reflection
+  const {id: reflectionId, isDropping, isEditing, remoteDrag} = reflection
   const spotlightGroupId = spotlightGroup?.id
   const isSpotlightOpen = !!spotlightGroupId
   const isInSpotlight = !openSpotlight
@@ -95,6 +95,9 @@ const DraggableReflectionCard = (props: Props) => {
             searchQuery: $searchQuery
           ) {
             id
+            reflections {
+              id
+            }
           }
         }
       }
@@ -105,12 +108,12 @@ const DraggableReflectionCard = (props: Props) => {
   )
   const {viewer} = spotlightSearchResults
   const {similarReflectionGroups} = viewer
-  const resultGroupIdsInSpotlight = similarReflectionGroups
-    ? similarReflectionGroups.map(({id}) => id)
-    : []
-  const isReflectionGroupIdInSpotlight = [...resultGroupIdsInSpotlight, spotlightGroupId].includes(
-    reflectionGroupId
-  )
+  const isReflectionIdInSpotlight = useMemo(() => {
+    const resultReflectionIdsInSpotlight =
+      similarReflectionGroups?.flatMap(({reflections}) => reflections.map(({id}) => id)) || []
+    return [...resultReflectionIdsInSpotlight, spotlightReflectionId].includes(reflectionId)
+  }, [similarReflectionGroups, reflectionId])
+
   const {onMouseDown} = useDraggableReflectionCard(
     meeting,
     reflection,
@@ -146,7 +149,7 @@ const DraggableReflectionCard = (props: Props) => {
         // Else, if it's a remote drag that is not in the spotlight
         // Else, if this is the instance in the source or search results
         const isPriorityCard =
-          !isSpotlightOpen || (!isReflectionGroupIdInSpotlight && remoteDrag) || isInSpotlight
+          !isSpotlightOpen || (!isReflectionIdInSpotlight && remoteDrag) || isInSpotlight
         if (isPriorityCard) {
           drag.ref = c
         }
@@ -211,6 +214,7 @@ export default createFragmentContainer(DraggableReflectionCard, {
       spotlightGroup {
         id
       }
+      spotlightReflectionId
     }
   `
 })


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/5623

When a reflection group is ungrouped, a new `reflectionGroupId` is created for the ungrouped reflection. When this happens, the new reflection group is added to the Spotlight [here](https://github.com/ParabolInc/parabol/blob/378944330900be841e7cc903974c0afc9a1c17f8/packages/client/mutations/handlers/handleUpdateSpotlightResults.ts#L47). However, momentarily, before the new reflection group is added to the Spotlight, the `reflectionGroupId` doesn't exist in the `resultGroupIdsInSpotlight` meaning `!isReflectionGroupIdInSpotlight` and therefore [isPriorityCard](https://github.com/ParabolInc/parabol/blob/45cae6676c2bf6051cd8042962e5bee243c04419/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx#L151) are briefly true when they shouldn't be.

This means that the kanban reflection will be a priority card when it shouldn't be, `drag.ref` will be assigned to `c`, and the height will collapse [here](https://github.com/ParabolInc/parabol/blob/3af17a3c22980852d20e9c53e4171b8d94360341/packages/client/hooks/useDraggableReflectionCard.tsx#L341).

While the `reflectionGroupId` doesn't exist in the Spotlight, the `reflectionId` does. Checking if `isReflectionIdInSpotlight` is true fixes the issue.

### To test

- Alice opens the Spotlight in Client A. The Spotlight results include a reflection group that contains two reflections
- Bob, in Client B, ungroups the group in the Spotlight that contains two reflections
- Alice closes the Spotlight and sees that the kanban does not include any collapsed reflections (see screenshot in issue for an example).

Note: after remotely ungrouping, the group doesn't return to the correct position in the results. We have an open issue for this here: https://github.com/ParabolInc/parabol/issues/5627
