### PR TITLE
Fix alignment of Add task button in discussions

### DIFF
--- a/packages/client/components/AddTaskButton.tsx
+++ b/packages/client/components/AddTaskButton.tsx
@@ -22,7 +22,7 @@ const AddTaskIcon = styled(Icon)({
   fontSize: 20,
   width: 20,
   height: 20,
-  margin: '0 4px'
+  margin: '0 4px 0 0'
 })
 
 const AddTaskLabel = styled('div')({


### PR DESCRIPTION
This super tiny PR fixes the center alignment of the `Add task` button in `Discussions`. It removes a  `4px` left margin on the icon.

**Before**
<img width="409" alt="Screen Shot 2021-08-13 at 12 43 41 p m" src="https://user-images.githubusercontent.com/3276087/149827323-f4913bf7-29b2-40f8-a609-8e24593474f2.png">

**After**
<img width="381" alt="Captura de Pantalla 2022-01-17 a la(s) 1 21 25 p m" src="https://user-images.githubusercontent.com/3276087/149827330-e3c49212-4b18-4692-a79c-d3a64e2c4d02.png">

