### PR TITLE
Implement choosing random person as facilitator

### DIFF
--- a/packages/client/components/Facilitator.tsx
+++ b/packages/client/components/Facilitator.tsx
@@ -3,7 +3,6 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 import {Facilitator_meeting} from '~/__generated__/Facilitator_meeting.graphql'
-import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
 import {PortalStatus} from '../hooks/usePortal'
@@ -97,7 +96,7 @@ const FacilitatorMenu = lazyPreload(() =>
 
 const Facilitator = (props: Props) => {
   const {meeting} = props
-  const {endedAt, facilitatorUserId, facilitator} = meeting
+  const {endedAt, facilitator} = meeting
   const {user, picture, preferredName} = facilitator
   // https://sentry.io/share/issue/efef01c3e7934ab981ed5c80ef2d64c8/
   const isConnected = user?.isConnected ?? false
@@ -107,9 +106,7 @@ const Facilitator = (props: Props) => {
       isDropdown: true
     }
   )
-  const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
-  const isReadOnly = isDemoRoute() || viewerId === facilitatorUserId || !!endedAt
+  const isReadOnly = isDemoRoute() || !!endedAt
   const handleOnMouseEnter = () => !isReadOnly && FacilitatorMenu.preload()
   const handleOnClick = () => !isReadOnly && togglePortal()
   return (
@@ -140,7 +137,6 @@ export default createFragmentContainer(Facilitator, {
     fragment Facilitator_meeting on NewMeeting {
       ...FacilitatorMenu_meeting
       endedAt
-      facilitatorUserId
       facilitator {
         picture
         preferredName

--- a/packages/client/components/Facilitator.tsx
+++ b/packages/client/components/Facilitator.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 import {Facilitator_meeting} from '~/__generated__/Facilitator_meeting.graphql'
+import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
 import {PortalStatus} from '../hooks/usePortal'
@@ -96,7 +97,7 @@ const FacilitatorMenu = lazyPreload(() =>
 
 const Facilitator = (props: Props) => {
   const {meeting} = props
-  const {endedAt, facilitator} = meeting
+  const {endedAt, facilitatorUserId, meetingMembers, facilitator} = meeting
   const {user, picture, preferredName} = facilitator
   // https://sentry.io/share/issue/efef01c3e7934ab981ed5c80ef2d64c8/
   const isConnected = user?.isConnected ?? false
@@ -106,7 +107,9 @@ const Facilitator = (props: Props) => {
       isDropdown: true
     }
   )
-  const isReadOnly = isDemoRoute() || !!endedAt
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
+  const isReadOnly = isDemoRoute() || (viewerId === facilitatorUserId && meetingMembers.length == 1 && meetingMembers[0].userId === viewerId) || !!endedAt
   const handleOnMouseEnter = () => !isReadOnly && FacilitatorMenu.preload()
   const handleOnClick = () => !isReadOnly && togglePortal()
   return (
@@ -137,6 +140,10 @@ export default createFragmentContainer(Facilitator, {
     fragment Facilitator_meeting on NewMeeting {
       ...FacilitatorMenu_meeting
       endedAt
+      facilitatorUserId
+      meetingMembers {
+        userId
+      }
       facilitator {
         picture
         preferredName

--- a/packages/client/components/Facilitator.tsx
+++ b/packages/client/components/Facilitator.tsx
@@ -98,6 +98,7 @@ const FacilitatorMenu = lazyPreload(() =>
 const Facilitator = (props: Props) => {
   const {meeting} = props
   const {endedAt, facilitatorUserId, meetingMembers, facilitator} = meeting
+  const connectedMemberIds = meetingMembers.filter(({user}) => user.isConnected).map(({user}) => user.id)
   const {user, picture, preferredName} = facilitator
   // https://sentry.io/share/issue/efef01c3e7934ab981ed5c80ef2d64c8/
   const isConnected = user?.isConnected ?? false
@@ -109,7 +110,7 @@ const Facilitator = (props: Props) => {
   )
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
-  const isReadOnly = isDemoRoute() || (viewerId === facilitatorUserId && meetingMembers.length == 1 && meetingMembers[0].userId === viewerId) || !!endedAt
+  const isReadOnly = isDemoRoute() || (viewerId === facilitatorUserId && connectedMemberIds.length === 1 && connectedMemberIds[0] === viewerId) || !!endedAt
   const handleOnMouseEnter = () => !isReadOnly && FacilitatorMenu.preload()
   const handleOnClick = () => !isReadOnly && togglePortal()
   return (
@@ -142,7 +143,10 @@ export default createFragmentContainer(Facilitator, {
       endedAt
       facilitatorUserId
       meetingMembers {
-        userId
+        user {
+          id
+          isConnected
+        }
       }
       facilitator {
         picture

--- a/packages/client/components/FacilitatorMenu.tsx
+++ b/packages/client/components/FacilitatorMenu.tsx
@@ -16,17 +16,26 @@ interface Props {
 
 const FacilitatorMenu = (props: Props) => {
   const {menuProps, meeting} = props
-  const {id: meetingId} = meeting
+  const {id: meetingId, facilitatorUserId, meetingMembers} = meeting
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
-  const promoteToFacilitator = () => {
+  const promoteViewerToFacilitator = () => {
     PromoteNewMeetingFacilitatorMutation(atmosphere, {facilitatorUserId: viewerId, meetingId})
   }
+  const promoteRandomPersonToFacilitator = () => {
+    const memberIdsWithoutCurrentFacilitator = meetingMembers.filter(({userId}) => userId != facilitatorUserId).map(({userId}) => userId)
+    const newFacilitatorId = memberIdsWithoutCurrentFacilitator[Math.floor(Math.random() * memberIdsWithoutCurrentFacilitator.length)]
+    PromoteNewMeetingFacilitatorMutation(atmosphere, {facilitatorUserId: newFacilitatorId, meetingId})
+  }
   return (
-    <Menu ariaLabel={'Take the Facilitator role'} {...menuProps}>
+    <Menu ariaLabel={'Change the Facilitator role'} {...menuProps}>
       <MenuItem
-        label={<MenuItemLabel>{'Take the Facilitator role'}</MenuItemLabel>}
-        onClick={promoteToFacilitator}
+        label={<MenuItemLabel>{'I want to be the Facilitator!'}</MenuItemLabel>}
+        onClick={promoteViewerToFacilitator}
+      />
+      <MenuItem
+        label={<MenuItemLabel>{'Pick someone for me...'}</MenuItemLabel>}
+        onClick={promoteRandomPersonToFacilitator}
       />
     </Menu>
   )
@@ -36,6 +45,10 @@ export default createFragmentContainer(FacilitatorMenu, {
   meeting: graphql`
     fragment FacilitatorMenu_meeting on NewMeeting {
       id
+      facilitatorUserId
+      meetingMembers {
+        userId
+      }
     }
   `
 })

--- a/packages/client/components/FacilitatorMenu.tsx
+++ b/packages/client/components/FacilitatorMenu.tsx
@@ -19,12 +19,12 @@ const FacilitatorMenu = (props: Props) => {
   const {id: meetingId, facilitatorUserId, meetingMembers} = meeting
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
+  const facilitatorCandidateIds = meetingMembers.filter(({user}) => user.id != facilitatorUserId && user.isConnected).map(({user}) => user.id)
   const promoteViewerToFacilitator = () => {
     PromoteNewMeetingFacilitatorMutation(atmosphere, {facilitatorUserId: viewerId, meetingId})
   }
   const promoteRandomPersonToFacilitator = () => {
-    const memberIdsWithoutCurrentFacilitator = meetingMembers.filter(({userId}) => userId != facilitatorUserId).map(({userId}) => userId)
-    const newFacilitatorId = memberIdsWithoutCurrentFacilitator[Math.floor(Math.random() * memberIdsWithoutCurrentFacilitator.length)]
+    const newFacilitatorId = facilitatorCandidateIds[Math.floor(Math.random() * facilitatorCandidateIds.length)]
     PromoteNewMeetingFacilitatorMutation(atmosphere, {facilitatorUserId: newFacilitatorId, meetingId})
   }
   return (
@@ -33,10 +33,10 @@ const FacilitatorMenu = (props: Props) => {
         label={<MenuItemLabel>{'Take the facilitator role'}</MenuItemLabel>}
         onClick={promoteViewerToFacilitator}
       />}
-      <MenuItem
+      {facilitatorCandidateIds.length >= 1 && <MenuItem
         label={<MenuItemLabel>{'Randomize facilitator'}</MenuItemLabel>}
         onClick={promoteRandomPersonToFacilitator}
-      />
+      />}
     </Menu>
   )
 }
@@ -47,7 +47,10 @@ export default createFragmentContainer(FacilitatorMenu, {
       id
       facilitatorUserId
       meetingMembers {
-        userId
+        user {
+          id
+          isConnected
+        }
       }
     }
   `

--- a/packages/client/components/FacilitatorMenu.tsx
+++ b/packages/client/components/FacilitatorMenu.tsx
@@ -28,13 +28,13 @@ const FacilitatorMenu = (props: Props) => {
     PromoteNewMeetingFacilitatorMutation(atmosphere, {facilitatorUserId: newFacilitatorId, meetingId})
   }
   return (
-    <Menu ariaLabel={'Change the Facilitator role'} {...menuProps}>
+    <Menu ariaLabel={'Change the facilitator role'} {...menuProps}>
       {viewerId !== facilitatorUserId && <MenuItem
-        label={<MenuItemLabel>{'I want to be the Facilitator!'}</MenuItemLabel>}
+        label={<MenuItemLabel>{'Take the facilitator role'}</MenuItemLabel>}
         onClick={promoteViewerToFacilitator}
       />}
       <MenuItem
-        label={<MenuItemLabel>{'Pick someone for me...'}</MenuItemLabel>}
+        label={<MenuItemLabel>{'Randomize facilitator'}</MenuItemLabel>}
         onClick={promoteRandomPersonToFacilitator}
       />
     </Menu>

--- a/packages/client/components/FacilitatorMenu.tsx
+++ b/packages/client/components/FacilitatorMenu.tsx
@@ -29,10 +29,10 @@ const FacilitatorMenu = (props: Props) => {
   }
   return (
     <Menu ariaLabel={'Change the Facilitator role'} {...menuProps}>
-      <MenuItem
+      {viewerId !== facilitatorUserId && <MenuItem
         label={<MenuItemLabel>{'I want to be the Facilitator!'}</MenuItemLabel>}
         onClick={promoteViewerToFacilitator}
-      />
+      />}
       <MenuItem
         label={<MenuItemLabel>{'Pick someone for me...'}</MenuItemLabel>}
         onClick={promoteRandomPersonToFacilitator}


### PR DESCRIPTION
Implements #5531 .

Notice the implementation is a little bit different than the issue description as I feel like this is a less intrusive change that's safe to try: no new visual changes, just adding one more item to the existing menu.

![](https://user-images.githubusercontent.com/1879975/149007122-028761ee-de64-4f02-8602-5b5cd5ef828c.png)

Tests:

- [ ] Create a meeting by yourself (user A) and see _no_ three-dot icon shown up as you can't change the facilitator or give it to anyone else
- [ ] Invite someone else (user B) to join
	- [ ] On User A's page, one can see "Pick someone for me" 
	- [ ] On User B's page, one can see both "I want to be the Facilitator" and "Pick someone for me"
	- [ ] Click "Pick someone for me" from User A's page should assign the facilitator role to user B
- [ ] Invite a 3rd member to join and verify "Pick someone for me" assigns the role randomly