### PR TITLE
feat(dd-rum): identify user on Datadog session

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -104,7 +104,8 @@ export default class Atmosphere extends Environment {
   upgradeTransportPromise: Promise<void> | null = null
   // it's only null before login, so it's just a little white lie
   viewerId: string = null!
-  userId: string | null = null // DEPRECATED
+  /** @deprecated */
+  userId: string | null = null
   constructor() {
     super({
       store,

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -44,7 +44,9 @@ if (dsn) {
   })
 }
 
-if (__PRODUCTION__ && datadogClientToken && datadogApplicationId && datadogService) {
+const datadogEnabled =
+  __PRODUCTION__ && datadogClientToken && datadogApplicationId && datadogService
+if (datadogEnabled) {
   datadogRum.init({
     applicationId: `${datadogApplicationId}`,
     clientToken: `${datadogClientToken}`,
@@ -57,17 +59,21 @@ if (__PRODUCTION__ && datadogClientToken && datadogApplicationId && datadogServi
   })
   datadogRum.startSessionReplayRecording()
 }
+
 // page titles are changed in child components via useDocumentTitle, which fires after this
 // we must guarantee that this runs after useDocumentTitle
 // we can't move this into useDocumentTitle since the pathname may change without chaging the title
 const TIME_TO_RENDER_TREE = 100
 
 const AnalyticsPage = () => {
-  const key = window.__ACTION__.segment
-  if (!key) return null // development use
+  if (!__PRODUCTION__) {
+    return null
+  }
+
   /* eslint-disable */
   const {href, pathname} = location
   const pathnameRef = useRef(pathname)
+  const segmentKey = window.__ACTION__.segment
   useEffect(() => {
     if (!window.analytics) {
       // we dont use the segment snippet because we can guarantee no call will be made to segment before it's loaded
@@ -79,7 +85,7 @@ const AnalyticsPage = () => {
     }
   }, [])
   const [isSegmentLoaded] = useScript(
-    `https://cdn.segment.com/analytics.js/v1/${key}/analytics.min.js`,
+    `https://cdn.segment.com/analytics.js/v1/${segmentKey}/analytics.min.js`,
     {
       crossOrigin: true
     }
@@ -157,6 +163,23 @@ const AnalyticsPage = () => {
       )
     }, TIME_TO_RENDER_TREE)
   }, [isSegmentLoaded, pathname])
+
+  useEffect(() => {
+    if (!datadogEnabled) {
+      return
+    }
+
+    const {viewerId} = atmosphere
+    if (viewerId) {
+      datadogRum.setUser({
+        id: atmosphere.viewerId,
+        isImpersonating: atmosphere.authObj?.rol === 'impersonate' ? true : false
+      })
+    } else {
+      datadogRum.removeUser()
+    }
+  }, [atmosphere, atmosphere.viewerId, atmosphere.authObj])
+
   return null
 }
 

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -172,13 +172,12 @@ const AnalyticsPage = () => {
     const {viewerId} = atmosphere
     if (viewerId) {
       datadogRum.setUser({
-        id: atmosphere.viewerId,
-        isImpersonating: atmosphere.authObj?.rol === 'impersonate' ? true : false
+        id: atmosphere.viewerId
       })
     } else {
       datadogRum.removeUser()
     }
-  }, [atmosphere, atmosphere.viewerId, atmosphere.authObj])
+  }, [atmosphere, atmosphere.viewerId])
 
   return null
 }


### PR DESCRIPTION
This PR adds logic to identify users with Datadog, so we can easily see their IDs in the Datadog UI. Here's an example of me running this code locally:

![Screen_Shot_2022-02-01_at_2_10_03_PM](https://user-images.githubusercontent.com/630449/152053987-957ab62d-b80a-4816-b4db-09c61d6c15a9.png)

