### PR TITLE
fix: ignore comparison order for equality

### DIFF
--- a/packages/server/postgres/utils/__tests__/checkEqBase.test.ts
+++ b/packages/server/postgres/utils/__tests__/checkEqBase.test.ts
@@ -17,7 +17,7 @@ describe('areEqual', () => {
     expect(areEqual(a, b)).toBe(true)
     expect(areEqual(b, a)).toBe(true)
   })
-  it('should ignore object keys with `undefined` value', async () => {
+  it("should ignore object keys with `undefined` value if they're missing in another object", async () => {
     const a = {
       issueKey: undefined,
       fieldName: 'Story point estimate',
@@ -33,6 +33,18 @@ describe('areEqual', () => {
 
     expect(areEqual(a, b)).toBe(true)
     expect(areEqual(b, a)).toBe(true)
+  })
+  it("should not ignore object keys with `undefined` value if they're present in another object", () => {
+    const a = {
+      issueKey: undefined,
+      fieldName: 'Story point estimate'
+    }
+    const b = {
+      issueKey: 'issue key'
+    }
+
+    expect(areEqual(a, b)).toBe(false)
+    expect(areEqual(b, a)).toBe(false)
   })
   it('should ignore the order of the elements in the array', () => {
     const a = [{k: 1}, {k: 2}, {k: 3}]

--- a/packages/server/postgres/utils/__tests__/checkEqBase.test.ts
+++ b/packages/server/postgres/utils/__tests__/checkEqBase.test.ts
@@ -1,0 +1,51 @@
+import {areEqual} from '../checkEqBase'
+
+describe('areEqual', () => {
+  it('should ignore the order of keys in objects', () => {
+    const a = {
+      fieldName: 'Story point estimate',
+      fieldType: 'number',
+      fieldId: 'customfield_10016'
+    }
+
+    const b = {
+      fieldId: 'customfield_10016',
+      fieldName: 'Story point estimate',
+      fieldType: 'number'
+    }
+
+    expect(areEqual(a, b)).toBe(true)
+    expect(areEqual(b, a)).toBe(true)
+  })
+  it('should ignore object keys with `undefined` value', async () => {
+    const a = {
+      issueKey: undefined,
+      fieldName: 'Story point estimate',
+      fieldType: 'number',
+      fieldId: 'customfield_10016'
+    }
+
+    const b = {
+      fieldName: 'Story point estimate',
+      fieldType: 'number',
+      fieldId: 'customfield_10016'
+    }
+
+    expect(areEqual(a, b)).toBe(true)
+    expect(areEqual(b, a)).toBe(true)
+  })
+  it('should ignore the order of the elements in the array', () => {
+    const a = [{k: 1}, {k: 2}, {k: 3}]
+    const b = [{k: 3}, {k: 1}, {k: 2}]
+
+    expect(areEqual(a, b)).toBe(true)
+    expect(areEqual(b, a)).toBe(true)
+  })
+  it('should check all elements in array', () => {
+    const a = [{k: 1}, {k: 1}, {k: 2}]
+    const b = [{k: 1}, {k: 2}, {k: 3}]
+
+    expect(areEqual(a, b)).toBe(false)
+    expect(areEqual(b, a)).toBe(false)
+  })
+})

--- a/packages/server/postgres/utils/checkEqBase.ts
+++ b/packages/server/postgres/utils/checkEqBase.ts
@@ -31,14 +31,15 @@ export function areEqual(a, b): boolean {
       if (result !== undefined) return result
 
       return areEqualObject(a, b)
-    default:
-      // ts check that all types are handled
-      const _: never = aType
-      return a === b
+    default: {
+      // ts check with never that all types are handled
+      const noop = (_: never) => a === b
+      return noop(aType)
+    }
   }
 }
 
-function areEqualDate(a, b): boolean | undefined {
+function areEqualDate(a: unknown, b: unknown): boolean | undefined {
   const isADate = a instanceof Date
   const isBDate = b instanceof Date
   if (isADate && isBDate) {
@@ -46,9 +47,10 @@ function areEqualDate(a, b): boolean | undefined {
   } else if (isADate || isBDate) {
     return false
   }
+  return undefined
 }
 
-function areEqualRegExp(a: RegExp, b: RegExp): boolean | undefined {
+function areEqualRegExp(a: unknown, b: unknown): boolean | undefined {
   const isARegExp = a instanceof RegExp
   const isBRegExp = b instanceof RegExp
   if (isARegExp && isBRegExp) {
@@ -61,9 +63,10 @@ function areEqualRegExp(a: RegExp, b: RegExp): boolean | undefined {
   } else if (isARegExp || isBRegExp) {
     return false
   }
+  return undefined
 }
 
-function areEqualArray(a, b): boolean | undefined {
+function areEqualArray(a: unknown, b: unknown): boolean | undefined {
   const isAArray = Array.isArray(a)
   const isBArray = Array.isArray(b)
   if (isAArray && isBArray) {
@@ -75,6 +78,7 @@ function areEqualArray(a, b): boolean | undefined {
   } else if (isAArray || isBArray) {
     return false
   }
+  return undefined
 }
 
 function areEqualObject(a: object, b: object): boolean {
@@ -84,8 +88,8 @@ function areEqualObject(a: object, b: object): boolean {
   if (aKeys.length !== bKeys.length) return false
   if (!aKeys.every((key) => bKeys.includes(key))) return false
 
-  for (let i = 0; i < aKeys.length; i++) {
-    if (!areEqual(a[aKeys[i]], b[aKeys[i]])) {
+  for (const key of aKeys) {
+    if (!areEqual(a[key], b[key])) {
       return false
     }
   }


### PR DESCRIPTION
unlock: #6239 

`checkRethinkPgEquality` should handle cases where the fields are an array with different element order.
