### PR TITLE
always create samlrequest

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/intranetSchema/mutations/enableSAMLForDomain.ts
@@ -5,11 +5,6 @@ import zlib from 'zlib'
 import getRethink from '../../../database/rethinkDriver'
 import EnableSAMLForDomainPayload from '../types/EnableSAMLForDomainPayload'
 
-const AZURE_AD_LOGIN_URL_HOSTNAME = `microsoftonline`
-
-const isMicrosoft = (url: string): boolean =>
-  new URL(url).hostname.includes(AZURE_AD_LOGIN_URL_HOSTNAME)
-
 const getURLWithSAMLRequestParam = (destination: string, slug: string) => {
   const template = `
   <samlp:AuthnRequest
@@ -89,9 +84,7 @@ const enableSAMLForDomain = {
     }
 
     // RESOLUTION
-    const url = isMicrosoft(signOnURL)
-      ? getURLWithSAMLRequestParam(signOnURL, normalizedName)
-      : signOnURL
+    const url = getURLWithSAMLRequestParam(signOnURL, normalizedName)
     await r
       .table('SAML')
       .insert(


### PR DESCRIPTION
fix #5985

SAMLRequest isn't required by all IdPs, but it does not harm to include it for all, so that's what this does.
Note this does NOT adjust the SAML records that have already been created. If some are broken there, we'll have to manually update them.

TEST
- [ ] call enableSAMLForDomain on the private schema locally for your email address (contact Matt for the metadata)
- [ ] try logging in locally & it just works (or at least gets you to okta) 🎉 