### PR TITLE
Add flow diagram for services

### DIFF
--- a/docs/serviceDiagram.md
+++ b/docs/serviceDiagram.md
@@ -1,0 +1,60 @@
+# Service architecture
+Overview how the different services interact with each other.
+
+## Flow
+Data flow for a GraphQL request which also publishes subscription data.
+```mermaid
+flowchart TD
+  Client
+  Server[Websocket/Subscription server]
+  RedisStream(Redis Stream)
+  RedisResultPubSub(Redis PubSub\ngqlExRes)
+  RedisSubscriptionPubSub(Redis PubSub\nTeam.teamId)
+  subgraph "per executor {serverChannel}"
+    GQLExecutor[GraphQL Executor]
+    RedisServerPubSub(Redis PubSub\nserverChannel)
+    RedisServerPubSub --> GQLExecutor
+  end
+
+  click Server "../packages/server/server.ts"
+  click RedisResultPubSub "../packages/server/utils/getPubSub.ts"
+  click GQLExecutor "../packages/gql-executor/gqlExecutor.ts"
+
+  Client <---->|Websocket| Server
+  Server -->|gqlStream| RedisStream -->|gqlConsumerGroup| GQLExecutor
+  GQLExecutor --> RedisResultPubSub
+  GQLExecutor --> |"{serverChannel}"| RedisSubscriptionPubSub
+  RedisSubscriptionPubSub --> |"{serverChannel}"|Server
+  Server --> RedisServerPubSub
+  RedisResultPubSub --> Server
+```
+
+## Sequence
+Example sequence of a mutation `updateTeamName`.
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Server
+  participant Redis
+  participant GQLExecutor
+
+  Client ->>+ Server: updateTeamName
+  Server ->> Redis: gqlStream
+  Redis ->>+ GQLExecutor: gqlConsumerGroup
+  note over GQLExecutor: resolve mutation
+  par Resolve and return result
+    GQLExecutor ->> Redis: gqlExRes
+    Redis ->> Server: gqlExRes
+    Server ->>- Client: execution result
+  and Publish subscription
+    GQLExecutor ->>- Redis: Team.teamId
+    Redis ->>+ Server: Team.teamId
+    Server ->> Redis: serverChannel
+    Redis ->>+ GQLExecutor: serverChannel
+    note over GQLExecutor: resolve subscription
+    GQLExecutor ->>- Redis: gqlExRes
+    Redis ->> Server: gqlExRes
+    Server ->>- Client: subscription next
+  end
+
+```


### PR DESCRIPTION
I created a diagram to help me understand how we're using the different
redis channels to connect the server with the GQL executor.

Relates to: #5910 