### PR TITLE
fix(sdl): Default resolveType on mutation payloads

### DIFF
--- a/packages/server/email/ServerEnvironment.ts
+++ b/packages/server/email/ServerEnvironment.ts
@@ -1,7 +1,6 @@
 import {FormattedExecutionResult} from 'graphql'
 import {Environment, FetchFunction, Network, RecordSource, Store} from 'relay-runtime'
 import AuthToken from '../database/types/AuthToken'
-import executeGraphQL from '../graphql/executeGraphQL'
 
 const noop = (): any => {
   /**/
@@ -32,6 +31,7 @@ export default class ServerEnvironment extends Environment {
   }
 
   fetch: FetchFunction = (request, variables) => {
+    const executeGraphQL = require('../graphql/executeGraphQL').default
     if (!this.isFetched) {
       this.requestCache.push(
         executeGraphQL({

--- a/packages/server/graphql/mutations/helpers/softDeleteUser.ts
+++ b/packages/server/graphql/mutations/helpers/softDeleteUser.ts
@@ -1,14 +1,14 @@
-import removeSlackAuths from './removeSlackAuths'
-import removeFromOrg from './removeFromOrg'
+import TeamMemberId from 'parabol-client/shared/gqlIds/TeamMemberId'
+import getRethink from '../../../database/rethinkDriver'
+// import executeGraphQL from '../../executeGraphQL'
+import AuthToken from '../../../database/types/AuthToken'
+import removeAtlassianAuth from '../../../postgres/queries/removeAtlassianAuth'
+import removeGitHubAuth from '../../../postgres/queries/removeGitHubAuth'
+import getDeletedEmail from '../../../utils/getDeletedEmail'
 import segmentIo from '../../../utils/segmentIo'
 import {DataLoaderWorker} from '../../graphql'
-import removeGitHubAuth from '../../../postgres/queries/removeGitHubAuth'
-import removeAtlassianAuth from '../../../postgres/queries/removeAtlassianAuth'
-import getRethink from '../../../database/rethinkDriver'
-import TeamMemberId from 'parabol-client/shared/gqlIds/TeamMemberId'
-import getDeletedEmail from '../../../utils/getDeletedEmail'
-import executeGraphQL from '../../executeGraphQL'
-import AuthToken from '../../../database/types/AuthToken'
+import removeFromOrg from './removeFromOrg'
+import removeSlackAuths from './removeSlackAuths'
 
 const removeGitHubAuths = async (userId: string, teamIds: string[]) =>
   Promise.all(teamIds.map((teamId) => removeGitHubAuth(userId, teamId)))
@@ -36,6 +36,7 @@ const softDeleteUser = async (
     .coerceTo('array')
     .run()
   const teamIds = teamMemberIds.map((id) => TeamMemberId.split(id).teamId)
+  const executeGraphQL = require('../../executeGraphQL').default
 
   const [parabolPayload] = await Promise.all([
     executeGraphQL({

--- a/packages/server/graphql/mutations/helpers/softDeleteUser.ts
+++ b/packages/server/graphql/mutations/helpers/softDeleteUser.ts
@@ -1,6 +1,5 @@
 import TeamMemberId from 'parabol-client/shared/gqlIds/TeamMemberId'
 import getRethink from '../../../database/rethinkDriver'
-// import executeGraphQL from '../../executeGraphQL'
 import AuthToken from '../../../database/types/AuthToken'
 import removeAtlassianAuth from '../../../postgres/queries/removeAtlassianAuth'
 import removeGitHubAuth from '../../../postgres/queries/removeGitHubAuth'

--- a/packages/server/graphql/private/rootSchema.ts
+++ b/packages/server/graphql/private/rootSchema.ts
@@ -5,19 +5,10 @@ import resolveTypesForMutationPayloads from '../resolveTypesForMutationPayloads'
 import publicSchema from '../rootSchema'
 import resolvers from './resolvers'
 
-// const publicSchema = new GraphQLSchema({
-//   query,
-//   mutation,
-//   types: rootTypes
-// })
-
 const typeDefs = loadFilesSync(
   path.join(__PROJECT_ROOT__, 'packages/server/graphql/private/typeDefs/*.graphql')
 )
 
 const privateSchema = resolveTypesForMutationPayloads(makeExecutableSchema({typeDefs, resolvers}))
-// const publicSchema = require('../rootSchema').default
-// console.log({publicSchema})
-// required to get the public types
 const fullSchema = mergeSchemas({schemas: [privateSchema, publicSchema]})
 export default fullSchema

--- a/packages/server/graphql/private/rootSchema.ts
+++ b/packages/server/graphql/private/rootSchema.ts
@@ -1,6 +1,7 @@
 import {loadFilesSync} from '@graphql-tools/load-files'
 import {makeExecutableSchema} from '@graphql-tools/schema'
 import path from 'path'
+import resolveTypesForMutationPayloads from '../resolveTypesForMutationPayloads'
 import resolvers from './resolvers'
 
 const typeDefs = loadFilesSync(
@@ -8,4 +9,4 @@ const typeDefs = loadFilesSync(
 )
 
 const schema = makeExecutableSchema({typeDefs, resolvers})
-export default schema
+export default resolveTypesForMutationPayloads(schema)

--- a/packages/server/graphql/private/rootSchema.ts
+++ b/packages/server/graphql/private/rootSchema.ts
@@ -1,12 +1,23 @@
 import {loadFilesSync} from '@graphql-tools/load-files'
-import {makeExecutableSchema} from '@graphql-tools/schema'
+import {makeExecutableSchema, mergeSchemas} from '@graphql-tools/schema'
 import path from 'path'
 import resolveTypesForMutationPayloads from '../resolveTypesForMutationPayloads'
+import publicSchema from '../rootSchema'
 import resolvers from './resolvers'
+
+// const publicSchema = new GraphQLSchema({
+//   query,
+//   mutation,
+//   types: rootTypes
+// })
 
 const typeDefs = loadFilesSync(
   path.join(__PROJECT_ROOT__, 'packages/server/graphql/private/typeDefs/*.graphql')
 )
 
-const schema = makeExecutableSchema({typeDefs, resolvers})
-export default resolveTypesForMutationPayloads(schema)
+const privateSchema = resolveTypesForMutationPayloads(makeExecutableSchema({typeDefs, resolvers}))
+// const publicSchema = require('../rootSchema').default
+// console.log({publicSchema})
+// required to get the public types
+const fullSchema = mergeSchemas({schemas: [privateSchema, publicSchema]})
+export default fullSchema

--- a/packages/server/graphql/resolveTypesForMutationPayloads.ts
+++ b/packages/server/graphql/resolveTypesForMutationPayloads.ts
@@ -1,0 +1,28 @@
+/*
+  By convention, a MutationPayload is a Union of ErrorPayload | MutationSuccess
+  e.g. type AddTaskPayload = ErrorPayload | AddTaskSuccess
+  When a mutation resolver returns a value, GraphQL needs to ascertain
+  whether the return value is an ErrorPayload or MutationSuccess
+  It does this by calling `resolveType` on the union.
+  This function finds all conventional MutationPayloads and
+  adds that `resolveType` if one is not already defined
+*/
+
+import {GraphQLSchema} from 'graphql'
+import {isUnionType} from 'graphql/type'
+
+const resolveTypesForMutationPayloads = (schema: GraphQLSchema) => {
+  Object.values(schema.getTypeMap()).forEach((type) => {
+    if (!isUnionType(type) || !type.name.endsWith('Payload')) return
+    const concreteTypes = type.getTypes()
+    const errorType = concreteTypes.find((type) => type.name === 'ErrorPayload')
+    const successName = `${type.name.slice(0, -'Payload'.length)}Success`
+    const successType = concreteTypes.find((type) => type.name === successName)
+    // Abort if the MutationPayload is not a default 2-part union of an ErrorPayload | Success
+    if (!errorType || !successType || concreteTypes.length !== 2 || type.resolveType) return
+    type.resolveType = ({error}) => (error?.message ? errorType : successType)
+  })
+  return schema
+}
+
+export default resolveTypesForMutationPayloads

--- a/packages/server/graphql/resolveTypesForMutationPayloads.ts
+++ b/packages/server/graphql/resolveTypesForMutationPayloads.ts
@@ -13,13 +13,13 @@ import {isUnionType} from 'graphql/type'
 
 const resolveTypesForMutationPayloads = (schema: GraphQLSchema) => {
   Object.values(schema.getTypeMap()).forEach((type) => {
-    if (!isUnionType(type) || !type.name.endsWith('Payload')) return
+    if (!isUnionType(type) || !type.name.endsWith('Payload') || type.resolveType) return
     const concreteTypes = type.getTypes()
     const errorType = concreteTypes.find((type) => type.name === 'ErrorPayload')
     const successName = `${type.name.slice(0, -'Payload'.length)}Success`
     const successType = concreteTypes.find((type) => type.name === successName)
     // Abort if the MutationPayload is not a default 2-part union of an ErrorPayload | Success
-    if (!errorType || !successType || concreteTypes.length !== 2 || type.resolveType) return
+    if (!errorType || !successType || concreteTypes.length !== 2) return
     type.resolveType = ({error}) => (error?.message ? errorType : successType)
   })
   return schema

--- a/packages/server/utils/updateHubspot.ts
+++ b/packages/server/utils/updateHubspot.ts
@@ -1,9 +1,8 @@
 import fetch from 'node-fetch'
 import sleep from 'parabol-client/utils/sleep'
+import ServerAuthToken from '../database/types/ServerAuthToken'
 import IUser from '../postgres/types/IUser'
 import sendToSentry from './sendToSentry'
-import executeGraphQL from '../graphql/executeGraphQL'
-import ServerAuthToken from '../database/types/ServerAuthToken'
 
 interface Company {
   userCount: number
@@ -229,6 +228,7 @@ const tierChanges = ['Upgrade to Pro', 'Enterprise invoice drafted', 'Downgrade 
 const hapiKey = process.env.HUBSPOT_API_KEY
 
 const parabolFetch = async (query: string, variables: Record<string, unknown>) => {
+  const executeGraphQL = require('../graphql/executeGraphQL').default
   const result = await executeGraphQL({
     authToken: new ServerAuthToken(),
     query,


### PR DESCRIPTION
root cause fix #6268

This bug was caused because graphql couldn't figure out if a mutation returned an error or a success.

TEST
- [ ] run the following on the private schema. you'll see the error message

```gql
mutation {
  enableSAMLForDomain(name:"foo", domains:["foo.co"], metadata: "as") {
    __typename
    ... on ErrorPayload {
      error {
        message
      }
    }
  }
}
```