### PR TITLE
Fix retro demo task integrate menu

### DIFF
--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -48,11 +48,7 @@ import initDB, {
   DemoThreadableEdge,
   demoViewerId,
   JiraProjectKeyLookup,
-  RetroDemoDB,
-  JiraDemoKey,
-  GitHubDemoKey,
-  makeSuggestedIntegrationJira,
-  makeSuggestedIntegrationGitHub
+  RetroDemoDB
 } from './initDB'
 import LocalAtmosphere from './LocalAtmosphere'
 
@@ -247,7 +243,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         }
       }
     },
-    TaskFooterIntegrateMenuRootQuery: (_$teamId, $userId) => {
+    TaskFooterIntegrateMenuRootQuery: (_teamId: unknown, userId: string) => {
       const user = this.db.users[0]
       return {
         viewer: {
@@ -255,43 +251,10 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
           userOnTeam: {
             ...user
           },
-          assigneeTeamMember: {
-            preferredName: user.id === $userId ? user.preferredName : 'assignee_name',
-            integrations:
-              user.id === $userId
-                ? {
-                    id: 'demoTeamIntegrations',
-                    atlassian: {
-                      id: 'demoTeamAtlassianIntegration',
-                      isActive: true,
-                      accessToken: '123'
-                    },
-                    github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'}
-                  }
-                : null,
-            suggestedIntegrations: {
-              hasMore: true,
-              items: [
-                makeSuggestedIntegrationJira(JiraDemoKey),
-                makeSuggestedIntegrationGitHub(GitHubDemoKey)
-              ]
-            }
-          },
-          viewerTeamMember: {
-            preferredName: user.preferredName,
-            integrations: {
-              id: 'demoTeamIntegrations',
-              atlassian: {id: 'demoTeamAtlassianIntegration', isActive: true, accessToken: '123'},
-              github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'}
-            },
-            suggestedIntegrations: {
-              hasMore: true,
-              items: [
-                makeSuggestedIntegrationJira(JiraDemoKey),
-                makeSuggestedIntegrationGitHub(GitHubDemoKey)
-              ]
-            }
-          }
+          assigneeTeamMember: this.db.teamMembers.find(
+            (teamMember) => teamMember.userId === userId
+          ),
+          viewerTeamMember: this.db.teamMembers[0]
         }
       }
     },

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -245,12 +245,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
     },
     TaskFooterIntegrateMenuRootQuery: () => {
       return {
-        viewer: {
-          ...this.db.users[0],
-          userOnTeam: {
-            ...this.db.users[0]
-          }
-        }
+        ...this.db.viewer
       }
     },
     NewMeetingSummaryRootQuery: () => {

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -48,7 +48,11 @@ import initDB, {
   DemoThreadableEdge,
   demoViewerId,
   JiraProjectKeyLookup,
-  RetroDemoDB
+  RetroDemoDB,
+  JiraDemoKey,
+  GitHubDemoKey,
+  makeSuggestedIntegrationJira,
+  makeSuggestedIntegrationGitHub
 } from './initDB'
 import LocalAtmosphere from './LocalAtmosphere'
 
@@ -243,9 +247,52 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         }
       }
     },
