### PR TITLE
Fix husky hooks

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn run post-commit

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run post-commit
+yarn run postcommit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn run pre-commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run pre-commit
+yarn run precommit

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
     "newMutation": "yarn sucrase-node scripts/codeshift/newMutation.ts",
     "typecheck": "lerna run --parallel --no-bail typecheck",
     "update-schema": "node scripts/updateSchemaCLI.js",
-    "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000"
+    "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
+    "pre-commit": "lerna run --concurrency 1 --stream precommit",
+    "post-commit": "git update-index --again",
+    "prepare": "husky install"
   },
   "resolutions": {
     "typescript": "4.4.2",
@@ -73,11 +76,5 @@
     "webpack": "5.64.1",
     "webpack-cli": "4.9.1",
     "yarn-deduplicate": "^3.1.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lerna run --concurrency 1 --stream precommit",
-      "post-commit": "git update-index --again"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "typecheck": "lerna run --parallel --no-bail typecheck",
     "update-schema": "node scripts/updateSchemaCLI.js",
     "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
-    "pre-commit": "lerna run --concurrency 1 --stream precommit",
-    "post-commit": "git update-index --again",
+    "precommit": "lerna run --stream precommit",
+    "postcommit": "git update-index --again",
     "prepare": "husky install"
   },
   "resolutions": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,7 @@
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-emotion": "^10.0.14",
-    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^1.6.1",
     "expect": "^24.8.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,7 +47,7 @@
     "eslint": "^8.2.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-emotion": "^10.0.14",
-    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^1.6.1",
     "expect": "^24.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7328,10 +7328,10 @@ eslint-plugin-emotion@^10.0.14:
   resolved "https://registry.yarnpkg.com/eslint-plugin-emotion/-/eslint-plugin-emotion-10.0.27.tgz#577a4265cc679f7bb826437a92fb9d709928e0a7"
   integrity sha512-0IG9KWmyQTAWZNM4WoGjFbdre1Xq6uMp2jYOSHvh3ZNcDfOjOLXeH3ky1MuWZlbWIHxz/Ed5DMGlJAeKnd26VA==
 
-eslint-plugin-prettier@^3.1.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz#e9ddb200efb6f3d05ffe83b1665a716af4a387e5"
-  integrity sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -9197,10 +9197,15 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immutable@3.8.2, immutable@~3.7.4, immutable@~3.7.6:
+immutable@3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
+
+immutable@~3.7.4, immutable@~3.7.6:
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Recently we updated `husky` from version `^3.0.1` to version `^7.0.4` ([commit](https://github.com/ParabolInc/parabol/commit/6086f859533faf087f1fcf840ea8f6a4470ee0b8#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519))

Looks like a new version of husky is no longer store hooks in `.git/hooks`, now it requires another approach.

From the README https://github.com/typicode/husky:

```
Edit package.json > prepare script and run it once:

npm set-script prepare "husky install"
npm run prepare

Add a hook:

npx husky add .husky/pre-commit "npm test"
git add .husky/pre-commit
```

**How to test:**

- Ideally, make a fresh clone of the repo, run `yarn`
- Be on `master`
- Make a commit and see it run without errors, but no hooks were executed
- Checkout to this branch — `fix-husky`
- Run `yarn` (it will install husky shell script)
- Make a commit, see both pre-commit, post-commit hooks are executed