### PR TITLE
ci: use official postgres image & sync with digital ocean version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: cimg/node:16.14.0
       - image: rethinkdb:2.4.0
-      - image: circleci/postgres:12.3
+      - image: postgres:12.3
         environment:
           # These env values need to be synced up with the `test` environment file
           POSTGRES_PASSWORD: "p9_p455w02d_f02_73575"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: cimg/node:16.14.0
       - image: rethinkdb:2.4.0
-      - image: postgres:12.3
+      - image: cimg/postgres:12.9 # TODO: update to 12.10 when https://github.com/CircleCI-Public/cimg-postgres/pull/42 is merged
         environment:
           # These env values need to be synced up with the `test` environment file
           POSTGRES_PASSWORD: "p9_p455w02d_f02_73575"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     networks:
       - parabol-network
   postgres:
-    image: postgres:12.5
+    image: postgres:12.10
     restart: always
     env_file: .env
     ports:

--- a/packages/server/postgres/Dockerfile
+++ b/packages/server/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.3
+FROM postgres:12.10
 
 ADD extensions /extensions
 


### PR DESCRIPTION
I noticed today that CircleCI started badging our builds with this warning about using deprecated images ([link from screenshot](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)).

![Screen Shot 2022-03-08 at 16 35 00](https://user-images.githubusercontent.com/630449/157343910-5cdf3b16-e784-4ddf-aaab-d456c06e051e.png)

We just needed to switch over to using the official postgres image vs. the `circle/` prefixed one.