### PR TITLE
fix: viewerMeetingMember can be undefined

### DIFF
--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -70,16 +70,14 @@ const ScopePhaseArea = (props: Props) => {
   const {meeting} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const {viewerMeetingMember} = meeting
-  if (!viewerMeetingMember) return null
-  const {user, teamMember} = viewerMeetingMember
-  const {featureFlags} = user
-  const gitlabIntegration = teamMember.integrations.gitlab
-  const jiraServerIntegration = teamMember.integrations.jiraServer
+  const featureFlags = viewerMeetingMember?.user.featureFlags
+  const gitlabIntegration = viewerMeetingMember?.teamMember.integrations.gitlab
+  const jiraServerIntegration = viewerMeetingMember?.teamMember.integrations.jiraServer
   const isGitLabProviderAvailable = !!(
-    gitlabIntegration.cloudProvider?.clientId || gitlabIntegration.sharedProviders.length
+    gitlabIntegration?.cloudProvider?.clientId || gitlabIntegration?.sharedProviders.length
   )
-  const allowGitLab = isGitLabProviderAvailable && featureFlags.gitlab
-  const allowJiraServer = !!jiraServerIntegration.sharedProviders.length
+  const allowGitLab = !!(isGitLabProviderAvailable && featureFlags?.gitlab)
+  const allowJiraServer = !!jiraServerIntegration?.sharedProviders.length
 
   const baseTabs = [
     {icon: <GitHubSVG />, label: 'GitHub', allow: true, Component: ScopePhaseAreaGitHub},
@@ -100,7 +98,6 @@ const ScopePhaseArea = (props: Props) => {
   ] as const
 
   const tabs = baseTabs.filter(({allow}) => allow)
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [activeIdx, setActiveIdx] = useState(() => {
     const favoriteService = window.localStorage.getItem('favoriteService') || 'Jira'
     const idx = tabs.findIndex((tab) => tab.label === favoriteService)

--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -100,6 +100,7 @@ const ScopePhaseArea = (props: Props) => {
   ] as const
 
   const tabs = baseTabs.filter(({allow}) => allow)
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [activeIdx, setActiveIdx] = useState(() => {
     const favoriteService = window.localStorage.getItem('favoriteService') || 'Jira'
     const idx = tabs.findIndex((tab) => tab.label === favoriteService)

--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -70,7 +70,8 @@ const ScopePhaseArea = (props: Props) => {
   const {meeting} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const {viewerMeetingMember} = meeting
-  const {user, teamMember} = viewerMeetingMember!
+  if (!viewerMeetingMember) return null
+  const {user, teamMember} = viewerMeetingMember
   const {featureFlags} = user
   const gitlabIntegration = teamMember.integrations.gitlab
   const jiraServerIntegration = teamMember.integrations.jiraServer

--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -105,6 +105,7 @@ const ScopePhaseArea = (props: Props) => {
     const idx = tabs.findIndex((tab) => tab.label === favoriteService)
     return idx === -1 ? 1 : idx
   })
+
   const isTabActive = (label: typeof baseTabs[number]['label']) => {
     return activeIdx === tabs.findIndex((tab) => tab.label === label)
   }


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6440

In a previous PR, I used the non-null assertion to fix the eslint complaint that we could return null before a hook. Matt mentioned that we could ignore the eslint complaint and return null if `viewerMeetingMember` is undefined. 

Unfortunately, while I made the change in that PR, a subsequent PR built off of that branch must have still included the change. This PR reverts that change. 

I'd like to get this PR merged into master before the ship on Wednesday. As the change is trivial and the urgency is high, I'll request a review from a Maintainer.

https://www.loom.com/share/3fdd2fbb01ef42a9a7691f9c1132a276