### PR TITLE
chore(comments): future of constants on client

### DIFF
--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -1,3 +1,14 @@
+/*
+  This file was created years ago.
+  Since then, const enums have largely been considered a mistake by Typescript because
+  they don't bundle well & changes to const enums require re-transpiling every single file.
+  Today, we get around this by compiling const enums to enums, which doesn't save as much space
+  But makes life easier in development.
+
+  Before adding a new enum, please consider the following:
+  - Are the values easy to read? If so, a string union might be a better choice
+  - Does the value live on the server? Then get it there (usually via a generated GraphQL type) instead of creating a second source of truth
+*/
 export const enum AppBar {
   HEIGHT = 56
 }

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -1,10 +1,16 @@
+/*
+ This file was created before we used TypeScript
+ Now that everything is strongly typed, we no longer need it & should work to deprecate it
+ Instead of adding variables to this file, please consider this list of alternatives:
+ - Does the variable come from the GraphQL schema? If so, import it from a file in the __generated__ folder
+ - Is the variable a string? Create a string union & pass in a plain string to get type safety
+*/
 import {TaskStatusEnum} from '~/__generated__/UpdateTaskMutation.graphql'
 
 /**
  * Big stuff:
  */
 export const APP_CDN_USER_ASSET_SUBDIR = '/store'
-export const APP_NAME = 'Action'
 
 /* Meeting Misc. */
 export const MEETING_NAME = 'Check-in Meeting'


### PR DESCRIPTION
Added comments on future direction of how we handle string constants, const enums, enums, etc.

In the bad old days, we didn't use typescript, so string constants were a nice way to avoid typos.
They're still good for naming hard-to-name things like color hex values.

Typescript enums are not equivalent to their string counterparts. For example, if something expects a string union, you can't pass in an enum, even if the underlying values are the same! So, they're not as useful as we once thought.

So as a rule of thumb:
- if the value comes from the server, try to reference it from that instead of making a second source of truth on the client
- If a value can be a string union, try to do that

Still not sure about all the best practices, but it's a start 🤷 