### PR TITLE
fix relay error on drag end

### DIFF
--- a/packages/server/graphql/mutations/endDraggingReflection.ts
+++ b/packages/server/graphql/mutations/endDraggingReflection.ts
@@ -72,7 +72,7 @@ export default {
     }
 
     // RESOLUTION
-    let newReflectionGroupId
+    let newReflectionGroupId: string | undefined
     if (dropTargetType === 'REFLECTION_GRID') {
       // ungroup
       try {

--- a/packages/server/graphql/mutations/helpers/updateReflectionLocation/addReflectionToGroup.ts
+++ b/packages/server/graphql/mutations/helpers/updateReflectionLocation/addReflectionToGroup.ts
@@ -33,17 +33,19 @@ const addReflectionToGroup = async (
     .run()
 
   // RESOLUTION
+  const sortOrder = maxSortOrder + 1 + dndNoise()
   await r
     .table('RetroReflection')
     .get(reflectionId)
     .update({
-      sortOrder: maxSortOrder + 1 + dndNoise(),
+      sortOrder,
       reflectionGroupId,
       updatedAt: now
     })
     .run()
 
   // mutate the dataLoader cache
+  reflection.sortOrder = sortOrder
   reflection.reflectionGroupId = reflectionGroupId
   reflection.updatedAt = now
 


### PR DESCRIPTION
In dev, relay would print some errors saying the same object in the same payload had different properties.

specifically, `reflection.reflectionGroupId` was different from `reflectionGroup.reflection.reflectionGroupId` in the endDragging payload.

the root cause was a dataloader with stale data.
@nickoferrall you might be interested in this