### PR TITLE
Fix image scaling in task description

### DIFF
--- a/packages/client/components/IntegratedTaskContent.tsx
+++ b/packages/client/components/IntegratedTaskContent.tsx
@@ -8,7 +8,10 @@ const Content = styled('div')({
   paddingLeft: 16,
   paddingRight: 16,
   maxHeight: 320,
-  overflow: 'auto'
+  overflow: 'auto',
+  img: {
+    height: 'auto'
+  }
 })
 const Summary = styled('div')({
   fontWeight: 600


### PR DESCRIPTION
#5247

How to test:

- Create a task in parabol and push to jira
- Edit task on jira and add images to description with different aspect ratios (vertical, horizontal)
- Go back to paraobl, see images are displayed correctly