### PR TITLE
fix(gitlab): add proper client-side alias handling

### DIFF
--- a/packages/client/components/GitLabScopingSearchResults.tsx
+++ b/packages/client/components/GitLabScopingSearchResults.tsx
@@ -59,15 +59,15 @@ const GitLabScopingSearchResults = (props: Props) => {
   >(
     graphql`
       fragment GitLabScopingSearchResults_query on Query
-        @argumentDefinitions(
-          projectsFirst: {type: "Int", defaultValue: 20}
-          issuesFirst: {type: "Int", defaultValue: 25}
-          projectsAfter: {type: "String"}
-          issuesAfter: {type: "String"}
-          search: {type: "String"}
-          projectIds: {type: "[ID!]", defaultValue: null}
-        )
-        @refetchable(queryName: "GitLabScopingSearchResultsPaginationQuery") {
+      @argumentDefinitions(
+        projectsFirst: {type: "Int", defaultValue: 20}
+        issuesFirst: {type: "Int", defaultValue: 25}
+        projectsAfter: {type: "String"}
+        issuesAfter: {type: "String"}
+        search: {type: "String"}
+        projectIds: {type: "[ID!]", defaultValue: null}
+      )
+      @refetchable(queryName: "GitLabScopingSearchResultsPaginationQuery") {
         viewer {
           ...NewGitLabIssueInput_viewer
           teamMember(teamId: $teamId) {
@@ -98,7 +98,6 @@ const GitLabScopingSearchResults = (props: Props) => {
                       edges {
                         node {
                           ... on _xGitLabProject {
-                            fullPath
                             issues(
                               includeSubepics: true
                               state: opened

--- a/packages/server/graphql/public/types/_xGitLabProject.ts
+++ b/packages/server/graphql/public/types/_xGitLabProject.ts
@@ -1,7 +1,7 @@
 import {_XGitLabProjectResolvers} from '../resolverTypes'
 
 const _xGitLabProject: _XGitLabProjectResolvers = {
-  __isTypeOf: ({__typename}) => __typename === '_xGitLabProject',
+  __isTypeOf: ({id}) => id.startsWith('gid://'),
   service: () => 'gitlab'
 }
 

--- a/packages/server/graphql/public/types/_xGitLabQuery.ts
+++ b/packages/server/graphql/public/types/_xGitLabQuery.ts
@@ -1,0 +1,19 @@
+import {GraphQLResolveInfo} from 'graphql'
+import {_XGitLabQueryResolvers} from '../resolverTypes'
+
+const resolveToFieldNameOrAlias = (
+  source: any,
+  _args: unknown,
+  _context: unknown,
+  info: GraphQLResolveInfo
+) => {
+  // fieldNodes will always have 1+ node
+  const key = info.fieldNodes[0]!.alias?.value ?? info.fieldName
+  return source[key]
+}
+
+const _xGitLabQuery: _XGitLabQueryResolvers = {
+  projects: resolveToFieldNameOrAlias
+}
+
+export default _xGitLabQuery


### PR DESCRIPTION
This fixes that problem where fullPath was required on the client side.
adding fullPath to the client didn't actually fix the problem, it just masked it.
full loom here: https://www.loom.com/share/79e4d705572c40bdba449b12bc3250b7
