### PR TITLE
Fix Original Estimate field can not be updated in Sprint Poker

### DIFF
--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -716,14 +716,15 @@ export default abstract class AtlassianManager {
       timeoriginalestimate: 'originalEstimate',
       timeestimate: 'remainingEstimate'
     }
-    const isTimeTrackingField = ['timeoriginalestimate', 'timeestimate'].includes(fieldId)
-    if (isTimeTrackingField) {
+    const timeTrackingFieldName = timeTrackingFieldLookup[fieldId]
+    if (timeTrackingFieldName) {
       payload = {
         update: {
           [timeTrackingFieldId]: [
             {
               set: {
-                [timeTrackingFieldLookup[fieldId]]: `${storyPoints}h`
+                // time tracking fields have to be set in time format, we're setting them in (h)ours
+                [timeTrackingFieldName]: `${storyPoints}h`
               }
             }
           ]
@@ -747,7 +748,7 @@ export default abstract class AtlassianManager {
       )
     }
     if (
-      res.message.startsWith(isTimeTrackingField ? timeTrackingFieldId : fieldId) &&
+      res.message.startsWith(timeTrackingFieldName ? timeTrackingFieldId : fieldId) &&
       res.message.includes('is not on the appropriate screen')
     ) {
       throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR)


### PR DESCRIPTION
Partially fixes #5705. 

There are 2 issues there, actually. This PR fixes only the first one.
1. Time tracking fields require different body format when calling Jira API
2. When field isn't on the issue screen, our mechanism for automatically fixing that for user will fail, because `timeoriginalestimate` and `timeestimate` fields depend on the `timetracking` field being added to the issue screen. Interestin part is, when `timetracking` isn't added, but `timeoriginalestimate` is, it can't be updated via REST API, even though it can be, via Jira UI. 
More context: https://github.com/ParabolInc/parabol/issues/5705#issuecomment-1007501068 

This PR fixes 1, the second issue [has its own ticket.](https://github.com/ParabolInc/parabol/issues/5868)

Tests:
1. Make sure time tracking and original estimate fields are added to the issue screen, like that:
![Screenshot 2022-01-12 at 16 35 42](https://user-images.githubusercontent.com/1017620/149171476-4714c5d9-37c0-4501-958a-b343698586a7.png)
2. Run sprint poker, try to update original estimate/remaining estimate fields 