### PR TITLE
Fix a bug where dragging item to original position cause an error

### DIFF
--- a/packages/client/components/PokerSidebarEstimateSection.tsx
+++ b/packages/client/components/PokerSidebarEstimateSection.tsx
@@ -62,17 +62,18 @@ const PokerSidebarEstimateSection = (props: Props) => {
 
   const onDragEnd = (result) => {
     const {source, destination} = result
-    const sourceTopic = stageSummaries[source.index]
-    const destinationTopic = stageSummaries[destination.index]
 
     if (
       !destination ||
       destination.droppableId !== 'TASK' ||
       source.droppableId !== 'TASK' ||
-      destination.index === source.index ||
-      !sourceTopic ||
-      !destinationTopic
+      destination.index === source.index
     ) {
+      return
+    }
+    const sourceTopic = stageSummaries[source.index]
+    const destinationTopic = stageSummaries[destination.index]
+    if (!sourceTopic ||!destinationTopic) {
       return
     }
 

--- a/packages/client/components/PokerSidebarEstimateSection.tsx
+++ b/packages/client/components/PokerSidebarEstimateSection.tsx
@@ -64,7 +64,7 @@ const PokerSidebarEstimateSection = (props: Props) => {
     const {source, destination} = result
 
     if (
-      !destination ||
+      !destination || !source ||
       destination.droppableId !== 'TASK' ||
       source.droppableId !== 'TASK' ||
       destination.index === source.index

--- a/packages/client/components/PokerSidebarEstimateSection.tsx
+++ b/packages/client/components/PokerSidebarEstimateSection.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {DragDropContext, Draggable, Droppable} from 'react-beautiful-dnd'
+import {DragDropContext, Draggable, Droppable, DropResult} from 'react-beautiful-dnd'
 import {createFragmentContainer} from 'react-relay'
 import useGotoStageId from '~/hooks/useGotoStageId'
 import {PokerSidebarEstimateSection_meeting} from '~/__generated__/PokerSidebarEstimateSection_meeting.graphql'
@@ -10,7 +10,7 @@ import useMakeStageSummaries from '../hooks/useMakeStageSummaries'
 import DragEstimatingTaskMutation from '../mutations/DragEstimatingTaskMutation'
 import {navItemRaised} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
-import {SORT_STEP} from '../utils/constants'
+import {ESTIMATING_TASK, SORT_STEP} from '../utils/constants'
 import dndNoise from '../utils/dndNoise'
 import MeetingSidebarPhaseItemChild from './MeetingSidebarPhaseItemChild'
 import MeetingSubnavItem from './MeetingSubnavItem'
@@ -60,20 +60,17 @@ const PokerSidebarEstimateSection = (props: Props) => {
   const stageSummaries = useMakeStageSummaries(estimatePhase, localStageId)
   const inSync = localStageId === facilitatorStageId
 
-  const onDragEnd = (result) => {
+  const onDragEnd = (result: DropResult) => {
     const {source, destination} = result
-
-    if (
-      !destination || !source ||
-      destination.droppableId !== 'TASK' ||
-      source.droppableId !== 'TASK' ||
-      destination.index === source.index
-    ) {
-      return
-    }
+    if (!destination) return
     const sourceTopic = stageSummaries[source.index]
     const destinationTopic = stageSummaries[destination.index]
-    if (!sourceTopic ||!destinationTopic) {
+    if (
+      destination.droppableId !== ESTIMATING_TASK ||
+      source.droppableId !== ESTIMATING_TASK ||
+      destination.index === source.index ||
+      !sourceTopic ||!destinationTopic
+    ) {
       return
     }
 
@@ -119,7 +116,7 @@ const PokerSidebarEstimateSection = (props: Props) => {
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <MeetingSidebarPhaseItemChild>
-        <Droppable droppableId={'TASK'}>
+        <Droppable droppableId={ESTIMATING_TASK}>
           {(provided) => {
             return (
               <ScrollWrapper ref={provided.innerRef}>

--- a/packages/client/components/RetroSidebarDiscussSection.tsx
+++ b/packages/client/components/RetroSidebarDiscussSection.tsx
@@ -75,7 +75,7 @@ const RetroSidebarDiscussSection = (props: Props) => {
     const {source, destination} = result
 
     if (
-      !destination ||
+      !destination || !source ||
       destination.droppableId !== DISCUSSION_TOPIC ||
       source.droppableId !== DISCUSSION_TOPIC ||
       destination.index === source.index

--- a/packages/client/components/RetroSidebarDiscussSection.tsx
+++ b/packages/client/components/RetroSidebarDiscussSection.tsx
@@ -73,17 +73,18 @@ const RetroSidebarDiscussSection = (props: Props) => {
 
   const onDragEnd = (result) => {
     const {source, destination} = result
-    const sourceTopic = stages[source.index]
-    const destinationTopic = stages[destination.index]
 
     if (
       !destination ||
       destination.droppableId !== DISCUSSION_TOPIC ||
       source.droppableId !== DISCUSSION_TOPIC ||
-      destination.index === source.index ||
-      !sourceTopic ||
-      !destinationTopic
+      destination.index === source.index
     ) {
+      return
+    }
+    const sourceTopic = stages[source.index]
+    const destinationTopic = stages[destination.index]
+    if (!sourceTopic || !destinationTopic) {
       return
     }
 

--- a/packages/client/components/RetroSidebarDiscussSection.tsx
+++ b/packages/client/components/RetroSidebarDiscussSection.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {DragDropContext, Draggable, Droppable} from 'react-beautiful-dnd'
+import {DragDropContext, Draggable, Droppable, DropResult} from 'react-beautiful-dnd'
 import {createFragmentContainer} from 'react-relay'
 import useGotoStageId from '~/hooks/useGotoStageId'
 import {DeepNonNullable} from '~/types/generics'
@@ -71,20 +71,17 @@ const RetroSidebarDiscussSection = (props: Props) => {
   const {id: localStageId} = localStage
   const inSync = localStageId === facilitatorStageId
 
-  const onDragEnd = (result) => {
+  const onDragEnd = (result: DropResult) => {
     const {source, destination} = result
-
-    if (
-      !destination || !source ||
-      destination.droppableId !== DISCUSSION_TOPIC ||
-      source.droppableId !== DISCUSSION_TOPIC ||
-      destination.index === source.index
-    ) {
-      return
-    }
+    if (!destination) return
     const sourceTopic = stages[source.index]
     const destinationTopic = stages[destination.index]
-    if (!sourceTopic || !destinationTopic) {
+    if (
+      destination.droppableId !== DISCUSSION_TOPIC ||
+      source.droppableId !== DISCUSSION_TOPIC ||
+      destination.index === source.index ||
+      !sourceTopic || !destinationTopic
+    ) {
       return
     }
 

--- a/packages/client/components/TimelinePriorityTasks.tsx
+++ b/packages/client/components/TimelinePriorityTasks.tsx
@@ -11,7 +11,7 @@ import UpdateTaskMutation from '../mutations/UpdateTaskMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
 import {DroppableType} from '../types/constEnums'
-import {ACTIVE, SORT_STEP} from '../utils/constants'
+import {ACTIVE, ACTIVE_TASK, SORT_STEP} from '../utils/constants'
 import dndNoise from '../utils/dndNoise'
 import {TimelinePriorityTasks_viewer} from '../__generated__/TimelinePriorityTasks_viewer.graphql'
 import Icon from './Icon'
@@ -84,7 +84,7 @@ const TimelinePriorityTasks = (props: Props) => {
   if (activeTasks.length === 0) return <TimelineNoTasks />
   return (
     <DragDropContext onDragEnd={onDragEnd}>
-      <Droppable droppableId='active' type={DroppableType.TASK}>
+      <Droppable droppableId={ACTIVE_TASK} type={DroppableType.TASK}>
         {(dropProvided: DroppableProvided) => (
           <TaskList>
             <PriorityTasksHeader>

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -23,7 +23,7 @@ import {
   RetroDemo,
   SubscriptionChannel
 } from '../../types/constEnums'
-import {DISCUSS, GROUP, REFLECT, TASK, TEAM, VOTE} from '../../utils/constants'
+import {DISCUSS, GROUP, REFLECT, VOTE} from '../../utils/constants'
 import dndNoise from '../../utils/dndNoise'
 import extractTextFromDraftString from '../../utils/draftjs/extractTextFromDraftString'
 import getTagsFromEntityMap from '../../utils/draftjs/getTagsFromEntityMap'
@@ -453,7 +453,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         task
       }
       if (userId !== demoViewerId) {
-        this.emit(TASK, data)
+        this.emit(SubscriptionChannel.TASK, data)
       }
       return {createTaskIntegration: data}
     },
@@ -830,7 +830,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         slackNotificationIds
       }
       if (userId !== demoViewerId) {
-        this.emit(TEAM, data)
+        this.emit(SubscriptionChannel.TEAM, data)
       }
       return {setSlackNotification: data}
     },
@@ -1214,7 +1214,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         involvementNotification: null
       }
       if (userId !== demoViewerId) {
-        this.emit(TASK, data)
+        this.emit(SubscriptionChannel.TASK, data)
       }
       // a strange error occurs without sleep.
       // To reproduce, get to the discuss phase & quickly add a task before the bots do
@@ -1276,7 +1276,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         isEditing
       }
       if (userId !== demoViewerId) {
-        this.emit(TASK, data)
+        this.emit(SubscriptionChannel.TASK, data)
       }
       return {editTask: data}
     },
@@ -1324,7 +1324,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         addedNotification: null
       }
       if (userId !== demoViewerId) {
-        this.emit(TASK, data)
+        this.emit(SubscriptionChannel.TASK, data)
       }
       return {updateTask: data}
     },
@@ -1346,7 +1346,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         involvementNotification: null
       }
       if (userId !== demoViewerId) {
-        this.emit(TASK, data)
+        this.emit(SubscriptionChannel.TASK, data)
       }
       return {deleteTask: data}
     },
@@ -1356,7 +1356,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
 
       const data = {__typename: 'UpdateTaskDueDatePayload', error: null, task}
       if (userId !== demoViewerId) {
-        this.emit(TASK, data)
+        this.emit(SubscriptionChannel.TASK, data)
       }
       return {updateTaskDueDate: data}
     },
@@ -1409,7 +1409,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         __typename: 'EndRetrospectiveSuccess'
       }
       if (userId !== demoViewerId) {
-        this.emit(TEAM, data)
+        this.emit(SubscriptionChannel.TEAM, data)
       }
       return {endRetrospective: data}
     },

--- a/packages/client/modules/demo/LocalAtmosphere.ts
+++ b/packages/client/modules/demo/LocalAtmosphere.ts
@@ -16,7 +16,6 @@ import {
 } from 'relay-runtime'
 import Atmosphere from '../../Atmosphere'
 import {SubscriptionChannel} from '../../types/constEnums'
-import {TASK, TEAM} from '../../utils/constants'
 import handlerProvider from '../../utils/relay/handlerProvider'
 import ClientGraphQLServer from './ClientGraphQLServer'
 // import sleep from 'universal/utils/sleep'
@@ -89,11 +88,11 @@ export default class LocalAtmosphere extends Environment {
     return Observable.create((sink) => {
       const channelLookup = {
         TaskSubscription: {
-          channel: TASK,
+          channel: SubscriptionChannel.TASK,
           dataField: 'taskSubscription'
         },
         TeamSubscription: {
-          channel: TEAM,
+          channel: SubscriptionChannel.TEAM,
           dataField: 'teamSubscription'
         },
         MeetingSubscription: {

--- a/packages/client/modules/meeting/components/TemplateDimensionList.tsx
+++ b/packages/client/modules/meeting/components/TemplateDimensionList.tsx
@@ -5,6 +5,7 @@ import {DragDropContext, Draggable, Droppable, DropResult} from 'react-beautiful
 import {createFragmentContainer} from 'react-relay'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import MovePokerTemplateDimensionMutation from '../../../mutations/MovePokerTemplateDimensionMutation'
+import {TEMPLATE_DIMENSION} from '../../../utils/constants'
 import dndNoise from '../../../utils/dndNoise'
 import {TemplateDimensionList_dimensions} from '../../../__generated__/TemplateDimensionList_dimensions.graphql'
 import TemplateDimensionItem from './TemplateDimensionItem'
@@ -21,26 +22,23 @@ const DimensionList = styled('div')({
   width: '100%'
 })
 
-const TEMPLATE_DIMENSION = 'TEMPLATE_DIMENSION'
-
 const TemplateDimensionList = (props: Props) => {
   const {isOwner, dimensions, templateId} = props
   const atmosphere = useAtmosphere()
 
   const onDragEnd = (result: DropResult) => {
     const {source, destination} = result
+    if (!destination) return
+    const sourceDimension = dimensions[source.index]
+    const destinationDimension = dimensions[destination.index]
     if (
-      !destination ||
       destination.droppableId !== TEMPLATE_DIMENSION ||
       source.droppableId !== TEMPLATE_DIMENSION ||
-      destination.index === source.index
+      destination.index === source.index ||
+      !sourceDimension || !destinationDimension
     ) {
       return
     }
-
-    const sourceDimension = dimensions[source.index]
-    const destinationDimension = dimensions[destination.index]
-    if (!sourceDimension || !destinationDimension) return
 
     let sortOrder
     if (destination.index === 0) {

--- a/packages/client/modules/meeting/components/TemplatePromptList.tsx
+++ b/packages/client/modules/meeting/components/TemplatePromptList.tsx
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {DragDropContext, Draggable, Droppable} from 'react-beautiful-dnd'
+import {DragDropContext, Draggable, Droppable, DropResult} from 'react-beautiful-dnd'
 import {createFragmentContainer} from 'react-relay'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import MoveReflectTemplatePromptMutation from '../../../mutations/MoveReflectTemplatePromptMutation'
+import {TEMPLATE_PROMPT} from '../../../utils/constants'
 import dndNoise from '../../../utils/dndNoise'
 import {TemplatePromptList_prompts} from '../../../__generated__/TemplatePromptList_prompts.graphql'
 import TemplatePromptItem from './TemplatePromptItem'
@@ -21,26 +22,24 @@ const PromptList = styled('div')({
   width: '100%'
 })
 
-const TEMPLATE_PROMPT = 'TEMPLATE_PROMPT'
 
 const TemplatePromptList = (props: Props) => {
   const {isOwner, prompts, templateId} = props
   const atmosphere = useAtmosphere()
 
-  const onDragEnd = (result) => {
+  const onDragEnd = (result: DropResult) => {
     const {source, destination} = result
+    if (!destination) return
+    const sourcePrompt = prompts[source.index]
+    const destinationPrompt = prompts[destination.index]
     if (
-      !destination ||
       destination.droppableId !== TEMPLATE_PROMPT ||
       source.droppableId !== TEMPLATE_PROMPT ||
-      destination.index === source.index
+      destination.index === source.index ||
+      !sourcePrompt || !destinationPrompt
     ) {
       return
     }
-
-    const sourcePrompt = prompts[source.index]
-    const destinationPrompt = prompts[destination.index]
-    if (!sourcePrompt || !destinationPrompt) return
 
     let sortOrder
     if (destination.index === 0) {

--- a/packages/client/modules/meeting/components/TemplateScaleValueList.tsx
+++ b/packages/client/modules/meeting/components/TemplateScaleValueList.tsx
@@ -7,6 +7,7 @@ import {TemplateScaleValueList_scale} from '~/__generated__/TemplateScaleValueLi
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import MovePokerTemplateScaleValueMutation from '../../../mutations/MovePokerTemplateScaleValueMutation'
+import {TEMPLATE_SCALE_VALUE} from '../../../utils/constants'
 import isSpecialPokerLabel from '../../../utils/isSpecialPokerLabel'
 import AddScaleValueButtonInput from './AddScaleValueButtonInput'
 import TemplateScaleValueItem from './TemplateScaleValueItem'
@@ -23,7 +24,6 @@ const ScaleList = styled('div')({
   width: '100%'
 })
 
-const TEMPLATE_SCALE_VALUE = 'TEMPLATE_SCALE_VALUE'
 
 const TemplateScaleValueList = (props: Props) => {
   const {isOwner, scale} = props
@@ -33,10 +33,10 @@ const TemplateScaleValueList = (props: Props) => {
 
   const onDragEnd = (result: DropResult) => {
     const {source, destination} = result
+    if (!destination) return
     const {values: scaleValues} = scale
     const sourceScaleValue = scaleValues[source.index]
     if (
-      !destination ||
       destination.droppableId !== TEMPLATE_SCALE_VALUE ||
       source.droppableId !== TEMPLATE_SCALE_VALUE ||
       destination.index === source.index ||

--- a/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
-import {DragDropContext, Draggable, Droppable} from 'react-beautiful-dnd'
+import {DragDropContext, Draggable, Droppable, DropResult} from 'react-beautiful-dnd'
 import {createFragmentContainer} from 'react-relay'
 import {AgendaList_meeting} from '~/__generated__/AgendaList_meeting.graphql'
 // import SexyScrollbar from 'universal/components/Dashboard/SexyScrollbar'
@@ -48,19 +48,17 @@ const AgendaList = (props: Props) => {
       : agendaItems.filter(({content}) => content)
   }, [dashSearch, agendaItems])
 
-  const onDragEnd = useEventCallback((result) => {
+  const onDragEnd = useEventCallback((result: DropResult) => {
     const {source, destination} = result
-    if (
-      !destination || !source ||
-      destination.droppableId !== AGENDA_ITEM ||
-      source.droppableId !== AGENDA_ITEM ||
-      destination.index === source.index
-    ) {
-      return
-    }
+    if (!destination) return
     const destinationItem = agendaItems[destination.index]
     const sourceItem = agendaItems[source.index]
-    if (!destinationItem || !sourceItem) {
+    if (
+      destination.droppableId !== AGENDA_ITEM ||
+      source.droppableId !== AGENDA_ITEM ||
+      destination.index === source.index ||
+      !destinationItem || !sourceItem
+    ) {
       return
     }
 

--- a/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
@@ -51,7 +51,7 @@ const AgendaList = (props: Props) => {
   const onDragEnd = useEventCallback((result) => {
     const {source, destination} = result
     if (
-      !destination ||
+      !destination || !source ||
       destination.droppableId !== AGENDA_ITEM ||
       source.droppableId !== AGENDA_ITEM ||
       destination.index === source.index

--- a/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaList/AgendaList.tsx
@@ -50,16 +50,17 @@ const AgendaList = (props: Props) => {
 
   const onDragEnd = useEventCallback((result) => {
     const {source, destination} = result
-    const destinationItem = agendaItems[destination.index]
-    const sourceItem = agendaItems[source.index]
     if (
       !destination ||
       destination.droppableId !== AGENDA_ITEM ||
       source.droppableId !== AGENDA_ITEM ||
-      destination.index === source.index ||
-      !destinationItem ||
-      !sourceItem
+      destination.index === source.index
     ) {
+      return
+    }
+    const destinationItem = agendaItems[destination.index]
+    const sourceItem = agendaItems[source.index]
+    if (!destinationItem || !sourceItem) {
       return
     }
 

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -40,8 +40,7 @@ export const meetingColumnArray = [DONE, ACTIVE, STUCK, FUTURE] as TaskStatusEnu
 /* Scoping Task Search Filter */
 export const taskScopingStatusFilters = [ACTIVE, STUCK, FUTURE] as TaskStatusEnum[]
 
-/* Drag-n-Drop Items */
-export const TASK = 'TASK'
+/* Drag-n-Drop Items DroppableId */
 export const AGENDA_ITEM = 'AGENDA_ITEM'
 export const DISCUSSION_TOPIC = 'DISCUSSION_TOPIC'
 export const ESTIMATING_TASK = 'ESTIMATING_TASK'
@@ -121,11 +120,6 @@ export const GITHUB_ENDPOINT = 'https://api.github.com/graphql'
 
 /* JavaScript specifics */
 export const MAX_INT = 2147483647
-
-/* Relay Subscription Channels */
-export const NOTIFICATION = 'notification'
-export const ORGANIZATION = 'organization'
-export const TEAM = 'team'
 
 /* Relay Subscription Event Types */
 export const UPDATED = 'updated'

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -41,8 +41,14 @@ export const meetingColumnArray = [DONE, ACTIVE, STUCK, FUTURE] as TaskStatusEnu
 export const taskScopingStatusFilters = [ACTIVE, STUCK, FUTURE] as TaskStatusEnum[]
 
 /* Drag-n-Drop Items */
-export const TASK = 'task'
-export const AGENDA_ITEM = 'agendaItem'
+export const TASK = 'TASK'
+export const AGENDA_ITEM = 'AGENDA_ITEM'
+export const DISCUSSION_TOPIC = 'DISCUSSION_TOPIC'
+export const ESTIMATING_TASK = 'ESTIMATING_TASK'
+export const TEMPLATE_DIMENSION = 'TEMPLATE_DIMENSION'
+export const TEMPLATE_PROMPT = 'TEMPLATE_PROMPT'
+export const TEMPLATE_SCALE_VALUE = 'TEMPLATE_SCALE_VALUE'
+export const ACTIVE_TASK = 'ACTIVE_TASK'
 
 /* Sorting */
 export const SORT_STEP = 1
@@ -140,9 +146,6 @@ export const CREATE_ACCOUNT_SLUG = 'create-account'
 /* Meeting Types */
 export const ACTION = 'action'
 export const RETROSPECTIVE = 'retrospective'
-
-/* Retro DnD types */
-export const DISCUSSION_TOPIC = 'DISCUSSION_TOPIC'
 
 /* Spotlight */
 export const MAX_REDUCTION_PERCENTAGE = 1


### PR DESCRIPTION
Fixes #6029.

The issue is that when an item is dropped to its original position or somewhere invalid, the `destination` will be `null`. See this [discussion](https://github.com/atlassian/react-beautiful-dnd/issues/558#issuecomment-399205587).

Tests:

- [ ] In a poker meeting, user can drag & drop estimated tasks freely
- [ ] In a retro meeting, user can drag & drop discussion topics freely
- [ ] In team dashboard, user can drag & drop agenda items freely