### PR TITLE
feat: disable rate limiter in test

### DIFF
--- a/packages/server/graphql/__tests__/InMemoryRateLimiter.test.ts
+++ b/packages/server/graphql/__tests__/InMemoryRateLimiter.test.ts
@@ -1,0 +1,178 @@
+import ms from 'ms'
+import {InMemoryRateLimiter, InMemoryRateLimiterConfig} from '../InMemoryRateLimiter'
+
+describe('InMemoryRateLimiter', () => {
+  function subject(configOverrides: Partial<InMemoryRateLimiterConfig> = {}): InMemoryRateLimiter {
+    const configDefaults: Required<InMemoryRateLimiterConfig> = {
+      scheduleGc: false
+    }
+
+    return new InMemoryRateLimiter(Object.assign(configDefaults, configOverrides))
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers('modern')
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('when not using extended logging', () => {
+    it('returns 1 call for last minute & hour on the first call', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the user requests a field
+      const result = inMemoryRateLimiter.log(userId, fieldName, false)
+
+      // Then it returns 1 call last hour, 1 call last minute
+      expect(result).toEqual({lastMinute: 1, lastHour: 1})
+    })
+
+    it('returns 2 calls for last minute & undefined for last hour on the second call', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the same user requests the same field twice within the same minute
+      inMemoryRateLimiter.log(userId, fieldName, false)
+      jest.advanceTimersByTime(ms('30s'))
+      const secondResult = inMemoryRateLimiter.log(userId, fieldName, false)
+
+      // Then it returns 2 calls last minute, undefined call last hour
+      expect(secondResult).toEqual({lastMinute: 2, lastHour: undefined})
+    })
+
+    it('returns 1 call last minute when two calls occur a minute apart', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the same user requests the same field one minute apart
+      inMemoryRateLimiter.log(userId, fieldName, false)
+      jest.advanceTimersByTime(ms('1m'))
+      const secondResult = inMemoryRateLimiter.log(userId, fieldName, false)
+
+      // Then it returns 1 call last minute, undefined lastHour
+      expect(secondResult).toEqual({lastMinute: 1, lastHour: undefined})
+    })
+
+    it('does not reuse the same rate limit for different users', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const firstUserId = '123'
+      const secondUserId = '456'
+      const fieldName = 'FieldName'
+
+      // When a different user requests the same field 1 minute apart
+      inMemoryRateLimiter.log(firstUserId, fieldName, false)
+      jest.advanceTimersByTime(ms('1m'))
+      const secondUserFirstCallResult = inMemoryRateLimiter.log(secondUserId, fieldName, false)
+
+      // Then it returns 1 call last minute, 1 call lastHour
+      expect(secondUserFirstCallResult).toEqual({lastMinute: 1, lastHour: 1})
+    })
+  })
+
+  describe('when using extended logging', () => {
+    it('returns 1 call for last minute & hour on the first call', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the user requests a field
+      const result = inMemoryRateLimiter.log(userId, fieldName, true)
+
+      // Then it returns 1 call last hour, 1 call last minute
+      expect(result).toEqual({lastMinute: 1, lastHour: 1})
+    })
+
+    it('returns 2 calls for last minute & 1 for last hour on the second call', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the same user requests the same field twice within the same minute
+      inMemoryRateLimiter.log(userId, fieldName, true)
+      jest.advanceTimersByTime(ms('30s'))
+      const secondResult = inMemoryRateLimiter.log(userId, fieldName, true)
+
+      // Then it returns 2 calls last minute, 2 calls last hour
+      expect(secondResult).toEqual({lastMinute: 2, lastHour: 2})
+    })
+
+    it('returns 1 call last minute, 2 calls last hour when two calls occur a minute apart', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the same user requests the same field one minute apart
+      inMemoryRateLimiter.log(userId, fieldName, true)
+      jest.advanceTimersByTime(ms('1m'))
+      const secondResult = inMemoryRateLimiter.log(userId, fieldName, true)
+
+      // Then it returns 1 call last minute, 2 calls last hour
+      expect(secondResult).toEqual({lastMinute: 1, lastHour: 2})
+    })
+
+    it('returns 1 call last minute, 1 calls last hour when two calls occur an hour apart', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When the same user requests the same field one hour apart
+      inMemoryRateLimiter.log(userId, fieldName, true)
+      jest.advanceTimersByTime(ms('1h'))
+      const secondResult = inMemoryRateLimiter.log(userId, fieldName, true)
+
+      // Then it returns 1 call last hour, 1 call last minute
+      expect(secondResult).toEqual({lastMinute: 1, lastHour: 1})
+    })
+
+    it('does not reuse the same rate limit for different users', () => {
+      // Given
+      const inMemoryRateLimiter = subject()
+      const firstUserId = '123'
+      const secondUserId = '456'
+      const fieldName = 'FieldName'
+
+      // When a different user requests the same field 1 minute apart
+      inMemoryRateLimiter.log(firstUserId, fieldName, true)
+      jest.advanceTimersByTime(ms('1m'))
+      const secondUserFirstCallResult = inMemoryRateLimiter.log(secondUserId, fieldName, true)
+
+      // Then it returns 1 call last minute, 1 call lastHour
+      expect(secondUserFirstCallResult).toEqual({lastMinute: 1, lastHour: 1})
+    })
+  })
+
+  describe('gc', () => {
+    it('cleans up users who have not called the service in the last hour', () => {
+      // Given an InMemoryRateLimiter with scheduled GC enabled
+      const inMemoryRateLimiter = subject({scheduleGc: true})
+      const userId = '123'
+      const fieldName = 'FieldName'
+
+      // When a user requested a field, triggering gc twice
+      inMemoryRateLimiter.log(userId, fieldName, false)
+      jest.advanceTimersByTime(ms('1h'))
+      jest.advanceTimersByTime(ms('1h'))
+      // When the same user requests the same field two hours later
+      const secondResult = inMemoryRateLimiter.log(userId, fieldName, false)
+
+      // Then it returns 1 call last minute, 1 lastHour
+      // We're relying on the behavior that you receive 1 lastHour the first time the user calls without
+      // extended logging for this assertion. If the user was not GC'ed we've get lastMinute: 1, lastHour: undefined
+      expect(secondResult).toEqual({lastMinute: 1, lastHour: 1})
+    })
+  })
+})

