### PR TITLE
Add standups feature flag

### DIFF
--- a/packages/client/types/graphql.ts
+++ b/packages/client/types/graphql.ts
@@ -51304,6 +51304,11 @@ export interface IUserFeatureFlags {
    * true if spotlight is allowed
    */
   spotlight: boolean;
+
+  /**
+   * true if standups is allowed
+   */
+  standups: boolean;
 }
 
 /**
@@ -57251,6 +57256,7 @@ export interface IAddFeatureFlagPayload {
  */
 export const enum UserFlagEnum {
   spotlight = 'spotlight',
+  standups = 'standups',
 }
 
 export interface IAddGitHubAuthPayload {

--- a/packages/server/graphql/types/UserFeatureFlags.ts
+++ b/packages/server/graphql/types/UserFeatureFlags.ts
@@ -9,6 +9,11 @@ const UserFeatureFlags = new GraphQLObjectType<any, GQLContext>({
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'true if spotlight is allowed',
       resolve: ({spotlight}) => !!spotlight
+    },
+    standups: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'true if standups is allowed',
+      resolve: ({standups}) => !!standups
     }
   })
 })

--- a/packages/server/graphql/types/UserFlagEnum.ts
+++ b/packages/server/graphql/types/UserFlagEnum.ts
@@ -1,12 +1,13 @@
 import {GraphQLEnumType} from 'graphql'
 
-export type UserFeatureFlagEnum = 'spotlight'
+export type UserFeatureFlagEnum = 'spotlight' | 'standups'
 
 const UserFlagEnum = new GraphQLEnumType({
   name: 'UserFlagEnum',
   description: 'A flag to give an individual user super powers',
   values: {
-    spotlight: {}
+    spotlight: {},
+    standups: {}
   }
 })
 


### PR DESCRIPTION
Fix #5753 

I haven't added a cheat code for standups yet as:

1. I imagine it should be added to the `NewMeeting` file, but I'm not sure yet as we haven't started building it
2. It's not in the AC
3. We need to use the `AddFeatureFlagMutation` which is added in #5699. I'd prefer to keep the PRs separate
4. Adding the cheat code is trivial once #5699 is merged

@BartoszJarocki could you review this one, please?