### PR TITLE
replace email with userId as ID for promoteTeamMember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 - ID users with datadog (#5990)
 - Log when reflections is null (#6010)
 - Send CC errors to client (#5906)
+- Promote to team lead works for users who just joined the team (#6078)
 
 ### Added
 

--- a/packages/client/modules/teamDashboard/components/PromoteTeamMemberModal/PromoteTeamMemberModal.tsx
+++ b/packages/client/modules/teamDashboard/components/PromoteTeamMemberModal/PromoteTeamMemberModal.tsx
@@ -1,18 +1,18 @@
-import {PromoteTeamMemberModal_teamMember} from '../../../../__generated__/PromoteTeamMemberModal_teamMember.graphql'
-import React from 'react'
 import styled from '@emotion/styled'
-import {createFragmentContainer} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
-import PrimaryButton from '../../../../components/PrimaryButton'
-import IconLabel from '../../../../components/IconLabel'
-import DialogTitle from '../../../../components/DialogTitle'
-import DialogContent from '../../../../components/DialogContent'
+import React from 'react'
+import {createFragmentContainer} from 'react-relay'
 import DialogContainer from '../../../../components/DialogContainer'
+import DialogContent from '../../../../components/DialogContent'
+import DialogTitle from '../../../../components/DialogTitle'
+import IconLabel from '../../../../components/IconLabel'
+import PrimaryButton from '../../../../components/PrimaryButton'
 import withAtmosphere, {
   WithAtmosphereProps
 } from '../../../../decorators/withAtmosphere/withAtmosphere'
 import PromoteToTeamLeadMutation from '../../../../mutations/PromoteToTeamLeadMutation'
 import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
+import {PromoteTeamMemberModal_teamMember} from '../../../../__generated__/PromoteTeamMemberModal_teamMember.graphql'
 
 const StyledDialogContainer = styled(DialogContainer)({
   width: 420
@@ -36,10 +36,10 @@ const PromoteTeamMemberModal = (props: Props) => {
     onCompleted,
     teamMember
   } = props
-  const {preferredName, teamId, newTeamLeadEmail} = teamMember
+  const {preferredName, teamId, userId} = teamMember
   const handleClick = () => {
     submitMutation()
-    PromoteToTeamLeadMutation(atmosphere, {teamId, newTeamLeadEmail}, {onError, onCompleted})
+    PromoteToTeamLeadMutation(atmosphere, {teamId, userId}, {onError, onCompleted})
     closePortal()
   }
   return (
@@ -58,7 +58,7 @@ const PromoteTeamMemberModal = (props: Props) => {
 export default createFragmentContainer(withMutationProps(withAtmosphere(PromoteTeamMemberModal)), {
   teamMember: graphql`
     fragment PromoteTeamMemberModal_teamMember on TeamMember {
-      newTeamLeadEmail: email
+      userId
       teamId
       preferredName
     }

--- a/packages/client/mutations/PromoteToTeamLeadMutation.ts
+++ b/packages/client/mutations/PromoteToTeamLeadMutation.ts
@@ -1,7 +1,7 @@
-import {commitMutation} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
-import {PromoteToTeamLeadMutation as TPromoteToTeamLeadMutation} from '../__generated__/PromoteToTeamLeadMutation.graphql'
+import {commitMutation} from 'react-relay'
 import {StandardMutation} from '../types/relayMutations'
+import {PromoteToTeamLeadMutation as TPromoteToTeamLeadMutation} from '../__generated__/PromoteToTeamLeadMutation.graphql'
 graphql`
   fragment PromoteToTeamLeadMutation_team on PromoteToTeamLeadPayload {
     team {
@@ -19,8 +19,8 @@ graphql`
 `
 
 const mutation = graphql`
-  mutation PromoteToTeamLeadMutation($teamId: ID!, $newTeamLeadEmail: Email!) {
-    promoteToTeamLead(teamId: $teamId, newTeamLeadEmail: $newTeamLeadEmail) {
+  mutation PromoteToTeamLeadMutation($teamId: ID!, $userId: ID!) {
+    promoteToTeamLead(teamId: $teamId, userId: $userId) {
       error {
         message
       }

--- a/packages/server/graphql/mutations/promoteToTeamLead.ts
+++ b/packages/server/graphql/mutations/promoteToTeamLead.ts
@@ -6,7 +6,6 @@ import {getUserId, isSuperUser} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
-import GraphQLEmailType from '../types/GraphQLEmailType'
 import PromoteToTeamLeadPayload from '../types/PromoteToTeamLeadPayload'
 
 export default {
@@ -17,14 +16,14 @@ export default {
       type: new GraphQLNonNull(GraphQLID),
       description: 'Team id of the team which is about to get a new team leader'
     },
-    newTeamLeadEmail: {
-      type: new GraphQLNonNull(GraphQLEmailType),
-      description: 'Email of the user who will be set as a new team leader'
+    userId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'userId who will be set as a new team leader'
     }
   },
   async resolve(
     _source: unknown,
-    {teamId, newTeamLeadEmail}: {teamId: string; newTeamLeadEmail: string},
+    {teamId, userId}: {teamId: string; userId: string},
     {authToken, dataLoader, socketId: mutatorId}: GQLContext
   ) {
     const r = await getRethink()
@@ -52,7 +51,7 @@ export default {
     const promoteeOnTeam = await r
       .table('TeamMember')
       .getAll(teamId, {index: 'teamId'})
-      .filter({email: newTeamLeadEmail, isNotRemoved: true})
+      .filter({userId, isNotRemoved: true})
       .nth(0)
       .default(null)
       .run()


### PR DESCRIPTION
when a user accepts a team invite we don't request their email, which means calls `promoteToTeamLead` has email == null.
we could either request their email, or use the userId of the person we want to join.
Since the userId is always requested, seems like that is a little more robust than having to remember to always request the email any time a new TeamMember object is created in the app.

fixes issues discovered in https://github.com/ParabolInc/parabol/issues/6074#issuecomment-1042367499 