### PR TITLE
Make dependency from DasboardAvatar to AcceptTeamInvitation explicit

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -48,6 +48,9 @@ graphql`
         id
       }
     }
+    teamMember {
+      ...DashboardAvatar_teamMember
+    }
     # this is just for the team lead
     teamLead {
       suggestedActions {


### PR DESCRIPTION
Follow up to https://github.com/ParabolInc/parabol/pull/5683#issuecomment-983006254

## Testing
* open two browsers with 2 parabol accounts Alice and Bob
* send an invite from Alice to Bob
* Bob accepts invite
* Without refresh Alice can see that Bobs avatar appears in the upper right panel and on hovering Bobs name is shown