### PR TITLE
Fix missing jira field dialog on mini card click

### DIFF
--- a/packages/client/components/PokerDimensionValueControl.tsx
+++ b/packages/client/components/PokerDimensionValueControl.tsx
@@ -167,9 +167,7 @@ const PokerDimensionValueControl = (props: Props) => {
             canUpdate={isStale}
             stage={stage}
             error={errorStr}
-            submitScore={() => {
-              onSubmitScore()
-            }}
+            submitScore={onSubmitScore}
             clearError={onCompleted}
             inputRef={inputRef}
             isFacilitator={isFacilitator}
@@ -180,9 +178,7 @@ const PokerDimensionValueControl = (props: Props) => {
             canUpdate={isStale}
             stageRef={stage}
             error={errorStr}
-            submitScore={() => {
-              onSubmitScore()
-            }}
+            submitScore={onSubmitScore}
             clearError={onCompleted}
             inputRef={inputRef}
             isFacilitator={isFacilitator}
@@ -192,13 +188,7 @@ const PokerDimensionValueControl = (props: Props) => {
           <>
             {isStale ? (
               <>
-                <StyledLinkButton
-                  onClick={() => {
-                    onSubmitScore()
-                  }}
-                >
-                  {'Update'}
-                </StyledLinkButton>
+                <StyledLinkButton onClick={onSubmitScore}>{'Update'}</StyledLinkButton>
                 {errorStr && <ErrorMessage>{errorStr}</ErrorMessage>}
               </>
             ) : (

--- a/packages/client/components/PokerDiscussVoting.tsx
+++ b/packages/client/components/PokerDiscussVoting.tsx
@@ -89,7 +89,7 @@ const PokerDiscussVoting = (props: Props) => {
     isLocallyValidatedRef.current = true
   }, [finalScore])
 
-  const onSubmitScore = (value?: string) => {
+  const submitScore = (value?: string) => {
     const score = value ?? cardScore
     if (submitting || !isStale(score) || !isLocallyValidatedRef.current) {
       return
@@ -129,7 +129,9 @@ const PokerDiscussVoting = (props: Props) => {
         error={error}
         onCompleted={onCompleted}
         onError={onError}
-        onSubmitScore={onSubmitScore}
+        onSubmitScore={() => {
+          submitScore()
+        }}
         isStale={isStale(cardScore)}
         isLocallyValidatedRef={isLocallyValidatedRef}
         setCardScore={setCardScore}
@@ -140,13 +142,13 @@ const PokerDiscussVoting = (props: Props) => {
           const {label} = scaleValue
           const canClick = isFacilitator && !isSpecialPokerLabel(label)
 
-          const submitScore = () => {
+          const setFinalScore = () => {
             // finalScore === label isn't 100% accurate because they could change the dimensionField & could still submit new info
             if (submitting || !label || finalScore === label) return
             setCardScore(label)
             isLocallyValidatedRef.current = true
             onCompleted()
-            onSubmitScore(label)
+            submitScore(label)
           }
 
           return (
@@ -154,7 +156,7 @@ const PokerDiscussVoting = (props: Props) => {
               <PokerVotingRow
                 scaleValue={scaleValue}
                 scores={scores}
-                setFinalScore={canClick ? submitScore : undefined}
+                setFinalScore={canClick ? setFinalScore : undefined}
                 isInitialStageRender={isInitialStageRender}
               />
             </React.Fragment>
@@ -163,9 +165,7 @@ const PokerDiscussVoting = (props: Props) => {
         {modalPortal(
           <AddMissingJiraFieldModal
             stage={stage}
-            submitScore={() => {
-              onSubmitScore()
-            }}
+            submitScore={submitScore}
             closePortal={closePortal}
           />
         )}

--- a/packages/client/components/PokerDiscussVoting.tsx
+++ b/packages/client/components/PokerDiscussVoting.tsx
@@ -1,16 +1,18 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useMemo} from 'react'
+import React, {useMemo, useRef, useState, useEffect} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useMutationProps from '../hooks/useMutationProps'
-import SetTaskEstimateMutation from '../mutations/SetTaskEstimateMutation'
 import {PokerCards} from '../types/constEnums'
 import isSpecialPokerLabel from '../utils/isSpecialPokerLabel'
 import {PokerDiscussVoting_meeting} from '../__generated__/PokerDiscussVoting_meeting.graphql'
 import {PokerDiscussVoting_stage} from '../__generated__/PokerDiscussVoting_stage.graphql'
 import PokerDimensionValueControl from './PokerDimensionValueControl'
 import PokerVotingRow from './PokerVotingRow'
+import useSetTaskEstimate from './useSetTaskEstimate'
+import AddMissingJiraFieldModal from './AddMissingJiraFieldModal'
+import useModal from '../hooks/useModal'
+import useForceUpdate from '../hooks/useForceUpdate'
 
 const GroupedVotes = styled('div')({
   display: 'flex',
@@ -27,13 +29,25 @@ interface Props {
 
 const PokerDiscussVoting = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
+  const {closePortal, openPortal, modalPortal} = useModal()
+  const {setTaskEstimate, error, submitting, onCompleted, onError} = useSetTaskEstimate()
+  const forceUpdate = useForceUpdate()
   const {viewerId} = atmosphere
   const {meeting, stage, isInitialStageRender} = props
   const {id: meetingId, facilitatorUserId} = meeting
-  const {id: stageId, finalScore, dimensionRef, scores, taskId} = stage
+  const {id: stageId, dimensionRef, scores, taskId, serviceField} = stage
+  const finalScore = stage.finalScore || ''
+  const {name: serviceFieldName} = serviceField
   const {name: dimensionName, scale} = dimensionRef
   const {values: scaleValues} = scale
+  const lastSubmittedFieldRef = useRef(serviceFieldName)
+  const isLocallyValidatedRef = useRef(true)
+  const [cardScore, setCardScore] = useState(finalScore)
+
+  const isStale = (score) => {
+    return score !== finalScore || lastSubmittedFieldRef.current !== serviceFieldName
+  }
+
   const {rows, topLabel} = useMemo(() => {
     const scoreObj = {} as {[label: string]: PokerDiscussVoting_stage['scores'][0][]}
     let highScore = 0
@@ -67,39 +81,94 @@ const PokerDiscussVoting = (props: Props) => {
   }, [scores])
 
   const isFacilitator = viewerId === facilitatorUserId
+
+  useEffect(() => {
+    // if the final score changes, change what the card says & recalculate is stale
+    setCardScore(finalScore)
+    lastSubmittedFieldRef.current = serviceFieldName
+    isLocallyValidatedRef.current = true
+  }, [finalScore])
+
+  const onSubmitScore = (value?: string) => {
+    const score = value ?? cardScore
+    if (submitting || !isStale(score) || !isLocallyValidatedRef.current) {
+      return
+    }
+    // submitScore might be called when changing the integration field to push to
+    const noScoreYet = score === '' && finalScore === ''
+    if (noScoreYet) return
+
+    const onJiraFieldUpdateError = () => {
+      openPortal()
+      // in case of error this will set the old value after the useEffect related to final score
+      setImmediate(() => {
+        setCardScore(score)
+      })
+    }
+
+    const onSuccess = () => {
+      // set field A to 1, change fields to B, then submit again. it should not say update
+      lastSubmittedFieldRef.current = serviceFieldName
+      forceUpdate()
+    }
+
+    setTaskEstimate(
+      {taskId, dimensionName, meetingId, value: score},
+      stageId,
+      onJiraFieldUpdateError,
+      onSuccess
+    )
+  }
+
   return (
     <>
       <PokerDimensionValueControl
         placeholder={isFacilitator ? topLabel : '?'}
         stage={stage}
         isFacilitator={isFacilitator}
+        error={error}
+        onCompleted={onCompleted}
+        onError={onError}
+        onSubmitScore={onSubmitScore}
+        isStale={isStale(cardScore)}
+        isLocallyValidatedRef={isLocallyValidatedRef}
+        setCardScore={setCardScore}
+        cardScore={cardScore}
       />
       <GroupedVotes>
         {rows.map(({scaleValue, scores, key}) => {
           const {label} = scaleValue
           const canClick = isFacilitator && !isSpecialPokerLabel(label)
-          const setFinalScore = canClick
-            ? () => {
-                // finalScore === label isn't 100% accurate because they could change the dimensionField & could still submit new info
-                if (submitting || !label || finalScore === label) return
-                submitMutation()
-                SetTaskEstimateMutation(
-                  atmosphere,
-                  {taskEstimate: {taskId, dimensionName, meetingId, value: label}},
-                  {onError, onCompleted, stageId}
-                )
-              }
-            : undefined
+
+          const submitScore = () => {
+            // finalScore === label isn't 100% accurate because they could change the dimensionField & could still submit new info
+            if (submitting || !label || finalScore === label) return
+            setCardScore(label)
+            isLocallyValidatedRef.current = true
+            onCompleted()
+            onSubmitScore(label)
+          }
+
           return (
-            <PokerVotingRow
-              key={key}
-              scaleValue={scaleValue}
-              scores={scores}
-              setFinalScore={setFinalScore}
-              isInitialStageRender={isInitialStageRender}
-            />
+            <React.Fragment key={key}>
+              <PokerVotingRow
+                scaleValue={scaleValue}
+                scores={scores}
+                setFinalScore={canClick ? submitScore : undefined}
+                isInitialStageRender={isInitialStageRender}
+              />
+            </React.Fragment>
           )
         })}
+        {modalPortal(
+          <AddMissingJiraFieldModal
+            stage={stage}
+            submitScore={() => {
+              onSubmitScore()
+            }}
+            closePortal={closePortal}
+          />
+        )}
       </GroupedVotes>
     </>
   )
@@ -108,9 +177,14 @@ const PokerDiscussVoting = (props: Props) => {
 export default createFragmentContainer(PokerDiscussVoting, {
   stage: graphql`
     fragment PokerDiscussVoting_stage on EstimateStage {
+      ...AddMissingJiraFieldModal_stage
       ...PokerDimensionValueControl_stage
       id
       finalScore
+      serviceField {
+        name
+        type
+      }
       taskId
       dimensionRef {
         name

--- a/packages/client/components/useSetTaskEstimate.ts
+++ b/packages/client/components/useSetTaskEstimate.ts
@@ -1,0 +1,44 @@
+import useMutationProps from '../hooks/useMutationProps'
+import {
+  SetTaskEstimateMutationResponse,
+  TaskEstimateInput
+} from '../__generated__/SetTaskEstimateMutation.graphql'
+import {SprintPokerDefaults} from '../types/constEnums'
+import SetTaskEstimateMutation from '../mutations/SetTaskEstimateMutation'
+import useAtmosphere from '../hooks/useAtmosphere'
+
+const useSetTaskEstimate = () => {
+  const {submitMutation, submitting, error, onError, onCompleted} = useMutationProps()
+  const atmosphere = useAtmosphere()
+
+  const setTaskEstimate = (
+    taskEstimate: TaskEstimateInput,
+    stageId: string,
+    onJiraFieldUpdateError?: () => void,
+    onSuccess?: () => void
+  ) => {
+    const handleCompleted = (res: SetTaskEstimateMutationResponse, errors) => {
+      onCompleted(res as any, errors)
+      const {setTaskEstimate} = res
+      const {error} = setTaskEstimate
+      if (error?.message.includes(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR)) {
+        onJiraFieldUpdateError && onJiraFieldUpdateError()
+      }
+      if (!error) {
+        onSuccess && onSuccess()
+      }
+    }
+
+    submitMutation()
+
+    SetTaskEstimateMutation(
+      atmosphere,
+      {taskEstimate},
+      {onError, onCompleted: handleCompleted, stageId}
+    )
+  }
+
+  return {setTaskEstimate, error, submitting, onError, onCompleted}
+}
+
+export default useSetTaskEstimate


### PR DESCRIPTION
This should fix both: #5508 #5846

How to test:
- Create poker meeting
- Add Jira integration
- Go to https://parabol-2.atlassian.net/secure/admin/ConfigureFieldScreen.jspa?id=10065 and remove `Story Points` field
- Add the following task https://parabol-2.atlassian.net/browse/FIXCOMP-1
- Enter any estimation, select `Story points` field, click `update` link, see fix field dialog appeared, see the field fixed correctly
- Go to https://parabol-2.atlassian.net/secure/admin/ConfigureFieldScreen.jspa?id=10065 and remove `Story Points` field again
- Estimate the above task again, but now click on mini card to update the score.
- See fix field dialog appeared, see the field fixed correctly
