### PR TITLE
Adds skip link to dashboard

### DIFF
--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import MobileDashSidebar from './Dashboard/MobileDashSidebar'
 import DashTopBar from './DashTopBar'
 import MobileDashTopBar from './MobileDashTopBar'
 import SwipeableDashSidebar from './SwipeableDashSidebar'
+import {PALETTE} from '~/styles/paletteV3'
 
 const MeetingsDash = lazy(() =>
   import(/* webpackChunkName: 'MeetingsDash' */ '../components/MeetingsDash')
@@ -50,7 +51,7 @@ const DashPanel = styled('div')({
   overflow: 'hidden'
 })
 
-const DashMain = styled('div')({
+const DashMain = styled('main')({
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
@@ -58,6 +59,30 @@ const DashMain = styled('div')({
   minHeight: 0,
   overflow: 'auto',
   position: 'relative'
+})
+
+const SkipLink = styled('a')({
+  position: 'absolute',
+  clip: 'rect(1px,1px,1px,1px)',
+  clipPath: 'inset(50%)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  width: '1px',
+  transition: 'background-color 0.1s ease',
+
+  ':focus': {
+    clip: 'auto !important',
+    clipPath: 'inherit',
+    width: 'auto',
+    height: 'auto',
+    color: PALETTE.SLATE_900,
+    backgroundColor: PALETTE.GOLD_300,
+    padding: '4px 44px',
+    lineHeight: '49px',
+    textDecoration: 'underline',
+    outline: 'none'
+  }
 })
 
 const Dashboard = (props: Props) => {
@@ -94,6 +119,7 @@ const Dashboard = (props: Props) => {
   useSnacksForNewMeetings(activeMeetings)
   return (
     <DashLayout>
+      <SkipLink href='#main'>Skip to content</SkipLink>
       {isDesktop ? (
         <DashTopBar viewer={viewer} toggle={toggle} />
       ) : (
@@ -107,7 +133,7 @@ const Dashboard = (props: Props) => {
             <MobileDashSidebar viewer={viewer} handleMenuClick={handleMenuClick} />
           </SwipeableDashSidebar>
         )}
-        <DashMain ref={meetingsDashRef}>
+        <DashMain id='main' ref={meetingsDashRef}>
           <Switch>
             <Route
               path='/meetings'


### PR DESCRIPTION
This PR adds a skip link to the app's dashboard views. It mainly consists of two changes:

1. Creates an `a` tag that is visually hidden unless it receives keyboard focus
2. Replaces a `div` with a `main` tag for the main content area. This is so the skip link can point to the main area.

In short, this makes the first interactive item in the Web page a link to the beginning of the main content.

**Related WCAG criteria:**
[2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.1#qr-navigation-mechanisms-skip)
_A mechanism is available to bypass blocks of content that are repeated on multiple Web pages._

This is a common a11y feature and there are many examples and best practices. For reference, check out [gov.uk](https://www.gov.uk/) and [whitehouse.gov](https://www.whitehouse.gov/).

![Screen Shot 2021-12-15 at 12 23 45-fullpage](https://user-images.githubusercontent.com/3276087/146250456-50112f5d-1d80-4dd2-958f-ff8c4f448c56.png)

It's important to note that the skip link will only be visible when focused using a keyboard or a screen reader. Users who navigate with touch or mouse will not see the skip link. 

**How to test**
Open the app on a web browser and press <kbd>TAB</kbd>.

