### PR TITLE
Add migration to fill missing plaintextContent for tasks

### DIFF
--- a/packages/server/database/migrations/20220112175838-addMissingPlainTextContentToTask.ts
+++ b/packages/server/database/migrations/20220112175838-addMissingPlainTextContentToTask.ts
@@ -1,0 +1,46 @@
+import {R} from 'rethinkdb-ts'
+import extractTextFromDraftString from 'parabol-client/utils/draftjs/extractTextFromDraftString'
+
+export const up = async function (r: R) {
+  // We have about 2500 such tasks
+  const missedTasks = await r
+    .table('Task')
+    .filter((row) => row.hasFields('plaintextContent').not())
+    .run()
+
+  console.log('Missed tasks found:', missedTasks.length)
+
+  if (missedTasks.length) {
+    const updates = [] as {
+      taskId: string
+      plaintextContent: string
+    }[]
+    for (const task of missedTasks) {
+      updates.push({
+        taskId: task.id,
+        plaintextContent: extractTextFromDraftString(task.content)
+      })
+    }
+    const updateResult = await r(updates)
+      .forEach((updateObj) => {
+        return r
+          .table('Task')
+          .get(updateObj('taskId'))
+          .update(
+            {
+              plaintextContent: updateObj('plaintextContent')
+            },
+            {
+              returnChanges: true
+            }
+          )
+      })('changes')
+      .run()
+
+    console.log('Updated:', updateResult?.length)
+  }
+}
+
+export const down = function () {
+  // noop
+}


### PR DESCRIPTION
#5438

How to test

1. If needed, remove some `plaintextContent`

```
r.db('actionDevelopment').table('Task').filter({
    "meetingId": "put_your_own_value"
}).replace(r.row.without('plaintextContent'))
```

2. Run migration `yarn db:migrate`


3. Check that all tasks have `plaintextContent`

```
r.db('actionDevelopment').table('Task').filter(function (row) {
    return row.hasFields({ plaintextContent: true }).not()
})
```

