### PR TITLE
Add migration to update prompt colors for Three Little Pigs template

### DIFF
--- a/packages/server/database/migrations/20220222141104-updateThreeLittlePigsPromptColors.ts
+++ b/packages/server/database/migrations/20220222141104-updateThreeLittlePigsPromptColors.ts
@@ -1,0 +1,44 @@
+import {R} from 'rethinkdb-ts'
+import {PALETTE} from '../../../client/styles/paletteV3'
+
+export const up = async function (r: R) {
+  try {
+    await r({
+      houseOfBricks: r
+        .table('ReflectPrompt')
+        .get('promptHouseOfBricks')
+        .update({groupColor: PALETTE.JADE_400}),
+      houseOfSticks: r
+        .table('ReflectPrompt')
+        .get('promptHouseOfSticks')
+        .update({groupColor: PALETTE.TOMATO_700}),
+      houseOfStraw: r
+        .table('ReflectPrompt')
+        .get('promptHouseOfStraw')
+        .update({groupColor: PALETTE.GOLD_300})
+    }).run()
+  } catch (e) {
+    console.error("error when migration up groupColors for the threeLittlePigsTemplate", e)
+  }
+};
+
+export const down = async function (r: R) {
+  try {
+    await r({
+      houseOfBricks: r
+        .table('ReflectPrompt')
+        .get('promptHouseOfBricks')
+        .update({groupColor: "#D9D916"}),
+      houseOfSticks: r
+        .table('ReflectPrompt')
+        .get('promptHouseOfSticks')
+        .update({groupColor: "#E55C5C"}),
+      houseOfStraw: r
+        .table('ReflectPrompt')
+        .get('promptHouseOfStraw')
+        .update({groupColor: "#52CC52"})
+    }).run()
+  } catch (e) {
+    console.error("error when migrating down groupColors for the threeLittlePigsTemplate", e)
+  }
+};


### PR DESCRIPTION
Fixes #4703 

Test steps:

1.  Pull down the branch and run `yarn dev`
2.  Migration should run: \[migrate-rethinkdb\]  ↑  up  ↑  20220222141104 updateThreeLittlePigsPromptColors
3.  In the template picker for retro meeting, select Three Little Pigs from Public templates, see the correct color should be present.

![](https://user-images.githubusercontent.com/1879975/155233100-1c9c0a1d-47be-4bb4-bd84-2bcbe3077670.png)