### PR TITLE
fix(integration-tests): support running integration tests against another env

### DIFF
--- a/packages/integration-tests/playwright.config.ts
+++ b/packages/integration-tests/playwright.config.ts
@@ -1,4 +1,4 @@
-import {PlaywrightTestConfig, devices} from '@playwright/test'
+import {devices, PlaywrightTestConfig} from '@playwright/test'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
   workers: process.env.CI ? 1 : undefined,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['list'], ['html']],
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/packages/integration-tests/tests/config.ts
+++ b/packages/integration-tests/tests/config.ts
@@ -1,6 +1,6 @@
-import '../../../scripts/webpack/utils/dotenv'
 import {Page} from '@playwright/test'
-import {newConfig, string, number} from 'ts-app-env'
+import {newConfig, number, string} from 'ts-app-env'
+import '../../../scripts/webpack/utils/dotenv'
 
 const EnvConfig = {
   HOST: string(),
@@ -24,7 +24,7 @@ export class Config {
 
   private rootUrlPathFromEnv({HOST, PORT}: typeof EnvConfig): string {
     const scheme = HOST === 'localhost' ? 'http' : 'https'
-    return `${scheme}://${HOST}${PORT ? `:${PORT}` : ''}`
+    return `${scheme}://${HOST}${HOST === 'localhost' ? `:${PORT}` : ''}`
   }
 }
 


### PR DESCRIPTION
This PR allows us to run the integration test suite against a different HOST (other than `localhost`). See inline comments for details.