### PR TITLE
Fix remotely ungrouped results position in Spotlight

### DIFF
--- a/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
+++ b/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
@@ -56,6 +56,7 @@ interface Props {
   staticReflections: DraggableReflectionCard_staticReflections | null
   swipeColumn?: SwipeColumn
   dataCy?: string
+  isSpotlightEntering?: boolean
 }
 
 export interface TargetBBox {
@@ -76,7 +77,8 @@ const DraggableReflectionCard = (props: Props) => {
     openSpotlight,
     isDraggable,
     swipeColumn,
-    dataCy
+    dataCy,
+    isSpotlightEntering
   } = props
   const {id: meetingId, teamId, localStage, spotlightGroup, spotlightReflectionId} = meeting
   const {isComplete, phaseType} = localStage
@@ -116,11 +118,13 @@ const DraggableReflectionCard = (props: Props) => {
   return (
     <DragWrapper
       ref={(c) => {
-        // if the spotlight is closed, this card is the single source of truth
+        // If the spotlight is closed, this card is the single source of truth
         // Else, if it's a remote drag that is not in the spotlight
         // Else, if this is the instance in the source or search results
+        // And Spotlight modal isn't entering. This throws off dropping remote card position
         const isPriorityCard =
-          !isSpotlightOpen || (!isReflectionIdInSpotlight && remoteDrag) || isInSpotlight
+          (!isSpotlightOpen || (!isReflectionIdInSpotlight && remoteDrag) || isInSpotlight) &&
+          !isSpotlightEntering
         if (isPriorityCard) {
           drag.ref = c
         }

--- a/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
+++ b/packages/client/components/ReflectionGroup/DraggableReflectionCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useEffect, useMemo, useState} from 'react'
+import React, {useMemo, useState} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import useSpotlightResults from '~/hooks/useSpotlightResults'
 import useDraggableReflectionCard from '../../hooks/useDraggableReflectionCard'
@@ -112,23 +112,10 @@ const DraggableReflectionCard = (props: Props) => {
   const showDragCursor = isDraggable && canHandleDrag && !isEditing && !isDropping
   // slow state updates can mean we miss an onMouseDown event
   const handleDrag = canHandleDrag ? onMouseDown : undefined
-  // if spotlight was just opened and card is in the middle of dropping we let it drop into original position
-  const [isFinishingRemoteDragging, setIsFinishingRemoteDragging] = useState(
-    () => isDropping && isSpotlightOpen && !!remoteDrag
-  )
-  // if the card was finishing remote drag and it was dropped into the original position, let it behave normally
-  useEffect(() => {
-    if (isFinishingRemoteDragging && !isDropping) {
-      setIsFinishingRemoteDragging(false)
-    }
-  }, [isFinishingRemoteDragging, isDropping])
 
   return (
     <DragWrapper
       ref={(c) => {
-        if (isFinishingRemoteDragging) {
-          return
-        }
         // if the spotlight is closed, this card is the single source of truth
         // Else, if it's a remote drag that is not in the spotlight
         // Else, if this is the instance in the source or search results

--- a/packages/client/components/ReflectionGroup/ReflectionGroup.tsx
+++ b/packages/client/components/ReflectionGroup/ReflectionGroup.tsx
@@ -75,6 +75,7 @@ interface Props {
   dataCy?: string
   expandedReflectionGroupPortalParentId?: PortalId
   reflectionIdsToHide?: string[] | null
+  isSpotlightEntering?: boolean
 }
 
 const ReflectionGroup = (props: Props) => {
@@ -86,7 +87,8 @@ const ReflectionGroup = (props: Props) => {
     swipeColumn,
     dataCy,
     expandedReflectionGroupPortalParentId,
-    reflectionIdsToHide
+    reflectionIdsToHide,
+    isSpotlightEntering
   } = props
   const meeting = useFragment(
     graphql`
@@ -296,6 +298,7 @@ const ReflectionGroup = (props: Props) => {
                   reflection={reflection}
                   staticReflections={staticReflections}
                   swipeColumn={swipeColumn}
+                  isSpotlightEntering={!!isSpotlightEntering}
                 />
               </ReflectionWrapper>
             )

--- a/packages/client/components/ResultsRoot.tsx
+++ b/packages/client/components/ResultsRoot.tsx
@@ -9,10 +9,11 @@ interface Props {
   spotlightGroupId?: string
   phaseRef: RefObject<HTMLDivElement>
   meetingId: string
+  isSpotlightEntering: boolean
 }
 
 const ResultsRoot = (props: Props) => {
-  const {meetingId, spotlightGroupId, phaseRef} = props
+  const {meetingId, spotlightGroupId, phaseRef, isSpotlightEntering} = props
   const searchQuery = '' // TODO: implement searchQuery
   const groupIdRef = useRef('')
   const nextGroupId = spotlightGroupId ?? ''
@@ -31,7 +32,13 @@ const ResultsRoot = (props: Props) => {
   )
   return (
     <Suspense fallback={''}>
-      {queryRef && <SpotlightGroups phaseRef={phaseRef} queryRef={queryRef} />}
+      {queryRef && (
+        <SpotlightGroups
+          phaseRef={phaseRef}
+          queryRef={queryRef}
+          isSpotlightEntering={isSpotlightEntering}
+        />
+      )}
     </Suspense>
   )
 }

--- a/packages/client/components/SpotlightGroups.tsx
+++ b/packages/client/components/SpotlightGroups.tsx
@@ -36,10 +36,12 @@ const Column = styled('div')({
 interface Props {
   phaseRef: RefObject<HTMLDivElement>
   queryRef: PreloadedQuery<SpotlightGroupsQuery>
+  isSpotlightEntering: boolean
 }
 
 const SpotlightGroups = (props: Props) => {
-  const {phaseRef, queryRef} = props
+  const {phaseRef, queryRef, isSpotlightEntering} = props
+
   const data = usePreloadedQuery<SpotlightGroupsQuery>(
     graphql`
       query SpotlightGroupsQuery($reflectionGroupId: ID!, $searchQuery: String!, $meetingId: ID!) {
@@ -102,6 +104,7 @@ const SpotlightGroups = (props: Props) => {
                 phaseRef={phaseRef}
                 reflectionGroupRef={group}
                 expandedReflectionGroupPortalParentId='spotlight'
+                isSpotlightEntering={isSpotlightEntering}
               />
             ))}
           </Column>

--- a/packages/client/components/SpotlightModal.tsx
+++ b/packages/client/components/SpotlightModal.tsx
@@ -212,7 +212,12 @@ const SpotlightModal = (props: Props) => {
           </Search>
         </SearchWrapper>
       </SourceSection>
-      <ResultsRoot meetingId={meetingId} phaseRef={modalRef} spotlightGroupId={spotlightGroupId} />
+      <ResultsRoot
+        meetingId={meetingId}
+        phaseRef={modalRef}
+        spotlightGroupId={spotlightGroupId}
+        isSpotlightEntering={portalStatus === PortalStatus.Entering}
+      />
     </Modal>
   )
 }


### PR DESCRIPTION
Fix #5627 

### To test

- [ ] If Alice remotely ungroups a result group, Bob sees the ungrouped reflection move into the expected position in the Spotlight modal
- [ ] If a remote reflection is dropping and the viewer opens the Spotlight, the dropping remote reflection does not move into the Spotlight (see gif example here https://github.com/ParabolInc/parabol/issues/5415#issuecomment-937912945)

