### PR TITLE
Reverted connectionContext type check

### DIFF
--- a/packages/server/graphql/httpGraphQLHandler.ts
+++ b/packages/server/graphql/httpGraphQLHandler.ts
@@ -1,5 +1,4 @@
 import {TrebuchetCloseReason} from 'parabol-client/types/constEnums'
-import ConnectionContext from '../socketHelpers/ConnectionContext'
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
 import AuthToken from '../database/types/AuthToken'
 import parseBody from '../parseBody'
@@ -23,7 +22,7 @@ const httpGraphQLBodyHandler = async (
   connectionId: string | undefined | null,
   ip: string
 ) => {
-  const connectionContext = connectionId
+  const connectionContext: any = connectionId
     ? sseClients.get(connectionId)
     : new StatelessContext(ip, authToken)
   if (!connectionContext) {
@@ -56,9 +55,7 @@ const httpGraphQLBodyHandler = async (
       }
     }
   }
-  const response =
-    connectionContext instanceof ConnectionContext &&
-    (await handleGraphQLTrebuchetRequest(body, connectionContext))
+  const response = await handleGraphQLTrebuchetRequest(body, connectionContext)
   res.cork(() => {
     if (response) {
       res.writeHeader('content-type', 'application/json').end(JSON.stringify(response))


### PR DESCRIPTION
In https://github.com/ParabolInc/parabol/pull/5830, I checked whether `connectionContext` was of type `ConnectionContext`, which is the type that `handleGraphQLTrebuchetRequest` is expecting. 

This broke the login & signup functionality as `connectionContext` can be of type `StatelessContext`. I've reverted the change. I haven't updated `handleGraphQLTrebuchetRequest` to expect `ConnectionContext | StatelessContext` yet as this will require many subsequent changes to the gql logic, which can be done in a separate PR.

I'll merge this PR right away as master is broken and this should fix it. 