### PR TITLE
bump nest-graphql-endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.48.1 2022-Feb-28
+
+### Fixed
+
+- GitHub Poker Integration with 2+ dimensions
+
 ## 6.48.0 2022-Feb-25
 
 ### Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "6.48.0",
+  "version": "6.48.1",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.48.0",
+  "version": "6.48.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/packages/gql-executor/package.json
+++ b/packages/gql-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-executor",
-  "version": "6.48.0",
+  "version": "6.48.1",
   "description": "A Stateless GraphQL Executor",
   "author": "Matt Krick <matt.krick@gmail.com>",
   "homepage": "https://github.com/ParabolInc/parabol/tree/master/packages/gqlExecutor#readme",
@@ -29,6 +29,6 @@
   "dependencies": {
     "dd-trace": "^2.2.0",
     "parabol-client": "^6.48.0",
-    "parabol-server": "^6.48.0"
+    "parabol-server": "^6.48.1"
   }
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -2,7 +2,7 @@
   "name": "integration-tests",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.48.0",
+  "version": "6.48.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -124,7 +124,7 @@
     "mailgun.js": "^3.5.2",
     "mime-types": "^2.1.16",
     "ms": "^2.0.0",
-    "nest-graphql-endpoint": "^0.4.3",
+    "nest-graphql-endpoint": "^0.4.4",
     "node-env-flag": "0.1.0",
     "node-fetch": "^2.6.1",
     "node-pg-migrate": "^5.9.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.48.0",
+  "version": "6.48.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12452,10 +12452,10 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nest-graphql-endpoint@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/nest-graphql-endpoint/-/nest-graphql-endpoint-0.4.3.tgz#e5239c7b7c771c852f7ecb181237be5772ede901"
-  integrity sha512-RAUQIi25QyUM6Dp/7ccIn0b4mGF7bWazuvGla+uQOhu8Ljt5kg5L2aIZ6mc6ocQ8LkZ0S5ImwhvleJ5drrSlUA==
+nest-graphql-endpoint@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/nest-graphql-endpoint/-/nest-graphql-endpoint-0.4.4.tgz#45682c45b9450ce2c606e3e8a8271330d49bcc32"
+  integrity sha512-AXjw+O3ruJPJHrrdl7GUOlE964kS5kwTNFVXC+HVzzj9KW+6yrCM4JmMF2GHmDr6mWVQFb1LWYd1DQJtlpfE6A==
   dependencies:
     "@graphql-tools/merge" "^6.2.13"
     "@graphql-tools/schema" "^7.1.5"


### PR DESCRIPTION
This hotfixes the issue where github poker meetings with 2+ dimensions don't load the issues from github

 