### PR TITLE
Track fatal bugs per 1,000 sessions

### DIFF
--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMu
 import {LocalStorageKey} from '~/types/constEnums'
 import safeInitLogRocket from '../utils/safeInitLogRocket'
 import ErrorComponent from './ErrorComponent/ErrorComponent'
+import {isOldBrowserError} from '../utils/isOldBrowserError'
 
 interface Props extends WithAtmosphereProps {
   fallback?: (error: Error, eventId: string) => ReactNode
@@ -40,8 +41,7 @@ class ErrorBoundary extends Component<Props, State> {
     const {viewerId} = atmosphere
     const store = atmosphere.getStore()
     const email = (store as any)?._recordSource?._records?.[viewerId]?.email ?? ''
-    const oldBrowserErrors = ['flatMap is not a function']
-    const isOldBrowserErr = !!oldBrowserErrors.find((err) => error.message.includes(err))
+    const isOldBrowserErr = isOldBrowserError(error.message)
     if (viewerId) {
       Sentry.configureScope((scope) => {
         scope.setUser({email, id: viewerId})
@@ -71,13 +71,13 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   render() {
-    const {error, eventId, isOldBrowserErr} = this.state
+    const {error, eventId} = this.state
     if (error && eventId) {
       const {fallback} = this.props
       return fallback ? (
         fallback(error, eventId)
       ) : (
-        <ErrorComponent error={error} eventId={eventId} isOldBrowserErr={isOldBrowserErr} />
+        <ErrorComponent error={error} eventId={eventId} />
       )
     }
     // Normally, just render children

--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import PrimaryButton from '~/components/PrimaryButton'
 import ReportErrorFeedback from '~/components/ReportErrorFeedback'
 import useModal from '~/hooks/useModal'
+import {isOldBrowserError} from '~/utils/isOldBrowserError'
 
 const ErrorBlock = styled('div')({
   alignItems: 'center',
@@ -25,13 +26,13 @@ const Link = styled('a')({
 interface Props {
   error: Error
   eventId: string
-  isOldBrowserErr?: boolean
 }
 
 const ErrorComponent = (props: Props) => {
-  const {error, eventId, isOldBrowserErr = false} = props
+  const {error, eventId} = props
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
+  const isOldBrowserErr = isOldBrowserError(error.message)
 
   if (isOldBrowserErr) {
     const url = 'https://browser-update.org/update-browser.html'

--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled'
-import React, {useEffect} from 'react'
+import React from 'react'
 import PrimaryButton from '~/components/PrimaryButton'
 import ReportErrorFeedback from '~/components/ReportErrorFeedback'
-import useAtmosphere from '~/hooks/useAtmosphere'
 import useModal from '~/hooks/useModal'
-import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 
 const ErrorBlock = styled('div')({
   alignItems: 'center',
@@ -27,23 +25,13 @@ const Link = styled('a')({
 interface Props {
   error: Error
   eventId: string
+  isOldBrowserErr?: boolean
 }
 
 const ErrorComponent = (props: Props) => {
-  const {error, eventId} = props
-  const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
+  const {error, eventId, isOldBrowserErr = false} = props
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
-  const oldBrowserErrs = ['flatMap is not a function']
-  const isOldBrowserErr = !!oldBrowserErrs.find((err) => error.message.includes(err))
-
-  useEffect(() => {
-    if (isOldBrowserErr) return
-    SendClientSegmentEventMutation(atmosphere, 'Fatal Error', {
-      viewerId
-    })
-  }, [])
 
   if (isOldBrowserErr) {
     const url = 'https://browser-update.org/update-browser.html'

--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, {useEffect} from 'react'
 import PrimaryButton from '~/components/PrimaryButton'
 import ReportErrorFeedback from '~/components/ReportErrorFeedback'
+import useAtmosphere from '~/hooks/useAtmosphere'
 import useModal from '~/hooks/useModal'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 
 const ErrorBlock = styled('div')({
   alignItems: 'center',
@@ -29,10 +31,20 @@ interface Props {
 
 const ErrorComponent = (props: Props) => {
   const {error, eventId} = props
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
   const oldBrowserErrs = ['flatMap is not a function']
-  const isOldBrowserErr = oldBrowserErrs.find((err) => error.message.includes(err))
+  const isOldBrowserErr = !!oldBrowserErrs.find((err) => error.message.includes(err))
+
+  useEffect(() => {
+    if (isOldBrowserErr) return
+    SendClientSegmentEventMutation(atmosphere, 'Fatal Error', {
+      viewerId
+    })
+  }, [])
+
   if (isOldBrowserErr) {
     const url = 'https://browser-update.org/update-browser.html'
     return (

--- a/packages/client/utils/isOldBrowserError.ts
+++ b/packages/client/utils/isOldBrowserError.ts
@@ -1,0 +1,4 @@
+export const isOldBrowserError = (message: string) => {
+  const oldBrowserErrors = ['flatMap is not a function']
+  return !!oldBrowserErrors.find((err) => message.includes(err))
+}


### PR DESCRIPTION
Fix #5995 

Once we have an idea of the expected number of fatal bugs per 1,000 sessions, we could send a notification to Slack when there's a sudden sharp increase.

I created a chart in amplitude to track this: https://analytics.amplitude.com/parabol/chart/8m2qx3s

### To test

- add the segment env vars
- add a fatal bug, e.g. add an undefined variable to the `TimelineEventCard` component, and then visit the Timeline page at `/me`
- search for your `userId` in amplitude and see that the `Fatal Error` event has been tracked