### PR TITLE
Fix alignment of logo

### DIFF
--- a/packages/client/components/DashTopBar.tsx
+++ b/packages/client/components/DashTopBar.tsx
@@ -58,7 +58,7 @@ const LogoWrapper = styled('button')({
   border: 'none',
   borderRadius: 4,
   cursor: 'pointer',
-  margin: '8px 0',
+  margin: '8px 0 8px -8px',
   padding: '8px 8px 4px 8px',
   ':focus': {
     boxShadow: `0 0 0 2px ${PALETTE.SKY_400}`,


### PR DESCRIPTION
This PR fixes the alignment of the logo in the dashboard's top bar, after the introduction of focus styles (#5607). The logo was pushed 8px to the right to allow for enough padding around:

<img width="263" alt="Screen Shot 2021-12-17 at 4 10 06 p m" src="https://user-images.githubusercontent.com/3276087/146819244-7baf83c5-ba04-4855-a1b2-4c5d9ea41b46.png">

Top was before, bottom is now.

Tested to make sure focus styles still work well and no issues are present on mobile views.