### PR TITLE
update password requirements for local accounts

### DIFF
--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -80,8 +80,8 @@ const validateEmail = (email: string) => {
 const validatePassword = (password: string) => {
   return new Legitity(password)
     .required('Please enter a password')
-    .min(6, '6 character minimum')
     .max(1000, `That's a book, not a password`)
+    .matches(new RegExp("^(?=.*\\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^\\w\\d\\s:])([^\\s]){8,}$"), 'Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character')
 }
 
 const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {

--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -80,8 +80,9 @@ const validateEmail = (email: string) => {
 const validatePassword = (password: string) => {
   return new Legitity(password)
     .required('Please enter a password')
+    .min(8, '8 character minimum')
     .max(1000, `That's a book, not a password`)
-    .matches(new RegExp("^(?=.*\\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^\\w\\d\\s:])([^\\s]){8,}$"), 'Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character')
+    .matches(new RegExp("^((?=(.*[\\d]){1,})(?=(.*[a-z]){1,})(?=(.*[A-Z]){1,})(?=(.*[^\\w\\d\\s]){1,}))"), 'Must include at least one uppercase letter, one lowercase letter, one number and one special character')
 }
 
 const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {

--- a/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
+++ b/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
@@ -41,8 +41,9 @@ const SubmitButton = styled(PrimaryButton)({
 const validatePassword = (password: string) => {
   return new Legitity(password)
     .required('Please enter a password')
+    .min(8, '8 character minimum')
     .max(1000, `That's a book, not a password`)
-    .matches(new RegExp("^(?=.*\\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^\\w\\d\\s:])([^\\s]){8,}$"), 'Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character')
+    .matches(new RegExp("^((?=(.*[\\d]){1,})(?=(.*[a-z]){1,})(?=(.*[A-Z]){1,})(?=(.*[^\\w\\d\\s]){1,}))"), 'Must include at least one uppercase letter, one lowercase letter, one number and one special character')
 }
 
 const SetNewPassword = (props: Props) => {

--- a/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
+++ b/packages/client/components/ResetPasswordPage/SetNewPassword.tsx
@@ -41,8 +41,8 @@ const SubmitButton = styled(PrimaryButton)({
 const validatePassword = (password: string) => {
   return new Legitity(password)
     .required('Please enter a password')
-    .min(6, '6 character minimum')
     .max(1000, `That's a book, not a password`)
+    .matches(new RegExp("^(?=.*\\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^\\w\\d\\s:])([^\\s]){8,}$"), 'Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character')
 }
 
 const SetNewPassword = (props: Props) => {


### PR DESCRIPTION
We've had the question a couple times regarding our password complexity in security questionnaires. We are currently only requiring any 6 characters. This PR increases the requirements to: Minimum eight characters, at least one uppercase letter, one lowercase letter, one number and one special character.