### PR TITLE
remove __STATIC_IMAGES__

### DIFF
--- a/packages/client/components/AddTeamMemberModal.tsx
+++ b/packages/client/components/AddTeamMemberModal.tsx
@@ -19,6 +19,7 @@ import Icon from './Icon'
 import BasicTextArea from './InputField/BasicTextArea'
 import MassInvitationTokenLinkRoot from './MassInvitationTokenLinkRoot'
 import PrimaryButton from './PrimaryButton'
+import momentumPng from '../../../static/images/illustrations/illus-momentum.png'
 
 interface Props {
   closePortal: () => void
@@ -113,8 +114,7 @@ const Label = styled('div')({
 
 const IllustrationBlock = () => {
   const showIllustration = useBreakpoint(INVITE_DIALOG_BREAKPOINT)
-  const imageSrc = `${__STATIC_IMAGES__}/illustrations/illus-momentum.png`
-  return showIllustration ? <Illustration alt='' src={imageSrc} /> : null
+  return showIllustration ? <Illustration alt='' src={momentumPng} /> : null
 }
 
 const AddTeamMemberModal = (props: Props) => {
@@ -162,7 +162,7 @@ const AddTeamMemberModal = (props: Props) => {
         onError(
           new Error(
             `${alreadyInvitedEmails[0]} and ${alreadyInvitedEmails.length -
-            1} other emails are already on the team`
+              1} other emails are already on the team`
           )
         )
       }

--- a/packages/client/components/AddTeamMemberModalDemo.tsx
+++ b/packages/client/components/AddTeamMemberModalDemo.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled'
 import DemoCreateAccountPrimaryButton from './DemoCreateAccountPrimaryButton'
 import DialogContainer from './DialogContainer'
 import hasToken from '../utils/hasToken'
+import momentumPng from '../../../static/images/illustrations/illus-momentum.png'
 
 const StyledDialogContainer = styled(DialogContainer)({
   alignItems: 'center',
@@ -31,10 +32,9 @@ const AddTeamMemberModalDemo = () => {
   const copy = hasToken()
     ? 'Invite your teammates to a team and kick off a real Retro!'
     : 'Sign up, invite your teammates, and kick off a real Retro!'
-  const imageSrc = `${__STATIC_IMAGES__}/illustrations/illus-momentum.png`
   return (
     <StyledDialogContainer>
-      <Illustration alt='' src={imageSrc} />
+      <Illustration alt='' src={momentumPng} />
       <StyledCopy>{copy}</StyledCopy>
       <DemoCreateAccountPrimaryButton />
     </StyledDialogContainer>

--- a/packages/client/components/CreditCardIcon.tsx
+++ b/packages/client/components/CreditCardIcon.tsx
@@ -3,6 +3,23 @@ import React from 'react'
 import useSVG from '../hooks/useSVG'
 import {BezierCurve} from '../types/constEnums'
 import {keyframes} from '@emotion/core'
+import {CardTypeIcon} from '../utils/StripeClientManager'
+import ccJCB from '../../../static/images/creditCards/cc-jcb-brands.svg'
+import ccAmex from '../../../static/images/creditCards/cc-amex-brands.svg'
+import ccDiners from '../../../static/images/creditCards/cc-diners-club-brands.svg'
+import ccDiscover from '../../../static/images/creditCards/cc-discover-brands.svg'
+import ccMastercard from '../../../static/images/creditCards/cc-mastercard-brands.svg'
+import ccVisa from '../../../static/images/creditCards/cc-visa-brands.svg'
+
+const cardTypeIconToFilename = {
+  'cc-amex-brands': ccAmex,
+  'cc-diners-club-brands': ccDiners,
+  'cc-discover-brands': ccDiscover,
+  'cc-jcb-brands': ccJCB,
+  'cc-mastercard-brands': ccMastercard,
+  'cc-visa-brands': ccVisa,
+  credit_card: ''
+} as Record<CardTypeIcon, string>
 
 const keyframesOpacity = keyframes`
   0% {
@@ -23,15 +40,13 @@ const SVGStyles = styled('div')({
 })
 
 interface Props {
-  cardTypeIcon: string
+  cardTypeIcon: CardTypeIcon
 }
-
-const CCDir = `${__STATIC_IMAGES__}/creditCards`
 
 const CreditCardIcon = (props: Props) => {
   const {cardTypeIcon} = props
-  const isFallback = cardTypeIcon === 'credit_card'
-  const {svg, svgRef} = useSVG(isFallback ? '' : `${CCDir}/${cardTypeIcon}.svg`)
+  const icon = cardTypeIconToFilename[cardTypeIcon]
+  const {svg, svgRef} = useSVG(icon)
   if (!svg) return null
   return <SVGStyles ref={svgRef} dangerouslySetInnerHTML={{__html: svg}} />
 }

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -116,7 +116,7 @@ const NewMeeting = (props: Props) => {
   const {history} = useRouter()
   const innerWidth = useInnerWidth()
   const [idx, setIdx] = useState(0)
-  const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)]
+  const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)] as MeetingTypeEnum
   const sendToMeRef = useRef(false)
   useEffect(() => {
     if (!teamId) {

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -110,13 +110,13 @@ const useInnerWidth = () => {
 const NewMeeting = (props: Props) => {
   const {teamId, viewer, retry} = props
   const {teams} = viewer
-  const newMeetingOrder = ['poker', 'retrospective', 'action']
+  const newMeetingOrder = ['poker', 'retrospective', 'action'] as const
 
   useStoreQueryRetry(retry)
   const {history} = useRouter()
   const innerWidth = useInnerWidth()
   const [idx, setIdx] = useState(0)
-  const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)] as MeetingTypeEnum
+  const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)]
   const sendToMeRef = useRef(false)
   useEffect(() => {
     if (!teamId) {

--- a/packages/client/components/NewMeetingIllustration.tsx
+++ b/packages/client/components/NewMeetingIllustration.tsx
@@ -3,6 +3,10 @@ import React, {Fragment} from 'react'
 import SwipeableViews from 'react-swipeable-views'
 import {mod} from 'react-swipeable-views-core'
 import {virtualize} from 'react-swipeable-views-utils'
+import {MeetingTypeEnum} from '~/__generated__/NewMeeting_viewer.graphql'
+import checkinSvg from '../../../static/images/illustrations/checkin.svg'
+import retrospectiveSvg from '../../../static/images/illustrations/retrospective.svg'
+import pokerSvg from '../../../static/images/illustrations/sprintPoker.svg'
 import useBreakpoint from '../hooks/useBreakpoint'
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
@@ -15,14 +19,14 @@ const MeetingImage = styled('img')({
 interface Props {
   idx: number
   setIdx: (idx: number) => void
-  newMeetingOrder: string[]
+  newMeetingOrder: readonly MeetingTypeEnum[]
 }
 
 const ILLUSTRATIONS = {
-  retrospective: `${__STATIC_IMAGES__}/illustrations/retrospective.svg`,
-  action: `${__STATIC_IMAGES__}/illustrations/checkin.svg`,
-  poker: `${__STATIC_IMAGES__}/illustrations/sprintPoker.svg`
-}
+  retrospective: retrospectiveSvg,
+  action: checkinSvg,
+  poker: pokerSvg
+} as Record<MeetingTypeEnum, string>
 
 const VirtualizeSwipeableViews = virtualize(SwipeableViews)
 

--- a/packages/client/components/ReflectionCard/AddReactjiButton.tsx
+++ b/packages/client/components/ReflectionCard/AddReactjiButton.tsx
@@ -4,8 +4,7 @@ import PlainButton from '~/components/PlainButton/PlainButton'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import lazyPreload from '~/utils/lazyPreload'
-
-const icon = `${__STATIC_IMAGES__}/icons/add_reactji_24.svg`
+import addReactjiSvg from '../../../../static/images/icons/add_reactji_24.svg'
 
 const Button = styled(PlainButton)({
   display: 'block',
@@ -50,7 +49,7 @@ const AddReactjiButton = (props: Props) => {
         ref={originRef}
         onMouseEnter={ReactjiPicker.preload}
       >
-        <AddIcon alt='' src={icon} />
+        <AddIcon alt='' src={addReactjiSvg} />
       </Button>
       {menuPortal(<ReactjiPicker menuProps={menuProps} onClick={onToggle} />)}
     </>

--- a/packages/client/components/UpgradeLater.tsx
+++ b/packages/client/components/UpgradeLater.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled'
 import InvitationDialogCopy from './InvitationDialogCopy'
 import SecondaryButton from './SecondaryButton'
 import DialogContainer from './DialogContainer'
+import upgradeLaterSvg from '../../../static/images/illustrations/conversion_prompt-upgrade_later.svg'
 
 const Illustration = styled('img')({
   display: 'block ',
@@ -34,9 +35,7 @@ const UpgradeLater = (props: Props) => {
   const {closePortal} = props
   return (
     <Container>
-      <Illustration
-        src={`${__STATIC_IMAGES__}/illustrations/conversion_prompt-upgrade_later.svg`}
-      />
+      <Illustration src={upgradeLaterSvg} />
       <InvitationDialogCopy>{'Your organization has exceeded'}</InvitationDialogCopy>
       <InvitationDialogCopy>
         {'the free tier limit of '}

--- a/packages/client/components/UpgradeSuccess.tsx
+++ b/packages/client/components/UpgradeSuccess.tsx
@@ -6,7 +6,7 @@ import DialogTitle from './DialogTitle'
 import InvitationDialogCopy from './InvitationDialogCopy'
 import SecondaryButton from './SecondaryButton'
 import DialogContainer from './DialogContainer'
-
+import paymentSuccessSvg from '../../../static/images/illustrations/conversion_prompt-payment_success.svg'
 const Illustration = styled('img')({
   display: 'block ',
   maxWidth: 256
@@ -43,9 +43,7 @@ const UpgradeSuccess = (props: Props) => {
   const {closePortal} = props
   return (
     <Container>
-      <Illustration
-        src={`${__STATIC_IMAGES__}/illustrations/conversion_prompt-payment_success.svg`}
-      />
+      <Illustration src={paymentSuccessSvg} />
       <StyledDialogTitle>{'Upgraded!'}</StyledDialogTitle>
       <InvitationDialogCopy>{'Your organization is'}</InvitationDialogCopy>
       <InvitationDialogCopy>

--- a/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardErrorLine.tsx
+++ b/packages/client/modules/userDashboard/components/CreditCardModal/CreditCardErrorLine.tsx
@@ -1,4 +1,4 @@
-import StripeClientManager from '../../../../utils/StripeClientManager'
+import StripeClientManager, {CardTypeIcon} from '../../../../utils/StripeClientManager'
 import React, {useEffect, useState} from 'react'
 import CreditCardIcon from '../../../../components/CreditCardIcon'
 import styled from '@emotion/styled'
@@ -45,7 +45,7 @@ const Message = styled('div')({
 
 const CreditCardErrorLine = (props: Props) => {
   const {fields, serverError, stripeClientManager} = props
-  const [cardTypeIcon, setCardTypeIcon] = useState<string>()
+  const [cardTypeIcon, setCardTypeIcon] = useState<CardTypeIcon>()
   const {creditCardNumber, cvc, expiry} = fields
   const primaryError =
     serverError ||

--- a/packages/client/types/modules.d.ts
+++ b/packages/client/types/modules.d.ts
@@ -10,7 +10,6 @@ declare module '*.woff2'
 
 declare const __PRODUCTION__: string
 declare const __APP_VERSION__: string
-declare const __STATIC_IMAGES__: string
 declare const __SOCKET_PORT__: string
 interface Window {
   __ACTION__: any

--- a/packages/client/utils/StripeClientManager.ts
+++ b/packages/client/utils/StripeClientManager.ts
@@ -11,7 +11,9 @@ export const cardTypeLookup = {
   'Diners Club': 'cc-diners-club-brands',
   JCB: 'cc-jcb-brands',
   Unknown: 'credit_card'
-}
+} as const
+
+export type CardTypeIcon = ValueOf<typeof cardTypeLookup>
 
 export const normalizeExpiry = (value = '', previousValue = '') => {
   const month = value.substr(0, 2)
@@ -110,6 +112,6 @@ export default class StripeClientManager {
   cardTypeIcon = (number: string) => {
     if (!this.stripe) return 'credit_card'
     const type = this.stripe.cardType(number)
-    return cardTypeLookup[type] as ValueOf<typeof cardTypeLookup>
+    return cardTypeLookup[type]
   }
 }

--- a/packages/server/types/modules.d.ts
+++ b/packages/server/types/modules.d.ts
@@ -10,7 +10,6 @@ declare module '*.graphql' {
 }
 
 declare const __PRODUCTION__: string
-declare const __STATIC_IMAGES__: string
 declare const __SOCKET_PORT__: string
 interface Window {
   __ACTION__: any

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -120,8 +120,7 @@ module.exports = {
       'process.env.NODE_ENV': JSON.stringify('development'),
       'process.env.DEBUG': JSON.stringify(process.env.DEBUG),
       'process.env.PROTOO_LISTEN_PORT': JSON.stringify(process.env.PROTOO_LISTEN_PORT || 4444),
-      __SOCKET_PORT__: JSON.stringify(process.env.SOCKET_PORT),
-      __STATIC_IMAGES__: JSON.stringify(`/static/images`)
+      __SOCKET_PORT__: JSON.stringify(process.env.SOCKET_PORT)
     }),
     new webpack.HotModuleReplacementPlugin()
   ],

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -63,16 +63,10 @@ module.exports = ({isDeploy, isStats}) => ({
       assert: path.join(PROJECT_ROOT, 'scripts/webpack/assert.js'),
       os: false
     },
-    modules: [
-      path.resolve(CLIENT_ROOT, '../node_modules'),
-      'node_modules'
-    ]
+    modules: [path.resolve(CLIENT_ROOT, '../node_modules'), 'node_modules']
   },
   resolveLoader: {
-    modules: [
-      path.resolve(CLIENT_ROOT, '../node_modules'),
-      'node_modules'
-    ]
+    modules: [path.resolve(CLIENT_ROOT, '../node_modules'), 'node_modules']
   },
   optimization: {
     minimize: Boolean(isDeploy || isStats),
@@ -127,10 +121,7 @@ module.exports = ({isDeploy, isStats}) => ({
       __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
       'process.env.DEBUG': false,
       'process.env.NODE_ENV': JSON.stringify('production'),
-      'process.env.PROTOO_LISTEN_PORT': JSON.stringify(
-        (process.env.PROTOO_LISTEN_PORT || 4444) - 1
-      ),
-      __STATIC_IMAGES__: JSON.stringify(`https://${process.env.AWS_S3_BUCKET}/static`)
+      'process.env.PROTOO_LISTEN_PORT': JSON.stringify((process.env.PROTOO_LISTEN_PORT || 4444) - 1)
     }),
     new webpack.SourceMapDevToolPlugin({
       filename: '[name]_[contenthash].js.map',
@@ -144,18 +135,18 @@ module.exports = ({isDeploy, isStats}) => ({
       exclude: [/GraphqlContainer/, /\.map$/, /^manifest.*\.js$/, /index.html$/]
     }),
     isDeploy &&
-    new S3Plugin({
-      s3Options: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        region: process.env.AWS_REGION
-      },
-      s3UploadOptions: {
-        Bucket: process.env.AWS_S3_BUCKET
-      },
-      basePath: getS3BasePath(),
-      directory: buildPath
-    }),
+      new S3Plugin({
+        s3Options: {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+          region: process.env.AWS_REGION
+        },
+        s3UploadOptions: {
+          Bucket: process.env.AWS_S3_BUCKET
+        },
+        basePath: getS3BasePath(),
+        directory: buildPath
+      }),
     isStats && new BundleAnalyzerPlugin({generateStatsFile: true})
   ].filter(Boolean),
   module: {


### PR DESCRIPTION
our build should be totally self-contained.
__STATIC_IMAGES__ is not. it is a link to a directory on our S3 server.
by removing it, all required assets are put into the webpack build.
this should make deploying to private instances easier.

TEST
- [ ] the credit card upgrade modal credit card icon changes as you type different credit cards (e.g. start with 4 and it turns into visa, start with 5 and it turns into mastercard, etc.)
- [ ] go to the new meeting view & scroll through the meeting illustrations, they all work
- [ ] running `yarn build` results in a /build directory that includes a bunch of new svgs & pngs
