### PR TITLE
fix retro template scrolling

### DIFF
--- a/packages/client/hooks/useScrollIntoVIew.ts
+++ b/packages/client/hooks/useScrollIntoVIew.ts
@@ -1,11 +1,23 @@
 import {RefObject, useEffect} from 'react'
 import {requestIdleCallback} from '../utils/requestIdleCallback'
+import useInitialRender from './useInitialRender'
 
-const useScrollIntoView = (ref: RefObject<HTMLElement>, isNeeded: boolean) => {
+const useScrollIntoView = (
+  ref: RefObject<HTMLElement>,
+  isNeeded: boolean,
+  onlyIfNotFullyVisible?: boolean
+) => {
+  const isInit = useInitialRender()
   useEffect(() => {
     if (isNeeded) {
       requestIdleCallback(() => {
-        ref.current && ref.current.scrollIntoView({behavior: 'smooth'})
+        if (!ref.current) return
+        if (onlyIfNotFullyVisible) {
+          // Be sure to put scroll-behavior: smooth on the overflowing div!
+          ref.current.scrollIntoViewIfNeeded()
+        } else {
+          ref.current.scrollIntoView({behavior: isInit ? undefined : 'smooth'})
+        }
       })
     }
   }, [isNeeded, ref])

--- a/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
-import useInitialRender from '~/hooks/useInitialRender'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useScrollIntoView from '../../../hooks/useScrollIntoVIew'
 import {DECELERATE} from '../../../styles/animation'
@@ -63,8 +62,7 @@ const ReflectTemplateItem = (props: Props) => {
   const description = makeTemplateDescription(lowestScope, template)
   const atmosphere = useAtmosphere()
   const ref = useRef<HTMLLIElement>(null)
-  const isInit = useInitialRender()
-  useScrollIntoView(ref, isInit)
+  useScrollIntoView(ref, isActive, true)
   const selectTemplate = () => {
     setActiveTemplate(atmosphere, teamId, templateId, 'retrospective')
   }

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useEffect, useRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import SwipeableViews from 'react-swipeable-views'
 import Icon from '../../../components/Icon'
@@ -72,11 +72,23 @@ interface Props {
   settings: ReflectTemplateList_settings
 }
 
+const useReadyToSmoothScroll = (activeTemplateId: string) => {
+  // Don't animate the scroll behavior on the initial render
+  const oldActiveTemplateIdRef = useRef(activeTemplateId)
+  const oldActiveTemplateId = oldActiveTemplateIdRef.current
+  useEffect(() => {
+    oldActiveTemplateIdRef.current = activeTemplateId
+  }, [activeTemplateId])
+  return oldActiveTemplateId !== activeTemplateId && oldActiveTemplateId !== '-tmp'
+}
+
 const ReflectTemplateList = (props: Props) => {
   const {activeIdx, setActiveIdx, settings} = props
   const {team, teamTemplates} = settings
   const {id: teamId} = team
-  const activeTemplateId = settings.activeTemplate?.id ?? "-tmp"
+  const activeTemplateId = settings.activeTemplate?.id ?? '-tmp'
+  const readyToScrollSmooth = useReadyToSmoothScroll(activeTemplateId)
+  const slideStyle = {scrollBehavior: readyToScrollSmooth ? 'smooth' : undefined}
 
   const gotoTeamTemplates = () => {
     setActiveIdx(0)
@@ -119,13 +131,18 @@ const ReflectTemplateList = (props: Props) => {
           onClick={gotoPublicTemplates}
         />
       </StyledTabsBar>
-      <AddNewReflectTemplate teamId={teamId} reflectTemplates={teamTemplates} gotoTeamTemplates={gotoTeamTemplates} />
+      <AddNewReflectTemplate
+        teamId={teamId}
+        reflectTemplates={teamTemplates}
+        gotoTeamTemplates={gotoTeamTemplates}
+      />
       <SwipeableViews
         enableMouseEvents
         index={activeIdx}
         onChangeIndex={onChangeIdx}
         containerStyle={containerStyle}
         style={innerStyle}
+        slideStyle={slideStyle}
       >
         <TabContents>
           <ReflectTemplateListTeam


### PR DESCRIPTION
fix for #5920

TEST
- [ ] have a list of 20+ retro templates. make the middle one active
- [ ] refresh & open the public template list. the active one is immediately visible without a scroll animation
- [ ] when you click any template items that are partially visible, they animate fully into view
- [ ] when you click any template items that are fully visible, no animation is applied

loom here: https://www.loom.com/share/69ecc2234fe64a3fbef064a064ffc457