--- a/packages/server/graphql/getRateLimiter.ts
+++ b/packages/server/graphql/getRateLimiter.ts
@@ -1,9 +1,9 @@
-import RateLimiter from './RateLimiter'
+import {InMemoryRateLimiter} from './InMemoryRateLimiter'
 
-let rateLimiter: RateLimiter
+let rateLimiter: InMemoryRateLimiter
 const getRateLimiter = () => {
   if (!rateLimiter) {
-    rateLimiter = new RateLimiter()
+    rateLimiter = new InMemoryRateLimiter()
   }
   return rateLimiter
 }

--- a/packages/server/graphql/graphql.ts
+++ b/packages/server/graphql/graphql.ts
@@ -2,14 +2,14 @@ import {GraphQLFieldConfig} from 'graphql'
 import AuthToken from '../database/types/AuthToken'
 import RootDataLoader from '../dataloader/RootDataLoader'
 import {CacheWorker} from './DataLoaderCache'
-import RateLimiter from './RateLimiter'
+import {InMemoryRateLimiter} from './InMemoryRateLimiter'
 
 // Avoid needless parsing & validating for the 300 hottest operations
 export type DataLoaderWorker = CacheWorker<RootDataLoader>
 
 export interface GQLContext {
   authToken: AuthToken
-  rateLimiter: RateLimiter
+  rateLimiter: InMemoryRateLimiter
   ip: string
   socketId: string
   dataLoader: DataLoaderWorker

--- a/packages/server/graphql/rateLimit.ts
+++ b/packages/server/graphql/rateLimit.ts
@@ -14,39 +14,38 @@ interface Options {
   perHour: number
 }
 
-const rateLimit = <TSource = any, TContext = GQLContext, TArgs = any>({
-  perMinute,
-  perHour
-}: Options) => (resolve: GraphQLFieldResolver<TSource, TContext, TArgs>) => (
-  source: TSource,
-  args: TArgs,
-  context: GQLContext,
-  info: GraphQLResolveInfo
-) => {
-  const {authToken, rateLimiter, ip} = context
-  const {fieldName, returnType} = info
-  const userId = getUserId(authToken) || ip
-  // when we scale horizontally & stop using sticky servers, periodically push to redis
-  const {lastMinute, lastHour} = rateLimiter.log(userId, fieldName, !!perHour)
-  if (lastMinute > perMinute || (lastHour && lastHour > perHour)) {
-    const returnVal = standardError(new Error('Rate limit reached'), {
-      userId,
-      tags: {query: fieldName, variables: JSON.stringify(args)}
-    })
-    // if (lastMinute > perMinute + 10) {
-    // TODO Handle suspected bot by dynamically blacklisting in nginx
-    // }
-    const baseType = ((returnType as GraphQLNonNull<GraphQLOutputType>).ofType ||
-      returnType) as GraphQLObjectType
-    const fields = baseType.getFields && baseType.getFields()
-    if (fields && fields.error) {
-      return returnVal
-    } else {
-      // this will get sanitized before sent to the client
-      throw new Error('429 Too Many Requests')
+const rateLimit =
+  <TSource = any, TContext = GQLContext, TArgs = any>({perMinute, perHour}: Options) =>
+  (resolve: GraphQLFieldResolver<TSource, TContext, TArgs>) =>
+  (source: TSource, args: TArgs, context: GQLContext, info: GraphQLResolveInfo) => {
+    const {authToken, rateLimiter, ip} = context
+    const {fieldName, returnType} = info
+    const userId = getUserId(authToken) || ip
+    // when we scale horizontally & stop using sticky servers, periodically push to redis
+    const {lastMinute, lastHour} = rateLimiter.log(userId, fieldName, !!perHour)
+    if (lastMinute > perMinute || (lastHour && lastHour > perHour)) {
+      if (process.env.NODE_ENV === 'test') {
+        return
+      }
+
+      const returnVal = standardError(new Error('Rate limit reached'), {
+        userId,
+        tags: {query: fieldName, variables: JSON.stringify(args)}
+      })
+      // if (lastMinute > perMinute + 10) {
+      // TODO Handle suspected bot by dynamically blacklisting in nginx
+      // }
+      const baseType = ((returnType as GraphQLNonNull<GraphQLOutputType>).ofType ||
+        returnType) as GraphQLObjectType
+      const fields = baseType.getFields && baseType.getFields()
+      if (fields && fields.error) {
+        return returnVal
+      } else {
+        // this will get sanitized before sent to the client
+        throw new Error('429 Too Many Requests')
+      }
     }
+    return resolve(source, args, context as any, info)
   }
-  return resolve(source, args, context as any, info)
-}
 
 export default rateLimit


### PR DESCRIPTION
This PR supersedes #6063. Instead of choosing between a StubRateLimiter and an InMemoryRateLimiter, we just disable it when `NODE_ENV` is `test`. See https://github.com/ParabolInc/parabol/pull/6063/files#r814362740 for details.

Relates to https://github.com/ParabolInc/parabol/issues/6018