### PR TITLE
fix(jira): remove calculated fields from dropdown

### DIFF
--- a/packages/server/dataloader/atlassianLoaders.ts
+++ b/packages/server/dataloader/atlassianLoaders.ts
@@ -216,7 +216,12 @@ export const jiraIssue = (
               new Set(
                 Object.entries<{type: string}>(issueRes.schema)
                   .filter(([fieldId, fieldSchema]) =>
-                    isValidEstimationField(fieldSchema.type, issueRes.names[fieldId], simplified)
+                    isValidEstimationField(
+                      fieldSchema.type,
+                      issueRes.names[fieldId],
+                      fieldId,
+                      simplified
+                    )
                   )
                   .map(([fieldId]) => {
                     return issueRes.names[fieldId]

--- a/packages/server/utils/atlassian/jiraFields.ts
+++ b/packages/server/utils/atlassian/jiraFields.ts
@@ -1,10 +1,12 @@
 const VALID_TYPES = ['string', 'number']
 const INVALID_WORDS = ['color', 'name', 'description', 'environment']
+const INVALID_ID_PREFIXES = ['aggregate']
 import {SprintPokerDefaults} from '~/types/constEnums'
 
 export const isValidEstimationField = (
   fieldType: string,
   fieldName: string,
+  fieldId: string,
   simplified: boolean
 ) => {
   if (!VALID_TYPES.includes(fieldType)) return false
@@ -12,7 +14,7 @@ export const isValidEstimationField = (
   for (let i = 0; i < INVALID_WORDS.length; i++) {
     if (fieldNameLower.includes(INVALID_WORDS[i]!)) return false
   }
-
+  if (INVALID_ID_PREFIXES.some((prefix) => fieldId.startsWith(prefix))) return false
   if (
     (!simplified && fieldNameLower === SprintPokerDefaults.JIRA_FIELD_DEFAULT.toLowerCase()) ||
     (simplified && fieldNameLower === SprintPokerDefaults.JIRA_FIELD_LEGACY_DEFAULT.toLowerCase())


### PR DESCRIPTION
Fix #5864
This removes the aggregated fields from the dropdown. Those fields are calculated & read-only, anyways.

TEST
- Look at the screenshot. no fields start wtih a big sigma
<img width="277" alt="Screen Shot 2022-03-03 at 2 59 57 PM" src="https://user-images.githubusercontent.com/5514175/156667305-610f34d0-e74e-4b8e-8a4c-f42733921288.png">
