### PR TITLE
Added caching Jira project avatars

### DIFF
--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -468,20 +468,10 @@ export default abstract class AtlassianManager {
 
     if (!imageRes || imageRes instanceof Error) return null
     const arrayBuffer = await imageRes.arrayBuffer()
-    return Buffer.from(arrayBuffer)
-  }
-
-  async getProjectAvatar(avatarUrl: string) {
-    // use fetchWithTimeout because we want a buffer
-    const imageRes = await this.fetchWithTimeout(avatarUrl, {
-      headers: {Authorization: this.headers.Authorization}
-    })
-
-    if (!imageRes || imageRes instanceof Error) return ''
-    const arrayBuffer = await imageRes.arrayBuffer()
-    const buffer = Buffer.from(arrayBuffer).toString('base64')
-    const contentType = imageRes.headers.get('content-type')
-    return `data:${contentType};base64,${buffer}`
+    return {
+      imageBuffer: Buffer.from(arrayBuffer),
+      contentType: imageRes.headers.get('content-type')
+    }
   }
 
   async getAllProjects(cloudIds: string[]) {

--- a/packages/server/graphql/types/JiraRemoteProject.ts
+++ b/packages/server/graphql/types/JiraRemoteProject.ts
@@ -1,7 +1,11 @@
 import {GraphQLBoolean, GraphQLID, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'graphql'
+import {
+  createImageUrlHash,
+  createParabolImageUrl,
+  downloadAndCacheImage
+} from '../../utils/atlassian/jiraImages'
 import JiraProjectId from '../../../client/shared/gqlIds/JiraProjectId'
 import AtlassianServerManager from '../../utils/AtlassianServerManager'
-import defaultJiraProjectAvatar from '../../utils/defaultJiraProjectAvatar'
 import {GQLContext} from '../graphql'
 import JiraRemoteAvatarUrls from './JiraRemoteAvatarUrls'
 import JiraRemoteProjectCategory from './JiraRemoteProjectCategory'
@@ -43,8 +47,9 @@ const JiraRemoteProject = new GraphQLObjectType<any, GQLContext>({
         if (!auth) return null
         const {accessToken} = auth
         const manager = new AtlassianServerManager(accessToken)
-        const avatar = await manager.getProjectAvatar(url)
-        return avatar || defaultJiraProjectAvatar
+        const avatarUrlHash = createImageUrlHash(url)
+        await downloadAndCacheImage(manager, avatarUrlHash, url)
+        return createParabolImageUrl(avatarUrlHash)
       }
     },
     avatarUrls: {


### PR DESCRIPTION
Fixes #5833 

To be able to use the existing code related to caching Jira images I had to make one change. Previously, the image mime type was calculated from filename (extension). The problem with this solution was that the file not necessarily has the extension in the filename. So far, it worked fine as Jira always returned the files with an extension. This isn't the case with avatars. 

Projects avatars are returned as an array of file URLs, without the extension.
```
{
  '48x48': 'https://api.atlassian.com/ex/jira/b8999f88-721c-49c7-aa0e-d60eeffc1eb6/rest/api/3/universal_avatar/view/type/project/avatar/10411',
  '24x24': 'https://api.atlassian.com/ex/jira/b8999f88-721c-49c7-aa0e-d60eeffc1eb6/rest/api/3/universal_avatar/view/type/project/avatar/10411?size=small',
  '16x16': 'https://api.atlassian.com/ex/jira/b8999f88-721c-49c7-aa0e-d60eeffc1eb6/rest/api/3/universal_avatar/view/type/project/avatar/10411?size=xsmall',
  '32x32': 'https://api.atlassian.com/ex/jira/b8999f88-721c-49c7-aa0e-d60eeffc1eb6/rest/api/3/universal_avatar/view/type/project/avatar/10411?size=medium'
}
```

Currently, the mime-type for a given file is taken from the Jira API response and it's stored in redis. I also prefixed all the redis keys for Jira images with `jira-image`. 

Tests
1. Check if project avatars are displayed correctly
![Screenshot 2022-01-18 at 16 56 12](https://user-images.githubusercontent.com/1017620/149972217-caf2bf67-7e79-4942-8336-28e96d295c3c.png)

2. Check if images in Jira issues descriptions are displayed correctly
![Screenshot 2022-01-18 at 16 56 04](https://user-images.githubusercontent.com/1017620/149972205-a350757e-0050-4e8a-9df4-1970bcfaf8ca.png)