-    TaskFooterIntegrateMenuRootQuery: () => {
+    TaskFooterIntegrateMenuRootQuery: (_$teamId, $userId) => {
+      const user = this.db.users[0]
       return {
-        ...this.db.viewer
+        viewer: {
+          ...user,
+          userOnTeam: {
+            ...user
+          },
+          assigneeTeamMember: {
+            preferredName: user.id === $userId ? user.preferredName : 'assignee_name',
+            integrations:
+              user.id === $userId
+                ? {
+                    id: 'demoTeamIntegrations',
+                    atlassian: {
+                      id: 'demoTeamAtlassianIntegration',
+                      isActive: true,
+                      accessToken: '123'
+                    },
+                    github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'}
+                  }
+                : null,
+            suggestedIntegrations: {
+              hasMore: true,
+              items: [
+                makeSuggestedIntegrationJira(JiraDemoKey),
+                makeSuggestedIntegrationGitHub(GitHubDemoKey)
+              ]
+            }
+          },
+          viewerTeamMember: {
+            preferredName: user.preferredName,
+            integrations: {
+              id: 'demoTeamIntegrations',
+              atlassian: {id: 'demoTeamAtlassianIntegration', isActive: true, accessToken: '123'},
+              github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'}
+            },
+            suggestedIntegrations: {
+              hasMore: true,
+              items: [
+                makeSuggestedIntegrationJira(JiraDemoKey),
+                makeSuggestedIntegrationGitHub(GitHubDemoKey)
+              ]
+            }
+          }
+        }
       }
     },
     NewMeetingSummaryRootQuery: () => {

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -125,9 +125,7 @@ export const makeSuggestedIntegrationJira = (key: keyof typeof JiraProjectKeyLoo
   }
 }
 
-export const makeSuggestedIntegrationGitHub = (
-  nameWithOwner: keyof typeof GitHubProjectKeyLookup
-) => ({
+const makeSuggestedIntegrationGitHub = (nameWithOwner: keyof typeof GitHubProjectKeyLookup) => ({
   __typename: 'SuggestedIntegrationGitHub',
   id: `si:${nameWithOwner}`,
   ...GitHubProjectKeyLookup[nameWithOwner]

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -116,7 +116,7 @@ export const GitHubProjectKeyLookup = {
   }
 }
 
-const makeSuggestedIntegrationJira = (key: keyof typeof JiraProjectKeyLookup) => {
+export const makeSuggestedIntegrationJira = (key: keyof typeof JiraProjectKeyLookup) => {
   return {
     __typename: 'SuggestedIntegrationJira',
     id: key,
@@ -125,7 +125,9 @@ const makeSuggestedIntegrationJira = (key: keyof typeof JiraProjectKeyLookup) =>
   }
 }
 
-const makeSuggestedIntegrationGitHub = (nameWithOwner: keyof typeof GitHubProjectKeyLookup) => ({
+export const makeSuggestedIntegrationGitHub = (
+  nameWithOwner: keyof typeof GitHubProjectKeyLookup
+) => ({
   __typename: 'SuggestedIntegrationGitHub',
   id: `si:${nameWithOwner}`,
   ...GitHubProjectKeyLookup[nameWithOwner]
@@ -420,49 +422,6 @@ const initNewMeeting = (organization, teamMembers, meetingMembers) => {
   } as Partial<IRetrospectiveMeeting>
 }
 
-const initViewer = (user) => {
-  return {
-    viewer: {
-      ...user,
-      userOnTeam: {
-        ...user
-      },
-      assigneeTeamMember: {
-        preferredName: user.preferredName,
-        integrations: {
-          id: 'demoTeamIntegrations',
-          atlassian: {id: 'demoTeamAtlassianIntegration', isActive: true, accessToken: '123'},
-          github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'},
-          slack: initSlackAuth(user.id)
-        },
-        suggestedIntegrations: {
-          hasMore: true,
-          items: [
-            makeSuggestedIntegrationJira(JiraDemoKey),
-            makeSuggestedIntegrationGitHub(GitHubDemoKey)
-          ]
-        }
-      },
-      viewerTeamMember: {
-        preferredName: user.preferredName,
-        integrations: {
-          id: 'demoTeamIntegrations',
-          atlassian: {id: 'demoTeamAtlassianIntegration', isActive: true, accessToken: '123'},
-          github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'},
-          slack: initSlackAuth(user.id)
-        },
-        suggestedIntegrations: {
-          hasMore: true,
-          items: [
-            makeSuggestedIntegrationJira(JiraDemoKey),
-            makeSuggestedIntegrationGitHub(GitHubDemoKey)
-          ]
-        }
-      }
-    }
-  }
-}
-
 type BaseUser = {
   preferredName: string
   email: string
@@ -505,7 +464,6 @@ const initDB = (botScript: ReturnType<typeof initBotScript>) => {
   newMeeting.teamId = team.id
   newMeeting.topicCount = 0
   newMeeting.settings = team.meetingSettings as any
-  const viewer = initViewer(users[0])
   return {
     discussions: [] as DemoDiscussion[],
     meetingMembers,
@@ -520,8 +478,7 @@ const initDB = (botScript: ReturnType<typeof initBotScript>) => {
     users,
     _updatedAt: new Date(),
     _tempID: 1,
-    _botScript: botScript,
-    viewer
+    _botScript: botScript
   }
 }
 

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -420,6 +420,49 @@ const initNewMeeting = (organization, teamMembers, meetingMembers) => {
   } as Partial<IRetrospectiveMeeting>
 }
 
+const initViewer = (user) => {
+  return {
+    viewer: {
+      ...user,
+      userOnTeam: {
+        ...user
+      },
+      assigneeTeamMember: {
+        preferredName: user.preferredName,
+        integrations: {
+          id: 'demoTeamIntegrations',
+          atlassian: {id: 'demoTeamAtlassianIntegration', isActive: true, accessToken: '123'},
+          github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'},
+          slack: initSlackAuth(user.id)
+        },
+        suggestedIntegrations: {
+          hasMore: true,
+          items: [
+            makeSuggestedIntegrationJira(JiraDemoKey),
+            makeSuggestedIntegrationGitHub(GitHubDemoKey)
+          ]
+        }
+      },
+      viewerTeamMember: {
+        preferredName: user.preferredName,
+        integrations: {
+          id: 'demoTeamIntegrations',
+          atlassian: {id: 'demoTeamAtlassianIntegration', isActive: true, accessToken: '123'},
+          github: {id: 'demoTeamGitHubIntegration', isActive: true, accessToken: '123'},
+          slack: initSlackAuth(user.id)
+        },
+        suggestedIntegrations: {
+          hasMore: true,
+          items: [
+            makeSuggestedIntegrationJira(JiraDemoKey),
+            makeSuggestedIntegrationGitHub(GitHubDemoKey)
+          ]
+        }
+      }
+    }
+  }
+}
+
 type BaseUser = {
   preferredName: string
   email: string
@@ -462,6 +505,7 @@ const initDB = (botScript: ReturnType<typeof initBotScript>) => {
   newMeeting.teamId = team.id
   newMeeting.topicCount = 0
   newMeeting.settings = team.meetingSettings as any
+  const viewer = initViewer(users[0])
   return {
     discussions: [] as DemoDiscussion[],
     meetingMembers,
@@ -476,7 +520,8 @@ const initDB = (botScript: ReturnType<typeof initBotScript>) => {
     users,
     _updatedAt: new Date(),
     _tempID: 1,
-    _botScript: botScript
+    _botScript: botScript,
+    viewer
   }
 }
 

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -116,7 +116,7 @@ export const GitHubProjectKeyLookup = {
   }
 }
 
-export const makeSuggestedIntegrationJira = (key: keyof typeof JiraProjectKeyLookup) => {
+const makeSuggestedIntegrationJira = (key: keyof typeof JiraProjectKeyLookup) => {
   return {
     __typename: 'SuggestedIntegrationJira',
     id: key,


### PR DESCRIPTION
### Overview
Fix retro demo task integrate menu, issue reported in #5826

### Summary
For demo user we do not set assigneeTeamMember/viewerTeamMember and return here:
https://github.com/ParabolInc/parabol/blob/1766b647c835e7ac4ce1bda2bf0a8844441c01c3/packages/client/components/TaskFooterIntegrateMenu.tsx#L72

This PR adds  assigneeTeamMember and viewerTeamMember in TaskFooterIntegrateMenuRootQuery

### Testing
- Ran reproduction steps in #5826 
![Screen Shot 2022-01-01 at 11 12 20 AM](https://user-images.githubusercontent.com/271577/147856723-b24e682f-d7cb-4a93-a72d-a0e78c7703d4.png)


