### PR TITLE
fix #6043 only fetch new tasks

### DIFF
--- a/packages/client/hooks/useMakeStageSummaries.ts
+++ b/packages/client/hooks/useMakeStageSummaries.ts
@@ -14,33 +14,39 @@ interface StageSummary {
   finalScores: (string | null)[]
 }
 
+graphql`
+  fragment useMakeStageSummaries_stages on EstimateStage @relay(plural: true) {
+    id
+    finalScore
+    isComplete
+    isNavigable
+    sortOrder
+    taskId
+    task {
+      title
+      integration {
+        ... on JiraIssue {
+          __typename
+          issueKey
+          summary
+        }
+        ... on _xGitHubIssue {
+          __typename
+          title
+          number
+        }
+      }
+    }
+  }
+`
+
 const useMakeStageSummaries = (phaseRef: useMakeStageSummaries_phase$key, localStageId: string) => {
   const estimatePhase = readInlineData(
     graphql`
       fragment useMakeStageSummaries_phase on EstimatePhase @inline {
         phaseType
         stages {
-          id
-          finalScore
-          isComplete
-          isNavigable
-          sortOrder
-          taskId
-          task {
-            title
-            integration {
-              ... on JiraIssue {
-                __typename
-                issueKey
-                summary
-              }
-              ... on _xGitHubIssue {
-                __typename
-                title
-                number
-              }
-            }
-          }
+          ...useMakeStageSummaries_stages @relay(mask: false)
         }
       }
     `,

--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -16,45 +16,50 @@ import {
 
 graphql`
   fragment UpdatePokerScopeMutation_meeting on UpdatePokerScopeSuccess {
+    newStages {
+      ...useMakeStageSummaries_stages
+      ...PokerEstimateHeaderCard_stage
+      ...PokerCardDeckStage
+      ...EstimatePhaseAreaStage
+      ...JiraFieldDimensionDropdown_stage
+      ...EstimateDimensionColumn_stage
+      ...EstimatePhaseDiscussionDrawerEstimateStage
+      id
+      isNavigableByFacilitator
+      sortOrder
+      isVoting
+      taskId
+      dimensionRef {
+        name
+        scale {
+          values {
+            color
+            label
+          }
+        }
+      }
+      serviceField {
+        name
+        type
+      }
+      scores {
+        userId
+        label
+        stageId
+        user {
+          picture
+          preferredName
+        }
+      }
+    }
     meeting {
-      facilitatorStageId
       phases {
-        ...useMakeStageSummaries_phase
         ... on EstimatePhase {
           stages {
-            ...PokerEstimateHeaderCard_stage
-            ...PokerCardDeckStage
-            ...EstimatePhaseAreaStage
-            ...JiraFieldDimensionDropdown_stage
-            ...EstimateDimensionColumn_stage
-            ...EstimatePhaseDiscussionDrawerEstimateStage
+            # separate out newStages from all stages so we don't have to fetch
+            # all the stage integrations on every update
+            # still fetch IDs so we can handle removes
             id
-            isNavigableByFacilitator
-            sortOrder
-            isVoting
-            taskId
-            dimensionRef {
-              name
-              scale {
-                values {
-                  color
-                  label
-                }
-              }
-            }
-            serviceField {
-              name
-              type
-            }
-            scores {
-              userId
-              label
-              stageId
-              user {
-                picture
-                preferredName
-              }
-            }
           }
         }
       }
@@ -89,6 +94,17 @@ const UpdatePokerScopeMutation: StandardMutation<TUpdatePokerScopeMutation, Hand
   return commitMutation<TUpdatePokerScopeMutation>(atmosphere, {
     mutation,
     variables,
+    updater: (store) => {
+      const payload = store.getRootField('updatePokerScope')
+      const meeting = payload.getLinkedRecord('meeting')
+      const newStages = payload.getLinkedRecords('newStages')
+      if (!meeting || !newStages) return
+      const phases = meeting.getLinkedRecords('phases')
+      const estimatePhase = phases.find((phase) => phase.getType() === 'EstimatePhase')!
+      const stages = estimatePhase.getLinkedRecords('stages')
+      const nextStages = [...stages, ...newStages]
+      estimatePhase.setLinkedRecords(nextStages, 'stages')
+    },
     optimisticUpdater: (store) => {
       const viewer = store.getRoot().getLinkedRecord('viewer')
       if (!viewer) return
@@ -140,7 +156,8 @@ const UpdatePokerScopeMutation: StandardMutation<TUpdatePokerScopeMutation, Hand
           )
           const stageExists = stageIntegrationHashes.includes(serviceTaskId)
           if (stageExists) return
-          const lastSortOrder = stages[stages.length - 1]?.getValue('sortOrder') ?? -1
+          const lastStage = stages[stages.length - 1]!
+          const lastSortOrder = (lastStage.getValue('sortOrder') as number) ?? -1
 
           // create a task if it doesn't exist
           const plaintextContent = contents[idx] ?? ''
@@ -182,8 +199,9 @@ const UpdatePokerScopeMutation: StandardMutation<TUpdatePokerScopeMutation, Hand
             optimisticTask.setLinkedRecord(optimisticTaskIntegration, 'integration')
           } else if (service === 'github') {
             const bodyHTML = stateToHTML(contentState)
-            const {issueNumber, nameWithOwner, repoName, repoOwner} =
-              GitHubIssueId.split(serviceTaskId)
+            const {issueNumber, nameWithOwner, repoName, repoOwner} = GitHubIssueId.split(
+              serviceTaskId
+            )
             const repository = createProxyRecord(store, '_xGitHubRepository', {
               nameWithOwner,
               name: repoName,

--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -139,6 +139,7 @@ const updatePokerScope = {
       meetingId
     )
 
+    let newStageIds = [] as string[]
     additiveUpdatesWithTaskIds.forEach((update) => {
       const {serviceTaskId, taskId} = update
       const lastSortOrder = stages[stages.length - 1]?.sortOrder ?? -1
@@ -164,6 +165,7 @@ const updatePokerScope = {
       // MUTATIVE
       newDiscussions.push(...discussions)
       stages.push(...newStages)
+      newStageIds = newStages.map(({id}) => id)
     })
 
     if (stages.length > Threshold.MAX_POKER_STORIES * dimensions.length) {
@@ -181,7 +183,7 @@ const updatePokerScope = {
     if (newDiscussions.length > 0) {
       await insertDiscussions(newDiscussions)
     }
-    const data = {meetingId}
+    const data = {meetingId, newStageIds}
     publish(SubscriptionChannel.MEETING, meetingId, 'UpdatePokerScopeSuccess', data, subOptions)
     await redisLock.unlock()
     return data

--- a/packages/server/graphql/types/UpdatePokerScopePayload.ts
+++ b/packages/server/graphql/types/UpdatePokerScopePayload.ts
@@ -1,5 +1,8 @@
-import {GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import {GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import getPhase from '../../utils/getPhase'
 import {GQLContext} from '../graphql'
+import {resolveGQLStagesFromPhase} from '../resolvers'
+import EstimateStage from './EstimateStage'
 import makeMutationPayload from './makeMutationPayload'
 import PokerMeeting from './PokerMeeting'
 
@@ -11,6 +14,23 @@ export const UpdatePokerScopeSuccess = new GraphQLObjectType<any, GQLContext>({
       description: 'The meeting with the updated estimate phases',
       resolve: ({meetingId}, _args: unknown, {dataLoader}) => {
         return dataLoader.get('newMeetings').load(meetingId)
+      }
+    },
+    newStages: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(EstimateStage))),
+      description: 'The estimate stages added to the meeting',
+      resolve: async ({meetingId, newStageIds}, _args: unknown, {dataLoader}) => {
+        const meeting = await dataLoader.get('newMeetings').load(meetingId)
+        const {phases, teamId} = meeting
+        const phase = getPhase(phases, 'ESTIMATE')
+        const {stages} = phase
+        const dbNewStages = stages.filter((stage) => newStageIds.includes(stage.id))
+        return resolveGQLStagesFromPhase({
+          meetingId,
+          phaseType: 'ESTIMATE',
+          stages: dbNewStages,
+          teamId
+        })
       }
     }
   })


### PR DESCRIPTION
fix #6043

Before, every add/remove to the poker scope would trigger a refetch of all stages, including the task for that stage, which included the integration associated with that task. That means if I had 50 stages & removed one, it'd reach out to jira or github 49 times just to remove the stage!

Now, it only reaches out to integrations for new stages, which makes sense because it needs to grab the title, description, etc. 
For removals, it doesn't reach out to any integrations.

TEST
- [ ] add 3 jira issues, look at the websocket response payload for the 3rd issue added. notice that newStages is an array that only includes 1 item per dimension

