### PR TITLE
Remove editor.wordWrap from workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,8 +41,6 @@
   "editor.formatOnSave": true,
   "editor.gotoLocation.multipleDefinitions": "goto",
   "editor.gotoLocation.multipleTypeDefinitions": "goto",
-  "editor.wordWrapColumn": 100,
-  "editor.wordWrap": "on",
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true


### PR DESCRIPTION
This is subjective and shouldn't be forced on everyone.