### PR TITLE
promoteToTeamLead filters on isNotRemoved

### DIFF
--- a/packages/server/graphql/mutations/promoteToTeamLead.ts
+++ b/packages/server/graphql/mutations/promoteToTeamLead.ts
@@ -56,7 +56,7 @@ export default {
       .nth(0)
       .default(null)
       .run()
-    if (!promoteeOnTeam || !promoteeOnTeam.isNotRemoved) {
+    if (!promoteeOnTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
 

--- a/packages/server/graphql/mutations/promoteToTeamLead.ts
+++ b/packages/server/graphql/mutations/promoteToTeamLead.ts
@@ -6,8 +6,8 @@ import {getUserId, isSuperUser} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
-import PromoteToTeamLeadPayload from '../types/PromoteToTeamLeadPayload'
 import GraphQLEmailType from '../types/GraphQLEmailType'
+import PromoteToTeamLeadPayload from '../types/PromoteToTeamLeadPayload'
 
 export default {
   type: PromoteToTeamLeadPayload,
@@ -52,7 +52,7 @@ export default {
     const promoteeOnTeam = await r
       .table('TeamMember')
       .getAll(teamId, {index: 'teamId'})
-      .filter({email: newTeamLeadEmail})
+      .filter({email: newTeamLeadEmail, isNotRemoved: true})
       .nth(0)
       .default(null)
       .run()
@@ -62,18 +62,12 @@ export default {
 
     // RESOLUTION
     await r({
-      teamLead: r
-        .table('TeamMember')
-        .get(oldLeadTeamMemberId)
-        .update({
-          isLead: false
-        }),
-      promotee: r
-        .table('TeamMember')
-        .get(promoteeOnTeam.id)
-        .update({
-          isLead: true
-        })
+      teamLead: r.table('TeamMember').get(oldLeadTeamMemberId).update({
+        isLead: false
+      }),
+      promotee: r.table('TeamMember').get(promoteeOnTeam.id).update({
+        isLead: true
+      })
     }).run()
 
     const data = {teamId, oldLeaderId: oldLeadTeamMemberId, newLeaderId: promoteeOnTeam.id}


### PR DESCRIPTION
Promoting someone who was previously removed from a team did not always work. 50% of the time, it worked all the time.
This fixes that.

TEST
- [x] join a team
- [x] leave a team
- [x] join a team again
- [x] the leader of that team promotes the person who joined/left/joined
