### PR TITLE
chore(dx): Don't truncate TypeScript types

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "noErrorTruncation": true
   }
 }


### PR DESCRIPTION
This setting influences truncation from TSServer in hover and error
messages.