### PR TITLE
Added needed data dependencies to add agenda item mutation result

### DIFF
--- a/packages/client/mutations/AddAgendaItemMutation.ts
+++ b/packages/client/mutations/AddAgendaItemMutation.ts
@@ -26,7 +26,6 @@ graphql`
         ...ActionSidebarAgendaItemsSectionAgendaItemPhase @relay(mask: false)
         stages {
           ...ActionMeetingAgendaItemsStage @relay(mask: false)
-          # For useGotoStageId
           isNavigableByFacilitator
         }
       }

--- a/packages/client/mutations/AddAgendaItemMutation.ts
+++ b/packages/client/mutations/AddAgendaItemMutation.ts
@@ -21,14 +21,12 @@ graphql`
       }
     }
     meeting {
+      ...useGotoStageId_meeting
       phases {
         ...ActionSidebarAgendaItemsSectionAgendaItemPhase @relay(mask: false)
         stages {
           ...ActionMeetingAgendaItemsStage @relay(mask: false)
           # For useGotoStageId
-          id
-          isComplete
-          isNavigable
           isNavigableByFacilitator
         }
       }

--- a/packages/client/mutations/AddAgendaItemMutation.ts
+++ b/packages/client/mutations/AddAgendaItemMutation.ts
@@ -25,7 +25,10 @@ graphql`
         ...ActionSidebarAgendaItemsSectionAgendaItemPhase @relay(mask: false)
         stages {
           ...ActionMeetingAgendaItemsStage @relay(mask: false)
-          # For useMeetingGotoStageId
+          # For useGotoStageId
+          id
+          isComplete
+          isNavigable
           isNavigableByFacilitator
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,10 +2852,10 @@
     shortid "^2.2.12"
     tslib "^1.9.3"
 
-"@mattkrick/graphql-trebuchet-client@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@mattkrick/graphql-trebuchet-client/-/graphql-trebuchet-client-2.2.0.tgz#2bf999ba96a83e1c60919cc62616fd289f4c8ba5"
-  integrity sha512-VJc58DQuZTPdBm5TmVOD5kNUdeEs8kYPbBSzv93ZltYmnQDIsccqWX6nRL7NH60Dha5lzt7btthI2gkrSblXRg==
+"@mattkrick/graphql-trebuchet-client@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mattkrick/graphql-trebuchet-client/-/graphql-trebuchet-client-2.2.1.tgz#c7f8c30c6c8fbb584f812725f4ac1590a9c02c21"
+  integrity sha512-0wuzcV9Pgo3pMdV/mf8OPbeXt+qrpVqCBHPAEpX2x2lpYrJrq7I61Kh9/h6uDHeAz3Zk+fzp39atk3oz+ohZmg==
   dependencies:
     tslib "~2.2.0"
 


### PR DESCRIPTION
Fixes #5400.

This was a fun one. I went through the whole process of team subscriptions, updating the relay store, checking how `isInterruptingChickenPhase` works to find out that `AddAgendaItemMutation` does not fetch data needed to check if stage `isNavigable`. As a result, `navigateMeetingTeamUpdater` was updating the relay store with data that wasn't enough to handle navigation in some cases. 