### PR TITLE
feat(standups): Discussion Drawer

### DIFF
--- a/packages/client/clientSchema.graphql
+++ b/packages/client/clientSchema.graphql
@@ -38,6 +38,11 @@ extend type RetrospectiveMeeting {
   spotlightSearchQuery: String
 }
 
+extend type TeamPromptMeeting {
+  localDiscussionId: String
+  isRightDrawerOpen: Boolean!
+}
+
 extend type Team {
   teamMemberFilter: TeamMember
   editingScaleId: ID

--- a/packages/client/components/ActionMeetingAgendaItems.tsx
+++ b/packages/client/components/ActionMeetingAgendaItems.tsx
@@ -11,7 +11,8 @@ import {Breakpoint} from '../types/constEnums'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import {ActionMeetingPhaseProps} from './ActionMeeting'
 import Avatar from './Avatar/Avatar'
-import {DiscussionThreadables} from './DiscussionThreadList'
+import {DiscussionThreadables, Header as DiscussionThreadHeader} from './DiscussionThreadList'
+import DiscussionThreadListEmptyState from './DiscussionThreadListEmptyState'
 import DiscussionThreadRoot from './DiscussionThreadRoot'
 import MeetingContent from './MeetingContent'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
@@ -83,6 +84,15 @@ const ActionMeetingAgendaItems = (props: Props) => {
               meetingContentRef={meetingContentRef}
               discussionId={discussionId!}
               allowedThreadables={allowedThreadables}
+              header={
+                <DiscussionThreadHeader>{'Discussion & Takeaway Tasks'}</DiscussionThreadHeader>
+              }
+              emptyState={
+                <DiscussionThreadListEmptyState
+                  allowTasks={true}
+                  isReadOnly={allowedThreadables.length === 0}
+                />
+              }
             />
           </ThreadColumn>
           <EditorHelpModalContainer />

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {RefObject, useMemo, useRef} from 'react'
+import React, {ReactNode, RefObject, useMemo, useRef} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {useCoverable} from '~/hooks/useControlBarCovers'
@@ -33,12 +33,12 @@ interface Props {
   allowedThreadables: DiscussionThreadables[]
   width?: string
   queryRef: PreloadedQuery<DiscussionThreadQuery>
-  showHeader?: boolean
-  showEmptyState?: boolean
+  header?: ReactNode
+  emptyState?: ReactNode
 }
 
 const DiscussionThread = (props: Props) => {
-  const {meetingContentRef, allowedThreadables, width, queryRef, showHeader, showEmptyState} = props
+  const {meetingContentRef, allowedThreadables, width, queryRef, header, emptyState} = props
   const {viewerId} = useAtmosphere()
   const isDrawer = !!width // hack to say this is in a poker meeting
   const listRef = useRef<HTMLDivElement>(null)
@@ -116,8 +116,8 @@ const DiscussionThread = (props: Props) => {
         ref={listRef}
         editorRef={editorRef}
         viewer={viewer}
-        showHeader={showHeader}
-        showEmptyState={showEmptyState}
+        header={header}
+        emptyState={emptyState}
       />
       <DiscussionThreadInput
         allowedThreadables={allowedThreadables}

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -33,10 +33,12 @@ interface Props {
   allowedThreadables: DiscussionThreadables[]
   width?: string
   queryRef: PreloadedQuery<DiscussionThreadQuery>
+  showHeader?: boolean
+  showEmptyState?: boolean
 }
 
 const DiscussionThread = (props: Props) => {
-  const {meetingContentRef, allowedThreadables, width, queryRef} = props
+  const {meetingContentRef, allowedThreadables, width, queryRef, showHeader, showEmptyState} = props
   const {viewerId} = useAtmosphere()
   const isDrawer = !!width // hack to say this is in a poker meeting
   const listRef = useRef<HTMLDivElement>(null)
@@ -114,6 +116,8 @@ const DiscussionThread = (props: Props) => {
         ref={listRef}
         editorRef={editorRef}
         viewer={viewer}
+        showHeader={showHeader}
+        showEmptyState={showEmptyState}
       />
       <DiscussionThreadInput
         allowedThreadables={allowedThreadables}

--- a/packages/client/components/DiscussionThreadList.tsx
+++ b/packages/client/components/DiscussionThreadList.tsx
@@ -58,6 +58,8 @@ interface Props {
   threadables: DiscussionThreadList_threadables
   viewer: DiscussionThreadList_viewer
   dataCy: string
+  showHeader?: boolean
+  showEmptyState?: boolean
 }
 
 const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
@@ -68,15 +70,17 @@ const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
     threadables,
     dataCy,
     preferredNames,
-    viewer
+    viewer,
+    showHeader = true,
+    showEmptyState = true
   } = props
   const isEmpty = threadables.length === 0
   useScrollThreadList(threadables, editorRef, ref, preferredNames)
   const allowTasks = allowedThreadables.includes('task')
-  if (isEmpty) {
+  if (isEmpty && showEmptyState) {
     return (
       <EmptyWrapper>
-        {allowTasks && <Header>{'Discussion & Takeaway Tasks'}</Header>}
+        {allowTasks && showHeader && <Header>{'Discussion & Takeaway Tasks'}</Header>}
         <DiscussionThreadListEmptyState
           allowTasks={allowTasks}
           isReadOnly={allowedThreadables.length === 0}
@@ -90,7 +94,7 @@ const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
 
   return (
     <Wrapper data-cy={`${dataCy}`} ref={ref}>
-      {allowTasks && <Header>{'Discussion & Takeaway Tasks'}</Header>}
+      {allowTasks && showHeader && <Header>{'Discussion & Takeaway Tasks'}</Header>}
       <PusherDowner />
       {threadables.map((threadable) => {
         const {id} = threadable

--- a/packages/client/components/DiscussionThreadList.tsx
+++ b/packages/client/components/DiscussionThreadList.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {forwardRef, RefObject} from 'react'
+import React, {forwardRef, ReactNode, RefObject} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import useScrollThreadList from '~/hooks/useScrollThreadList'
 import {DiscussionThreadList_discussion} from '~/__generated__/DiscussionThreadList_discussion.graphql'
@@ -8,7 +8,6 @@ import {DiscussionThreadList_threadables} from '~/__generated__/DiscussionThread
 import {DiscussionThreadList_viewer} from '~/__generated__/DiscussionThreadList_viewer.graphql'
 import {PALETTE} from '../styles/paletteV3'
 import CommentingStatusText from './CommentingStatusText'
-import DiscussionThreadListEmptyState from './DiscussionThreadListEmptyState'
 import LabelHeading from './LabelHeading/LabelHeading'
 import ThreadedItem from './ThreadedItem'
 
@@ -35,7 +34,7 @@ const PusherDowner = styled('div')({
   margin: '0 0 auto'
 })
 
-const Header = styled(LabelHeading)({
+export const Header = styled(LabelHeading)({
   borderBottom: `1px solid ${PALETTE.SLATE_300}`,
   margin: '0 0 8px',
   padding: '6px 12px 12px',
@@ -58,8 +57,8 @@ interface Props {
   threadables: DiscussionThreadList_threadables
   viewer: DiscussionThreadList_viewer
   dataCy: string
-  showHeader?: boolean
-  showEmptyState?: boolean
+  header?: ReactNode
+  emptyState?: ReactNode
 }
 
 const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
@@ -71,20 +70,16 @@ const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
     dataCy,
     preferredNames,
     viewer,
-    showHeader = true,
-    showEmptyState = true
+    header,
+    emptyState
   } = props
   const isEmpty = threadables.length === 0
   useScrollThreadList(threadables, editorRef, ref, preferredNames)
-  const allowTasks = allowedThreadables.includes('task')
-  if (isEmpty && showEmptyState) {
+  if (isEmpty && emptyState) {
     return (
       <EmptyWrapper>
-        {allowTasks && showHeader && <Header>{'Discussion & Takeaway Tasks'}</Header>}
-        <DiscussionThreadListEmptyState
-          allowTasks={allowTasks}
-          isReadOnly={allowedThreadables.length === 0}
-        />
+        {header}
+        {emptyState}
         <CommentingStatusBlock>
           <CommentingStatusText preferredNames={preferredNames} />
         </CommentingStatusBlock>
@@ -94,7 +89,7 @@ const DiscussionThreadList = forwardRef((props: Props, ref: any) => {
 
   return (
     <Wrapper data-cy={`${dataCy}`} ref={ref}>
-      {allowTasks && showHeader && <Header>{'Discussion & Takeaway Tasks'}</Header>}
+      {header}
       <PusherDowner />
       {threadables.map((threadable) => {
         const {id} = threadable

--- a/packages/client/components/DiscussionThreadRoot.tsx
+++ b/packages/client/components/DiscussionThreadRoot.tsx
@@ -11,10 +11,13 @@ interface Props {
   discussionId: string
   allowedThreadables: DiscussionThreadables[]
   width?: string
+  showHeader?: boolean
+  showEmptyState?: boolean
 }
 
 const DiscussionThreadRoot = (props: Props) => {
-  const {allowedThreadables, meetingContentRef, discussionId, width} = props
+  const {allowedThreadables, meetingContentRef, discussionId, width, showHeader, showEmptyState} =
+    props
   const queryRef = useQueryLoaderNow<DiscussionThreadQuery>(discussionThreadQuery, {discussionId})
   return (
     <Suspense fallback={''}>
@@ -24,6 +27,8 @@ const DiscussionThreadRoot = (props: Props) => {
           meetingContentRef={meetingContentRef}
           queryRef={queryRef}
           width={width}
+          showHeader={showHeader}
+          showEmptyState={showEmptyState}
         />
       )}
     </Suspense>

--- a/packages/client/components/DiscussionThreadRoot.tsx
+++ b/packages/client/components/DiscussionThreadRoot.tsx
@@ -1,4 +1,4 @@
-import React, {RefObject, Suspense} from 'react'
+import React, {ReactNode, RefObject, Suspense} from 'react'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
 import discussionThreadQuery, {
   DiscussionThreadQuery
@@ -11,13 +11,12 @@ interface Props {
   discussionId: string
   allowedThreadables: DiscussionThreadables[]
   width?: string
-  showHeader?: boolean
-  showEmptyState?: boolean
+  header?: ReactNode
+  emptyState?: ReactNode
 }
 
 const DiscussionThreadRoot = (props: Props) => {
-  const {allowedThreadables, meetingContentRef, discussionId, width, showHeader, showEmptyState} =
-    props
+  const {allowedThreadables, meetingContentRef, discussionId, width, header, emptyState} = props
   const queryRef = useQueryLoaderNow<DiscussionThreadQuery>(discussionThreadQuery, {discussionId})
   return (
     <Suspense fallback={''}>
@@ -27,8 +26,8 @@ const DiscussionThreadRoot = (props: Props) => {
           meetingContentRef={meetingContentRef}
           queryRef={queryRef}
           width={width}
-          showHeader={showHeader}
-          showEmptyState={showEmptyState}
+          header={header}
+          emptyState={emptyState}
         />
       )}
     </Suspense>

--- a/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
+++ b/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
@@ -7,11 +7,12 @@ import {PALETTE} from '~/styles/paletteV3'
 import {ICON_SIZE} from '~/styles/typographyV2'
 import {EstimatePhaseDiscussionDrawer_meeting} from '~/__generated__/EstimatePhaseDiscussionDrawer_meeting.graphql'
 import {BezierCurve, DiscussionThreadEnum, ZIndex} from '../types/constEnums'
+import {DiscussionThreadables} from './DiscussionThreadList'
+import DiscussionThreadListEmptyState from './DiscussionThreadListEmptyState'
 import DiscussionThreadRoot from './DiscussionThreadRoot'
 import Icon from './Icon'
 import LabelHeading from './LabelHeading/LabelHeading'
 import PlainButton from './PlainButton/PlainButton'
-import {DiscussionThreadables} from './DiscussionThreadList'
 
 const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
   boxShadow: isDesktop ? desktopSidebarShadow : undefined,
@@ -98,6 +99,12 @@ const EstimatePhaseDiscussionDrawer = (props: Props) => {
           allowedThreadables={allowedThreadables}
           discussionId={discussionId!}
           width={'calc(100% - 16px)'}
+          emptyState={
+            <DiscussionThreadListEmptyState
+              allowTasks={false}
+              isReadOnly={allowedThreadables.length === 0}
+            />
+          }
         />
       </ThreadColumn>
     </Drawer>

--- a/packages/client/components/RetroDiscussPhase.tsx
+++ b/packages/client/components/RetroDiscussPhase.tsx
@@ -12,7 +12,8 @@ import {ICON_SIZE} from '../styles/typographyV2'
 import {Breakpoint} from '../types/constEnums'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import plural from '../utils/plural'
-import {DiscussionThreadables} from './DiscussionThreadList'
+import {DiscussionThreadables, Header as DiscussionThreadHeader} from './DiscussionThreadList'
+import DiscussionThreadListEmptyState from './DiscussionThreadListEmptyState'
 import DiscussionThreadRoot from './DiscussionThreadRoot'
 import DiscussPhaseReflectionGrid from './DiscussPhaseReflectionGrid'
 import DiscussPhaseSqueeze from './DiscussPhaseSqueeze'
@@ -211,6 +212,15 @@ const RetroDiscussPhase = (props: Props) => {
                   allowedThreadables={allowedThreadables}
                   meetingContentRef={phaseRef}
                   discussionId={discussionId!}
+                  header={
+                    <DiscussionThreadHeader>{'Discussion & Takeaway Tasks'}</DiscussionThreadHeader>
+                  }
+                  emptyState={
+                    <DiscussionThreadListEmptyState
+                      allowTasks={true}
+                      isReadOnly={allowedThreadables.length === 0}
+                    />
+                  }
                 />
               </ThreadColumn>
             </ColumnsContainer>

--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -124,8 +124,6 @@ const TeamPromptDiscussionDrawer = ({meetingRef, isDesktop}: Props) => {
               discussionId={localDiscussionId!}
               allowedThreadables={['comment', 'task']}
               width={'100%'}
-              showHeader={false}
-              showEmptyState={false}
             />
           </ThreadColumn>
         )}

--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -104,7 +104,7 @@ const TeamPromptDiscussionDrawer = ({meetingRef, isDesktop}: Props) => {
     })
   }
 
-  return (
+  return localDiscussionId ? (
     <ResponsiveDashSidebar
       isOpen={isRightDrawerOpen}
       isRightDrawer
@@ -118,18 +118,16 @@ const TeamPromptDiscussionDrawer = ({meetingRef, isDesktop}: Props) => {
             <CloseIcon>close</CloseIcon>
           </StyledCloseButton>
         </Header>
-        {localDiscussionId && (
-          <ThreadColumn>
-            <DiscussionThreadRoot
-              discussionId={localDiscussionId!}
-              allowedThreadables={['comment', 'task']}
-              width={'100%'}
-            />
-          </ThreadColumn>
-        )}
+        <ThreadColumn>
+          <DiscussionThreadRoot
+            discussionId={localDiscussionId!}
+            allowedThreadables={['comment', 'task']}
+            width={'100%'}
+          />
+        </ThreadColumn>
       </Drawer>
     </ResponsiveDashSidebar>
-  )
+  ) : null
 }
 
 export default TeamPromptDiscussionDrawer

--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -1,0 +1,137 @@
+import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {commitLocalUpdate, useFragment} from 'react-relay'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import {TeamPromptDiscussionDrawer_meeting$key} from '~/__generated__/TeamPromptDiscussionDrawer_meeting.graphql'
+import {desktopSidebarShadow} from '../../styles/elevation'
+import {PALETTE} from '../../styles/paletteV3'
+import {ICON_SIZE} from '../../styles/typographyV2'
+import {BezierCurve, DiscussionThreadEnum, ZIndex} from '../../types/constEnums'
+import DiscussionThreadRoot from '../DiscussionThreadRoot'
+import Icon from '../Icon'
+import LabelHeading from '../LabelHeading/LabelHeading'
+import PlainButton from '../PlainButton/PlainButton'
+import ResponsiveDashSidebar from '../ResponsiveDashSidebar'
+
+const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
+  boxShadow: isDesktop ? desktopSidebarShadow : undefined,
+  backgroundColor: '#FFFFFF',
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  height: '100%',
+  justifyContent: 'stretch',
+  overflow: 'hidden',
+  position: isDesktop ? 'fixed' : 'static',
+  bottom: 0,
+  top: 0,
+  right: isDesktop ? 0 : undefined,
+  transition: `all 200ms ${BezierCurve.DECELERATE}`,
+  userSelect: 'none',
+  width: isOpen || !isDesktop ? DiscussionThreadEnum.WIDTH : 0,
+  zIndex: ZIndex.SIDEBAR
+}))
+
+const ThreadColumn = styled('div')({
+  alignItems: 'center',
+  bottom: 0,
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  height: '100%',
+  justifyContent: 'flex-end',
+  maxWidth: 700,
+  overflow: 'auto',
+  position: 'relative',
+  width: '100%'
+})
+
+const CloseIcon = styled(Icon)({
+  color: PALETTE.SLATE_600,
+  cursor: 'pointer',
+  fontSize: ICON_SIZE.MD24,
+  '&:hover': {
+    opacity: 0.5
+  }
+})
+
+const Header = styled('div')({
+  alignItems: 'center',
+  borderBottom: `1px solid ${PALETTE.SLATE_300}`,
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '8px 8px 8px 12px',
+  width: '100%'
+})
+
+const HeaderLabel = styled(LabelHeading)({
+  textTransform: 'none',
+  width: '100%'
+})
+
+const StyledCloseButton = styled(PlainButton)({
+  height: 24
+})
+
+interface Props {
+  meetingRef: TeamPromptDiscussionDrawer_meeting$key
+  isDesktop: boolean
+}
+
+const TeamPromptDiscussionDrawer = ({meetingRef, isDesktop}: Props) => {
+  const meeting = useFragment(
+    graphql`
+      fragment TeamPromptDiscussionDrawer_meeting on TeamPromptMeeting {
+        localDiscussionId
+        isRightDrawerOpen
+        id
+      }
+    `,
+    meetingRef
+  )
+
+  const atmosphere = useAtmosphere()
+
+  const {localDiscussionId, id: meetingId, isRightDrawerOpen} = meeting
+
+  const onToggle = () => {
+    commitLocalUpdate(atmosphere, (store) => {
+      const meeting = store.get(meetingId)
+      if (!meeting) return
+      const isRightDrawerOpen = meeting.getValue('isRightDrawerOpen')
+      meeting.setValue(!isRightDrawerOpen, 'isRightDrawerOpen')
+    })
+  }
+
+  return (
+    <ResponsiveDashSidebar
+      isOpen={isRightDrawerOpen}
+      isRightDrawer
+      onToggle={onToggle}
+      sidebarWidth={DiscussionThreadEnum.WIDTH}
+    >
+      <Drawer isDesktop={isDesktop} isOpen={isRightDrawerOpen}>
+        <Header>
+          <HeaderLabel>{'TODO: show response card'}</HeaderLabel>
+          <StyledCloseButton onClick={onToggle}>
+            <CloseIcon>close</CloseIcon>
+          </StyledCloseButton>
+        </Header>
+        {localDiscussionId && (
+          <ThreadColumn>
+            <DiscussionThreadRoot
+              discussionId={localDiscussionId!}
+              allowedThreadables={['comment', 'task']}
+              width={'100%'}
+              showHeader={false}
+              showEmptyState={false}
+            />
+          </ThreadColumn>
+        )}
+      </Drawer>
+    </ResponsiveDashSidebar>
+  )
+}
+
+export default TeamPromptDiscussionDrawer

--- a/packages/server/graphql/mutations/addComment.ts
+++ b/packages/server/graphql/mutations/addComment.ts
@@ -1,13 +1,13 @@
 import {GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import normalizeRawDraftJS from 'parabol-client/validation/normalizeRawDraftJS'
-import GenericMeetingStage from '../../database/types/GenericMeetingStage'
 import MeetingMemberId from '../../../client/shared/gqlIds/MeetingMemberId'
 import getRethink from '../../database/rethinkDriver'
 import Comment from '../../database/types/Comment'
 import GenericMeetingPhase, {
   NewMeetingPhaseTypeEnum
 } from '../../database/types/GenericMeetingPhase'
+import GenericMeetingStage from '../../database/types/GenericMeetingStage'
 import {getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import segmentIo from '../../utils/segmentIo'
@@ -67,14 +67,16 @@ const addComment = {
 
     const dbComment = new Comment({...comment, content, createdBy: viewerId})
     const {id: commentId, isAnonymous, threadParentId} = dbComment
-    await r
-      .table('Comment')
-      .insert(dbComment)
-      .run()
+    await r.table('Comment').insert(dbComment).run()
 
     const data = {commentId, meetingId}
     const {phases, teamId} = meeting!
-    const threadablePhases = ['discuss', 'agendaitems', 'ESTIMATE'] as NewMeetingPhaseTypeEnum[]
+    const threadablePhases = [
+      'discuss',
+      'agendaitems',
+      'ESTIMATE',
+      'RESPONSES'
+    ] as NewMeetingPhaseTypeEnum[]
     const containsThreadablePhase = phases.find(({phaseType}: GenericMeetingPhase) =>
       threadablePhases.includes(phaseType)
     )!


### PR DESCRIPTION
fixes https://github.com/ParabolInc/parabol/issues/5796

Mobile design impl is the same as the reduced space case per [this discussion](https://parabol.slack.com/archives/C039L3XG6BH/p1649356110824849) (vs. the mobile design impl in Figma)

https://www.loom.com/share/5282c3ac078d4bfba9b8f8ca74bb4065

Test:
* Discussion drawer opens when placeholder icon is clicked
* User can interact with the discussion thread
  * Add comments
  * Add task
  * React to comments
  * Reply to comments
* Drawer closes when the top right close icon is clicked
* Drawer overlays the rest of the meeting space when space is limited