### PR TITLE
chore: Remove backfilling invoices logic from migration

### DIFF
--- a/packages/server/database/migrations/20170516165400-backfillInvoices.js
+++ b/packages/server/database/migrations/20170516165400-backfillInvoices.js
@@ -1,3 +1,4 @@
+/*
 import stripe from '../../billing/stripe'
 
 const fetchAllInvoices = async () => {
@@ -36,6 +37,10 @@ exports.up = async (r) => {
   } catch (e) {
     // noop
   }
+}
+*/
+exports.up = async (r) => {
+  // invoices where migrated years ago and the legacy stripe logic was removed in #6161
 }
 
 exports.down = async () => {


### PR DESCRIPTION
Migration is many years old and the used stripe manager was deleted in
PR #6161.