### PR TITLE
Remove instanceof TouchEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.41.0 2021-Dec-16
+
+### Added
+
+- Add updatedAt trigger to User table (#5733)
+- Add standups feature flag (#5754)
+- Release Spotlight (#5785)
+
+### Fixed
+
+- Spotlight height doesn't change when searching (#5747)
+- This is proper this again in make resolve (#5769)
+- Fix mapping to jira dimension field (#5770)
+- noUncheckedIndexedAccess fixes (#5737)
+- Fix image scaling in task description (#5758)
+- Fix typo in comment (#5784)
+
 ## 6.40.0 2021-Dec-09
 
 ### Added

--- a/packages/client/hooks/useDraggableFixture.ts
+++ b/packages/client/hooks/useDraggableFixture.ts
@@ -30,8 +30,8 @@ const useDraggableFixture = (isLeftSidebarOpen: boolean, isRightDrawerOpen: bool
   const onMouseMove = useEventCallback((e: MouseEvent | TouchEvent) => {
     // required to prevent address bar scrolling & other strange browser things on mobile view
     e.preventDefault()
-    const isTouchMove = e instanceof TouchEvent
-    const {clientX} = isTouchMove ? e.touches[0]! : e
+    const isTouchMove = e.type === 'touchmove'
+    const {clientX} = isTouchMove ? (e as TouchEvent).touches[0]! : (e as MouseEvent)
     const wasDrag = drag.isDrag
     if (!wasDrag) {
       drag.isDrag = getIsDrag(clientX, 0, drag.lastX, 0)

--- a/packages/client/hooks/useDraggableReflectionCard.tsx
+++ b/packages/client/hooks/useDraggableReflectionCard.tsx
@@ -298,8 +298,8 @@ const useDragAndDrop = (
   const onMouseMove = useEventCallback((e: MouseEvent | TouchEvent) => {
     // required to prevent address bar scrolling & other strange browser things on mobile view
     e.preventDefault()
-    const isTouchMove = e instanceof TouchEvent
-    const {clientX, clientY} = isTouchMove ? e.touches[0]! : e
+    const isTouchMove = e.type === 'touchmove'
+    const {clientX, clientY} = isTouchMove ? (e as TouchEvent).touches[0]! : (e as MouseEvent)
     const wasDrag = drag.isDrag
     if (!wasDrag) {
       const isDrag = getIsDrag(clientX, clientY, drag.startX, drag.startY)
@@ -337,7 +337,7 @@ const useDragAndDrop = (
       }
     }
     if (isTouchMove && swipeColumn) {
-      const {clientX} = e.touches[0]!
+      const {clientX} = (e as TouchEvent).touches[0]!
       const minThresh = windowDims.clientWidth * 0.1
       if (clientX <= minThresh) {
         swipeColumn(-1)


### PR DESCRIPTION
Fix #5806 

`TouchEvent` can be undefined on Firefox ([see here](https://bugzilla.mozilla.org/show_bug.cgi?id=1693172)). Reverting back to the previous implementation. 

I had committed the Changelog update to `master`, which is why this PR includes the Changelog update. I think it's fine to still include that here. 