### PR TITLE
Fix undefined in team invitation email

### DIFF
--- a/packages/client/components/MeetingHelp/CheckInHelpMenu.tsx
+++ b/packages/client/components/MeetingHelp/CheckInHelpMenu.tsx
@@ -10,7 +10,8 @@ import HelpMenuLink from './HelpMenuLink'
 
 const linkLookup = {
   action: `${ExternalLinks.GETTING_STARTED_CHECK_INS}#icebreaker`,
-  retrospective: `${ExternalLinks.GETTING_STARTED_RETROS}#icebreaker`
+  retrospective: `${ExternalLinks.GETTING_STARTED_RETROS}#icebreaker`,
+  poker: `${ExternalLinks.GETTING_STARTED_SPRINT_POKER}#icebreaker`
 } as Record<MeetingTypeEnum, string>
 
 interface Props {

--- a/packages/client/modules/email/components/TeamInvite.tsx
+++ b/packages/client/modules/email/components/TeamInvite.tsx
@@ -64,7 +64,8 @@ const TeamInvite = (props: TeamInviteProps) => {
   const nameOrEmail = inviteeName || inviteeEmailBlock
   const meetingCopyLabelLookup = {
     action: 'a Check-in Meeting',
-    retrospective: 'a Retrospective Meeting'
+    retrospective: 'a Retrospective Meeting',
+    poker: 'a Sprint Poker Meeting'
   }
   return (
     <Layout maxWidth={544}>


### PR DESCRIPTION
Resolves #5641

The problem existed only for poker meeting.
Also, fixed Icebreaker->Tips->Lean more link for poker meeting

![image](https://user-images.githubusercontent.com/466991/148818660-2586fefb-a6af-4cbb-b8df-2857c83a62a8.png)

**How to test:**

* Create a new team
* Create a poker meeting
* Send an email invite
* See no `undefined` in email text
* Go to icebreaker step of a poker meeting on mobile view
* Click on Tips at the bottom menu
* Click Lear more
* See the link opened correctly

