### PR TITLE
feat: Display a message when there are no more items to paginate

### DIFF
--- a/packages/client/components/NullableTask/NullableTask.tsx
+++ b/packages/client/components/NullableTask/NullableTask.tsx
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {convertFromRaw} from 'draft-js'
-import React, {useEffect, useMemo} from 'react'
+import React, {useMemo} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import {AreaEnum, TaskStatusEnum} from '~/__generated__/UpdateTaskMutation.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
@@ -14,7 +14,6 @@ interface Props {
   className?: string
   isAgenda?: boolean
   isDraggingOver?: TaskStatusEnum
-  measure?: () => void
   task: NullableTask_task
   dataCy: string
   isViewerMeetingSection?: boolean
@@ -34,20 +33,6 @@ const NullableTask = (props: Props) => {
   }, [content])
 
   const atmosphere = useAtmosphere()
-  useEffect(
-    () => {
-      let isMounted = true
-      setTimeout(() => {
-        isMounted && props.measure && props.measure()
-      })
-      return () => {
-        isMounted = false
-      }
-    },
-    [
-      /* eslint-disable-line react-hooks/exhaustive-deps*/
-    ]
-  )
 
   const showOutcome = contentState.hasText() || createdBy === atmosphere.viewerId || integration
   return showOutcome ? (

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -194,8 +194,10 @@ const TeamArchive = (props: Props) => {
   }
   const isRowLoaded = ({index}) => index < edges.length
   const maybeLoadMore = () => {
-    if (!hasNext || isLoadingNext) return
-    loadNext(columnCount * 10)
+    if (!hasNext || isLoadingNext) return Promise.resolve()
+    return new Promise<void>((resolve, reject) => {
+      loadNext(columnCount * 10, {onComplete: (err) => (err ? reject(err) : resolve())})
+    })
   }
   const [cellCache] = useState(
     () =>

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -246,7 +246,7 @@ const TeamArchive = (props: Props) => {
     oldEdgesRef.current = edges
   }, [edges, oldEdgesRef])
 
-  const rowRenderer = ({columnIndex, parent, rowIndex, key, style}) => {
+  const cellRenderer = ({columnIndex, parent, rowIndex, key, style}) => {
     // TODO render a very inexpensive lo-fi card while scrolling. We should reuse that cheap card for drags, too
     const index = getIndex(columnIndex, rowIndex)
     if (!isRowLoaded({index})) return undefined
@@ -280,7 +280,7 @@ const TeamArchive = (props: Props) => {
     )
   }
 
-  const _onSectionRendered = ({columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex}) => {
+  const onSectionRendered = ({columnStartIndex, columnStopIndex, rowStartIndex, rowStopIndex}) => {
     if (!_onRowsRenderedRef.current) return
     _onRowsRenderedRef.current({
       startIndex: getIndex(columnStartIndex, rowStartIndex),
@@ -314,7 +314,7 @@ const TeamArchive = (props: Props) => {
                         {({height, width}) => {
                           return (
                             <Grid
-                              cellRenderer={rowRenderer}
+                              cellRenderer={cellRenderer}
                               columnCount={columnCount}
                               columnWidth={CARD_WIDTH}
                               deferredMeasurementCache={cellCache}
@@ -322,7 +322,7 @@ const TeamArchive = (props: Props) => {
                               estimatedRowSize={182}
                               height={height}
                               onRowsRendered={onRowsRendered}
-                              onSectionRendered={_onSectionRendered}
+                              onSectionRendered={onSectionRendered}
                               ref={(c) => {
                                 gridRef.current = c
                                 registerChild(c)

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -72,11 +72,10 @@ const CardGrid = styled('div')({
 })
 
 const EmptyMsg = styled('div')({
-  backgroundColor: Card.BACKGROUND_COLOR as string,
+  backgroundColor: `${Card.BACKGROUND_COLOR}`,
   border: `1px solid ${PALETTE.SLATE_400}`,
   borderRadius: Card.BORDER_RADIUS,
   fontSize: Card.FONT_SIZE,
-  display: 'inline-block',
   margin: 20,
   padding: Card.PADDING
 })
@@ -86,11 +85,10 @@ const LinkSpan = styled('div')({
 })
 
 const NoMoreMsg = styled('div')({
-  backgroundColor: Card.BACKGROUND_COLOR as string,
+  backgroundColor: `${Card.BACKGROUND_COLOR}`,
   border: `1px solid ${PALETTE.SLATE_400}`,
   borderRadius: Card.BORDER_RADIUS,
   fontSize: Card.FONT_SIZE,
-  display: 'inline-block',
   padding: Card.PADDING
 })
 
@@ -196,9 +194,8 @@ const TeamArchive = (props: Props) => {
   const rowCount = Math.ceil(edges.length / columnCount) + 1 // used +1 for "no more" message row
   const noMoreMsgIndex = hasNext ? Number.MAX_VALUE : (rowCount - 1) * columnCount
 
-  const _onRowsRenderedRef = useRef<
-    ({startIndex, stopIndex}: {startIndex: number; stopIndex: number}) => void
-  >()
+  const _onRowsRenderedRef =
+    useRef<({startIndex, stopIndex}: {startIndex: number; stopIndex: number}) => void>()
   const gridRef = useRef<any>(null)
   const oldEdgesRef = useRef<typeof edges>()
   const getIndex = (columnIndex: number, rowIndex: number) => {
@@ -280,8 +277,7 @@ const TeamArchive = (props: Props) => {
                   width: 'auto',
                   height: 'auto',
                   left: '50%',
-                  transform: 'translate(-50%, 0)',
-                  padding: '1rem 0.5rem'
+                  transform: 'translate(-50%, 0)'
                 }}
               >
                 🎉 That's all folks! There are no further tasks in the archive.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,6 +32,7 @@
     "@types/react-relay": "^11.0.2",
     "@types/react-router": "^5.0.3",
     "@types/react-router-dom": "^4.3.2",
+    "@types/react-virtualized": "^9.21.20",
     "@types/relay-runtime": "^12.0.0",
     "@types/segment-analytics": "^0.0.31",
     "@types/stripe-v2": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4143,6 +4143,14 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-virtualized@^9.21.20":
+  version "9.21.20"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.20.tgz#756c78b5512a2a1804fdaf749a5f5cff3d805e5b"
+  integrity sha512-i8nZf1LpuX5rG4DZLaPGayIQwjxsZwmst5VdNhEznDTENel9p3A735AdRRp2iueFOyOuWBmaEaDxg8AD3GHilA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.9.11":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"


### PR DESCRIPTION
successor: #6282 
fixes:  #1450

Always display a "no more items" message (for simplicity and UX consistency) when the user reaches the end of the archive, even if there is no scroll in the archive (few cards).

few cards
<img width="1190" alt="Screenshot 2022-04-03 at 17 14 34" src="https://user-images.githubusercontent.com/790487/161432243-dafffa88-2f5f-4cec-8f55-bec7d60b29f5.png">
many cards
<img width="1379" alt="Screenshot 2022-04-03 at 17 15 08" src="https://user-images.githubusercontent.com/790487/161432268-9e1a051d-f070-48e0-8a67-181d80a2377b.png">

