### PR TITLE
feat(standups): Added empty team prompt meeting component

### DIFF
--- a/packages/client/components/MeetingSelector.tsx
+++ b/packages/client/components/MeetingSelector.tsx
@@ -19,7 +19,10 @@ interface Props {
 const meetingLookup = {
   action: lazyPreload(() => import(/* webpackChunkName: 'ActionMeeting' */ './ActionMeeting')),
   poker: lazyPreload(() => import(/* webpackChunkName: 'PokerMeeting' */ './PokerMeeting')),
-  retrospective: lazyPreload(() => import(/* webpackChunkName: 'RetroMeeting' */ './RetroMeeting'))
+  retrospective: lazyPreload(() => import(/* webpackChunkName: 'RetroMeeting' */ './RetroMeeting')),
+  teamPrompt: lazyPreload(
+    () => import(/* webpackChunkName: 'TeamPromptMeeting' */ './TeamPromptMeeting')
+  )
 }
 
 const MeetingSelector = (props: Props) => {

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -1,0 +1,9 @@
+interface Props {
+  meeting: any
+}
+
+const TeamPromptMeeting = (_props: Props) => {
+  return null
+}
+
+export default TeamPromptMeeting


### PR DESCRIPTION
Fixes #5932, #5933 

This PR adds an empty implementation of `TeamPromptMeeting` component and handling of a new meeting type in the `MeetingSelector`. Not much to review here, as the main purpose is to unblock the work on the UI of standups while the backend is still in progress.