### PR TITLE
feat(scale): give a pubsub channel to each socket server

### DIFF
--- a/packages/client/shared/gqlIds/GQLExecutorChannelId.ts
+++ b/packages/client/shared/gqlIds/GQLExecutorChannelId.ts
@@ -1,4 +1,4 @@
-const GQLExecutorId = {
+const GQLExecutorChannelId = {
   join: (serverId: string) => `gqlExecutor:${serverId}`,
   split: (id: string) => {
     const [, serverId] = id.split(':')
@@ -6,4 +6,4 @@ const GQLExecutorId = {
   }
 }
 
-export default GQLExecutorId
+export default GQLExecutorChannelId

--- a/packages/client/shared/gqlIds/SocketServerChannelId.ts
+++ b/packages/client/shared/gqlIds/SocketServerChannelId.ts
@@ -1,4 +1,4 @@
-const SocketServerId = {
+const SocketServerChannelId = {
   join: (serverId: string) => `socketServer:${serverId}`,
   split: (id: string) => {
     const [, serverId] = id.split(':')
@@ -6,4 +6,4 @@ const SocketServerId = {
   }
 }
 
-export default SocketServerId
+export default SocketServerChannelId

--- a/packages/client/shared/gqlIds/SocketServerId.ts
+++ b/packages/client/shared/gqlIds/SocketServerId.ts
@@ -1,0 +1,9 @@
+const SocketServerId = {
+  join: (serverId: string) => `socketServer:${serverId}`,
+  split: (id: string) => {
+    const [, serverId] = id.split(':')
+    return serverId
+  }
+}
+
+export default SocketServerId

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -307,7 +307,6 @@ export const enum Security {
 }
 
 export const enum ServerChannel {
-  GQL_EXECUTOR_RESPONSE = 'gqlExRes',
   GQL_EXECUTOR_STREAM = 'gqlStream',
   GQL_EXECUTOR_CONSUMER_GROUP = 'gqlConsumerGroup'
 }

--- a/packages/gql-executor/README.md
+++ b/packages/gql-executor/README.md
@@ -7,4 +7,4 @@
 Each GraphQL Executor is a consumer in the consumer group `ServerChannel.GQL_EXECUTOR_CONSUMER_GROUP`.
 That consumer group listens to the stream `ServerChannel.GQL_EXECUTOR_STREAM`.
 When the group receives a message, redis delegates it to one of the consumers.
-A consumer receives the request & the consumer then creates a standard GraphQL Response and publishes it to `ServerChannel.GQL_EXECUTOR_RESPONSE`.
+A consumer receives the request & the consumer then creates a standard GraphQL Response and publishes it back to the server that sent the message by reading the `socketServerId` in the message payload.

--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -2,6 +2,7 @@ import tracer from 'dd-trace'
 import Redis from 'ioredis'
 import {ServerChannel} from 'parabol-client/types/constEnums'
 import GQLExecutorId from '../client/shared/gqlIds/GQLExecutorId'
+import SocketServerId from '../client/shared/gqlIds/SocketServerId'
 import executeGraphQL, {GQLRequest} from '../server/graphql/executeGraphQL'
 import '../server/initSentry'
 import RedisStream from './RedisStream'
@@ -16,23 +17,25 @@ tracer.init({
 const {REDIS_URL, SERVER_ID} = process.env
 interface PubSubPromiseMessage {
   jobId: string
+  socketServerId: string
   request: GQLRequest
 }
 
 const run = async () => {
   const publisher = new Redis(REDIS_URL, {connectionName: 'gql_pub'})
   const subscriber = new Redis(REDIS_URL, {connectionName: 'gql_sub'})
-  const serverChannel = GQLExecutorId.join(SERVER_ID)
+  const executorChannel = GQLExecutorId.join(SERVER_ID)
 
   // subscribe to direct messages
   const onMessage = async (_channel: string, message: string) => {
-    const {jobId, request} = JSON.parse(message) as PubSubPromiseMessage
+    const {jobId, socketServerId, request} = JSON.parse(message) as PubSubPromiseMessage
     const response = await executeGraphQL(request)
-    publisher.publish(ServerChannel.GQL_EXECUTOR_RESPONSE, JSON.stringify({response, jobId}))
+    const channel = SocketServerId.join(socketServerId)
+    publisher.publish(channel, JSON.stringify({response, jobId}))
   }
 
   subscriber.on('message', onMessage)
-  subscriber.subscribe(serverChannel)
+  subscriber.subscribe(executorChannel)
 
   // subscribe to consumer group
   try {
@@ -50,7 +53,7 @@ const run = async () => {
   const incomingStream = new RedisStream(
     ServerChannel.GQL_EXECUTOR_STREAM,
     ServerChannel.GQL_EXECUTOR_CONSUMER_GROUP,
-    serverChannel
+    executorChannel
   )
   console.log(`\n💧💧💧 Ready for GraphQL Execution: ${SERVER_ID} 💧💧💧`)
 

--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -1,8 +1,8 @@
 import tracer from 'dd-trace'
 import Redis from 'ioredis'
 import {ServerChannel} from 'parabol-client/types/constEnums'
-import GQLExecutorId from '../client/shared/gqlIds/GQLExecutorId'
-import SocketServerId from '../client/shared/gqlIds/SocketServerId'
+import GQLExecutorChannelId from '../client/shared/gqlIds/GQLExecutorChannelId'
+import SocketServerChannelId from '../client/shared/gqlIds/SocketServerChannelId'
 import executeGraphQL, {GQLRequest} from '../server/graphql/executeGraphQL'
 import '../server/initSentry'
 import RedisStream from './RedisStream'
@@ -24,13 +24,13 @@ interface PubSubPromiseMessage {
 const run = async () => {
   const publisher = new Redis(REDIS_URL, {connectionName: 'gql_pub'})
   const subscriber = new Redis(REDIS_URL, {connectionName: 'gql_sub'})
-  const executorChannel = GQLExecutorId.join(SERVER_ID)
+  const executorChannel = GQLExecutorChannelId.join(SERVER_ID)
 
   // subscribe to direct messages
   const onMessage = async (_channel: string, message: string) => {
     const {jobId, socketServerId, request} = JSON.parse(message) as PubSubPromiseMessage
     const response = await executeGraphQL(request)
-    const channel = SocketServerId.join(socketServerId)
+    const channel = SocketServerChannelId.join(socketServerId)
     publisher.publish(channel, JSON.stringify({response, jobId}))
   }
 

--- a/packages/server/graphql/ResponseStream.ts
+++ b/packages/server/graphql/ResponseStream.ts
@@ -20,7 +20,7 @@ export default class ResponseStream implements AsyncIterableIterator<ExecutionRe
   async next(): Promise<IteratorResult<ExecutionResult>> {
     const sourceIter = await this.sourceStream.next()
     if (sourceIter.done) return sourceIter
-    const {mutatorId, operationId: dataLoaderId, rootValue, serverChannel} = sourceIter.value
+    const {mutatorId, operationId: dataLoaderId, rootValue, executorServerId} = sourceIter.value
     const {connectionContext, query, variables, docId} = this.req
     const {id: socketId, authToken, ip} = connectionContext
     if (mutatorId === socketId) return this.next()
@@ -34,7 +34,7 @@ export default class ResponseStream implements AsyncIterableIterator<ExecutionRe
         variables,
         rootValue,
         socketId,
-        serverChannel
+        executorServerId
       })
       if (result.errors) {
         sendToSentry(new Error(result.errors[0]?.message))

--- a/packages/server/utils/PubSubPromise.ts
+++ b/packages/server/utils/PubSubPromise.ts
@@ -1,6 +1,6 @@
 import Redis from 'ioredis'
 import ms from 'ms'
-import GQLExecutorId from '../../client/shared/gqlIds/GQLExecutorId'
+import GQLExecutorChannelId from '../../client/shared/gqlIds/GQLExecutorChannelId'
 import numToBase64 from './numToBase64'
 import sendToSentry from './sendToSentry'
 
@@ -64,7 +64,7 @@ export default class PubSubPromise<Request extends BaseRequest, Response> {
       const {executorServerId, ...rest} = request
       const message = JSON.stringify({jobId, socketServerId: SERVER_ID, request: rest})
       if (executorServerId) {
-        const executorChannel = GQLExecutorId.join(executorServerId)
+        const executorChannel = GQLExecutorChannelId.join(executorServerId)
         this.publisher.publish(executorChannel, message)
       } else {
         // cap the stream to slightly more than 1000 entries.

--- a/packages/server/utils/getGraphQLExecutor.ts
+++ b/packages/server/utils/getGraphQLExecutor.ts
@@ -1,6 +1,6 @@
 import {ExecutionResult} from 'graphql'
 import {ServerChannel} from 'parabol-client/types/constEnums'
-import SocketServerId from '../../client/shared/gqlIds/SocketServerId'
+import SocketServerChannelId from '../../client/shared/gqlIds/SocketServerChannelId'
 import {GQLRequest} from '../graphql/executeGraphQL'
 import PubSubPromise from './PubSubPromise'
 
@@ -9,7 +9,7 @@ const getGraphQLExecutor = () => {
   if (!pubsub) {
     pubsub = new PubSubPromise(
       ServerChannel.GQL_EXECUTOR_STREAM,
-      SocketServerId.join(process.env.SERVER_ID!)
+      SocketServerChannelId.join(process.env.SERVER_ID!)
     )
   }
   return pubsub

--- a/packages/server/utils/getGraphQLExecutor.ts
+++ b/packages/server/utils/getGraphQLExecutor.ts
@@ -1,14 +1,15 @@
 import {ExecutionResult} from 'graphql'
 import {ServerChannel} from 'parabol-client/types/constEnums'
+import SocketServerId from '../../client/shared/gqlIds/SocketServerId'
 import {GQLRequest} from '../graphql/executeGraphQL'
 import PubSubPromise from './PubSubPromise'
 
-let pubsub: PubSubPromise<GQLRequest & {serverChannel?: string}, ExecutionResult>
+let pubsub: PubSubPromise<GQLRequest & {executorServerId?: string}, ExecutionResult>
 const getGraphQLExecutor = () => {
   if (!pubsub) {
     pubsub = new PubSubPromise(
       ServerChannel.GQL_EXECUTOR_STREAM,
-      ServerChannel.GQL_EXECUTOR_RESPONSE
+      SocketServerId.join(process.env.SERVER_ID!)
     )
   }
   return pubsub

--- a/packages/server/utils/publish.ts
+++ b/packages/server/utils/publish.ts
@@ -1,5 +1,4 @@
 import getPubSub from './getPubSub'
-import GQLExecutorId from '../../client/shared/gqlIds/GQLExecutorId'
 
 export interface SubOptions {
   mutatorId?: string
@@ -7,7 +6,6 @@ export interface SubOptions {
 }
 
 const {SERVER_ID} = process.env
-const serverChannel = GQLExecutorId.join(SERVER_ID!)
 
 const publish = <T>(
   topic: T,
@@ -20,7 +18,7 @@ const publish = <T>(
   const data = {...payload, type}
   const rootValue = {[subName]: data}
   getPubSub()
-    .publish(`${topic}.${channel}`, {rootValue, serverChannel, ...subOptions})
+    .publish(`${topic}.${channel}`, {rootValue, executorServerId: SERVER_ID!, ...subOptions})
     .catch(console.error)
 }
 


### PR DESCRIPTION
before, a graphql executor would send the response payload to a fixed server (because the channel name was static).
now, it sends it to the server that requested it.

I also renamed `serverChannel` to `executorChannel` since that could get ambiguous.
