### PR TITLE
Add string filtering to team / team member filter dropdowns

### DIFF
--- a/packages/client/components/EmptyDropdownMenuItemLabel.ts
+++ b/packages/client/components/EmptyDropdownMenuItemLabel.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled'
+
+import {PALETTE} from '~/styles/paletteV3'
+
+import MenuItemLabel from './MenuItemLabel'
+
+export const EmptyDropdownMenuItemLabel = styled(MenuItemLabel)({
+  color: PALETTE.SLATE_600,
+  justifyContent: 'center',
+  paddingLeft: 8,
+  paddingRight: 8,
+  fontStyle: 'italic'
+})

--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -48,8 +48,7 @@ type Contribution = Pick<IXGitHubCreatedCommitContribution, 'occurredAt' | 'repo
 const MAX_REPOS = 10
 
 const getValue = (item: {nameWithOwner?: string}) => {
-  const repoName = item.nameWithOwner || 'Unknown Repo'
-  return repoName.toLowerCase()
+  return item.nameWithOwner || 'Unknown Repo'
 }
 
 const GitHubScopingSearchFilterMenu = (props: Props) => {

--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -6,7 +6,6 @@ import useSearchFilter from '~/hooks/useSearchFilter'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import SearchQueryId from '../shared/gqlIds/SearchQueryId'
-import {PALETTE} from '../styles/paletteV3'
 import {IXGitHubCreatedCommitContribution} from '../types/graphql'
 import getReposFromQueryStr from '../utils/getReposFromQueryStr'
 import {
@@ -14,19 +13,12 @@ import {
   GitHubScopingSearchFilterMenuQueryResponse
 } from '../__generated__/GitHubScopingSearchFilterMenuQuery.graphql'
 import Checkbox from './Checkbox'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
 import MenuItemLabel from './MenuItemLabel'
 import {SearchMenuItem} from './SearchMenuItem'
 import TypeAheadLabel from './TypeAheadLabel'
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const StyledCheckBox = styled(Checkbox)({
   marginLeft: -8,
@@ -147,7 +139,9 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
         onChange={onQueryChange}
         value={searchQuery}
       />
-      {repoContributions.length === 0 && <NoResults key='no-results'>No repos found!</NoResults>}
+      {repoContributions.length === 0 && (
+        <EmptyDropdownMenuItemLabel key='no-results'>No repos found!</EmptyDropdownMenuItemLabel>
+      )}
       {selectedAndFilteredRepos.map((repo) => {
         const isSelected = selectedRepos.includes(repo)
         const handleClick = () => {

--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -123,7 +123,7 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
     query: searchQuery,
     filteredItems: filteredRepoContributions,
     onQueryChange
-  } = useSearchFilter(repoContributions!, getValue)
+  } = useSearchFilter(repoContributions, getValue)
 
   // TODO parse the query string & extract out the repositories
   const selectedRepos = getReposFromQueryStr(queryString)
@@ -143,7 +143,11 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
       portalStatus={portalStatus}
       isDropdown={isDropdown}
     >
-      <SearchMenuItem placeholder='Search your GitHub repos' onChange={onQueryChange} value={searchQuery} />
+      <SearchMenuItem
+        placeholder='Search your GitHub repos'
+        onChange={onQueryChange}
+        value={searchQuery}
+      />
       {repoContributions.length === 0 && <NoResults key='no-results'>No repos found!</NoResults>}
       {selectedAndFilteredRepos.map((repo) => {
         const isSelected = selectedRepos.includes(repo)

--- a/packages/client/components/GitHubScopingSearchHistoryMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchHistoryMenu.tsx
@@ -9,18 +9,11 @@ import SearchQueryId from '../shared/gqlIds/SearchQueryId'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
 import {GitHubScopingSearchHistoryMenu_teamMember$key} from '../__generated__/GitHubScopingSearchHistoryMenu_teamMember.graphql'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import IconButton from './IconButton'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
 import MenuItemLabel from './MenuItemLabel'
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const QueryString = styled('span')({
   color: PALETTE.SLATE_600,
@@ -95,7 +88,9 @@ const GitHubScopingSearchHistoryMenu = (props: Props) => {
       closePortal={closePortal}
     >
       {githubSearchQueries.length === 0 && (
-        <NoResults key='no-results'>No saved queries yet!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No saved queries yet!
+        </EmptyDropdownMenuItemLabel>
       )}
       {githubSearchQueries.map((githubSearchQuery) => {
         const {id: queryId, queryString} = githubSearchQuery

--- a/packages/client/components/JiraScopingSearchFilterMenu.tsx
+++ b/packages/client/components/JiraScopingSearchFilterMenu.tsx
@@ -81,7 +81,7 @@ const JiraScopingSearchFilterMenu = (props: Props) => {
     query,
     filteredItems: queryFilteredProjects,
     onQueryChange
-  } = useSearchFilter(projects!, getValue)
+  } = useSearchFilter(projects, getValue)
 
   const showSearch = projects.length > MAX_PROJECTS
   const selectedAndFilteredProjects = useMemo(() => {

--- a/packages/client/components/JiraScopingSearchFilterMenu.tsx
+++ b/packages/client/components/JiraScopingSearchFilterMenu.tsx
@@ -3,29 +3,20 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
 import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useFilteredItems from '../hooks/useFilteredItems'
-import useForm from '../hooks/useForm'
 import {MenuProps} from '../hooks/useMenu'
 import SearchQueryId from '../shared/gqlIds/SearchQueryId'
 import {PALETTE} from '../styles/paletteV3'
-import {ICON_SIZE} from '../styles/typographyV2'
 import {JiraScopingSearchFilterMenu_viewer} from '../__generated__/JiraScopingSearchFilterMenu_viewer.graphql'
 import Checkbox from './Checkbox'
 import DropdownMenuLabel from './DropdownMenuLabel'
-import Icon from './Icon'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
-import MenuItemComponentAvatar from './MenuItemComponentAvatar'
 import MenuItemHR from './MenuItemHR'
 import MenuItemLabel from './MenuItemLabel'
 import MockFieldList from './MockFieldList'
-import MenuSearch from './MenuSearch'
 import TypeAheadLabel from './TypeAheadLabel'
-
-const SearchIcon = styled(Icon)({
-  color: PALETTE.SLATE_600,
-  fontSize: ICON_SIZE.MD18
-})
+import useSearchFilter from '~/hooks/useSearchFilter'
+import {SearchMenuItem} from './SearchMenuItem'
 
 const StyledMenu = styled(Menu)({
   width: 250
@@ -37,21 +28,6 @@ const NoResults = styled(MenuItemLabel)({
   paddingLeft: 8,
   paddingRight: 8,
   fontStyle: 'italic'
-})
-
-const SearchItem = styled(MenuItemLabel)({
-  margin: '0 8px 8px',
-  overflow: 'visible',
-  padding: 0,
-  position: 'relative'
-})
-
-const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
-  position: 'absolute',
-  left: 8,
-  margin: 0,
-  pointerEvents: 'none',
-  top: 4
 })
 
 const ProjectAvatar = styled('img')({
@@ -100,16 +76,14 @@ const JiraScopingSearchFilterMenu = (props: Props) => {
   const jiraSearchQuery = meeting?.jiraSearchQuery ?? null
   const projectKeyFilters = jiraSearchQuery?.projectKeyFilters ?? []
   const isJQL = jiraSearchQuery?.isJQL ?? false
-  const {fields, onChange} = useForm({
-    search: {
-      getDefault: () => ''
-    }
-  })
-  const {search} = fields
-  const {value} = search
-  const query = value.toLowerCase()
+
+  const {
+    query,
+    filteredItems: queryFilteredProjects,
+    onQueryChange
+  } = useSearchFilter(projects!, getValue)
+
   const showSearch = projects.length > MAX_PROJECTS
-  const queryFilteredProjects = useFilteredItems(query, projects, getValue)
   const selectedAndFilteredProjects = useMemo(() => {
     const selectedProjects = projects.filter((project) => projectKeyFilters.includes(project.id))
     const adjustedMax =
@@ -154,12 +128,7 @@ const JiraScopingSearchFilterMenu = (props: Props) => {
       {isLoading && <MockFieldList />}
       {selectedAndFilteredProjects.length > 0 && <FilterLabel>Filter by project:</FilterLabel>}
       {showSearch && (
-        <SearchItem key='search'>
-          <StyledMenuItemIcon>
-            <SearchIcon>search</SearchIcon>
-          </StyledMenuItemIcon>
-          <MenuSearch placeholder={'Search Jira'} value={value} onChange={onChange} />
-        </SearchItem>
+        <SearchMenuItem placeholder='Search Jira' onChange={onQueryChange} value={query} />
       )}
       {(query && selectedAndFilteredProjects.length === 0 && !isLoading && (
         <NoResults key='no-results'>No Jira Projects found!</NoResults>

--- a/packages/client/components/JiraScopingSearchFilterMenu.tsx
+++ b/packages/client/components/JiraScopingSearchFilterMenu.tsx
@@ -5,7 +5,6 @@ import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import SearchQueryId from '../shared/gqlIds/SearchQueryId'
-import {PALETTE} from '../styles/paletteV3'
 import {JiraScopingSearchFilterMenu_viewer} from '../__generated__/JiraScopingSearchFilterMenu_viewer.graphql'
 import Checkbox from './Checkbox'
 import DropdownMenuLabel from './DropdownMenuLabel'
@@ -17,17 +16,10 @@ import MockFieldList from './MockFieldList'
 import TypeAheadLabel from './TypeAheadLabel'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {SearchMenuItem} from './SearchMenuItem'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 
 const StyledMenu = styled(Menu)({
   width: 250
-})
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
 })
 
 const ProjectAvatar = styled('img')({
@@ -131,7 +123,9 @@ const JiraScopingSearchFilterMenu = (props: Props) => {
         <SearchMenuItem placeholder='Search Jira' onChange={onQueryChange} value={query} />
       )}
       {(query && selectedAndFilteredProjects.length === 0 && !isLoading && (
-        <NoResults key='no-results'>No Jira Projects found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No Jira Projects found!
+        </EmptyDropdownMenuItemLabel>
       )) ||
         null}
       {selectedAndFilteredProjects.map((project) => {

--- a/packages/client/components/JiraScopingSearchFilterMenu.tsx
+++ b/packages/client/components/JiraScopingSearchFilterMenu.tsx
@@ -63,7 +63,7 @@ type JiraSearchQuery = NonNullable<
   NonNullable<JiraScopingSearchFilterMenu_viewer['meeting']>['jiraSearchQuery']
 >
 
-const getValue = (item: {name: string}) => item.name.toLowerCase()
+const getValue = (item: {name: string}) => item.name
 
 const MAX_PROJECTS = 10
 

--- a/packages/client/components/JiraScopingSearchHistoryMenu.tsx
+++ b/packages/client/components/JiraScopingSearchHistoryMenu.tsx
@@ -13,14 +13,7 @@ import MenuItemLabel from './MenuItemLabel'
 import PersistJiraSearchQueryMutation from '../mutations/PersistJiraSearchQueryMutation'
 import IconButton from './IconButton'
 import {ICON_SIZE} from '../styles/typographyV2'
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 
 const QueryString = styled('span')({
   color: PALETTE.SLATE_600
@@ -81,7 +74,9 @@ const JiraScopingSearchHistoryMenu = (props: Props) => {
       closePortal={closePortal}
     >
       {jiraSearchQueries.length === 0 && (
-        <NoResults key='no-results'>No saved queries yet!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No saved queries yet!
+        </EmptyDropdownMenuItemLabel>
       )}
       {jiraSearchQueries.map((jiraSearchQuery) => {
         const {id: queryId, queryString, isJQL, projectKeyFilters} = jiraSearchQuery

--- a/packages/client/components/NewGitHubIssueMenu.tsx
+++ b/packages/client/components/NewGitHubIssueMenu.tsx
@@ -1,19 +1,16 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useCallback, useRef} from 'react'
+import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 import useAllIntegrations from '~/hooks/useAllIntegrations'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useFilteredItems from '~/hooks/useFilteredItems'
-import useForm from '~/hooks/useForm'
 import {MenuProps} from '~/hooks/useMenu'
+import useSearchFilter from '~/hooks/useSearchFilter'
 import {PALETTE} from '~/styles/paletteV3'
-import {ICON_SIZE} from '~/styles/typographyV2'
 import {NewGitHubIssueMenu_suggestedIntegrations} from '~/__generated__/NewGitHubIssueMenu_suggestedIntegrations.graphql'
-import Icon from './Icon'
 import Menu from './Menu'
-import MenuItemComponentAvatar from './MenuItemComponentAvatar'
 import MenuItemLabel from './MenuItemLabel'
+import {SearchMenuItem} from './SearchMenuItem'
 import SuggestedIntegrationGitHubMenuItem from './SuggestedIntegrationGitHubMenuItem'
 
 const NoResults = styled(MenuItemLabel)({
@@ -22,43 +19,6 @@ const NoResults = styled(MenuItemLabel)({
   paddingLeft: 8,
   paddingRight: 8,
   fontStyle: 'italic'
-})
-
-const SearchItem = styled(MenuItemLabel)({
-  margin: '0 8px 8px',
-  overflow: 'visible',
-  padding: 0,
-  position: 'relative'
-})
-
-const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
-  position: 'absolute',
-  left: 8,
-  margin: 0,
-  pointerEvents: 'none',
-  top: 4
-})
-
-const SearchIcon = styled(Icon)({
-  color: PALETTE.SLATE_600,
-  fontSize: ICON_SIZE.MD18
-})
-
-const Input = styled('input')({
-  appearance: 'none',
-  background: 'inherit',
-  border: `1px solid ${PALETTE.SLATE_400}`,
-  borderRadius: 2,
-  display: 'block',
-  fontSize: 14,
-  lineHeight: '24px',
-  outline: 'none',
-  padding: '3px 0 3px 39px',
-  width: '100%',
-  '&:focus, &:active': {
-    border: `1px solid ${PALETTE.SKY_500}`,
-    boxShadow: `0 0 1px 1px ${PALETTE.SKY_300}`
-  }
 })
 
 interface Props {
@@ -77,16 +37,14 @@ const getValue = (item: {projectName?: string; nameWithOwner?: string}) => {
 const NewGitHubIssueMenu = (props: Props) => {
   const {handleSelectNameWithOwner, menuProps, suggestedIntegrations, teamId, userId} = props
   const {hasMore, items} = suggestedIntegrations
-  const {fields, onChange} = useForm({
-    search: {
-      getDefault: () => ''
-    }
-  })
+
+  const {
+    query,
+    filteredItems: filteredIntegrations,
+    onQueryChange
+  } = useSearchFilter(items!, getValue)
+
   const atmosphere = useAtmosphere()
-  const {search} = fields
-  const {value} = search
-  const query = value.toLowerCase()
-  const filteredIntegrations = useFilteredItems(query, items!, getValue)
   const {allItems, status} = useAllIntegrations(
     atmosphere,
     query,
@@ -96,11 +54,6 @@ const NewGitHubIssueMenu = (props: Props) => {
     userId
   )
 
-  const ref = useRef<HTMLInputElement>(null)
-  const onBlur = useCallback(() => {
-    ref.current && ref.current.focus()
-  }, [])
-
   return (
     <Menu
       ariaLabel='Select GitHub project'
@@ -108,21 +61,7 @@ const NewGitHubIssueMenu = (props: Props) => {
       {...menuProps}
       resetActiveOnChanges={[allItems]}
     >
-      <SearchItem>
-        <StyledMenuItemIcon>
-          <SearchIcon>search</SearchIcon>
-        </StyledMenuItemIcon>
-        <Input
-          autoFocus
-          autoComplete='off'
-          name='search'
-          onBlur={onBlur}
-          onChange={onChange}
-          placeholder='Search GitHub'
-          ref={ref}
-          type='text'
-        />
-      </SearchItem>
+      <SearchMenuItem placeholder='Search GitHub' onChange={onQueryChange} value={query} />
       {(query && allItems.length === 0 && status !== 'loading' && (
         <NoResults key='no-results'>No integrations found!</NoResults>
       )) ||

--- a/packages/client/components/NewGitHubIssueMenu.tsx
+++ b/packages/client/components/NewGitHubIssueMenu.tsx
@@ -30,8 +30,7 @@ interface Props {
 }
 
 const getValue = (item: {projectName?: string; nameWithOwner?: string}) => {
-  const repoName = item.projectName || item.nameWithOwner || 'Unknown Project'
-  return repoName.toLowerCase()
+  return item.projectName || item.nameWithOwner || 'Unknown Project'
 }
 
 const NewGitHubIssueMenu = (props: Props) => {

--- a/packages/client/components/NewGitHubIssueMenu.tsx
+++ b/packages/client/components/NewGitHubIssueMenu.tsx
@@ -42,7 +42,7 @@ const NewGitHubIssueMenu = (props: Props) => {
     query,
     filteredItems: filteredIntegrations,
     onQueryChange
-  } = useSearchFilter(items!, getValue)
+  } = useSearchFilter(items ?? [], getValue)
 
   const atmosphere = useAtmosphere()
   const {allItems, status} = useAllIntegrations(

--- a/packages/client/components/NewGitHubIssueMenu.tsx
+++ b/packages/client/components/NewGitHubIssueMenu.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
@@ -6,20 +5,11 @@ import useAllIntegrations from '~/hooks/useAllIntegrations'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuProps} from '~/hooks/useMenu'
 import useSearchFilter from '~/hooks/useSearchFilter'
-import {PALETTE} from '~/styles/paletteV3'
 import {NewGitHubIssueMenu_suggestedIntegrations} from '~/__generated__/NewGitHubIssueMenu_suggestedIntegrations.graphql'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
-import MenuItemLabel from './MenuItemLabel'
 import {SearchMenuItem} from './SearchMenuItem'
 import SuggestedIntegrationGitHubMenuItem from './SuggestedIntegrationGitHubMenuItem'
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 interface Props {
   handleSelectNameWithOwner: (key: string) => void
@@ -62,7 +52,9 @@ const NewGitHubIssueMenu = (props: Props) => {
     >
       <SearchMenuItem placeholder='Search GitHub' onChange={onQueryChange} value={query} />
       {(query && allItems.length === 0 && status !== 'loading' && (
-        <NoResults key='no-results'>No integrations found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No integrations found!
+        </EmptyDropdownMenuItemLabel>
       )) ||
         null}
 

--- a/packages/client/components/NewJiraIssueMenu.tsx
+++ b/packages/client/components/NewJiraIssueMenu.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
@@ -6,20 +5,11 @@ import useAllIntegrations from '~/hooks/useAllIntegrations'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuProps} from '~/hooks/useMenu'
 import useSearchFilter from '~/hooks/useSearchFilter'
-import {PALETTE} from '~/styles/paletteV3'
 import {NewJiraIssueMenu_suggestedIntegrations} from '~/__generated__/NewJiraIssueMenu_suggestedIntegrations.graphql'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
-import MenuItemLabel from './MenuItemLabel'
 import {SearchMenuItem} from './SearchMenuItem'
 import SuggestedIntegrationJiraMenuItem from './SuggestedIntegrationJiraMenuItem'
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 interface Props {
   handleSelectProjectKey: (key: string) => void
@@ -62,7 +52,9 @@ const NewJiraIssueMenu = (props: Props) => {
     >
       <SearchMenuItem placeholder='Search Jira' onChange={onQueryChange} value={query} />
       {(query && allItems.length === 0 && status !== 'loading' && (
-        <NoResults key='no-results'>No integrations found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No integrations found!
+        </EmptyDropdownMenuItemLabel>
       )) ||
         null}
 

--- a/packages/client/components/NewJiraIssueMenu.tsx
+++ b/packages/client/components/NewJiraIssueMenu.tsx
@@ -42,7 +42,7 @@ const NewJiraIssueMenu = (props: Props) => {
     query,
     filteredItems: filteredIntegrations,
     onQueryChange
-  } = useSearchFilter(items!, getValue)
+  } = useSearchFilter(items ?? [], getValue)
 
   const atmosphere = useAtmosphere()
   const {allItems, status} = useAllIntegrations(

--- a/packages/client/components/NewJiraIssueMenu.tsx
+++ b/packages/client/components/NewJiraIssueMenu.tsx
@@ -1,19 +1,16 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useCallback, useRef} from 'react'
+import React from 'react'
 import {createFragmentContainer} from 'react-relay'
 import useAllIntegrations from '~/hooks/useAllIntegrations'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import useFilteredItems from '~/hooks/useFilteredItems'
-import useForm from '~/hooks/useForm'
 import {MenuProps} from '~/hooks/useMenu'
+import useSearchFilter from '~/hooks/useSearchFilter'
 import {PALETTE} from '~/styles/paletteV3'
-import {ICON_SIZE} from '~/styles/typographyV2'
 import {NewJiraIssueMenu_suggestedIntegrations} from '~/__generated__/NewJiraIssueMenu_suggestedIntegrations.graphql'
-import Icon from './Icon'
 import Menu from './Menu'
-import MenuItemComponentAvatar from './MenuItemComponentAvatar'
 import MenuItemLabel from './MenuItemLabel'
+import {SearchMenuItem} from './SearchMenuItem'
 import SuggestedIntegrationJiraMenuItem from './SuggestedIntegrationJiraMenuItem'
 
 const NoResults = styled(MenuItemLabel)({
@@ -22,43 +19,6 @@ const NoResults = styled(MenuItemLabel)({
   paddingLeft: 8,
   paddingRight: 8,
   fontStyle: 'italic'
-})
-
-const SearchItem = styled(MenuItemLabel)({
-  margin: '0 8px 8px',
-  overflow: 'visible',
-  padding: 0,
-  position: 'relative'
-})
-
-const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
-  position: 'absolute',
-  left: 8,
-  margin: 0,
-  pointerEvents: 'none',
-  top: 4
-})
-
-const SearchIcon = styled(Icon)({
-  color: PALETTE.SLATE_600,
-  fontSize: ICON_SIZE.MD18
-})
-
-const Input = styled('input')({
-  appearance: 'none',
-  background: 'inherit',
-  border: `1px solid ${PALETTE.SLATE_400}`,
-  borderRadius: 2,
-  display: 'block',
-  fontSize: 14,
-  lineHeight: '24px',
-  outline: 'none',
-  padding: '3px 0 3px 39px',
-  width: '100%',
-  '&:focus, &:active': {
-    border: `1px solid ${PALETTE.SKY_500}`,
-    boxShadow: `0 0 1px 1px ${PALETTE.SKY_300}`
-  }
 })
 
 interface Props {
@@ -77,16 +37,14 @@ const getValue = (item: {remoteProject?: any; nameWithOwner?: string}) => {
 const NewJiraIssueMenu = (props: Props) => {
   const {handleSelectProjectKey, menuProps, suggestedIntegrations, teamId, userId} = props
   const {hasMore, items} = suggestedIntegrations
-  const {fields, onChange} = useForm({
-    search: {
-      getDefault: () => ''
-    }
-  })
+
+  const {
+    query,
+    filteredItems: filteredIntegrations,
+    onQueryChange
+  } = useSearchFilter(items!, getValue)
+
   const atmosphere = useAtmosphere()
-  const {search} = fields
-  const {value} = search
-  const query = value.toLowerCase()
-  const filteredIntegrations = useFilteredItems(query, items!, getValue)
   const {allItems, status} = useAllIntegrations(
     atmosphere,
     query,
@@ -96,11 +54,6 @@ const NewJiraIssueMenu = (props: Props) => {
     userId
   )
 
-  const ref = useRef<HTMLInputElement>(null)
-  const onBlur = useCallback(() => {
-    ref.current && ref.current.focus()
-  }, [])
-
   return (
     <Menu
       ariaLabel='Select Jira project'
@@ -108,21 +61,7 @@ const NewJiraIssueMenu = (props: Props) => {
       {...menuProps}
       resetActiveOnChanges={[allItems]}
     >
-      <SearchItem>
-        <StyledMenuItemIcon>
-          <SearchIcon>search</SearchIcon>
-        </StyledMenuItemIcon>
-        <Input
-          autoFocus
-          autoComplete='off'
-          name='search'
-          onBlur={onBlur}
-          onChange={onChange}
-          placeholder='Search Jira'
-          ref={ref}
-          type='text'
-        />
-      </SearchItem>
+      <SearchMenuItem placeholder='Search Jira' onChange={onQueryChange} value={query} />
       {(query && allItems.length === 0 && status !== 'loading' && (
         <NoResults key='no-results'>No integrations found!</NoResults>
       )) ||

--- a/packages/client/components/NewJiraIssueMenu.tsx
+++ b/packages/client/components/NewJiraIssueMenu.tsx
@@ -30,8 +30,7 @@ interface Props {
 }
 
 const getValue = (item: {remoteProject?: any; nameWithOwner?: string}) => {
-  const repoName = item.remoteProject?.name ?? item.nameWithOwner ?? 'Unknown Project'
-  return repoName.toLowerCase()
+  return item.remoteProject?.name ?? item.nameWithOwner ?? 'Unknown Project'
 }
 
 const NewJiraIssueMenu = (props: Props) => {

--- a/packages/client/components/SearchMenuItem.tsx
+++ b/packages/client/components/SearchMenuItem.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled'
+import React from 'react'
+
+import {PALETTE} from '~/styles/paletteV3'
+import {ICON_SIZE} from '~/styles/typographyV2'
+
+import Icon from './Icon'
+import MenuItemComponentAvatar from './MenuItemComponentAvatar'
+import MenuItemLabel from './MenuItemLabel'
+import MenuSearch from './MenuSearch'
+
+const SearchItem = styled(MenuItemLabel)({
+  margin: '0 8px 8px',
+  overflow: 'visible',
+  padding: 0,
+  position: 'relative'
+});
+
+const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
+  position: 'absolute',
+  left: 8,
+  margin: 0,
+  pointerEvents: 'none',
+  top: 4
+});
+
+const SearchIcon = styled(Icon)({
+  color: PALETTE.SLATE_600,
+  fontSize: ICON_SIZE.MD18
+});
+
+interface Props {
+  placeholder: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+}
+
+export const SearchMenuItem: React.FC<Props> = ({placeholder, onChange, value}) => {
+  return (
+    <SearchItem>
+      <StyledMenuItemIcon>
+        <SearchIcon>search</SearchIcon>
+      </StyledMenuItemIcon>
+      <MenuSearch placeholder={placeholder} onChange={onChange} value={value} />
+    </SearchItem>
+  );
+}

--- a/packages/client/components/SearchMenuItem.tsx
+++ b/packages/client/components/SearchMenuItem.tsx
@@ -14,7 +14,7 @@ const SearchItem = styled(MenuItemLabel)({
   overflow: 'visible',
   padding: 0,
   position: 'relative'
-});
+})
 
 const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
   position: 'absolute',
@@ -22,17 +22,17 @@ const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
   margin: 0,
   pointerEvents: 'none',
   top: 4
-});
+})
 
 const SearchIcon = styled(Icon)({
   color: PALETTE.SLATE_600,
   fontSize: ICON_SIZE.MD18
-});
+})
 
 interface Props {
-  placeholder: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  value: string;
+  placeholder: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  value: string
 }
 
 export const SearchMenuItem: React.FC<Props> = ({placeholder, onChange, value}) => {
@@ -43,5 +43,5 @@ export const SearchMenuItem: React.FC<Props> = ({placeholder, onChange, value}) 
       </StyledMenuItemIcon>
       <MenuSearch placeholder={placeholder} onChange={onChange} value={value} />
     </SearchItem>
-  );
+  )
 }

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -48,8 +48,7 @@ const getValue = (
 ) => {
   const jiraItemName = item?.projectKey ?? ''
   const githubName = item?.nameWithOwner ?? ''
-  const name = jiraItemName || githubName
-  return name.toLowerCase()
+  return jiraItemName || githubName
 }
 
 const TaskFooterIntegrateMenuList = (props: Props) => {

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -2,25 +2,21 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import useSearchFilter from '~/hooks/useSearchFilter'
 import useAllIntegrations from '../hooks/useAllIntegrations'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useFilteredItems from '../hooks/useFilteredItems'
-import useForm from '../hooks/useForm'
 import {MenuProps} from '../hooks/useMenu'
 import {MenuMutationProps} from '../hooks/useMutationProps'
 import CreateGitHubTaskIntegrationMutation from '../mutations/CreateGitHubTaskIntegrationMutation'
 import CreateJiraTaskIntegrationMutation from '../mutations/CreateJiraTaskIntegrationMutation'
 import {PALETTE} from '../styles/paletteV3'
-import {ICON_SIZE} from '../styles/typographyV2'
 import {TaskFooterIntegrateMenuList_suggestedIntegrations} from '../__generated__/TaskFooterIntegrateMenuList_suggestedIntegrations.graphql'
 import {TaskFooterIntegrateMenuList_task} from '../__generated__/TaskFooterIntegrateMenuList_task.graphql'
-import Icon from './Icon'
 import LoadingComponent from './LoadingComponent/LoadingComponent'
 import Menu from './Menu'
-import MenuItemComponentAvatar from './MenuItemComponentAvatar'
 import MenuItemHR from './MenuItemHR'
 import MenuItemLabel from './MenuItemLabel'
-import MenuSearch from './MenuSearch'
+import {SearchMenuItem} from './SearchMenuItem'
 import SuggestedIntegrationGitHubMenuItem from './SuggestedIntegrationGitHubMenuItem'
 import SuggestedIntegrationJiraMenuItem from './SuggestedIntegrationJiraMenuItem'
 
@@ -33,32 +29,12 @@ interface Props {
   label?: string
 }
 
-const SearchIcon = styled(Icon)({
-  color: PALETTE.SLATE_600,
-  fontSize: ICON_SIZE.MD18
-})
-
 const NoResults = styled(MenuItemLabel)({
   color: PALETTE.SLATE_600,
   justifyContent: 'center',
   paddingLeft: 8,
   paddingRight: 8,
   fontStyle: 'italic'
-})
-
-const SearchItem = styled(MenuItemLabel)({
-  margin: '0 8px 8px',
-  overflow: 'visible',
-  padding: 0,
-  position: 'relative'
-})
-
-const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
-  position: 'absolute',
-  left: 8,
-  margin: 0,
-  pointerEvents: 'none',
-  top: 4
 })
 
 const Label = styled('div')({
@@ -82,16 +58,13 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
   const items = suggestedIntegrations.items || []
   const {id: taskId, teamId, userId} = task
 
-  const {fields, onChange} = useForm({
-    search: {
-      getDefault: () => ''
-    }
-  })
-  const {search} = fields
-  const {value} = search
-  const query = value.toLowerCase()
+  const {
+    query,
+    filteredItems: filteredIntegrations,
+    onQueryChange
+  } = useSearchFilter(items!, getValue)
+
   const atmosphere = useAtmosphere()
-  const filteredIntegrations = useFilteredItems(query, items, getValue)
   const {allItems, status} = useAllIntegrations(
     atmosphere,
     query,
@@ -113,12 +86,7 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
           <MenuItemHR />
         </>
       )}
-      <SearchItem key='search'>
-        <StyledMenuItemIcon>
-          <SearchIcon>search</SearchIcon>
-        </StyledMenuItemIcon>
-        <MenuSearch placeholder={placeholder} value={value} onChange={onChange} />
-      </SearchItem>
+      <SearchMenuItem placeholder={placeholder} onChange={onQueryChange} value={query} />
       {(query && allItems.length === 0 && status !== 'loading' && (
         <NoResults key='no-results'>No integrations found!</NoResults>
       )) ||

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -62,7 +62,7 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
     query,
     filteredItems: filteredIntegrations,
     onQueryChange
-  } = useSearchFilter(items!, getValue)
+  } = useSearchFilter(items, getValue)
 
   const atmosphere = useAtmosphere()
   const {allItems, status} = useAllIntegrations(

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -12,10 +12,10 @@ import CreateJiraTaskIntegrationMutation from '../mutations/CreateJiraTaskIntegr
 import {PALETTE} from '../styles/paletteV3'
 import {TaskFooterIntegrateMenuList_suggestedIntegrations} from '../__generated__/TaskFooterIntegrateMenuList_suggestedIntegrations.graphql'
 import {TaskFooterIntegrateMenuList_task} from '../__generated__/TaskFooterIntegrateMenuList_task.graphql'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import LoadingComponent from './LoadingComponent/LoadingComponent'
 import Menu from './Menu'
 import MenuItemHR from './MenuItemHR'
-import MenuItemLabel from './MenuItemLabel'
 import {SearchMenuItem} from './SearchMenuItem'
 import SuggestedIntegrationGitHubMenuItem from './SuggestedIntegrationGitHubMenuItem'
 import SuggestedIntegrationJiraMenuItem from './SuggestedIntegrationJiraMenuItem'
@@ -28,14 +28,6 @@ interface Props {
   task: TaskFooterIntegrateMenuList_task
   label?: string
 }
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const Label = styled('div')({
   color: PALETTE.SLATE_600,
@@ -87,7 +79,9 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
       )}
       <SearchMenuItem placeholder={placeholder} onChange={onQueryChange} value={query} />
       {(query && allItems.length === 0 && status !== 'loading' && (
-        <NoResults key='no-results'>No integrations found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No integrations found!
+        </EmptyDropdownMenuItemLabel>
       )) ||
         null}
       {allItems.slice(0, 10).map((suggestedIntegration) => {

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -43,6 +43,7 @@ const TeamDashTeamMemberMenu = (props: Props) => {
 
   return (
     <Menu
+      keepParentFocus
       ariaLabel={'Select the team member to filter by'}
       {...menuProps}
       defaultActiveIdx={defaultActiveIdx}

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -24,7 +24,11 @@ const TeamDashTeamMemberMenu = (props: Props) => {
   const defaultActiveIdx =
     teamMembers.findIndex((teamMember) => teamMember.id === teamMemberFilterId) + 2
 
-  const {query, filteredItems: matchedTeamMembers, onQueryChange} = useSearchFilter(teamMembers!, teamMember => teamMember.preferredName);
+  const {
+    query,
+    filteredItems: matchedTeamMembers,
+    onQueryChange
+  } = useSearchFilter(teamMembers!, (teamMember) => teamMember.preferredName)
 
   return (
     <Menu
@@ -33,18 +37,14 @@ const TeamDashTeamMemberMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
-      <SearchMenuItem
-        placeholder='Search team members'
-        onChange={onQueryChange}
-        value={query}
-      />
-      {query === '' &&
+      <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {query === '' && (
         <MenuItem
           key={'teamMemberFilterNULL'}
           label={'All team members'}
           onClick={() => filterTeamMember(atmosphere, teamId, null)}
         />
-      }
+      )}
       {matchedTeamMembers.map((teamMember) => (
         <MenuItem
           key={`teamMemberFilter${teamMember.id}`}

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -39,7 +39,7 @@ const TeamDashTeamMemberMenu = (props: Props) => {
     query,
     filteredItems: matchedTeamMembers,
     onQueryChange
-  } = useSearchFilter(teamMembers, (teamMember) => teamMember.preferredName.toLowerCase())
+  } = useSearchFilter(teamMembers, (teamMember) => teamMember.preferredName)
 
   return (
     <Menu

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -10,11 +10,22 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import filterTeamMember from '../utils/relay/filterTeamMember'
 import {SearchMenuItem} from './SearchMenuItem'
 import useSearchFilter from '~/hooks/useSearchFilter'
+import styled from '@emotion/styled'
+import {PALETTE} from '~/styles/paletteV3'
+import MenuItemLabel from './MenuItemLabel'
 
 interface Props {
   menuProps: MenuProps
   team: TeamDashTeamMemberMenu_team
 }
+
+const NoResults = styled(MenuItemLabel)({
+  color: PALETTE.SLATE_600,
+  justifyContent: 'center',
+  paddingLeft: 8,
+  paddingRight: 8,
+  fontStyle: 'italic'
+})
 
 const TeamDashTeamMemberMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
@@ -38,6 +49,9 @@ const TeamDashTeamMemberMenu = (props: Props) => {
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
       <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {query && matchedTeamMembers.length === 0 &&
+        <NoResults key='no-results'>No team members found!</NoResults>
+      }
       {query === '' && (
         <MenuItem
           key={'teamMemberFilterNULL'}

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -8,10 +8,16 @@ import DropdownMenuLabel from './DropdownMenuLabel'
 import {TeamDashTeamMemberMenu_team} from '../__generated__/TeamDashTeamMemberMenu_team.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import filterTeamMember from '../utils/relay/filterTeamMember'
+import {SearchMenuItem} from './SearchMenuItem'
+import useSearchFilter from '~/hooks/useSearchFilter'
 
 interface Props {
   menuProps: MenuProps
   team: TeamDashTeamMemberMenu_team
+}
+
+const getValue = (teamMember) => {
+  return teamMember.preferredName
 }
 
 const TeamDashTeamMemberMenu = (props: Props) => {
@@ -21,6 +27,9 @@ const TeamDashTeamMemberMenu = (props: Props) => {
   const teamMemberFilterId = teamMemberFilter && teamMemberFilter.id
   const defaultActiveIdx =
     teamMembers.findIndex((teamMember) => teamMember.id === teamMemberFilterId) + 2
+
+  const {query, filteredItems: matchedTeamMembers, onQueryChange} = useSearchFilter(teamMembers!, getValue);
+
   return (
     <Menu
       ariaLabel={'Select the team member to filter by'}
@@ -28,12 +37,19 @@ const TeamDashTeamMemberMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
-      <MenuItem
-        key={'teamMemberFilterNULL'}
-        label={'All team members'}
-        onClick={() => filterTeamMember(atmosphere, teamId, null)}
+      <SearchMenuItem
+        placeholder='Search team members'
+        onChange={onQueryChange}
+        value={query}
       />
-      {teamMembers.map((teamMember) => (
+      {query === '' &&
+        <MenuItem
+          key={'teamMemberFilterNULL'}
+          label={'All team members'}
+          onClick={() => filterTeamMember(atmosphere, teamId, null)}
+        />
+      }
+      {matchedTeamMembers.map((teamMember) => (
         <MenuItem
           key={`teamMemberFilter${teamMember.id}`}
           label={teamMember.preferredName}

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -10,22 +10,12 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import filterTeamMember from '../utils/relay/filterTeamMember'
 import {SearchMenuItem} from './SearchMenuItem'
 import useSearchFilter from '~/hooks/useSearchFilter'
-import styled from '@emotion/styled'
-import {PALETTE} from '~/styles/paletteV3'
-import MenuItemLabel from './MenuItemLabel'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 
 interface Props {
   menuProps: MenuProps
   team: TeamDashTeamMemberMenu_team
 }
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const TeamDashTeamMemberMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
@@ -53,7 +43,9 @@ const TeamDashTeamMemberMenu = (props: Props) => {
         <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
       )}
       {query && matchedTeamMembers.length === 0 && (
-        <NoResults key='no-results'>No team members found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No team members found!
+        </EmptyDropdownMenuItemLabel>
       )}
       {query === '' && (
         <MenuItem

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -49,7 +49,9 @@ const TeamDashTeamMemberMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
-      <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {teamMembers.length > 5 && (
+        <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      )}
       {query && matchedTeamMembers.length === 0 && (
         <NoResults key='no-results'>No team members found!</NoResults>
       )}

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -39,7 +39,7 @@ const TeamDashTeamMemberMenu = (props: Props) => {
     query,
     filteredItems: matchedTeamMembers,
     onQueryChange
-  } = useSearchFilter(teamMembers!, (teamMember) => teamMember.preferredName)
+  } = useSearchFilter(teamMembers, (teamMember) => teamMember.preferredName.toLowerCase())
 
   return (
     <Menu
@@ -49,9 +49,9 @@ const TeamDashTeamMemberMenu = (props: Props) => {
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
       <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
-      {query && matchedTeamMembers.length === 0 &&
+      {query && matchedTeamMembers.length === 0 && (
         <NoResults key='no-results'>No team members found!</NoResults>
-      }
+      )}
       {query === '' && (
         <MenuItem
           key={'teamMemberFilterNULL'}

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -16,10 +16,6 @@ interface Props {
   team: TeamDashTeamMemberMenu_team
 }
 
-const getValue = (teamMember) => {
-  return teamMember.preferredName
-}
-
 const TeamDashTeamMemberMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {menuProps, team} = props
@@ -28,7 +24,7 @@ const TeamDashTeamMemberMenu = (props: Props) => {
   const defaultActiveIdx =
     teamMembers.findIndex((teamMember) => teamMember.id === teamMemberFilterId) + 2
 
-  const {query, filteredItems: matchedTeamMembers, onQueryChange} = useSearchFilter(teamMembers!, getValue);
+  const {query, filteredItems: matchedTeamMembers, onQueryChange} = useSearchFilter(teamMembers!, teamMember => teamMember.preferredName);
 
   return (
     <Menu

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -73,7 +73,7 @@ const UserDashTeamMemberMenu = (props: Props) => {
     query,
     filteredItems: matchedFilteredTeamMembers,
     onQueryChange
-  } = useSearchFilter(filteredTeamMembers, (item) => item.preferredName.toLowerCase())
+  } = useSearchFilter(filteredTeamMembers, (item) => item.preferredName)
 
   return (
     <Menu

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -13,11 +13,22 @@ import useRouter from '~/hooks/useRouter'
 import constructUserTaskFilterQueryParamURL from '~/utils/constructUserTaskFilterQueryParamURL'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {UserTaskViewFilterLabels} from '~/types/constEnums'
+import styled from '@emotion/styled'
+import {PALETTE} from '~/styles/paletteV3'
+import MenuItemLabel from './MenuItemLabel'
 
 interface Props {
   menuProps: MenuProps
   viewer: UserDashTeamMemberMenu_viewer | null
 }
+
+const NoResults = styled(MenuItemLabel)({
+  color: PALETTE.SLATE_600,
+  justifyContent: 'center',
+  paddingLeft: 8,
+  paddingRight: 8,
+  fontStyle: 'italic'
+})
 
 const UserDashTeamMemberMenu = (props: Props) => {
   const {history} = useRouter()
@@ -72,6 +83,9 @@ const UserDashTeamMemberMenu = (props: Props) => {
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
       <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {query && matchedFilteredTeamMembers.length === 0 &&
+        <NoResults key='no-results'>No team members found!</NoResults>
+      }
       {query === '' && showAllTeamMembers && (
         <MenuItem
           key={'teamMemberFilterNULL'}

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -73,7 +73,7 @@ const UserDashTeamMemberMenu = (props: Props) => {
     query,
     filteredItems: matchedFilteredTeamMembers,
     onQueryChange
-  } = useSearchFilter(filteredTeamMembers!, (item) => item.preferredName.toLowerCase())
+  } = useSearchFilter(filteredTeamMembers, (item) => item.preferredName.toLowerCase())
 
   return (
     <Menu
@@ -83,9 +83,9 @@ const UserDashTeamMemberMenu = (props: Props) => {
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
       <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
-      {query && matchedFilteredTeamMembers.length === 0 &&
+      {query && matchedFilteredTeamMembers.length === 0 && (
         <NoResults key='no-results'>No team members found!</NoResults>
-      }
+      )}
       {query === '' && showAllTeamMembers && (
         <MenuItem
           key={'teamMemberFilterNULL'}

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -19,12 +19,6 @@ interface Props {
   viewer: UserDashTeamMemberMenu_viewer | null
 }
 
-const getValue = (
-  item: NonNullable<{userId: string, preferredName: string}>
-) => {
-  return item.preferredName.toLowerCase();
-};
-
 const UserDashTeamMemberMenu = (props: Props) => {
   const {history} = useRouter()
   const {menuProps, viewer} = props
@@ -63,7 +57,7 @@ const UserDashTeamMemberMenu = (props: Props) => {
     }
   }, [teamIds, userIds])
 
-  const {query, filteredItems: matchedFilteredTeamMembers, onQueryChange} = useSearchFilter(filteredTeamMembers!, getValue);
+  const {query, filteredItems: matchedFilteredTeamMembers, onQueryChange} = useSearchFilter(filteredTeamMembers!, item => item.preferredName.toLowerCase());
 
   return (
     <Menu

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -77,6 +77,7 @@ const UserDashTeamMemberMenu = (props: Props) => {
 
   return (
     <Menu
+      keepParentFocus
       ariaLabel={'Select the team member to filter by'}
       {...menuProps}
       defaultActiveIdx={defaultActiveIdx}

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -83,7 +83,9 @@ const UserDashTeamMemberMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
-      <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {filteredTeamMembers.length > 5 && (
+        <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      )}
       {query && matchedFilteredTeamMembers.length === 0 && (
         <NoResults key='no-results'>No team members found!</NoResults>
       )}

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -13,22 +13,12 @@ import useRouter from '~/hooks/useRouter'
 import constructUserTaskFilterQueryParamURL from '~/utils/constructUserTaskFilterQueryParamURL'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {UserTaskViewFilterLabels} from '~/types/constEnums'
-import styled from '@emotion/styled'
-import {PALETTE} from '~/styles/paletteV3'
-import MenuItemLabel from './MenuItemLabel'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 
 interface Props {
   menuProps: MenuProps
   viewer: UserDashTeamMemberMenu_viewer | null
 }
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const UserDashTeamMemberMenu = (props: Props) => {
   const {history} = useRouter()
@@ -87,7 +77,9 @@ const UserDashTeamMemberMenu = (props: Props) => {
         <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
       )}
       {query && matchedFilteredTeamMembers.length === 0 && (
-        <NoResults key='no-results'>No team members found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No team members found!
+        </EmptyDropdownMenuItemLabel>
       )}
       {query === '' && showAllTeamMembers && (
         <MenuItem

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -5,6 +5,8 @@ import Menu from './Menu'
 import MenuItem from './MenuItem'
 import {MenuProps} from '../hooks/useMenu'
 import DropdownMenuLabel from './DropdownMenuLabel'
+import useSearchFilter from '~/hooks/useSearchFilter'
+import {SearchMenuItem} from './SearchMenuItem'
 import {UserDashTeamMemberMenu_viewer} from '../__generated__/UserDashTeamMemberMenu_viewer.graphql'
 import {useUserTaskFilters} from '~/utils/useUserTaskFilters'
 import useRouter from '~/hooks/useRouter'
@@ -16,6 +18,12 @@ interface Props {
   menuProps: MenuProps
   viewer: UserDashTeamMemberMenu_viewer | null
 }
+
+const getValue = (
+  item: NonNullable<{userId: string, preferredName: string}>
+) => {
+  return item.preferredName.toLowerCase();
+};
 
 const UserDashTeamMemberMenu = (props: Props) => {
   const {history} = useRouter()
@@ -55,6 +63,8 @@ const UserDashTeamMemberMenu = (props: Props) => {
     }
   }, [teamIds, userIds])
 
+  const {query, filteredItems: matchedFilteredTeamMembers, onQueryChange} = useSearchFilter(filteredTeamMembers!, getValue);
+
   return (
     <Menu
       ariaLabel={'Select the team member to filter by'}
@@ -62,13 +72,18 @@ const UserDashTeamMemberMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
-      {showAllTeamMembers &&
+      <SearchMenuItem
+        placeholder='Search team members'
+        onChange={onQueryChange}
+        value={query}
+      />
+      {query === '' && showAllTeamMembers &&
         <MenuItem
           key={'teamMemberFilterNULL'}
           label={UserTaskViewFilterLabels.ALL_TEAM_MEMBERS}
           onClick={() => history.push(constructUserTaskFilterQueryParamURL(teamIds, null, showArchived))}
         />}
-      {filteredTeamMembers.map((teamMember) => (
+      {matchedFilteredTeamMembers.map((teamMember) => (
         <MenuItem
           key={`teamMemberFilter${teamMember.userId}`}
           dataCy={`team-member-filter-${teamMember.userId}`}

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -52,12 +52,17 @@ const UserDashTeamMemberMenu = (props: Props) => {
     filteredTeamMembers.sort((a, b) => (a.preferredName > b.preferredName ? 1 : -1))
     return {
       filteredTeamMembers,
-      defaultActiveIdx: filteredTeamMembers.findIndex((teamMember) => userIds?.includes(teamMember.userId))
-        + (showAllTeamMembers ? 2 : 1)
+      defaultActiveIdx:
+        filteredTeamMembers.findIndex((teamMember) => userIds?.includes(teamMember.userId)) +
+        (showAllTeamMembers ? 2 : 1)
     }
   }, [teamIds, userIds])
 
-  const {query, filteredItems: matchedFilteredTeamMembers, onQueryChange} = useSearchFilter(filteredTeamMembers!, item => item.preferredName.toLowerCase());
+  const {
+    query,
+    filteredItems: matchedFilteredTeamMembers,
+    onQueryChange
+  } = useSearchFilter(filteredTeamMembers!, (item) => item.preferredName.toLowerCase())
 
   return (
     <Menu
@@ -66,23 +71,26 @@ const UserDashTeamMemberMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team member:'}</DropdownMenuLabel>
-      <SearchMenuItem
-        placeholder='Search team members'
-        onChange={onQueryChange}
-        value={query}
-      />
-      {query === '' && showAllTeamMembers &&
+      <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {query === '' && showAllTeamMembers && (
         <MenuItem
           key={'teamMemberFilterNULL'}
           label={UserTaskViewFilterLabels.ALL_TEAM_MEMBERS}
-          onClick={() => history.push(constructUserTaskFilterQueryParamURL(teamIds, null, showArchived))}
-        />}
+          onClick={() =>
+            history.push(constructUserTaskFilterQueryParamURL(teamIds, null, showArchived))
+          }
+        />
+      )}
       {matchedFilteredTeamMembers.map((teamMember) => (
         <MenuItem
           key={`teamMemberFilter${teamMember.userId}`}
           dataCy={`team-member-filter-${teamMember.userId}`}
           label={teamMember.preferredName}
-          onClick={() => history.push(constructUserTaskFilterQueryParamURL(teamIds, [teamMember.userId], showArchived))}
+          onClick={() =>
+            history.push(
+              constructUserTaskFilterQueryParamURL(teamIds, [teamMember.userId], showArchived)
+            )
+          }
         />
       ))}
     </Menu>

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -11,10 +11,16 @@ import constructUserTaskFilterQueryParamURL from '~/utils/constructUserTaskFilte
 import useRouter from '~/hooks/useRouter'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {UserTaskViewFilterLabels} from '~/types/constEnums'
+import useSearchFilter from '~/hooks/useSearchFilter'
+import {SearchMenuItem} from './SearchMenuItem'
 
 interface Props {
   menuProps: MenuProps
   viewer: UserDashTeamMenu_viewer | null
+}
+
+const getValue = (team) => {
+  return team.name;
 }
 
 const UserDashTeamMenu = (props: Props) => {
@@ -38,6 +44,9 @@ const UserDashTeamMenu = (props: Props) => {
       defaultActiveIdx: filteredTeams.findIndex((team) => teamIds?.includes(team.id)) + (showAllTeams ? 2 : 1)
     }
   }, [userIds, teamIds])
+
+  const {query, filteredItems: matchedFilteredTeams, onQueryChange} = useSearchFilter(filteredTeams!, getValue);
+
   return (
     <Menu
       ariaLabel={'Select the team to filter by'}
@@ -45,13 +54,18 @@ const UserDashTeamMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team:'}</DropdownMenuLabel>
-      {showAllTeams &&
+      <SearchMenuItem
+        placeholder='Search teams'
+        onChange={onQueryChange}
+        value={query}
+      />
+      {query === '' && showAllTeams &&
         <MenuItem
           key={'teamFilterNULL'}
           label={UserTaskViewFilterLabels.ALL_TEAMS}
           onClick={() => history.push(constructUserTaskFilterQueryParamURL(null, userIds, showArchived))}
         />}
-      {filteredTeams.map((team) => (
+      {matchedFilteredTeams.map((team) => (
         <MenuItem
           key={`teamFilter${team.id}`}
           dataCy={`team-filter-${team.id}`}

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -13,22 +13,12 @@ import useAtmosphere from '~/hooks/useAtmosphere'
 import {UserTaskViewFilterLabels} from '~/types/constEnums'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {SearchMenuItem} from './SearchMenuItem'
-import styled from '@emotion/styled'
-import {PALETTE} from '~/styles/paletteV3'
-import MenuItemLabel from './MenuItemLabel'
+import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 
 interface Props {
   menuProps: MenuProps
   viewer: UserDashTeamMenu_viewer | null
 }
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const UserDashTeamMenu = (props: Props) => {
   const {history} = useRouter()
@@ -71,7 +61,7 @@ const UserDashTeamMenu = (props: Props) => {
         <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={query} />
       )}
       {query && matchedFilteredTeams.length === 0 && (
-        <NoResults key='no-results'>No teams found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>No teams found!</EmptyDropdownMenuItemLabel>
       )}
       {query === '' && showAllTeams && (
         <MenuItem

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -57,7 +57,7 @@ const UserDashTeamMenu = (props: Props) => {
     query,
     filteredItems: matchedFilteredTeams,
     onQueryChange
-  } = useSearchFilter(filteredTeams, (team) => team.name.toLowerCase())
+  } = useSearchFilter(filteredTeams, (team) => team.name)
 
   return (
     <Menu

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -19,14 +19,10 @@ interface Props {
   viewer: UserDashTeamMenu_viewer | null
 }
 
-const getValue = (team) => {
-  return team.name;
-}
-
 const UserDashTeamMenu = (props: Props) => {
   const {history} = useRouter()
   const {menuProps, viewer} = props
-  const oldTeamsRef = useRef<any>([])
+  const oldTeamsRef = useRef<UserDashTeamMenu_viewer['teams']>([])
   const nextTeams = viewer?.teams ?? oldTeamsRef.current
   if (nextTeams) {
     oldTeamsRef.current = nextTeams
@@ -45,7 +41,7 @@ const UserDashTeamMenu = (props: Props) => {
     }
   }, [userIds, teamIds])
 
-  const {query, filteredItems: matchedFilteredTeams, onQueryChange} = useSearchFilter(filteredTeams!, getValue);
+  const {query, filteredItems: matchedFilteredTeams, onQueryChange} = useSearchFilter(filteredTeams!, team => team.name);
 
   return (
     <Menu

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -61,6 +61,7 @@ const UserDashTeamMenu = (props: Props) => {
 
   return (
     <Menu
+      keepParentFocus
       ariaLabel={'Select the team to filter by'}
       {...menuProps}
       defaultActiveIdx={defaultActiveIdx}

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -32,16 +32,21 @@ const UserDashTeamMenu = (props: Props) => {
   const {teamIds, userIds, showArchived} = useUserTaskFilters(atmosphere.viewerId)
   const showAllTeams = !!userIds
   const {filteredTeams, defaultActiveIdx} = useMemo(() => {
-    const filteredTeams = userIds ? teams.filter(({teamMembers}) =>
-      !!teamMembers.find(({userId}) => userIds.includes(userId))
-    ) : teams
+    const filteredTeams = userIds
+      ? teams.filter(({teamMembers}) => !!teamMembers.find(({userId}) => userIds.includes(userId)))
+      : teams
     return {
       filteredTeams,
-      defaultActiveIdx: filteredTeams.findIndex((team) => teamIds?.includes(team.id)) + (showAllTeams ? 2 : 1)
+      defaultActiveIdx:
+        filteredTeams.findIndex((team) => teamIds?.includes(team.id)) + (showAllTeams ? 2 : 1)
     }
   }, [userIds, teamIds])
 
-  const {query, filteredItems: matchedFilteredTeams, onQueryChange} = useSearchFilter(filteredTeams!, team => team.name);
+  const {
+    query,
+    filteredItems: matchedFilteredTeams,
+    onQueryChange
+  } = useSearchFilter(filteredTeams!, (team) => team.name)
 
   return (
     <Menu
@@ -50,23 +55,24 @@ const UserDashTeamMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team:'}</DropdownMenuLabel>
-      <SearchMenuItem
-        placeholder='Search teams'
-        onChange={onQueryChange}
-        value={query}
-      />
-      {query === '' && showAllTeams &&
+      <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={query} />
+      {query === '' && showAllTeams && (
         <MenuItem
           key={'teamFilterNULL'}
           label={UserTaskViewFilterLabels.ALL_TEAMS}
-          onClick={() => history.push(constructUserTaskFilterQueryParamURL(null, userIds, showArchived))}
-        />}
+          onClick={() =>
+            history.push(constructUserTaskFilterQueryParamURL(null, userIds, showArchived))
+          }
+        />
+      )}
       {matchedFilteredTeams.map((team) => (
         <MenuItem
           key={`teamFilter${team.id}`}
           dataCy={`team-filter-${team.id}`}
           label={team.name}
-          onClick={() => history.push(constructUserTaskFilterQueryParamURL([team.id], userIds, showArchived))}
+          onClick={() =>
+            history.push(constructUserTaskFilterQueryParamURL([team.id], userIds, showArchived))
+          }
         />
       ))}
     </Menu>

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -57,7 +57,7 @@ const UserDashTeamMenu = (props: Props) => {
     query,
     filteredItems: matchedFilteredTeams,
     onQueryChange
-  } = useSearchFilter(filteredTeams!, (team) => team.name)
+  } = useSearchFilter(filteredTeams, (team) => team.name.toLowerCase())
 
   return (
     <Menu
@@ -67,9 +67,9 @@ const UserDashTeamMenu = (props: Props) => {
     >
       <DropdownMenuLabel>{'Filter by team:'}</DropdownMenuLabel>
       <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={query} />
-      {query && matchedFilteredTeams.length === 0 &&
+      {query && matchedFilteredTeams.length === 0 && (
         <NoResults key='no-results'>No teams found!</NoResults>
-      }
+      )}
       {query === '' && showAllTeams && (
         <MenuItem
           key={'teamFilterNULL'}

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -67,7 +67,9 @@ const UserDashTeamMenu = (props: Props) => {
       defaultActiveIdx={defaultActiveIdx}
     >
       <DropdownMenuLabel>{'Filter by team:'}</DropdownMenuLabel>
-      <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={query} />
+      {filteredTeams.length > 5 && (
+        <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={query} />
+      )}
       {query && matchedFilteredTeams.length === 0 && (
         <NoResults key='no-results'>No teams found!</NoResults>
       )}

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -13,11 +13,22 @@ import useAtmosphere from '~/hooks/useAtmosphere'
 import {UserTaskViewFilterLabels} from '~/types/constEnums'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {SearchMenuItem} from './SearchMenuItem'
+import styled from '@emotion/styled'
+import {PALETTE} from '~/styles/paletteV3'
+import MenuItemLabel from './MenuItemLabel'
 
 interface Props {
   menuProps: MenuProps
   viewer: UserDashTeamMenu_viewer | null
 }
+
+const NoResults = styled(MenuItemLabel)({
+  color: PALETTE.SLATE_600,
+  justifyContent: 'center',
+  paddingLeft: 8,
+  paddingRight: 8,
+  fontStyle: 'italic'
+})
 
 const UserDashTeamMenu = (props: Props) => {
   const {history} = useRouter()
@@ -56,6 +67,9 @@ const UserDashTeamMenu = (props: Props) => {
     >
       <DropdownMenuLabel>{'Filter by team:'}</DropdownMenuLabel>
       <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={query} />
+      {query && matchedFilteredTeams.length === 0 &&
+        <NoResults key='no-results'>No teams found!</NoResults>
+      }
       {query === '' && showAllTeams && (
         <MenuItem
           key={'teamFilterNULL'}

--- a/packages/client/hooks/useSearchFilter.ts
+++ b/packages/client/hooks/useSearchFilter.ts
@@ -1,0 +1,21 @@
+import useFilteredItems from '~/hooks/useFilteredItems'
+import useForm from '~/hooks/useForm'
+
+// Matches 'items' based on the item's 'getValue' result and the value passed to 'onQueryChange'.
+const useSearchFilter = <T>(
+  items: readonly T[],
+  getValue: (item: T) => string
+) => {
+  const {fields, onChange} = useForm({
+    search: {
+      getDefault: () => ''
+    }
+  })
+  const {search} = fields
+  const {value} = search
+  const query = value.toLowerCase()
+  const filteredItems = useFilteredItems(query, items, getValue)
+  return {query: value, filteredItems, onQueryChange: onChange}
+}
+
+export default useSearchFilter

--- a/packages/client/hooks/useSearchFilter.ts
+++ b/packages/client/hooks/useSearchFilter.ts
@@ -2,10 +2,7 @@ import useFilteredItems from '~/hooks/useFilteredItems'
 import useForm from '~/hooks/useForm'
 
 // Matches 'items' based on the item's 'getValue' result and the value passed to 'onQueryChange'.
-const useSearchFilter = <T>(
-  items: readonly T[],
-  getValue: (item: T) => string
-) => {
+const useSearchFilter = <T>(items: readonly T[], getValue: (item: T) => string) => {
   const {fields, onChange} = useForm({
     search: {
       getDefault: () => ''

--- a/packages/client/hooks/useSearchFilter.ts
+++ b/packages/client/hooks/useSearchFilter.ts
@@ -11,7 +11,7 @@ const useSearchFilter = <T>(items: readonly T[], getValue: (item: T) => string) 
   const {search} = fields
   const {value} = search
   const query = value.toLowerCase()
-  const filteredItems = useFilteredItems(query, items, getValue)
+  const filteredItems = useFilteredItems(query, items, (item) => getValue(item).toLowerCase())
   return {query: value, filteredItems, onQueryChange: onChange}
 }
 

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -17,17 +17,7 @@ import TaskFooterTeamAssigneeAddIntegrationDialog from './TaskFooterTeamAssignee
 import useEventCallback from '~/hooks/useEventCallback'
 import {SearchMenuItem} from '~/components/SearchMenuItem'
 import useSearchFilter from '~/hooks/useSearchFilter'
-import styled from '@emotion/styled'
-import {PALETTE} from '~/styles/paletteV3'
-import MenuItemLabel from '~/components/MenuItemLabel'
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
+import {EmptyDropdownMenuItemLabel} from '~/components/EmptyDropdownMenuItemLabel'
 
 const query = graphql`
   query TaskFooterTeamAssigneeMenu_viewerIntegrationsQuery($teamId: ID!) {
@@ -153,7 +143,7 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
         <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={searchQuery} />
       )}
       {query && matchedAssignableTeams.length === 0 && (
-        <NoResults key='no-results'>No teams found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>No teams found!</EmptyDropdownMenuItemLabel>
       )}
       {matchedAssignableTeams.map((team) => {
         return (

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -15,6 +15,8 @@ import {TaskFooterTeamAssigneeMenu_viewerIntegrationsQuery} from '~/__generated_
 import useModal from '~/hooks/useModal'
 import TaskFooterTeamAssigneeAddIntegrationDialog from './TaskFooterTeamAssigneeAddIntegrationDialog'
 import useEventCallback from '~/hooks/useEventCallback'
+import {SearchMenuItem} from '~/components/SearchMenuItem'
+import useSearchFilter from '~/hooks/useSearchFilter'
 
 const query = graphql`
   query TaskFooterTeamAssigneeMenu_viewerIntegrationsQuery($teamId: ID!) {
@@ -123,6 +125,8 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
     }
   }
 
+  const {query: searchQuery, filteredItems: matchedAssignableTeams, onQueryChange} = useSearchFilter(assignableTeams!, team => team.name);
+
   return (
     <Menu
       {...menuProps}
@@ -130,7 +134,12 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
       ariaLabel={'Assign this task to another team'}
     >
       <DropdownMenuLabel>Move to:</DropdownMenuLabel>
-      {assignableTeams.map((team) => {
+      <SearchMenuItem
+        placeholder='Search teams'
+        onChange={onQueryChange}
+        value={searchQuery}
+      />
+      {matchedAssignableTeams.map((team) => {
         return (
           <MenuItem
             key={team.id}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -17,6 +17,17 @@ import TaskFooterTeamAssigneeAddIntegrationDialog from './TaskFooterTeamAssignee
 import useEventCallback from '~/hooks/useEventCallback'
 import {SearchMenuItem} from '~/components/SearchMenuItem'
 import useSearchFilter from '~/hooks/useSearchFilter'
+import styled from '@emotion/styled'
+import {PALETTE} from '~/styles/paletteV3'
+import MenuItemLabel from '~/components/MenuItemLabel'
+
+const NoResults = styled(MenuItemLabel)({
+  color: PALETTE.SLATE_600,
+  justifyContent: 'center',
+  paddingLeft: 8,
+  paddingRight: 8,
+  fontStyle: 'italic'
+})
 
 const query = graphql`
   query TaskFooterTeamAssigneeMenu_viewerIntegrationsQuery($teamId: ID!) {
@@ -139,6 +150,9 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
         onChange={onQueryChange}
         value={searchQuery}
       />
+      {query && matchedAssignableTeams.length === 0 &&
+        <NoResults key='no-results'>No teams found!</NoResults>
+      }
       {matchedAssignableTeams.map((team) => {
         return (
           <MenuItem

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -139,7 +139,7 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
     query: searchQuery,
     filteredItems: matchedAssignableTeams,
     onQueryChange
-  } = useSearchFilter(assignableTeams, (team) => team.name.toLowerCase())
+  } = useSearchFilter(assignableTeams, (team) => team.name)
 
   return (
     <Menu

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -149,7 +149,9 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
       ariaLabel={'Assign this task to another team'}
     >
       <DropdownMenuLabel>Move to:</DropdownMenuLabel>
-      <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={searchQuery} />
+      {assignableTeams.length > 5 && (
+        <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={searchQuery} />
+      )}
       {query && matchedAssignableTeams.length === 0 && (
         <NoResults key='no-results'>No teams found!</NoResults>
       )}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -73,10 +73,10 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
       : teams
     return filteredTeams
   }, [teamIds, userIds])
-  const taskTeamIdx = useMemo(() => assignableTeams.findIndex(({id}) => id === teamId) + 1, [
-    teamId,
-    assignableTeams
-  ])
+  const taskTeamIdx = useMemo(
+    () => assignableTeams.findIndex(({id}) => id === teamId) + 1,
+    [teamId, assignableTeams]
+  )
 
   const atmosphere = useAtmosphere()
   const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
@@ -112,11 +112,10 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
   const handleTaskUpdate = (nextTeam: typeof newTeam) => async () => {
     if (!submitting && teamId !== nextTeam.id) {
       if (isGitHubTask || isJiraTask) {
-        const result = await atmosphere.fetchQuery<
-          TaskFooterTeamAssigneeMenu_viewerIntegrationsQuery
-        >(query, {
-          teamId: nextTeam.id
-        })
+        const result =
+          await atmosphere.fetchQuery<TaskFooterTeamAssigneeMenu_viewerIntegrationsQuery>(query, {
+            teamId: nextTeam.id
+          })
         const {github, atlassian} = result?.viewer?.teamMember?.integrations ?? {}
 
         if ((isGitHubTask && !github?.isActive) || (isJiraTask && !atlassian?.isActive)) {
@@ -136,7 +135,11 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
     }
   }
 
-  const {query: searchQuery, filteredItems: matchedAssignableTeams, onQueryChange} = useSearchFilter(assignableTeams!, team => team.name);
+  const {
+    query: searchQuery,
+    filteredItems: matchedAssignableTeams,
+    onQueryChange
+  } = useSearchFilter(assignableTeams, (team) => team.name.toLowerCase())
 
   return (
     <Menu
@@ -145,14 +148,10 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
       ariaLabel={'Assign this task to another team'}
     >
       <DropdownMenuLabel>Move to:</DropdownMenuLabel>
-      <SearchMenuItem
-        placeholder='Search teams'
-        onChange={onQueryChange}
-        value={searchQuery}
-      />
-      {query && matchedAssignableTeams.length === 0 &&
+      <SearchMenuItem placeholder='Search teams' onChange={onQueryChange} value={searchQuery} />
+      {query && matchedAssignableTeams.length === 0 && (
         <NoResults key='no-results'>No teams found!</NoResults>
-      }
+      )}
       {matchedAssignableTeams.map((team) => {
         return (
           <MenuItem

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -143,6 +143,7 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
 
   return (
     <Menu
+      keepParentFocus
       {...menuProps}
       defaultActiveIdx={taskTeamIdx}
       ariaLabel={'Assign this task to another team'}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -38,10 +38,10 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
   const {team} = viewer
   const atmosphere = useAtmosphere()
   const teamMembers = team?.teamMembers || []
-  const taskUserIdx = useMemo(() => teamMembers.findIndex(({userId}) => userId) + 1, [
-    userId,
-    teamMembers
-  ])
+  const taskUserIdx = useMemo(
+    () => teamMembers.findIndex(({userId}) => userId) + 1,
+    [userId, teamMembers]
+  )
   const assignees = useMemo(
     () => teamMembers.filter((teamMember) => teamMember.userId !== userId),
     [userId, teamMembers]
@@ -51,7 +51,11 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
     UpdateTaskMutation(atmosphere, {updatedTask: {id: taskId, userId: newUserId}, area}, {})
   }
 
-  const {query, filteredItems: matchedAssignees, onQueryChange} = useSearchFilter(assignees!, assignee => assignee.preferredName);
+  const {
+    query,
+    filteredItems: matchedAssignees,
+    onQueryChange
+  } = useSearchFilter(assignees, (assignee) => assignee.preferredName.toLowerCase())
 
   if (!team) return null
   return (
@@ -61,14 +65,10 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
       {...menuProps}
     >
       <DropdownMenuLabel>Assign to:</DropdownMenuLabel>
-      <SearchMenuItem
-        placeholder='Search team members'
-        onChange={onQueryChange}
-        value={query}
-      />
-      {query && matchedAssignees.length === 0 &&
+      <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {query && matchedAssignees.length === 0 && (
         <NoResults key='no-results'>No team members found!</NoResults>
-      }
+      )}
       {matchedAssignees.map((assignee) => {
         return (
           <MenuItem

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -60,6 +60,7 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
   if (!team) return null
   return (
     <Menu
+      keepParentFocus
       ariaLabel={'Assign this task to a teammate'}
       defaultActiveIdx={userId ? taskUserIdx : undefined}
       {...menuProps}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -13,6 +13,8 @@ import {MenuProps} from '../../../../hooks/useMenu'
 import UpdateTaskMutation from '../../../../mutations/UpdateTaskMutation'
 import avatarUser from '../../../../styles/theme/images/avatar-user.svg'
 import {AreaEnum} from '~/__generated__/UpdateTaskMutation.graphql'
+import useSearchFilter from '~/hooks/useSearchFilter'
+import {SearchMenuItem} from '~/components/SearchMenuItem'
 interface Props {
   area: AreaEnum
   menuProps: MenuProps
@@ -39,6 +41,8 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
     UpdateTaskMutation(atmosphere, {updatedTask: {id: taskId, userId: newUserId}, area}, {})
   }
 
+  const {query, filteredItems: matchedAssignees, onQueryChange} = useSearchFilter(assignees!, assignee => assignee.preferredName);
+
   if (!team) return null
   return (
     <Menu
@@ -47,7 +51,12 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
       {...menuProps}
     >
       <DropdownMenuLabel>Assign to:</DropdownMenuLabel>
-      {assignees.map((assignee) => {
+      <SearchMenuItem
+        placeholder='Search team members'
+        onChange={onQueryChange}
+        value={query}
+      />
+      {matchedAssignees.map((assignee) => {
         return (
           <MenuItem
             key={assignee.id}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -15,12 +15,22 @@ import avatarUser from '../../../../styles/theme/images/avatar-user.svg'
 import {AreaEnum} from '~/__generated__/UpdateTaskMutation.graphql'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {SearchMenuItem} from '~/components/SearchMenuItem'
+import styled from '@emotion/styled'
+import {PALETTE} from '~/styles/paletteV3'
 interface Props {
   area: AreaEnum
   menuProps: MenuProps
   viewer: TaskFooterUserAssigneeMenu_viewer
   task: TaskFooterUserAssigneeMenu_task
 }
+
+const NoResults = styled(MenuItemLabel)({
+  color: PALETTE.SLATE_600,
+  justifyContent: 'center',
+  paddingLeft: 8,
+  paddingRight: 8,
+  fontStyle: 'italic'
+})
 
 const TaskFooterUserAssigneeMenu = (props: Props) => {
   const {area, menuProps, task, viewer} = props
@@ -56,6 +66,9 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
         onChange={onQueryChange}
         value={query}
       />
+      {query && matchedAssignees.length === 0 &&
+        <NoResults key='no-results'>No team members found!</NoResults>
+      }
       {matchedAssignees.map((assignee) => {
         return (
           <MenuItem

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -66,7 +66,9 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
       {...menuProps}
     >
       <DropdownMenuLabel>Assign to:</DropdownMenuLabel>
-      <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      {assignees.length > 5 && (
+        <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
+      )}
       {query && matchedAssignees.length === 0 && (
         <NoResults key='no-results'>No team members found!</NoResults>
       )}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -15,22 +15,13 @@ import avatarUser from '../../../../styles/theme/images/avatar-user.svg'
 import {AreaEnum} from '~/__generated__/UpdateTaskMutation.graphql'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {SearchMenuItem} from '~/components/SearchMenuItem'
-import styled from '@emotion/styled'
-import {PALETTE} from '~/styles/paletteV3'
+import {EmptyDropdownMenuItemLabel} from '~/components/EmptyDropdownMenuItemLabel'
 interface Props {
   area: AreaEnum
   menuProps: MenuProps
   viewer: TaskFooterUserAssigneeMenu_viewer
   task: TaskFooterUserAssigneeMenu_task
 }
-
-const NoResults = styled(MenuItemLabel)({
-  color: PALETTE.SLATE_600,
-  justifyContent: 'center',
-  paddingLeft: 8,
-  paddingRight: 8,
-  fontStyle: 'italic'
-})
 
 const TaskFooterUserAssigneeMenu = (props: Props) => {
   const {area, menuProps, task, viewer} = props
@@ -70,7 +61,9 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
         <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
       )}
       {query && matchedAssignees.length === 0 && (
-        <NoResults key='no-results'>No team members found!</NoResults>
+        <EmptyDropdownMenuItemLabel key='no-results'>
+          No team members found!
+        </EmptyDropdownMenuItemLabel>
       )}
       {matchedAssignees.map((assignee) => {
         return (

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -55,7 +55,7 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
     query,
     filteredItems: matchedAssignees,
     onQueryChange
-  } = useSearchFilter(assignees, (assignee) => assignee.preferredName.toLowerCase())
+  } = useSearchFilter(assignees, (assignee) => assignee.preferredName)
 
   if (!team) return null
   return (


### PR DESCRIPTION
fixes https://github.com/ParabolInc/parabol/issues/5777.

Adds search functionality to the team / team member filter dropdowns.  This is done by creating a couple of new things:
* A `SearchMenuItem` component - a styled menu label that accepts text input
* A `useSearchFilter` hook - A hook that takes in an array of items and a function for getting a string value of those items, and returns:
  * An `onQueryChange` handler - Takes a query string.  Pass this as `SearchMenuItem`'s `onChange` handler, or any other text input.
  * `filteredItems` - An array of items that match the query string
  * `query` - The last query passed to `onQueryChange`.
  
These patterns are based on the [filtering logic](https://github.com/ParabolInc/parabol/blob/2d134896d2da154b34fc80a5025022a63cd35a4b/packages/client/components/GitHubScopingSearchFilterMenu.tsx#L145-L154)+[components](https://github.com/ParabolInc/parabol/blob/2d134896d2da154b34fc80a5025022a63cd35a4b/packages/client/components/GitHubScopingSearchFilterMenu.tsx#L172-L177) for integrations mentioned in the original ticket.

This also refactors several existing search filters to use this component+hook:
* TaskFooterIntegrateMenuList.tsx
* GitHubScopingSearchFilterMenu.tsx
* JiraScopingSearchFilterMenu.tsx
* NewGitHubIssueMenu.tsx
* NewJiraIssueMenu.tsx

(Each of these refactors have been tested with local GH + Atlassian integrations)

<img width="244" alt="Screen Shot 2022-01-26 at 2 40 51 PM" src="https://user-images.githubusercontent.com/9013217/151234898-edbe7e20-3355-4ba7-8bcc-83f64ae78d7a.png">

**Testing**
New search filtering:
* /me/tasks
  * Open the team dropdown (defaults to "All teams"), search for a team
  * Open the team member filter dropdown (defaults to current user), and search for a team member
  * Add a task to the board, click the task card's team, and search for a different team
* /team/:teamId
  * Open the team member filter dropdown ("all team members"), and search for a team member.  Confirm that team members are filtered and "All team members" is not shown when there's a search query.
  * Add a task card, click the task card's team member, and search for a different team member

Regression testing (for the refactors on existing search filtering):
* /me/tasks
  * Click the task card's "push to integration" button and search for GH and Atlassian integrations
* Sprint poker scoping
  * Filter by GH integration in scoping view
  * Filter by Jira integration in scoping view (search only shows up when more than 10 integrations are available)
  * For both Jira and GH, click new issue, and search for a different integration