### PR TITLE
feat(analytics): support querying organization for superusers

### DIFF
--- a/packages/server/graphql/intranetSchema/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/intranetSchema/mutations/draftEnterpriseInvoice.ts
@@ -26,10 +26,9 @@ const getBillingLeaderUser = async (
       throw new Error('User for email not found')
     }
     const {id: userId} = user
-    const organizationUsers = await dataLoader.get('organizationUsersByUserId').load(userId)
-    const organizationUser = organizationUsers.find(
-      (organizationUser) => organizationUser.orgId === orgId
-    )
+    const organizationUser = await dataLoader
+      .get('organizationUsersByUserIdOrgId')
+      .load({userId, orgId})
     if (!organizationUser) {
       throw new Error('Email not associated with a user on that org')
     }

--- a/packages/server/graphql/queries/organization.ts
+++ b/packages/server/graphql/queries/organization.ts
@@ -1,8 +1,7 @@
-import {GQLContext} from './../graphql'
 import {GraphQLID, GraphQLNonNull} from 'graphql'
+import {getUserId, isSuperUser} from '../../utils/authorization'
 import Organization from '../types/Organization'
-import {getUserId} from '../../utils/authorization'
-import OrganizationUser from '../../database/types/OrganizationUser'
+import {GQLContext} from './../graphql'
 
 export default {
   type: Organization,
@@ -12,26 +11,18 @@ export default {
       description: 'the orgId'
     }
   },
