### PR TITLE
Remove 4px  left margin from Add Poll button

### DIFF
--- a/packages/client/components/AddPollButton.tsx
+++ b/packages/client/components/AddPollButton.tsx
@@ -22,7 +22,7 @@ const AddPollIcon = styled(IconOutlined)({
   fontSize: 20,
   width: 20,
   height: 20,
-  margin: '0 4px'
+  margin: '0 4px 0 0'
 })
 
 const AddPollLabel = styled('div')({


### PR DESCRIPTION
Another tiny PR that removes a `4px` left margin from the icon of the `Add a poll` button. See #5876 for additional context