### PR TITLE
fix unresponsive github poker meeting

### DIFF
--- a/packages/client/components/PokerEstimateHeaderCardJira.tsx
+++ b/packages/client/components/PokerEstimateHeaderCardJira.tsx
@@ -83,7 +83,7 @@ const PokerEstimateHeaderCardJira = (props: Props) => {
     setIsExpanded((isExpanded) => !isExpanded)
   }
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
-  const {issueKey, summary, descriptionHTML, url} = issue
+  const {issueKey, summary, descriptionHTML, jiraUrl} = issue
   return (
     <HeaderCardWrapper isDesktop={isDesktop}>
       <HeaderCard>
@@ -100,7 +100,7 @@ const PokerEstimateHeaderCardJira = (props: Props) => {
           dangerouslySetInnerHTML={{__html: descriptionHTML}}
         />
         <StyledLink
-          href={url}
+          href={jiraUrl}
           rel='noopener noreferrer'
           target='_blank'
           title={`Jira Issue #${issueKey}`}
@@ -119,7 +119,7 @@ export default createFragmentContainer(PokerEstimateHeaderCardJira, {
       issueKey
       summary
       descriptionHTML
-      url
+      jiraUrl: url
     }
   `
 })

--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -62,9 +62,16 @@ const ThreadedCommentBase = (props: Props) => {
   } = props
   const isReply = !!props.isReply
   const {id: discussionId, meetingId, replyingToCommentId, teamId} = discussion
-  const {id: commentId, content, createdByUser, isActive, reactjis, threadParentId} = comment
+  const {
+    id: commentId,
+    content,
+    createdByUserNullable,
+    isActive,
+    reactjis,
+    threadParentId
+  } = comment
   const ownerId = threadParentId || commentId
-  const picture = isActive ? createdByUser?.picture ?? anonymousAvatar : deletedAvatar
+  const picture = isActive ? createdByUserNullable?.picture ?? anonymousAvatar : deletedAvatar
   const {submitMutation, submitting, onError, onCompleted} = useMutationProps()
   const [editorState, setEditorState] = useEditorState(content)
   const editorRef = useRef<HTMLTextAreaElement>(null)
@@ -103,8 +110,8 @@ const ThreadedCommentBase = (props: Props) => {
   }
 
   const onReply = () => {
-    if (createdByUser && threadParentId) {
-      const {id: userId, preferredName} = createdByUser
+    if (createdByUserNullable && threadParentId) {
+      const {id: userId, preferredName} = createdByUserNullable
       setReplyMention({userId, preferredName})
     }
 
@@ -222,7 +229,7 @@ export default createFragmentContainer(ThreadedCommentBase, {
       id
       isActive
       content
-      createdByUser {
+      createdByUserNullable: createdByUser {
         id
         preferredName
         picture

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -32,9 +32,9 @@ interface Props {
 }
 
 const getName = (comment) => {
-  const {isActive, createdByUser, isViewerComment} = comment
+  const {isActive, createdByUserNullable, isViewerComment} = comment
   if (!isActive) return 'Message Deleted'
-  if (createdByUser?.preferredName) return createdByUser.preferredName
+  if (createdByUserNullable?.preferredName) return createdByUserNullable.preferredName
   return isViewerComment ? 'Anonymous (You)' : 'Anonymous'
 }
 
@@ -71,7 +71,7 @@ export default createFragmentContainer(ThreadedCommentHeader, {
   comment: graphql`
     fragment ThreadedCommentHeader_comment on Comment {
       id
-      createdByUser {
+      createdByUserNullable: createdByUser {
         preferredName
       }
       isActive

--- a/packages/server/graphql/types/Task.ts
+++ b/packages/server/graphql/types/Task.ts
@@ -17,6 +17,7 @@ import getIssueLabels from '../../utils/githubQueries/getIssueLabels.graphql'
 import sendToSentry from '../../utils/sendToSentry'
 import connectionDefinitions from '../connectionDefinitions'
 import {GQLContext} from '../graphql'
+import isValid from '../isValid'
 import {IGetLatestTaskEstimatesQueryResult} from './../../postgres/queries/generated/getLatestTaskEstimatesQuery'
 import AgendaItem from './AgendaItem'
 import GraphQLISO8601Type from './GraphQLISO8601Type'
@@ -65,11 +66,8 @@ const Task: GraphQLObjectType = new GraphQLObjectType<any, GQLContext>({
     estimates: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TaskEstimate))),
       description: 'A list of the most recent estimates for the task',
-      resolve: async (
-        {id: taskId, integration, teamId}: DBTask,
-        _args: unknown,
-        {dataLoader, authToken}: GQLContext
-      ) => {
+      resolve: async ({id: taskId, integration, teamId}: DBTask, _args: unknown, context, info) => {
+        const {dataLoader, authToken} = context
         const viewerId = getUserId(authToken)
         if (integration?.service === 'jira') {
           const {accessUserId, cloudId, issueKey} = integration
@@ -77,6 +75,68 @@ const Task: GraphQLObjectType = new GraphQLObjectType<any, GQLContext>({
           await dataLoader
             .get('jiraIssue')
             .load({teamId, userId: accessUserId, cloudId, issueKey, taskId, viewerId})
+        } else if (integration?.service === 'github') {
+          const {accessUserId, nameWithOwner, issueNumber} = integration
+          const [githubAuth, estimates] = await Promise.all([
+            dataLoader.get('githubAuth').load({userId: accessUserId, teamId}),
+            dataLoader.get('latestTaskEstimates').load(taskId)
+          ])
+          if (estimates.length === 0) return estimates
+          // TODO schedule this work to be done & pump in the updates via subcription
+          if (!githubAuth) return estimates
+          // fetch fresh estimates from GH
+          const {accessToken} = githubAuth
+          const {repoOwner, repoName} = GitHubRepoId.split(nameWithOwner)
+          const githubRequest = getGitHubRequest(info, context, {accessToken})
+          const [labelsData, labelsError] = await githubRequest<
+            GetIssueLabelsQuery,
+            GetIssueLabelsQueryVariables
+          >(getIssueLabels, {
+            first: 100,
+            repoName,
+            repoOwner,
+            issueNumber
+          })
+          if (!labelsData) {
+            if (labelsError) {
+              sendToSentry(labelsError, {userId: accessUserId})
+            }
+            return estimates
+          }
+          const labelNodes = labelsData.repository?.issue?.labels?.nodes
+          if (!labelNodes) return estimates
+          const ghIssueLabels = labelNodes.map((node) => node?.name).filter(isValid)
+          await Promise.all(
+            estimates.map(async (estimate: IGetLatestTaskEstimatesQueryResult) => {
+              const {githubLabelName, name: dimensionName} = estimate
+              const existingLabel = ghIssueLabels.includes(githubLabelName!)
+              if (existingLabel) return
+              // VERY EXPENSIVE. We do this only if we're darn sure we need to
+              const taskIds = await dataLoader
+                .get('taskIdsByTeamAndGitHubRepo')
+                .load({teamId, nameWithOwner})
+              const similarEstimate = await getSimilarTaskEstimate(
+                taskIds,
+                dimensionName,
+                ghIssueLabels
+              )
+              if (!similarEstimate) return
+              dataLoader.get('latestTaskEstimates').clear(taskId)
+              return insertTaskEstimate({
+                changeSource: 'external',
+                // keep the link to the discussion alive, if possible
+                discussionId: estimate.discussionId,
+                jiraFieldId: undefined,
+                label: similarEstimate.label,
+                name: estimate.name,
+                meetingId: null,
+                stageId: null,
+                taskId,
+                userId: accessUserId,
+                githubLabelName: similarEstimate.githubLabelName!
+              })
+            })
+          )
         }
         return dataLoader.get('latestTaskEstimates').load(taskId)
       }
@@ -101,11 +161,7 @@ const Task: GraphQLObjectType = new GraphQLObjectType<any, GQLContext>({
             .get('jiraIssue')
             .load({teamId, userId: accessUserId, cloudId, issueKey, taskId, viewerId})
         } else if (integration.service === 'github') {
-          const [githubAuth, estimates] = await Promise.all([
-            dataLoader.get('githubAuth').load({userId: accessUserId, teamId}),
-            dataLoader.get('latestTaskEstimates').load(taskId)
-          ])
-
+          const githubAuth = await dataLoader.get('githubAuth').load({userId: accessUserId, teamId})
           if (!githubAuth) return null
           const {accessToken} = githubAuth
           const {nameWithOwner, issueNumber} = integration
@@ -119,60 +175,9 @@ const Task: GraphQLObjectType = new GraphQLObjectType<any, GQLContext>({
                   }
                 }`
           const githubRequest = getGitHubRequest(info, context, {accessToken})
-          const [[data, error], [labelsData, labelsError]] = await Promise.all([
-            githubRequest(query),
-            estimates.length > 0
-              ? githubRequest<GetIssueLabelsQuery, GetIssueLabelsQueryVariables>(getIssueLabels, {
-                  first: 100,
-                  repoName,
-                  repoOwner,
-                  issueNumber
-                })
-              : [null, null]
-          ])
-
-          if (error || labelsError) {
-            if (error) {
-              sendToSentry(error, {userId: accessUserId})
-            }
-            if (labelsError) {
-              sendToSentry(labelsError, {userId: accessUserId})
-            }
-          } else if (estimates.length) {
-            const ghIssueLabels = labelsData.repository.issue.labels.nodes.map(
-              ({name}: {name: string}) => name
-            )
-            await Promise.all(
-              estimates.map(async (estimate: IGetLatestTaskEstimatesQueryResult) => {
-                const {githubLabelName, name: dimensionName} = estimate
-                const existingLabel = ghIssueLabels.includes(githubLabelName)
-                if (existingLabel) return
-                const taskIds = await dataLoader
-                  .get('taskIdsByTeamAndGitHubRepo')
-                  .load({teamId, nameWithOwner})
-                const similarEstimate = await getSimilarTaskEstimate(
-                  taskIds,
-                  dimensionName,
-                  ghIssueLabels
-                )
-
-                if (!similarEstimate) return
-
-                return insertTaskEstimate({
-                  changeSource: 'external',
-                  // keep the link to the discussion alive, if possible
-                  discussionId: estimate.discussionId,
-                  jiraFieldId: undefined,
-                  label: similarEstimate.label,
-                  name: estimate.name,
-                  meetingId: null,
-                  stageId: null,
-                  taskId,
-                  userId: accessUserId,
-                  githubLabelName: similarEstimate.githubLabelName!
-                })
-              })
-            )
+          const [data, error] = await githubRequest(query)
+          if (error) {
+            sendToSentry(error, {userId: accessUserId})
           }
           return data
         }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -122,7 +122,7 @@
     "mailgun.js": "^3.5.2",
     "mime-types": "^2.1.16",
     "ms": "^2.0.0",
-    "nest-graphql-endpoint": "^0.3.2",
+    "nest-graphql-endpoint": "^0.4.1",
     "node-env-flag": "0.1.0",
     "node-fetch": "^2.6.1",
     "node-pg-migrate": "^5.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12000,10 +12000,10 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nest-graphql-endpoint@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/nest-graphql-endpoint/-/nest-graphql-endpoint-0.3.2.tgz#317933280222b844cd25ed2bac341152cb48cd5d"
-  integrity sha512-JWJl4mTkSZa2xhSA2qoUXmAKx649KoPPmwdV5AIovTfNK72UzEQPGLWdFn2qojnGytksLmh2fnnQlf0c/i4w0A==
+nest-graphql-endpoint@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/nest-graphql-endpoint/-/nest-graphql-endpoint-0.4.1.tgz#624bc97667f89fcaec5116e7027ae832b8fb5149"
+  integrity sha512-kOcoiDXVOX5BFZPfd4oWOdoEgcFmQ2KnoEu8aVS+xhVRsPYDLSgzumLQwEU9dAMZDZoTf8JtqY6tV+FZ/v+sBQ==
   dependencies:
     "@graphql-tools/merge" "^6.2.13"
     "@graphql-tools/schema" "^7.1.5"


### PR DESCRIPTION
Fix #6024
Fix #6015 
Fix #6023

Our big poker meeting shined the light on some big bugs!

- If 2 fragments have a field with the same name but a different type, then 1 or both must be aliased. `_xGitHubIssue.url` is a `_xGitHubURI` whereas `JiraIssue.url` is a `string`. Since we use graphql-jit, our server technically doesn't perform this validation so we could keep getting away with it, but while debugging I like to remove graphql-jit to get better stack traces so I figured it was a good time to fix it. The same goes for a nullable vs. non-null type, as see in  `createdByUser` (since that can be null for a comment but non-null for a poll or task)
- The above bug showed me that nest-graphql-endpoint couldn't handle client-aliased fields. The workaround is to edit the default resolver for external fields that requires the use of an alias. That added a lot of complexity, so instead I aliased the JiraIssue field (since we control that resolver). However, the day may come when we'll have to tackle this, so I fixed it for the GitHubIssue.url field as a proof of concept. All that's left is to write something that creates a defaultResolver for GitHub fields. Note: other schema stitching packages face this same problem! https://github.com/ardatan/graphql-tools/issues/967
- As @igorlesnenko discovered, the `taskIdsByTeamAndGitHubRepo` query is CRAZY expensive for the parabol product team in prod. I clocked it in at 1500ms! This was getting called once per estimate per task, or a total of 42 times per meeting (in the buggy meeting). I turned this into a dataloader so it only gets called once per meeting. Then, i moved it to the `task.estimates` field so now it doesn't even run during a meeting 🎉 
- nest-graphql-endpoint had 2-3 bugs in it & some medium-hanging fruit for HUGE performance gains. It now recursively  merges fields instead of just at the root level (like https://www.graphql-tools.com/docs/batch-execution). GitHub's rate limit is calculated by multiplying all the `first, last` args it traverses in the request (https://docs.github.com/en/graphql/overview/resource-limitations). For every `first,last` we merge, we reduce the cost by that __factor__, which is huge! 