### PR TITLE
fix template picker sizing issue on mobile

### DIFF
--- a/packages/client/modules/meeting/components/PokerTemplateList.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateList.tsx
@@ -63,8 +63,8 @@ const TabIcon = styled(Icon)({
   marginRight: 4
 })
 
-const containerStyle = {height: '100%'}
-const innerStyle = {width: '100%', height: '100%'}
+const containerStyle = {width: '100%', height: '85%'}
+const innerStyle = {width: '100%', height: '100%', maxWidth: 'calc(100vw - 48px)'}
 interface Props {
   activeIdx: number
   setActiveIdx: (idx: number) => void
@@ -75,7 +75,7 @@ const PokerTemplateList = (props: Props) => {
   const {activeIdx, setActiveIdx, settings} = props
   const {team, teamTemplates} = settings
   const {id: teamId} = team
-  const activeTemplateId = settings.activeTemplate?.id ?? "-tmp"
+  const activeTemplateId = settings.activeTemplate?.id ?? '-tmp'
 
   const gotoTeamTemplates = () => {
     setActiveIdx(0)
@@ -118,7 +118,11 @@ const PokerTemplateList = (props: Props) => {
           onClick={gotoPublicTemplates}
         />
       </StyledTabsBar>
-      <AddNewPokerTemplate teamId={teamId} pokerTemplates={teamTemplates} gotoTeamTemplates={gotoTeamTemplates} />
+      <AddNewPokerTemplate
+        teamId={teamId}
+        pokerTemplates={teamTemplates}
+        gotoTeamTemplates={gotoTeamTemplates}
+      />
       <SwipeableViews
         enableMouseEvents
         index={activeIdx}

--- a/packages/client/modules/meeting/components/PokerTemplateList.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateList.tsx
@@ -63,7 +63,7 @@ const TabIcon = styled(Icon)({
   marginRight: 4
 })
 
-const containerStyle = {width: '100%', height: '85%'}
+const containerStyle = {height: '85%'}
 const innerStyle = {width: '100%', height: '100%', maxWidth: 'calc(100vw - 48px)'}
 interface Props {
   activeIdx: number

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -35,7 +35,8 @@ const Label = styled('div')({
 })
 
 const StyledTabsBar = styled(Tabs)({
-  boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`
+  boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`,
+  flexShrink: 0
 })
 
 const FullTab = styled(Tab)({
@@ -63,7 +64,7 @@ const TabIcon = styled(Icon)({
   marginRight: 4
 })
 
-const containerStyle = {width: '100%', height: '85%'}
+const containerStyle = {height: '85%'}
 const innerStyle = {width: '100%', height: '100%', maxWidth: 'calc(100vw - 48px)'}
 interface Props {
   activeIdx: number

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -35,8 +35,7 @@ const Label = styled('div')({
 })
 
 const StyledTabsBar = styled(Tabs)({
-  boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`,
-  flexShrink: 0
+  boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`
 })
 
 const FullTab = styled(Tab)({
@@ -64,8 +63,8 @@ const TabIcon = styled(Icon)({
   marginRight: 4
 })
 
-const containerStyle = {height: '100%'}
-const innerStyle = {width: '100%', height: '100%'}
+const containerStyle = {width: '100%', height: '85%'}
+const innerStyle = {width: '100%', height: '100%', maxWidth: 'calc(100vw - 48px)'}
 interface Props {
   activeIdx: number
   setActiveIdx: (idx: number) => void

--- a/packages/client/modules/meeting/components/SelectTemplate.tsx
+++ b/packages/client/modules/meeting/components/SelectTemplate.tsx
@@ -9,7 +9,7 @@ import StyledError from '../../../components/StyledError'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import SelectTemplateMutation from '../../../mutations/SelectTemplateMutation'
-import {BezierCurve} from '../../../types/constEnums'
+import {BezierCurve, ZIndex} from '../../../types/constEnums'
 import {SelectTemplate_template} from '../../../__generated__/SelectTemplate_template.graphql'
 
 const fadein = keyframes`
@@ -28,6 +28,7 @@ const ButtonBlock = styled('div')({
   right: 16,
   bottom: 16,
   width: '100%',
+  zIndex: ZIndex.DIALOG
 })
 
 const Button = styled(FloatingActionButton)({


### PR DESCRIPTION
Changes to both retro and poker template pickers:
- Reducing the height of the template list so the action button can appear below
- Increasing the z-index of the action button so it does not sit behind the list (it was unclickable before)
- adding a max-width to the template list containers so they don't overflow

TODO: 
- make the active tab bar display in the correct position on load