### PR TITLE
Rethrow exceptions in traceGraphQL

### DIFF
--- a/packages/server/graphql/traceGraphQL.ts
+++ b/packages/server/graphql/traceGraphQL.ts
@@ -227,6 +227,7 @@ function wrappedResolve(
       return result
     } catch (error) {
       field.error = field.error || error
+      throw field.error
     } finally {
       field.finishTime = (field.span as any)._getTime?.() ?? 0
     }


### PR DESCRIPTION
Errors thrown in resolvers were swallowed silently when tracing is
enabled.