### PR TITLE
monkeypatch uWS res.cork

### DIFF
--- a/packages/server/pipeStreamOverResponse.ts
+++ b/packages/server/pipeStreamOverResponse.ts
@@ -8,11 +8,11 @@ const pipeStreamOverResponse = (
 ) => {
   res.onAborted(() => {
     readStream.destroy()
-    res.done = true
+    res.aborted = true
   })
   readStream
     .on('data', (chunk: Buffer) => {
-      if (res.done) {
+      if (res.aborted) {
         readStream.destroy()
         return
       }
@@ -40,7 +40,7 @@ const pipeStreamOverResponse = (
     })
 
     .on('error', () => {
-      if (!res.done) {
+      if (!res.aborted) {
         res.writeStatus('500').end()
       }
       readStream.destroy()

--- a/packages/server/safetyPatchRes.ts
+++ b/packages/server/safetyPatchRes.ts
@@ -37,6 +37,15 @@ const safetyPatchRes = (res: HttpResponse) => {
     return res._close()
   }
 
+  res._cork = res.cork
+  res.cork = (cb: () => void) => {
+    if (res.done) {
+      console.log(`uWS DEBUG: Called cork after done`)
+      return
+    }
+    res._cork(cb)
+  }
+
   res._tryEnd = res.tryEnd
   res.tryEnd = (fullBodyOrChunk: RecognizedString, totalSize: number) => {
     if (res.done) {

--- a/packages/server/safetyPatchRes.ts
+++ b/packages/server/safetyPatchRes.ts
@@ -5,7 +5,7 @@ const safetyPatchRes = (res: HttpResponse) => {
     throw new Error('already patched')
   }
   res.onAborted(() => {
-    res.done = true
+    res.aborted = true
     if (res.abortEvents) {
       res.abortEvents.forEach((f) => f())
     }
@@ -20,9 +20,9 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._end = res.end
   res.end = (body?: RecognizedString) => {
     if (res.done) {
-      console.log(`uWS DEBUG: Called end after done`)
-      return res
+      console.warn(`uWS: Called end after done`)
     }
+    if (res.done || res.aborted) return res
     res.done = true
     return res._end(body)
   }
@@ -30,9 +30,9 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._close = res.close
   res.close = () => {
     if (res.done) {
-      console.log(`uWS DEBUG: Called close after done`)
-      return res
+      console.warn(`uWS: Called close after done`)
     }
+    if (res.done || res.aborted) return res
     res.done = true
     return res._close()
   }
@@ -40,46 +40,64 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._cork = res.cork
   res.cork = (cb: () => void) => {
     if (res.done) {
-      console.log(`uWS DEBUG: Called cork after done`)
-      return
+      console.warn(`uWS: Called cork after done`)
     }
+    if (res.done || res.aborted) return
     res._cork(cb)
   }
 
   res._tryEnd = res.tryEnd
   res.tryEnd = (fullBodyOrChunk: RecognizedString, totalSize: number) => {
     if (res.done) {
-      console.log(`uWS DEBUG: Called tryEnd after done`)
-      return [true, true]
+      console.warn(`uWS: Called tryEnd after done`)
     }
+    if (res.done || res.aborted) return [true, true]
     return res._tryEnd(fullBodyOrChunk, totalSize)
   }
 
   res._write = res.write
   res.write = (chunk: RecognizedString) => {
     if (res.done) {
-      console.log(`uWS DEBUG: Called write after done`)
-      return res
+      console.warn(`uWS: Called write after done`)
     }
+    if (res.done || res.aborted) return res
     return res._write(chunk)
   }
 
   res._writeHeader = res.writeHeader
   res.writeHeader = (key: RecognizedString, value: RecognizedString) => {
     if (res.done) {
-      console.log(`uWS DEBUG: Called writeHeader after done ${key}`)
-      return res
+      console.warn(`uWS: Called writeHeader after done`)
     }
+    if (res.done || res.aborted) return res
     return res._writeHeader(key, value)
   }
 
   res._writeStatus = res.writeStatus
   res.writeStatus = (status: RecognizedString) => {
     if (res.done) {
-      console.error(`uWS DEBUG: Called writeStatus after done ${status}`)
-      return res
+      console.error(`uWS: Called writeStatus after done ${status}`)
     }
+    if (res.done || res.aborted) return res
     return res._writeStatus(status)
+  }
+
+  res._upgrade = res.upgrade
+  res.upgrade = (...args) => {
+    if (res.done) {
+      console.error(`uWS: Called upgrade after done`)
+    }
+    if (res.done || res.aborted) return
+    return res._upgrade(...args)
+  }
+
+  res._getRemoteAddressAsText = res.getRemoteAddressAsText
+  res.getRemoteAddressAsText = () => {
+    if (res.done) {
+      console.error(`uWS: Called upgrade after done`)
+    }
+    if (res.done || res.aborted) return Buffer.from('')
+    return res._getRemoteAddressAsText()
   }
 }
 


### PR DESCRIPTION
this guarantees that we no longer attempt to access responses that have already been disposed of.
it'll still emit a console log, but we can turn those off later & it'd be AOK.

instead of turning them off, i'm thinking we track both `done` and `aborted` booleans & only log if it is done but not aborted. that way we'll still get log statements when the handler isn't doing it right