### PR TITLE
Fix missing `isSpotlight` in `useSpotlightReflectionGroup`

### DIFF
--- a/packages/client/components/ReflectionGroup/ReflectionGroup.tsx
+++ b/packages/client/components/ReflectionGroup/ReflectionGroup.tsx
@@ -6,7 +6,7 @@ import {PortalId} from '~/hooks/usePortal'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useEventCallback from '../../hooks/useEventCallback'
 import useExpandedReflections from '../../hooks/useExpandedReflections'
-import useSpotlightReflectionGroup from '../../hooks/useSpotlightReflectionGroup'
+import useSpotlightReflectionGroup from './useSpotlightReflectionGroup'
 import {
   DragAttribute,
   ElementWidth,
@@ -133,6 +133,7 @@ const ReflectionGroup = (props: Props) => {
           isEditing
           remoteDrag {
             dragUserId
+            isSpotlight
           }
         }
         isExpanded

--- a/packages/client/components/ReflectionGroup/useSpotlightReflectionGroup.ts
+++ b/packages/client/components/ReflectionGroup/useSpotlightReflectionGroup.ts
@@ -1,6 +1,6 @@
 import useSpotlightResults from '~/hooks/useSpotlightResults'
-import {ReflectionGroup_reflectionGroup} from './../__generated__/ReflectionGroup_reflectionGroup.graphql'
 import {useMemo} from 'react'
+import {ReflectionGroup_reflectionGroup} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
 
 const useSpotlightReflectionGroup = (
   visibleReflections: ReflectionGroup_reflectionGroup['reflections'],


### PR DESCRIPTION
The property was missing from the `ReflectionGroup`s fragment. Also
moved the hook in the `ReflectionGroup` subdirectory as it's tightly
coupled to `ReflectionGroup`