### PR TITLE
ensure window.opener is same-origin

### DIFF
--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -1,10 +1,10 @@
 import React, {useEffect, useState} from 'react'
-import DialogTitle from './DialogTitle'
-import DialogContent from './DialogContent'
-import StyledError from './StyledError'
-import InviteDialog from './InviteDialog'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useRouter from '../hooks/useRouter'
+import DialogContent from './DialogContent'
+import DialogTitle from './DialogTitle'
+import InviteDialog from './InviteDialog'
+import StyledError from './StyledError'
 import TeamInvitationMeetingAbstract from './TeamInvitationMeetingAbstract'
 
 const SAMLRedirect = () => {
@@ -15,7 +15,15 @@ const SAMLRedirect = () => {
     const params = new URLSearchParams(location.search)
     const token = params.get('token')
     const error = params.get('error')
+    let isSameOriginPopup = false
     if (window.opener) {
+      try {
+        // cross-domain attempts to access opener.location.origin will throw
+        // this makes sure that Parabol opened the popup
+        isSameOriginPopup = !!window.opener.location.origin
+      } catch {}
+    }
+    if (isSameOriginPopup) {
       // SP-initiated
       window.opener.postMessage({token, error}, window.location.origin)
     } else {


### PR DESCRIPTION
One of our customers is using google apps which is opening parabol with a `window.opener` which is a huge vulnerability to them trusting that we won't send any phishing attacks their way. There's no risk to us, but it does cause a bug with logging in because we assume that if something opened up the login page in a popup, we should close that popup.

This fix addresses that problem & makes sure that the thing that opened the login page is from the same origin.

AC
- [ ] login with SSO from parabol. it works. you'll need a SAML row in the DB & an okta account
- [ ] login with SSO from a different origin, it works. To achieve a different origin, just make a dumb HTML page & save it & open it & click the button (see below)
- [x] Above tested in Safari (we're using an optional catch binding, which wasn't supported before 2019)

```html
<html>
  <body>
    <button onclick="NewTab()">Parabol</button>

    <script>
      function NewTab() {
        window.open(
          "http://localhost:3000/saml-redirect?token=badToken"
        );
      }
    </script>
  </body>
</html>
``` 