-  description: 'get a single organization and the count of users by status',
+  description: 'get a single organization',
   resolve: async (
-    {id: userId}: {id: string},
+    _source: unknown,
     {orgId}: {orgId: string},
     {authToken, dataLoader}: GQLContext
   ) => {
     const viewerId = getUserId(authToken)
-
-    const organizationUsers = await dataLoader.get('organizationUsersByUserId').load(userId)
-    const organizationUser = organizationUsers.find(
-      (organizationUser: OrganizationUser) => organizationUser.orgId === orgId
-    )
-    if (!organizationUser) return null
-    const organization = await dataLoader.get('organizations').load(orgId)
-    if (viewerId === userId) return organization
-
-    const viewerOrganizationUsers = await dataLoader.get('organizationUsersByUserId').load(userId)
-    const viewerOrganizationUser = viewerOrganizationUsers.find(
-      (organizationUser: OrganizationUser) => organizationUser.orgId === orgId
-    )
-    return viewerOrganizationUser ? organization : null
+    const [organization, viewerOrganizationUser] = await Promise.all([
+      dataLoader.get('organizations').load(orgId),
+      dataLoader.get('organizationUsersByUserIdOrgId').load({userId: viewerId, orgId})
+    ])
+    if (!isSuperUser(authToken) && !viewerOrganizationUser) return null
+    return organization
   }
 } as any

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -1,4 +1,3 @@
-import MeetingMemberId from 'parabol-client/shared/gqlIds/MeetingMemberId'
 import {
   GraphQLBoolean,
   GraphQLID,
@@ -8,6 +7,7 @@ import {
   GraphQLObjectType,
   GraphQLString
 } from 'graphql'
+import MeetingMemberId from 'parabol-client/shared/gqlIds/MeetingMemberId'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import {
   AUTO_GROUPING_THRESHOLD,
@@ -15,8 +15,14 @@ import {
   MAX_RESULT_GROUP_SIZE
 } from '../../../client/utils/constants'
 import groupReflections from '../../../client/utils/smartGroup/groupReflections'
-import getPg from '../../postgres/getPg'
 import getRethink from '../../database/rethinkDriver'
+import MeetingMemberType from '../../database/types/MeetingMember'
+import OrganizationType from '../../database/types/Organization'
+import OrganizationUserType from '../../database/types/OrganizationUser'
+import Reflection from '../../database/types/Reflection'
+import SuggestedActionType from '../../database/types/SuggestedAction'
+import TeamInvitation from '../../database/types/TeamInvitation'
+import getPg from '../../postgres/getPg'
 import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import getDomainFromEmail from '../../utils/getDomainFromEmail'
 import getMonthlyStreak from '../../utils/getMonthlyStreak'
@@ -25,6 +31,7 @@ import isCompanyDomain from '../../utils/isCompanyDomain'
 import standardError from '../../utils/standardError'
 import errorFilter from '../errorFilter'
 import {DataLoaderWorker, GQLContext} from '../graphql'
+import isValid from '../isValid'
 import invoiceDetails from '../queries/invoiceDetails'
 import invoices from '../queries/invoices'
 import organization from '../queries/organization'
@@ -46,14 +53,7 @@ import TeamMember from './TeamMember'
 import TierEnum from './TierEnum'
 import {TimelineEventConnection} from './TimelineEvent'
 import UserFeatureFlags from './UserFeatureFlags'
-import OrganizationUserType from '../../database/types/OrganizationUser'
-import TeamInvitation from '../../database/types/TeamInvitation'
-import OrganizationType from '../../database/types/Organization'
-import SuggestedActionType from '../../database/types/SuggestedAction'
-import MeetingMemberType from '../../database/types/MeetingMember'
 import {UserFeatureFlagEnum} from './UserFlagEnum'
-import Reflection from '../../database/types/Reflection'
-import isValid from '../isValid'
 
 const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLContext>({
   name: 'User',
@@ -363,22 +363,13 @@ const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLC
         }
       },
       resolve: async ({id: userId}: {id: string}, {orgId}, {authToken, dataLoader}: GQLContext) => {
-        // AUTH
         const viewerId = getUserId(authToken)
-        const organizationUsers = await dataLoader.get('organizationUsersByUserId').load(userId)
-        const organizationUsersForOrgId = organizationUsers.find(
-          (organizationUser: OrganizationUserType) => organizationUser.orgId === orgId
-        )
-        if (viewerId === userId || isSuperUser(authToken)) {
-          return organizationUsersForOrgId
-        }
-        const viewerOrganizationUsers = await dataLoader
-          .get('organizationUsersByUserId')
-          .load(viewerId)
-        const viewerOrganizationUsersForOrgId = viewerOrganizationUsers.find(
-          (organizationUser: OrganizationUserType) => organizationUser.orgId === orgId
-        )
-        return viewerOrganizationUsersForOrgId ? organizationUsersForOrgId : null
+        const [viewerOrganizationUser, userOrganizationUser] = await Promise.all([
+          dataLoader.get('organizationUsersByUserIdOrgId').load({userId: viewerId, orgId}),
+          dataLoader.get('organizationUsersByUserIdOrgId').load({userId, orgId})
+        ])
+        if (viewerOrganizationUser || isSuperUser(authToken)) return userOrganizationUser
+        return null
       }
     },
     organizationUsers: {
@@ -491,7 +482,7 @@ const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLC
             plaintextContent.toLowerCase().includes(searchQuery)
           )
           const relatedReflections = matchedReflections.filter(
-            ({reflectionGroupId: groupId}: Reflection) => groupId != reflectionGroupId
+            ({reflectionGroupId: groupId}: Reflection) => groupId !== reflectionGroupId
           )
           const relatedGroupIds = [
             ...new Set(relatedReflections.map(({reflectionGroupId}) => reflectionGroupId))

--- a/packages/server/utils/authorization.ts
+++ b/packages/server/utils/authorization.ts
@@ -54,10 +54,9 @@ export const isUserBillingLeader = async (
   dataLoader: DataLoaderWorker,
   options?: Options
 ) => {
-  const organizationUsers = await dataLoader.get('organizationUsersByUserId').load(userId)
-  const organizationUser = organizationUsers.find(
-    (organizationUser: OrganizationUser) => organizationUser.orgId === orgId
-  )
+  const organizationUser = await dataLoader
+    .get('organizationUsersByUserIdOrgId')
+    .load({userId, orgId})
   if (options && options.clearCache) {
     dataLoader.get('organizationUsersByUserId').clear(userId)
   }


### PR DESCRIPTION
I realized i couldn't get the name of an organization from graphiql, now i can.

TEST
```gql
viewer {
  organization(orgId: "foo") {
    name
  }
}
```
- [ ] the above query works for an organization that you're not a part of as long as you're a super user