### PR TITLE
build(server): fix jest transforms

### DIFF
--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -1,4 +1,4 @@
-const {jsWithTs: tsjPreset} = require('ts-jest/presets')
+const tsJestPresets = require('ts-jest/presets')
 
 module.exports = {
   preset: 'ts-jest',
@@ -9,8 +9,14 @@ module.exports = {
     }
   },
   transform: {
-    ...tsjPreset.transform
+    '\\.(gql|graphql)$': 'jest-transform-graphql',
+    ...tsJestPresets.jsWithBabel.transform
   },
   modulePaths: ['<rootDir>/packages/'],
+  moduleNameMapper: {
+    'server/(.*)': ['<rootDir>/$1'],
+    'parabol-client/(.*)': ['<rootDir>/../client/$1'],
+    '~/(.*)': ['<rootDir>/../client/$1']
+  },
   testRegex: '/__tests__/.*.test\\.ts?$'
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -63,6 +63,7 @@
     "jest": "^27.0.6",
     "jest-extended": "^1.2.0",
     "jest-junit": "^13.0.0",
+    "jest-transform-graphql": "^2.1.0",
     "jsdom": "^16.6.0",
     "json-loader": "^0.5.7",
     "lint-staged": "^10.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4764,6 +4764,14 @@ are-we-there-yet@^2.0.0:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
 
+are-we-there-yet@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz#ba20bd6b553e31d62fc8c31bd23d22b95734390d"
+  integrity sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^3.6.0"
+
 are-we-there-yet@~1.1.2:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
@@ -8279,9 +8287,9 @@ gauge@^3.0.0:
     wide-align "^1.1.2"
 
 gauge@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.0.tgz#afba07aa0374a93c6219603b1fb83eaa2264d8f8"
-  integrity sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-4.0.1.tgz#82984bc08c90357d60b0a46c03a296beb1affec4"
+  integrity sha512-zJ4jePUHR8cceduZ53b6temRalyGpkC2Kc2r3ecNphmL+uWNoJ3YcOcUjpbG6WwoE/Ef6/+aEZz63neI2WIa1Q==
   dependencies:
     ansi-regex "^5.0.1"
     aproba "^1.0.3 || ^2.0.0"
@@ -10423,6 +10431,11 @@ jest-snapshot@^27.4.5:
     pretty-format "^27.4.2"
     semver "^7.3.2"
 
+jest-transform-graphql@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-graphql/-/jest-transform-graphql-2.1.0.tgz#903cb66bb27bc2772fd3e5dd4f7e9b57230f5829"
+  integrity sha1-kDy2a7J7wncv0+XdT36bVyMPWCk=
+
 jest-util@^27.0.0, jest-util@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
@@ -11941,9 +11954,9 @@ nan@^2.14.0, nan@^2.14.2:
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nanoid@3.1.25, nanoid@^2.1.0, nanoid@^3.1.30, nanoid@^3.1.31:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
-  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -12353,11 +12366,11 @@ npmlog@^5.0.1:
     set-blocking "^2.0.0"
 
 npmlog@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.0.tgz#ba9ef39413c3d936ea91553db7be49c34ad0520c"
-  integrity sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.1.tgz#06f1344a174c06e8de9c6c70834cfba2964bba17"
+  integrity sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==
   dependencies:
-    are-we-there-yet "^2.0.0"
+    are-we-there-yet "^3.0.0"
     console-control-strings "^1.1.0"
     gauge "^4.0.0"
     set-blocking "^2.0.0"


### PR DESCRIPTION
@igorlesnenko ran into some issues on his PR (#6092) where `jest` was throwing this error in [CI](https://app.circleci.com/pipelines/github/ParabolInc/parabol/4405/workflows/c60f5290-e766-485c-a1eb-e0cf00d53f7d/jobs/13207):

```console
 FAIL  dataloader/__tests__/usersCustomRedisQueries.test.ts
  ● Test suite failed to run

    Cannot find module '~/shared/gqlIds/JiraProjectId' from 'integrations/JiraTaskIntegrationManager.ts'

    Require stack:
      integrations/JiraTaskIntegrationManager.ts
      integrations/TaskIntegrationManagerFactory.ts
      dataloader/jiraServerLoaders.ts
      dataloader/RootDataLoader.ts
      graphql/getDataLoader.ts
      dataloader/__tests__/usersCustomRedisQueries.test.ts

      1 | import makeCreateJiraTaskComment from '../utils/makeCreateJiraTaskComment'
    > 2 | import JiraProjectId from '~/shared/gqlIds/JiraProjectId'
        | ^
      3 | import createJiraTask from '../graphql/mutations/helpers/createJiraTask'
      4 | import JiraIssueId from '~/shared/gqlIds/JiraIssueId'
      5 | import {CreateTaskResponse, TaskIntegrationManager} from './TaskIntegrationManagerFactory'

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/resolver.js:324:11)
      at Object.<anonymous> (integrations/JiraTaskIntegrationManager.ts:2:1)
```

The problem is because `jest`/`ts-jest` doesn't automatically map `tsconfig.json`'s `paths` to its internal module mapper (used for mocking in Jest). There's documentation on this [here](https://kulshekhar.github.io/ts-jest/docs/getting-started/paths-mapping/).

Additionally, once that module mapping was working, we ran into another problem:

```console
 FAIL  dataloader/__tests__/usersCustomRedisQueries.test.ts
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /Users/blimmer/code/parabol/parabol/packages/server/utils/githubQueries/createIssue.graphql:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){mutation createIssue($input: CreateIssueInput!) {
                                                                                               ^^^^^^^^^^^

    SyntaxError: Unexpected identifier

      11 |   GetRepoInfoQueryVariables
      12 | } from '../../../types/githubTypes'
    > 13 | import createIssueMutation from '../../../utils/githubQueries/createIssue.graphql'
         | ^
      14 | import addComment from '../../../utils/githubQueries/addComment.graphql'
      15 | import getRepoInfo from '../../../utils/githubQueries/getRepoInfo.graphql'
      16 | import {GQLContext} from '../../graphql'

      at Runtime.createScriptFromCode (../../node_modules/jest-runtime/build/index.js:1728:14)
      at Object.<anonymous> (graphql/mutations/helpers/createGitHubTask.ts:13:1)
```

To fix that problem, I added a `graphql` transformer.

See inline comments for additional details.