### PR TITLE
feat(standups): Options menu - end meeting

### DIFF
--- a/packages/client/components/MeetingTopBar.tsx
+++ b/packages/client/components/MeetingTopBar.tsx
@@ -47,7 +47,7 @@ const PrimaryActionBlock = styled('div')({
   display: 'flex'
 })
 
-const AvatarGroupBlock = styled('div')({
+export const AvatarGroupBlock = styled('div')({
   alignItems: 'center',
   display: 'flex',
   justifyContent: 'center',

--- a/packages/client/components/MeetingTopBar.tsx
+++ b/packages/client/components/MeetingTopBar.tsx
@@ -1,15 +1,15 @@
-import React, {ReactElement, ReactNode} from 'react'
 import styled from '@emotion/styled'
-import DemoCreateAccountButton from './DemoCreateAccountButton'
-import SidebarToggle from './SidebarToggle'
-import isDemoRoute from '../utils/isDemoRoute'
-import hasToken from '../utils/hasToken'
-import {meetingAvatarMediaQueries} from '../styles/meeting'
-import makeMinWidthMediaQuery from '../utils/makeMinWidthMediaQuery'
-import PlainButton from './PlainButton/PlainButton'
+import React, {ReactElement, ReactNode} from 'react'
 import {PALETTE} from '~/styles/paletteV3'
-import Icon from './Icon'
 import {ICON_SIZE} from '~/styles/typographyV2'
+import {meetingAvatarMediaQueries} from '../styles/meeting'
+import hasToken from '../utils/hasToken'
+import isDemoRoute from '../utils/isDemoRoute'
+import makeMinWidthMediaQuery from '../utils/makeMinWidthMediaQuery'
+import DemoCreateAccountButton from './DemoCreateAccountButton'
+import Icon from './Icon'
+import PlainButton from './PlainButton/PlainButton'
+import SidebarToggle from './SidebarToggle'
 
 const localHeaderBreakpoint = makeMinWidthMediaQuery(600)
 
@@ -47,7 +47,7 @@ const PrimaryActionBlock = styled('div')({
   display: 'flex'
 })
 
-export const AvatarGroupBlock = styled('div')({
+export const IconGroupBlock = styled('div')({
   alignItems: 'center',
   display: 'flex',
   justifyContent: 'center',
@@ -167,7 +167,7 @@ const MeetingTopBar = (props: Props) => {
         )}
         <ChildrenBlock>{children}</ChildrenBlock>
       </HeadingBlock>
-      <AvatarGroupBlock>
+      <IconGroupBlock>
         {showButton && (
           <PrimaryActionBlock>
             <DemoCreateAccountButton />
@@ -184,7 +184,7 @@ const MeetingTopBar = (props: Props) => {
             </DiscussionButton>
           </ButtonContainer>
         )}
-      </AvatarGroupBlock>
+      </IconGroupBlock>
     </MeetingTopBarStyles>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {MenuPosition} from '~/hooks/useCoords'
+import useMenu from '~/hooks/useMenu'
+import {TeamPromptOptions_meeting$key} from '~/__generated__/TeamPromptOptions_meeting.graphql'
+import {PALETTE} from '../../styles/paletteV3'
+import CardButton from '../CardButton'
+import IconLabel from '../IconLabel'
+import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
+
+const Options = styled(CardButton)({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  color: PALETTE.SLATE_700,
+  height: 32,
+  width: 32,
+  opacity: 1,
+  ':hover': {
+    backgroundColor: PALETTE.SLATE_300
+  }
+})
+
+interface Props {
+  meetingRef: TeamPromptOptions_meeting$key
+}
+
+const TeamPromptOptions = (props: Props) => {
+  const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
+
+  const {meetingRef} = props
+
+  const meeting = useFragment(
+    graphql`
+      fragment TeamPromptOptions_meeting on TeamPromptMeeting {
+        ...TeamPromptOptionsMenu_meeting
+      }
+    `,
+    meetingRef
+  )
+
+  return (
+    <>
+      <Options ref={originRef} onClick={togglePortal}>
+        <IconLabel ref={originRef} icon='more_vert' />
+      </Options>
+      {menuPortal(<TeamPromptOptionsMenu meetingRef={meeting} menuProps={menuProps} />)}
+    </>
+  )
+}
+
+export default TeamPromptOptions

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -1,9 +1,15 @@
 import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
+import {useFragment} from 'react-relay'
+import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
-import {PALETTE} from '../../styles/paletteV3'
+import useMutationProps from '~/hooks/useMutationProps'
+import EndTeamPromptMutation from '~/mutations/EndTeamPromptMutation'
 import {ICON_SIZE} from '~/styles/typographyV2'
+import {TeamPromptOptionsMenu_meeting$key} from '~/__generated__/TeamPromptOptionsMenu_meeting.graphql'
+import {PALETTE} from '../../styles/paletteV3'
 import CardButton from '../CardButton'
 import Icon from '../Icon'
 import IconLabel from '../IconLabel'
@@ -35,8 +41,27 @@ const OptionMenuItem = styled('div')({
   width: '200px'
 })
 
-const TeamPromptOptionsMenu = () => {
+interface Props {
+  meeting: TeamPromptOptionsMenu_meeting$key
+}
+
+const TeamPromptOptionsMenu = (props: Props) => {
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
+
+  const {meeting: meetingRef} = props
+
+  const meeting = useFragment(
+    graphql`
+      fragment TeamPromptOptionsMenu_meeting on TeamPromptMeeting {
+        id
+      }
+    `,
+    meetingRef
+  )
+
+  const {id: meetingId} = meeting
+  const atmosphere = useAtmosphere()
+  const {onCompleted, onError} = useMutationProps()
 
   const renderedMenu = (
     <Menu ariaLabel={'Edit the meeting'} {...menuProps}>
@@ -50,7 +75,7 @@ const TeamPromptOptionsMenu = () => {
         }
         onClick={async () => {
           menuProps.closePortal()
-          // :TODO: (jmtaber129): Actually end meeting.
+          EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError})
         }}
       />
     </Menu>

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -42,24 +42,25 @@ const OptionMenuItem = styled('div')({
 })
 
 interface Props {
-  meeting: TeamPromptOptionsMenu_meeting$key
+  meetingRef: TeamPromptOptionsMenu_meeting$key
 }
 
 const TeamPromptOptionsMenu = (props: Props) => {
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
 
-  const {meeting: meetingRef} = props
+  const {meetingRef} = props
 
   const meeting = useFragment(
     graphql`
       fragment TeamPromptOptionsMenu_meeting on TeamPromptMeeting {
         id
+        endedAt
       }
     `,
     meetingRef
   )
 
-  const {id: meetingId} = meeting
+  const {id: meetingId, endedAt} = meeting
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
 
@@ -67,6 +68,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
     <Menu ariaLabel={'Edit the meeting'} {...menuProps}>
       <MenuItem
         key='copy'
+        isDisabled={!!endedAt}
         label={
           <OptionMenuItem>
             <StyledIcon>flag</StyledIcon>

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {MenuPosition} from '~/hooks/useCoords'
+import useMenu from '~/hooks/useMenu'
+import {PALETTE} from '../../styles/paletteV3'
+import {ICON_SIZE} from '~/styles/typographyV2'
+import CardButton from '../CardButton'
+import Icon from '../Icon'
+import IconLabel from '../IconLabel'
+import Menu from '../Menu'
+import MenuItem from '../MenuItem'
+import {MenuItemLabelStyle} from '../MenuItemLabel'
+
+const Options = styled(CardButton)({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  color: PALETTE.SLATE_700,
+  height: 32,
+  width: 32,
+  opacity: 1,
+  ':hover': {
+    backgroundColor: PALETTE.SLATE_300
+  }
+})
+
+const StyledIcon = styled(Icon)({
+  color: PALETTE.SLATE_600,
+  fontSize: ICON_SIZE.MD24,
+  marginRight: 8
+})
+
+const OptionMenuItem = styled('div')({
+  ...MenuItemLabelStyle,
+  width: '200px'
+})
+
+const TeamPromptOptionsMenu = () => {
+  const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
+
+  const renderedMenu = (
+    <Menu ariaLabel={'Edit the meeting'} {...menuProps}>
+      <MenuItem
+        key='copy'
+        label={
+          <OptionMenuItem>
+            <StyledIcon>flag</StyledIcon>
+            <span>{'End this activity'}</span>
+          </OptionMenuItem>
+        }
+        onClick={async () => {
+          menuProps.closePortal()
+          // :TODO: (jmtaber129): Actually end meeting.
+        }}
+      />
+    </Menu>
+  )
+
+  return (
+    <>
+      <Options ref={originRef} onClick={togglePortal}>
+        <IconLabel ref={originRef} icon='more_vert' />
+      </Options>
+      {menuPortal(renderedMenu)}
+    </>
+  )
+}
+
+export default TeamPromptOptionsMenu

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -3,32 +3,16 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
-import {MenuPosition} from '~/hooks/useCoords'
-import useMenu from '~/hooks/useMenu'
+import {MenuProps} from '~/hooks/useMenu'
 import useMutationProps from '~/hooks/useMutationProps'
 import EndTeamPromptMutation from '~/mutations/EndTeamPromptMutation'
 import {ICON_SIZE} from '~/styles/typographyV2'
 import {TeamPromptOptionsMenu_meeting$key} from '~/__generated__/TeamPromptOptionsMenu_meeting.graphql'
 import {PALETTE} from '../../styles/paletteV3'
-import CardButton from '../CardButton'
 import Icon from '../Icon'
-import IconLabel from '../IconLabel'
 import Menu from '../Menu'
 import MenuItem from '../MenuItem'
 import {MenuItemLabelStyle} from '../MenuItemLabel'
-
-const Options = styled(CardButton)({
-  position: 'absolute',
-  top: 0,
-  right: 0,
-  color: PALETTE.SLATE_700,
-  height: 32,
-  width: 32,
-  opacity: 1,
-  ':hover': {
-    backgroundColor: PALETTE.SLATE_300
-  }
-})
 
 const StyledIcon = styled(Icon)({
   color: PALETTE.SLATE_600,
@@ -43,12 +27,11 @@ const OptionMenuItem = styled('div')({
 
 interface Props {
   meetingRef: TeamPromptOptionsMenu_meeting$key
+  menuProps: MenuProps
 }
 
 const TeamPromptOptionsMenu = (props: Props) => {
-  const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
-
-  const {meetingRef} = props
+  const {meetingRef, menuProps} = props
 
   const meeting = useFragment(
     graphql`
@@ -64,7 +47,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
 
-  const renderedMenu = (
+  return (
     <Menu ariaLabel={'Edit the meeting'} {...menuProps}>
       <MenuItem
         key='copy'
@@ -81,15 +64,6 @@ const TeamPromptOptionsMenu = (props: Props) => {
         }}
       />
     </Menu>
-  )
-
-  return (
-    <>
-      <Options ref={originRef} onClick={togglePortal}>
-        <IconLabel ref={originRef} icon='more_vert' />
-      </Options>
-      {menuPortal(renderedMenu)}
-    </>
   )
 }
 

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -75,7 +75,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
             <span>{'End this activity'}</span>
           </OptionMenuItem>
         }
-        onClick={async () => {
+        onClick={() => {
           menuProps.closePortal()
           EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError})
         }}

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -66,11 +66,11 @@ const TeamPromptTopBar = (props: Props) => {
         </TeamPromptHeader>
       </HeadingBlock>
       <AvatarGroupBlock>
+        {/* :TODO: (jmtaber129): Add avatars, etc. */}
         <ButtonContainer>
           <TeamPromptOptionsMenu meetingRef={meeting} />
         </ButtonContainer>
       </AvatarGroupBlock>
-      {/* :TODO: (jmtaber129): Add avatars, overflow menu, etc. */}
     </MeetingTopBarStyles>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -6,7 +6,7 @@ import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_mee
 import {meetingAvatarMediaQueries} from '../../styles/meeting'
 import BackButton from '../BackButton'
 import {HeadingBlock, IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
-import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
+import TeamPromptOptions from './TeamPromptOptions'
 
 const TeamPromptHeaderTitle = styled('h1')({
   fontSize: 16,
@@ -49,7 +49,7 @@ const TeamPromptTopBar = (props: Props) => {
     graphql`
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         name
-        ...TeamPromptOptionsMenu_meeting
+        ...TeamPromptOptions_meeting
       }
     `,
     meetingRef
@@ -68,7 +68,7 @@ const TeamPromptTopBar = (props: Props) => {
       <IconGroupBlock>
         {/* :TODO: (jmtaber129): Add avatars, etc. */}
         <ButtonContainer>
-          <TeamPromptOptionsMenu meetingRef={meeting} />
+          <TeamPromptOptions meetingRef={meeting} />
         </ButtonContainer>
       </IconGroupBlock>
     </MeetingTopBarStyles>

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -1,13 +1,12 @@
-import graphql from 'babel-plugin-relay/macro'
 import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
-
 import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
+import {meetingAvatarMediaQueries} from '../../styles/meeting'
 import BackButton from '../BackButton'
 import {AvatarGroupBlock, HeadingBlock, MeetingTopBarStyles} from '../MeetingTopBar'
 import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
-import {meetingAvatarMediaQueries} from '../../styles/meeting'
 
 const TeamPromptHeaderTitle = styled('h1')({
   fontSize: 16,
@@ -50,6 +49,7 @@ const TeamPromptTopBar = (props: Props) => {
     graphql`
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         name
+        ...TeamPromptOptionsMenu_meeting
       }
     `,
     meetingRef
@@ -67,7 +67,7 @@ const TeamPromptTopBar = (props: Props) => {
       </HeadingBlock>
       <AvatarGroupBlock>
         <ButtonContainer>
-          <TeamPromptOptionsMenu />
+          <TeamPromptOptionsMenu meeting={meeting} />
         </ButtonContainer>
       </AvatarGroupBlock>
       {/* :TODO: (jmtaber129): Add avatars, overflow menu, etc. */}

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -67,7 +67,7 @@ const TeamPromptTopBar = (props: Props) => {
       </HeadingBlock>
       <AvatarGroupBlock>
         <ButtonContainer>
-          <TeamPromptOptionsMenu meeting={meeting} />
+          <TeamPromptOptionsMenu meetingRef={meeting} />
         </ButtonContainer>
       </AvatarGroupBlock>
       {/* :TODO: (jmtaber129): Add avatars, overflow menu, etc. */}

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -5,7 +5,7 @@ import {useFragment} from 'react-relay'
 import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
 import {meetingAvatarMediaQueries} from '../../styles/meeting'
 import BackButton from '../BackButton'
-import {AvatarGroupBlock, HeadingBlock, MeetingTopBarStyles} from '../MeetingTopBar'
+import {HeadingBlock, IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
 import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
 
 const TeamPromptHeaderTitle = styled('h1')({
@@ -65,12 +65,12 @@ const TeamPromptTopBar = (props: Props) => {
           <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
         </TeamPromptHeader>
       </HeadingBlock>
-      <AvatarGroupBlock>
+      <IconGroupBlock>
         {/* :TODO: (jmtaber129): Add avatars, etc. */}
         <ButtonContainer>
           <TeamPromptOptionsMenu meetingRef={meeting} />
         </ButtonContainer>
-      </AvatarGroupBlock>
+      </IconGroupBlock>
     </MeetingTopBarStyles>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -3,9 +3,11 @@ import styled from '@emotion/styled'
 import React from 'react'
 import {useFragment} from 'react-relay'
 
-import { TeamPromptTopBar_meeting$key } from '~/__generated__/TeamPromptTopBar_meeting.graphql'
+import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
 import BackButton from '../BackButton'
-import {HeadingBlock, MeetingTopBarStyles} from '../MeetingTopBar'
+import {AvatarGroupBlock, HeadingBlock, MeetingTopBarStyles} from '../MeetingTopBar'
+import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
+import {meetingAvatarMediaQueries} from '../../styles/meeting'
 
 const TeamPromptHeaderTitle = styled('h1')({
   fontSize: 16,
@@ -19,6 +21,22 @@ const TeamPromptHeader = styled('div')({
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'flex-start'
+})
+
+const ButtonContainer = styled('div')({
+  alignItems: 'center',
+  alignContent: 'center',
+  display: 'flex',
+  height: 32,
+  marginLeft: 11,
+  position: 'relative',
+  [meetingAvatarMediaQueries[0]]: {
+    height: 48,
+    marginLeft: 10
+  },
+  [meetingAvatarMediaQueries[1]]: {
+    height: 56
+  }
 })
 
 interface Props {
@@ -37,7 +55,7 @@ const TeamPromptTopBar = (props: Props) => {
     meetingRef
   )
 
-  const { name: meetingName } = meeting
+  const {name: meetingName} = meeting
 
   return (
     <MeetingTopBarStyles>
@@ -47,6 +65,11 @@ const TeamPromptTopBar = (props: Props) => {
           <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
         </TeamPromptHeader>
       </HeadingBlock>
+      <AvatarGroupBlock>
+        <ButtonContainer>
+          <TeamPromptOptionsMenu />
+        </ButtonContainer>
+      </AvatarGroupBlock>
       {/* :TODO: (jmtaber129): Add avatars, overflow menu, etc. */}
     </MeetingTopBarStyles>
   )


### PR DESCRIPTION
fixes https://github.com/ParabolInc/parabol/issues/6199

Current behavior is to end the meeting, but stay on the meeting page.  After meeting is ended, "End Meeting" button is still present, but disabled.

(commits https://github.com/ParabolInc/parabol/commit/f0635559c344aacda1bdbcc76763b97095c56f4b and later are the relevant ones; the diff against https://github.com/ParabolInc/parabol/pull/6336's branch is inaccurate due to the merge from `master`)

Needs rebase after https://github.com/ParabolInc/parabol/pull/6336 is merged.

https://www.loom.com/share/b1871e6f2f29435f84e83e570e2db457