### PR TITLE
chore: remove postcommit git command

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn run postcommit

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "update-schema": "node scripts/updateSchemaCLI.js",
     "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
     "precommit": "lerna run --stream precommit",
-    "postcommit": "git update-index --again",
     "prepare": "husky install"
   },
   "resolutions": {


### PR DESCRIPTION
This PR removes the `postcommit` hook to call `git update-index` because it slows down git operations like `rebase`. According to @mattkrick - this used to be required by JetBrains IDEs, but we don't need it anymore.