### PR TITLE
Fix empty name on tooltip when onboarding new member

### DIFF
--- a/packages/client/components/DashboardAvatars/DashboardAvatar.tsx
+++ b/packages/client/components/DashboardAvatars/DashboardAvatar.tsx
@@ -37,12 +37,12 @@ const StyledAvatar = styled(Avatar)<{isConnected: boolean; picture: string}>(
 
 const DashboardAvatar = (props: Props) => {
   const {teamMember} = props
-  const {id: teamMemberId, picture, teamId} = teamMember
+  const {id: teamMemberId, picture, teamId, preferredName} = teamMember
   const {user} = teamMember
   if (!user) {
     throw new Error(`User Avatar unavailable. ${JSON.stringify(teamMember)}`)
   }
-  const {isConnected, preferredName} = user
+  const {isConnected} = user
   const atmosphere = useAtmosphere()
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
@@ -91,9 +91,9 @@ export default createFragmentContainer(DashboardAvatar, {
       id
       picture
       teamId
+      preferredName
       user {
         isConnected
-        preferredName
       }
     }
   `


### PR DESCRIPTION
Fixed [Issue 5553](https://github.com/ParabolInc/parabol/issues/5553)

Had to change the PropType interface for `DashboardAvatar_teamMember` since the graphQL data structure could not be changed.
@jordanh 