### PR TITLE
create env var and logic for FULLSCREEN auth dialog

### DIFF
--- a/packages/client/types/modules.d.ts
+++ b/packages/client/types/modules.d.ts
@@ -28,6 +28,7 @@ interface Window {
     AUTH_INTERNAL_ENABLED: boolean
     AUTH_GOOGLE_ENABLED: boolean
     AUTH_SSO_ENABLED: boolean
+    UI_AUTH_FULLSCREEN: boolean
   }
 }
 declare type Json = null | boolean | number | string | Json[] | {[key: string]: Json}

--- a/packages/client/utils/getOAuthPopupFeatures.ts
+++ b/packages/client/utils/getOAuthPopupFeatures.ts
@@ -1,3 +1,4 @@
+
 interface Box {
   width: number
   height: number
@@ -11,6 +12,12 @@ const getOAuthPopupFeatures = ({width, height, top}: Box) => {
   const left = Math.round(startX + (innerWidth - width) / 2)
   // 64 is the Parabol header
   const topOff = Math.round(startY + (innerHeight - height) / 2 + top)
+  const {UI_AUTH_FULLSCREEN} = window.__ACTION__
+  console.log(UI_AUTH_FULLSCREEN)
+  if (UI_AUTH_FULLSCREEN)
+  {
+    return `popup,width=${outerWidth},height=${outerHeight},left=${left},top=${topOff}`
+  }
   return `popup,width=${width},height=${height},left=${left},top=${topOff}`
 }
 

--- a/packages/client/utils/getOAuthPopupFeatures.ts
+++ b/packages/client/utils/getOAuthPopupFeatures.ts
@@ -13,7 +13,7 @@ const getOAuthPopupFeatures = ({width, height, top}: Box) => {
   // 64 is the Parabol header
   const topOff = Math.round(startY + (innerHeight - height) / 2 + top)
   const {UI_AUTH_FULLSCREEN} = window.__ACTION__
-  console.log(UI_AUTH_FULLSCREEN)
+
   if (UI_AUTH_FULLSCREEN)
   {
     return `popup,width=${outerWidth},height=${outerHeight},left=${left},top=${topOff}`

--- a/packages/server/createSSR.ts
+++ b/packages/server/createSSR.ts
@@ -22,7 +22,8 @@ const getClientKeys = () => {
     prblIn: process.env.INVITATION_SHORTLINK,
     AUTH_INTERNAL_ENABLED: process.env.AUTH_INTERNAL_DISABLED !== 'true',
     AUTH_GOOGLE_ENABLED: process.env.AUTH_GOOGLE_DISABLED !== 'true',
-    AUTH_SSO_ENABLED: process.env.AUTH_SSO_DISABLED !== 'true'
+    AUTH_SSO_ENABLED: process.env.AUTH_SSO_DISABLED !== 'true',
+    UI_AUTH_FULLSCREEN: process.env.UI_AUTH_FULLSCREEN !== 'false'
   }
 }
 

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -133,7 +133,8 @@ module.exports = {
         prblIn: process.env.INVITATION_SHORTLINK,
         AUTH_INTERNAL_ENABLED: process.env.AUTH_INTERNAL_DISABLED !== 'true',
         AUTH_GOOGLE_ENABLED: process.env.AUTH_GOOGLE_DISABLED !== 'true',
-        AUTH_SSO_ENABLED: process.env.AUTH_SSO_DISABLED !== 'true'
+        AUTH_SSO_ENABLED: process.env.AUTH_SSO_DISABLED !== 'true',
+        UI_AUTH_FULLSCREEN: process.env.UI_AUTH_FULLSCREEN !== 'false'
       })
     }),
     new ReactRefreshWebpackPlugin(),


### PR DESCRIPTION
Resolves #6204 this was requested by non Parabol SaaS users as they had to scroll. On the public SaaS Parabol UI_AUTH_FULLSCREEN would be set to false