### PR TITLE
fix(sprint-poker): Only reset current estimation stage on revote

### DIFF
--- a/packages/server/graphql/mutations/pokerResetDimension.ts
+++ b/packages/server/graphql/mutations/pokerResetDimension.ts
@@ -80,7 +80,7 @@ const pokerResetDimension = {
     const updater = (estimateStage: RValue) => estimateStage.merge(updates)
     await Promise.all([
       updateStage(meetingId, stageId, 'ESTIMATE', updater),
-      removeMeetingTaskEstimates(meetingId)
+      removeMeetingTaskEstimates(meetingId, stageId)
     ])
     const data = {meetingId, stageId}
 

--- a/packages/server/postgres/queries/generated/removeMeetingTaskEstimatesQuery.ts
+++ b/packages/server/postgres/queries/generated/removeMeetingTaskEstimatesQuery.ts
@@ -4,6 +4,7 @@ import { PreparedQuery } from '@pgtyped/query';
 /** 'RemoveMeetingTaskEstimatesQuery' parameters type */
 export interface IRemoveMeetingTaskEstimatesQueryParams {
   meetingId: string | null | void;
+  stageId: string | null | void;
 }
 
 /** 'RemoveMeetingTaskEstimatesQuery' return type */
@@ -15,13 +16,13 @@ export interface IRemoveMeetingTaskEstimatesQueryQuery {
   result: IRemoveMeetingTaskEstimatesQueryResult;
 }
 
-const removeMeetingTaskEstimatesQueryIR: any = {"name":"removeMeetingTaskEstimatesQuery","params":[{"name":"meetingId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":94,"b":102,"line":5,"col":21}]}}],"usedParamSet":{"meetingId":true},"statement":{"body":"DELETE FROM \"TaskEstimate\"\nWHERE \"meetingId\" = :meetingId","loc":{"a":46,"b":102,"line":4,"col":0}}};
+const removeMeetingTaskEstimatesQueryIR: any = {"name":"removeMeetingTaskEstimatesQuery","params":[{"name":"meetingId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":94,"b":102,"line":5,"col":21}]}},{"name":"stageId","transform":{"type":"scalar"},"codeRefs":{"used":[{"a":121,"b":127,"line":5,"col":48}]}}],"usedParamSet":{"meetingId":true,"stageId":true},"statement":{"body":"DELETE FROM \"TaskEstimate\"\nWHERE \"meetingId\" = :meetingId AND \"stageId\" = :stageId","loc":{"a":46,"b":127,"line":4,"col":0}}};
 
 /**
  * Query generated from SQL:
  * ```
  * DELETE FROM "TaskEstimate"
- * WHERE "meetingId" = :meetingId
+ * WHERE "meetingId" = :meetingId AND "stageId" = :stageId
  * ```
  */
 export const removeMeetingTaskEstimatesQuery = new PreparedQuery<IRemoveMeetingTaskEstimatesQueryParams,IRemoveMeetingTaskEstimatesQueryResult>(removeMeetingTaskEstimatesQueryIR);

--- a/packages/server/postgres/queries/removeMeetingTaskEstimates.ts
+++ b/packages/server/postgres/queries/removeMeetingTaskEstimates.ts
@@ -1,8 +1,8 @@
 import getPg from '../getPg'
 import {removeMeetingTaskEstimatesQuery} from './generated/removeMeetingTaskEstimatesQuery'
 
-const removeMeetingTaskEstimates = async (meetingId: string) => {
-  return removeMeetingTaskEstimatesQuery.run({meetingId}, getPg())
+const removeMeetingTaskEstimates = async (meetingId: string, stageId: string) => {
+  return removeMeetingTaskEstimatesQuery.run({meetingId, stageId}, getPg())
 }
 
 export default removeMeetingTaskEstimates

--- a/packages/server/postgres/queries/src/removeMeetingTaskEstimatesQuery.sql
+++ b/packages/server/postgres/queries/src/removeMeetingTaskEstimatesQuery.sql
@@ -2,4 +2,4 @@
   @name removeMeetingTaskEstimatesQuery
 */
 DELETE FROM "TaskEstimate"
-WHERE "meetingId" = :meetingId;
+WHERE "meetingId" = :meetingId AND "stageId" = :stageId;


### PR DESCRIPTION
Fixes #6243

Currently, the `removeMeetingTaskEstimates` query called by the `pokerResetDimension` mutation performs a deletion on any task estimate in the meeting, not just the task estimate in the meeting for the current stage.

Modify the `removeMeetingTaskEstimates` to take a `stageId` param and only delete rows with that stage.

Test:
* Perform the setup steps in #6243 up to revoting on the third task
* Click revote, confirm that the current estimation is reset
* Refresh the page, confirm the current estimation is reset, and confirm that the first two tasks are still scored
* Score the third task, refresh the page, and confirm that the first two tasks are still scored, and the third task has the new score
* End the meeting, and confirm that all tasks are correctly scored in the summary