### PR TITLE
chore: Drop unused MattermostAuth table

### DIFF
--- a/packages/server/postgres/migrations/1647259140753_dropMattermostAuthTable.ts
+++ b/packages/server/postgres/migrations/1647259140753_dropMattermostAuthTable.ts
@@ -1,0 +1,15 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    DROP TABLE "MattermostAuth";
+  `)
+  await client.end()
+}
+
+export async function down() {
+  // No undo magic, table was migrated some time ago in https://github.com/ParabolInc/parabol/pull/5829
+}

--- a/packages/server/postgres/migrations/1647259140753_dropMattermostAuthTable.ts
+++ b/packages/server/postgres/migrations/1647259140753_dropMattermostAuthTable.ts
@@ -5,7 +5,7 @@ export async function up() {
   const client = new Client(getPgConfig())
   await client.connect()
   await client.query(`
-    DROP TABLE "MattermostAuth";
+    DROP TABLE IF EXISTS "MattermostAuth";
   `)
   await client.end()
 }


### PR DESCRIPTION
The table was unused since #5829.
https://github.com/ParabolInc/parabol/blob/eb295331feba7e2534c48012d252c2a52b802905/packages/server/postgres/migrations/1640229261909_mattermostToIntegrationsTables.ts#L72
Now is later.