### PR TITLE
feat(standups): Response Cards

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import {Elevation} from '~/styles/elevation'
+import {PALETTE} from '~/styles/paletteV3'
+import {Card} from '~/types/constEnums'
+import {TeamPromptResponseCard_stage$key} from '~/__generated__/TeamPromptResponseCard_stage.graphql'
+import Avatar from '../Avatar/Avatar'
+import PromptResponseEditor from '../promptResponse/PromptResponseEditor'
+
+const MIN_CARD_HEIGHT = 100
+
+const ResponseHeader = styled('div')({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  padding: '0 8px'
+})
+
+const ResponseCard = styled('div')<{isEmpty: boolean}>(({isEmpty = false}) => ({
+  background: isEmpty ? PALETTE.SLATE_300 : Card.BACKGROUND_COLOR,
+  borderRadius: Card.BORDER_RADIUS,
+  boxShadow: isEmpty ? undefined : Elevation.CARD_SHADOW,
+  flex: 1,
+  color: isEmpty ? PALETTE.SLATE_600 : undefined,
+  padding: Card.PADDING,
+  minHeight: MIN_CARD_HEIGHT,
+  userSelect: 'none'
+}))
+
+const TeamMemberName = styled('h3')({
+  padding: '0 8px'
+})
+
+interface Props {
+  stageRef: TeamPromptResponseCard_stage$key
+}
+
+const TeamPromptResponseCard = (props: Props) => {
+  const {stageRef} = props
+
+  const responseStage = useFragment(
+    graphql`
+      fragment TeamPromptResponseCard_stage on TeamPromptResponseStage {
+        teamMember {
+          userId
+          picture
+          preferredName
+        }
+      }
+    `,
+    stageRef
+  )
+
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
+
+  const {teamMember} = responseStage
+  const {picture, preferredName, userId} = teamMember
+
+  const isCurrentViewer = userId === viewerId
+  const isEmptyResponse = !isCurrentViewer // :TODO: (jmtaber129): Determine based on actual response, too
+
+  return (
+    <>
+      <ResponseHeader>
+        <Avatar picture={picture} size={48} />
+        <TeamMemberName>{preferredName}</TeamMemberName>
+        {/* :TODO: (jmtaber129): Show when response was last updated */}
+      </ResponseHeader>
+      <ResponseCard isEmpty={isEmptyResponse}>
+        {isEmptyResponse ? (
+          'No response, yet...'
+        ) : (
+          <PromptResponseEditor
+            autoFocus={true}
+            handleSubmit={(editorState) => {
+              console.log('submitting response', editorState.getJSON())
+            }}
+            content={null}
+            readOnly={!isCurrentViewer}
+            placeholder={'Share your response...'}
+          />
+        )}
+        {/* :TODO: (jmtaber129): Add reactjis + response button */}
+      </ResponseCard>
+    </>
+  )
+}
+
+export default TeamPromptResponseCard

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -1,20 +1,33 @@
-import React, {useState} from 'react'
-import Placeholder from '@tiptap/extension-placeholder'
-import {EditorContent, Editor, EditorEvents, useEditor} from '@tiptap/react'
+import styled from '@emotion/styled'
 import {Editor as EditorState} from '@tiptap/core'
+import Placeholder from '@tiptap/extension-placeholder'
+import {Editor, EditorContent, EditorEvents, JSONContent, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import React, {useState} from 'react'
+
+const StyledEditor = styled('div')`
+  .ProseMirror p.is-editor-empty:first-child::before {
+    color: #adb5bd;
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+  }
+  .ProseMirror-focused:focus {
+    outline: none;
+  }
+`
 
 interface Props {
   autoFocus?: boolean
-  editorState: EditorState
-  setEditorState: (newEditorState: EditorState) => void
+  content: JSONContent | null
   handleSubmit: (editor: EditorState) => void
   readOnly: boolean
   placeholder: string
 }
 
 const PromptResponseEditor = (props: Props) => {
-  const {autoFocus: autoFocusProp, editorState, setEditorState, handleSubmit, readOnly, placeholder} = props
+  const {autoFocus: autoFocusProp, content, handleSubmit, readOnly, placeholder} = props
   const [_isEditing, setIsEditing] = useState(false)
   const [autoFocus, setAutoFocus] = useState(autoFocusProp)
 
@@ -23,9 +36,8 @@ const PromptResponseEditor = (props: Props) => {
     setAutoFocus(false)
   }
 
-  const onUpdate = ({editor: newEditorState}: EditorEvents['update']) => {
+  const onUpdate = () => {
     setEditing(true)
-    setEditorState(newEditorState)
   }
 
   const onSubmit = async ({editor: newEditorState}: EditorEvents['blur']) => {
@@ -33,26 +45,24 @@ const PromptResponseEditor = (props: Props) => {
     handleSubmit(newEditorState)
   }
 
-  const doc = editorState.getText()
-  const showPlaceholder = !doc && !!placeholder
   const editor: Editor | null = useEditor({
-    content: editorState.getJSON(),
+    content,
     extensions: [
       StarterKit,
       Placeholder.configure({
-        placeholder: showPlaceholder ? placeholder : ''
+        placeholder
       })
     ],
     autofocus: autoFocus,
     onUpdate,
     onBlur: onSubmit,
-    editable: !readOnly,
+    editable: !readOnly
   })
 
   return (
-    <EditorContent
-      editor={editor}
-    />
+    <StyledEditor>
+      <EditorContent editor={editor} />
+    </StyledEditor>
   )
 }
 export default PromptResponseEditor


### PR DESCRIPTION
fixes https://github.com/ParabolInc/parabol/issues/6202

~**Do not merge until https://github.com/ParabolInc/parabol/pull/6353 lands**~ ✅ 

Basic response cards.

A couple things left out of scope because the backend isn't yet implemented:
* Hooking cards up to responses from the backend (just the team member associated with the stage) - this should be easy once the data loading implemented in https://github.com/ParabolInc/parabol/pull/6333 lands.
* Showing when the response was last updated - this data isn't actually included on the response object as-is.  Maybe we pull this into its own issue?

Blank responses for viewer + other member:
<img width="1096" alt="Screen Shot 2022-04-12 at 6 09 29 PM" src="https://user-images.githubusercontent.com/9013217/163055506-1c86234b-93b7-4221-b9fd-adbeb1e6a8c6.png">

Filled response for other member:
<img width="883" alt="Screen Shot 2022-04-12 at 6 12 01 PM" src="https://user-images.githubusercontent.com/9013217/163055517-e4c2e6ec-aaf1-4320-bd3c-8acf27e99160.png">

Filled response for viewer:
<img width="1099" alt="Screen Shot 2022-04-12 at 6 09 53 PM" src="https://user-images.githubusercontent.com/9013217/163055521-1294f310-a220-4f3c-87cd-3a56893d8463.png">

https://www.loom.com/share/4e5919b191db469ebe1ba4619cf6b22d
