### PR TITLE
Notify when user scrolls to the end of an archive

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -194,8 +194,10 @@ const TeamArchive = (props: Props) => {
   }
   const isRowLoaded = ({index}) => index < edges.length
   const maybeLoadMore = () => {
-    if (!hasNext || isLoadingNext) return
-    loadNext(columnCount * 10)
+    if (!hasNext || isLoadingNext) return Promise.resolve()
+    return new Promise<void>((resolve, reject) => {
+      loadNext(columnCount * 10, {onComplete: (err) => (err ? reject(err) : resolve())})
+    })
   }
   const [cellCache] = useState(
     () =>

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -246,7 +246,7 @@ const TeamArchive = (props: Props) => {
     oldEdgesRef.current = edges
   }, [edges, oldEdgesRef])
 
-  const rowRenderer = ({columnIndex, parent, rowIndex, key, style}) => {
+  const cellRenderer = ({columnIndex, parent, rowIndex, key, style}) => {
     // TODO render a very inexpensive lo-fi card while scrolling. We should reuse that cheap card for drags, too
     const index = getIndex(columnIndex, rowIndex)
     if (!isRowLoaded({index})) return undefined
@@ -280,7 +280,7 @@ const TeamArchive = (props: Props) => {
     )
   }
 
-  const _onSectionRendered = ({columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex}) => {
+  const onSectionRendered = ({columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex}) => {
     if (!_onRowsRenderedRef.current) return
     _onRowsRenderedRef.current({
       startIndex: getIndex(columnStartIndex, rowStartIndex),
@@ -314,7 +314,7 @@ const TeamArchive = (props: Props) => {
                         {({height, width}) => {
                           return (
                             <Grid
-                              cellRenderer={rowRenderer}
+                              cellRenderer={cellRenderer}
                               columnCount={columnCount}
                               columnWidth={CARD_WIDTH}
                               deferredMeasurementCache={cellCache}
@@ -322,7 +322,7 @@ const TeamArchive = (props: Props) => {
                               estimatedRowSize={182}
                               height={height}
                               onRowsRendered={onRowsRendered}
-                              onSectionRendered={_onSectionRendered}
+                              onSectionRendered={onSectionRendered}
                               ref={(c) => {
                                 gridRef.current = c
                                 registerChild(c)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,6 +32,7 @@
     "@types/react-relay": "^11.0.2",
     "@types/react-router": "^5.0.3",
     "@types/react-router-dom": "^4.3.2",
+    "@types/react-virtualized": "^9.21.20",
     "@types/relay-runtime": "^12.0.0",
     "@types/segment-analytics": "^0.0.31",
     "@types/stripe-v2": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4058,6 +4058,14 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-virtualized@^9.21.20":
+  version "9.21.20"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.20.tgz#756c78b5512a2a1804fdaf749a5f5cff3d805e5b"
+  integrity sha512-i8nZf1LpuX5rG4DZLaPGayIQwjxsZwmst5VdNhEznDTENel9p3A735AdRRp2iueFOyOuWBmaEaDxg8AD3GHilA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.9.11":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"


### PR DESCRIPTION
Hello
Below you can find my attempt to deal with #1450

According to my quick research 
- There is no such functionality in react-virtualized lib to help deal with such case (compared with https://github.com/ankeetmaini/react-infinite-scroll-component or similar libs)  
- I tried to use CSS `::after` pseudo-element with content, but unfortunately it was hard to central it inside the container with scrolling on different resolutions (same issue with complicated way to change react-virtualized controls)
<img width="1920" alt="Screenshot 2022-03-18 at 11 36 50" src="https://user-images.githubusercontent.com/790487/158988212-a41c2504-89d9-4eed-b28e-f26b1524fae8.png">


Then I realised that snackbar control can be used for this purpose.  So when (and only if) user scrolled to the end of grid and there are not more items to load, then you snackbar will be shown.

And it's looks much better/native to me than result of previous attempt.
<img width="1483" alt="Screenshot 2022-03-18 at 13 11 56" src="https://user-images.githubusercontent.com/790487/158988294-084f3ad9-71c8-4ff1-bce2-ac422fa6795b.png">

