### PR TITLE
Workaround for null reflections in GroupingKanban

### DIFF
--- a/packages/client/components/GroupingKanban.tsx
+++ b/packages/client/components/GroupingKanban.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import {captureException} from '@sentry/minimal'
 import graphql from 'babel-plugin-relay/macro'
 import React, {RefObject, useEffect, useMemo, useRef, useState} from 'react'
 import {createFragmentContainer} from 'react-relay'
@@ -83,7 +84,9 @@ const GroupingKanban = (props: Props) => {
       const {reflections, promptId} = group
       container[promptId] = container[promptId] ?? []
       container[promptId]!.push(group)
-      if (!isEditing && reflections.some((reflection) => reflection.isEditing)) {
+      if (!reflections) {
+        captureException(new Error('Invalid invariant: reflectionGroup.reflections is null'))
+      } else if (!isEditing && reflections.some((reflection) => reflection.isEditing)) {
         isEditing = true
       }
     })


### PR DESCRIPTION
There is nothing obvious causing this issue and I couldn't reproduce it. Handle the error for now so the client is not affected but still track the error in Sentry so we can eventually find the root cause.

Resolves: #5902