### PR TITLE
Fix sticky tooltip in agenda item pins

### DIFF
--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -172,8 +172,8 @@ const AgendaItem = (props: Props) => {
           metaContent={
             <IconBlock
               onClick={handleIconClick}
-              onMouseEnter={openTooltip}
-              onMouseLeave={closeTooltip}
+              onMouseOver={openTooltip}
+              onMouseOut={closeTooltip}
               ref={originRef}
             >
               {getIcon()}


### PR DESCRIPTION
Sometimes the tooltip for the agenda item pins can be a little sticky. `onMouseOver` & `onMouseOut` fire more frequently as they execute when the cursor leaves the child element as well as the current element. Matt mentioned the issue and solution here: https://github.com/ParabolInc/parabol/pull/5550#discussion_r739439423

Hey @tianrunhe, would you mind reviewing this one, please? 