### PR TITLE
Update dataLoader cache in inactivateUser mutation

### DIFF
--- a/packages/server/graphql/mutations/inactivateUser.ts
+++ b/packages/server/graphql/mutations/inactivateUser.ts
@@ -74,6 +74,8 @@ export default {
 
     // RESOLUTION
     const orgIds = orgs.map((org) => org.id)
+    // update the dataLoader cache
+    user.inactive = true
     await adjustUserCount(userId, orgIds, InvoiceItemType.PAUSE_USER)
 
     // TODO wire up subscription


### PR DESCRIPTION
Fixes #5832.

Notes on testing: please create a fresh new user, team and org locally. An existing user might be in the Parabol org that was restored from production DB, depends on your local setup. Since for local development we use the test Stripe key, it won't work if there are subscriptions initially created in production with a prod Stripe key.

Tests:

*   [ ] Go to organization page for a pro org, go to the Members tab. Toggle an active user to inactive, the toggle should stay greyed. In DB, this user should:
    *    [ ]  have `inactive` property as true in `User` table
    *   [ ] have `inactive` property as true for the `userId` & `orgId` pair in `OrganizationUser` table