### PR TITLE
chore: Track integrations in createTask

### DIFF
--- a/packages/server/graphql/mutations/createTask.ts
+++ b/packages/server/graphql/mutations/createTask.ts
@@ -49,6 +49,7 @@ const sendToSentryTaskCreated = async (
   viewerId: string,
   teamId: string,
   isReply: boolean,
+  integrationService: string | undefined,
   dataLoader: DataLoaderWorker
 ) => {
   let isAsync
@@ -73,7 +74,8 @@ const sendToSentryTaskCreated = async (
       meetingId,
       teamId,
       isAsync,
-      isReply
+      isReply,
+      integrationService
     }
   })
 }
@@ -139,9 +141,7 @@ const handleAddTaskNotifications = async (
 
   if (notificationsToAdd.length) {
     // don't await to speed up task creation
-    r.table('Notification')
-      .insert(notificationsToAdd)
-      .run()
+    r.table('Notification').insert(notificationsToAdd).run()
     notificationsToAdd.forEach((notification) => {
       publish(
         SubscriptionChannel.NOTIFICATION,
@@ -261,13 +261,13 @@ export default {
     const {teamMembers} = await r({
       task: r.table('Task').insert(task),
       history: r.table('TaskHistory').insert(history),
-      teamMembers: (r
+      teamMembers: r
         .table('TeamMember')
         .getAll(teamId, {index: 'teamId'})
         .filter({
           isNotRemoved: true
         })
-        .coerceTo('array') as unknown) as TeamMember[]
+        .coerceTo('array') as unknown as TeamMember[]
     }).run()
 
     handleAddTaskNotifications(teamMembers, task, viewerId, teamId, {
@@ -275,7 +275,14 @@ export default {
       mutatorId
     }).catch()
 
-    sendToSentryTaskCreated(meetingId, viewerId, teamId, !!threadParentId, dataLoader).catch()
+    sendToSentryTaskCreated(
+      meetingId,
+      viewerId,
+      teamId,
+      !!threadParentId,
+      integration?.service,
+      dataLoader
+    ).catch()
     return {taskId}
   }
 }


### PR DESCRIPTION
At the moment we do not know how many users use the "Add issue" fab in
Poker meetings to create new tasks in their integration. Add the
integration field in the segment message to track it.