### PR TITLE
feat(enableSAMLforDomain): support updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prepare": "husky install"
   },
   "resolutions": {
-    "typescript": "4.5.5",
+    "typescript": "4.6.3",
     "hoist-non-react-statics": "^3.3.0",
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -50,7 +50,7 @@
     "prettier": "^2.6.1",
     "react-refresh": "^0.9.0",
     "strict-event-emitter-types": "^2.0.0",
-    "typescript": "4.5.5",
+    "typescript": "4.6.3",
     "webpack": "5.64.1",
     "webpack-dev-server": "^4.7.3"
   },

--- a/packages/gql-executor/package.json
+++ b/packages/gql-executor/package.json
@@ -24,7 +24,7 @@
     "chokidar": "^3.3.1",
     "sucrase": "^3.16.0",
     "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "4.5.5"
+    "typescript": "4.6.3"
   },
   "dependencies": {
     "dd-trace": "^2.2.0",

--- a/packages/server/__tests__/globalSetup.ts
+++ b/packages/server/__tests__/globalSetup.ts
@@ -7,7 +7,8 @@ async function setup() {
   // so the safety checks will eventually fail if run too much
   await Promise.all([
     r.table('FailedAuthRequest').delete().run(),
-    r.table('PasswordResetRequest').delete().run()
+    r.table('PasswordResetRequest').delete().run(),
+    r.table('SAML').getAll('example.com', {index: 'domains'}).delete().run()
   ])
 }
 

--- a/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
@@ -23,61 +23,85 @@ const getURLWithSAMLRequestParam = (destination: string, slug: string) => {
   return url.toString()
 }
 
+const normalizeName = (name: string) => {
+  const normalizedName = name.trim().toLowerCase()
+  const nameRegex = /^[a-z0-9_-]+$/
+  if (!nameRegex.test(normalizedName)) {
+    return new Error('Name must be letters and numbers or _ or - with no spaces')
+  }
+  return normalizedName
+}
+
+const validateDomains = async (domains: string[] | null | undefined, slugName: string) => {
+  if (!domains) return undefined
+  const r = await getRethink()
+
+  const normalizedDomains = domains.map((domain) => domain.toLowerCase())
+  const domainOwner = await r
+    .table('SAML')
+    .getAll(r.args(normalizedDomains), {index: 'domains'})
+    .filter((row) => row('id').ne(slugName))
+    .limit(1)
+    .nth(0)
+    .run()
+  if (domainOwner) return new Error(`Domain is already owned by ${domainOwner.id}`)
+  return normalizedDomains
+}
+
+const getSignOnURL = (metadata: string | null | undefined, slugName: string) => {
+  if (!metadata) return undefined
+  const idp = samlify.IdentityProvider({metadata})
+  const {singleSignOnService} = idp.entityMeta.meta
+  const [fallbackKey] = Object.keys(singleSignOnService)
+  if (!fallbackKey) {
+    return new Error('Invalid metadata. Does not contain sign on URL')
+  }
+  const postKey = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
+  const inputURL = singleSignOnService[postKey] || singleSignOnService[fallbackKey]
+  try {
+    new URL(inputURL)
+  } catch (e) {
+    return new Error(`Invalid Sign on URL: ${inputURL}`)
+  }
+  return getURLWithSAMLRequestParam(inputURL, slugName)
+}
+
 const enableSAMLForDomain: MutationResolvers['enableSAMLForDomain'] = async (
   _source,
   {name, domains, metadata}
 ) => {
   const r = await getRethink()
-  const normalizedDomains = domains.map((domain) => domain.toLowerCase())
-  const normalizedName = name.trim().toLowerCase()
 
   // VALIDATION
-  const nameRegex = /^[a-z0-9_-]+$/
-  if (!nameRegex.test(normalizedName)) {
-    return {error: {message: 'Name must be letters and numbers or _ or - with no spaces'}}
-  }
-  const idp = samlify.IdentityProvider({metadata})
-  const {singleSignOnService} = idp.entityMeta.meta
-  const [fallbackKey] = Object.keys(singleSignOnService)
-  if (!fallbackKey) {
-    return {error: {message: 'Invalid metadata. Does not contain sign on URL'}}
-  }
-  const postKey = 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
-  const signOnURL = singleSignOnService[postKey] || singleSignOnService[fallbackKey]
-  try {
-    new URL(signOnURL)
-  } catch (e) {
-    return {error: {message: `Invalid Sign on URL: ${signOnURL}`}}
-  }
+  const slugName = normalizeName(name)
+  if (slugName instanceof Error) return {error: {message: slugName.message}}
 
-  const conflictingRecord = await r
-    .table('SAML')
-    .getAll(r.args(normalizedDomains), {index: 'domains'})
-    .filter({id: name})
-    .nth(0)
-    .default(null)
-    .run()
+  const signOnURL = getSignOnURL(metadata, slugName)
+  if (signOnURL instanceof Error) return {error: {message: signOnURL.message}}
 
-  if (conflictingRecord) {
-    const {id: conflictId, domains: conflictDomains} = conflictingRecord
-    const domainStr = conflictDomains.join(', ')
-    return {error: {message: `${conflictId} already controls ${domainStr}`}}
-  }
+  const normalizedDomains = await validateDomains(domains, slugName)
+  if (normalizedDomains instanceof Error) return {error: {message: normalizedDomains.message}}
 
   // RESOLUTION
-  const url = getURLWithSAMLRequestParam(signOnURL, normalizedName)
-  await r
-    .table('SAML')
-    .insert(
-      {
-        id: normalizedName,
+  const existingRecord = await r.table('SAML').get(slugName).run()
+  if (existingRecord) {
+    await r
+      .table('SAML')
+      .get(slugName)
+      .update({
         domains: normalizedDomains,
-        url,
-        metadata: metadata
-      },
-      {conflict: 'replace'}
-    )
-    .run()
+        url: signOnURL,
+        metadata: metadata || undefined
+      })
+      .run()
+  } else {
+    if (!normalizedDomains) return {error: {message: 'domains is required for new SAML customers'}}
+    if (!metadata || !signOnURL) return {error: {message: 'Invalid metadata'}}
+    await r
+      .table('SAML')
+      .insert({id: slugName, domains: normalizedDomains, metadata: metadata, signOnURL})
+      .run()
+  }
 
   return {success: true}
 }

--- a/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
@@ -43,6 +43,7 @@ const validateDomains = async (domains: string[] | null | undefined, slugName: s
     .filter((row) => row('id').ne(slugName))
     .limit(1)
     .nth(0)
+    .default(null)
     .run()
   if (domainOwner) return new Error(`Domain is already owned by ${domainOwner.id}`)
   return normalizedDomains

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -363,26 +363,6 @@ type Mutation {
   ): LoginSAMLPayload!
 
   """
-  Enable SAML for domain
-  """
-  enableSAMLForDomain(
-    """
-    A name to use for the redirect URL. Usually the company name without any spaces
-    """
-    name: ID!
-
-    """
-    a list of domains that the account has control over. usually the part after the @ of their email
-    """
-    domains: [ID!]!
-
-    """
-    A big chunk of XML data containing the redirect URL and X.509 certificate
-    """
-    metadata: String!
-  ): EnableSAMLForDomainPayload!
-
-  """
   Send a message to all authorised Slack users
   """
   messageAllSlackUsers(
@@ -7801,17 +7781,8 @@ type LoginSAMLPayload {
   authToken: ID
 }
 
-"""
-Return object for EnableSAMLForDomainPayload
-"""
-union EnableSAMLForDomainPayload = ErrorPayload | EnableSAMLForDomainSuccess
-
 type ErrorPayload {
   error: StandardMutationError!
-}
-
-type EnableSAMLForDomainSuccess {
-  success: Boolean!
 }
 
 """

--- a/packages/server/graphql/private/typeDefs/enableSAMLForDomain.graphql
+++ b/packages/server/graphql/private/typeDefs/enableSAMLForDomain.graphql
@@ -1,0 +1,34 @@
+extend type Mutation {
+  """
+  Enable SAML for domain
+  """
+  enableSAMLForDomain(
+    """
+    A name to use for the redirect URL. Usually the company name without any spaces
+    """
+    name: ID!
+
+    """
+    a list of domains that the account has control over. usually the part after the @ of their email
+    """
+    domains: [ID!]
+
+    """
+    A big chunk of XML data containing the redirect URL and X.509 certificate
+    """
+    metadata: String
+  ): EnableSAMLForDomainPayload!
+}
+
+"""
+Return object for EnableSAMLForDomainPayload
+"""
+union EnableSAMLForDomainPayload = ErrorPayload | EnableSAMLForDomainSuccess
+
+type ErrorPayload {
+  error: StandardMutationError!
+}
+
+type EnableSAMLForDomainSuccess {
+  success: Boolean!
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -80,7 +80,7 @@
     "terser-webpack-plugin": "5.0.3",
     "ts-jest": "^27.0.5",
     "ts-node": "^8.6.2",
-    "typescript": "^4.5.5",
+    "typescript": "4.6.3",
     "url-loader": "4.1.1",
     "vscode-apollo-relay": "^1.5.0",
     "webpack": "5.64.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -130,7 +130,7 @@
     "mailgun.js": "^3.5.2",
     "mime-types": "^2.1.16",
     "ms": "^2.0.0",
-    "nest-graphql-endpoint": "^0.6.1",
+    "nest-graphql-endpoint": "^0.6.2",
     "node-env-flag": "0.1.0",
     "node-fetch": "^2.6.1",
     "node-pg-migrate": "^5.9.0",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -16,12 +16,10 @@
   "files": [
     "types/webpackEnv.ts",
     "types/modules.d.ts",
-    "../client/modules/email/components/SummaryEmail/MeetingSummaryEmail/MeetingSummaryEmail.tsx",
-    "graphql/queries/tasks.ts",
-    "graphql/queries/archivedTasks.ts",
-    "billing/debug.ts",
-    "hubspot/backfillHubSpot.ts",
     "server.ts",
-    "debugJira.ts"
+    "../client/modules/email/components/SummaryEmail/MeetingSummaryEmail/MeetingSummaryEmail.tsx"
   ]
+
+  // if "include" or "files" is added, even if they are empty arrays, then strictNullChecks breaks
+  // repro: https://www.typescriptlang.org/play?strictFunctionTypes=false&strictPropertyInitialization=false&strictBindCallApply=false&noImplicitThis=false&noImplicitReturns=false&alwaysStrict=false&declaration=false&experimentalDecorators=false&emitDecoratorMetadata=false&target=6&ts=3.5.1#code/C4TwDgpgBA8gRgKygXigbwFBSgWwIYhwQDKwATgIJlkD8AXFAM7kCWAdgOYDaAuhgL4ZQkKFTIpYiLgHJ8hEuTHS+AYwD2bZlDwS2AVwA2B7Y21sQJ0dQx4AdADM1ZAKJ4VACwAUngF4BKFAA+KH8MIA
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7852,7 +7852,6 @@ draft-js-utils@^1.4.0:
 
 "draft-js@https://github.com/mattkrick/draft-js/tarball/559a21968370c4944511657817d601a6c4ade0f6":
   version "0.10.5"
-  uid "025fddba56f21aaf3383aee778e0b17025c9a7bc"
   resolved "https://github.com/mattkrick/draft-js/tarball/559a21968370c4944511657817d601a6c4ade0f6#025fddba56f21aaf3383aee778e0b17025c9a7bc"
   dependencies:
     fbjs "^0.8.15"
@@ -17229,10 +17228,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.5.5, typescript@^4.2.4, typescript@^4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@4.6.3, typescript@^4.2.4, typescript@^4.5.5:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 uWebSockets.js@uNetworking/uWebSockets.js#v19.3.0:
   version "19.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12873,10 +12873,10 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-nest-graphql-endpoint@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/nest-graphql-endpoint/-/nest-graphql-endpoint-0.6.1.tgz#a0fa207dbf77b3e371ac919f415d0e94b0a81bd3"
-  integrity sha512-lk5BMhIM3gJb3871zkGK6Iun+w0n3VEnCGh6ocGp5gA4IfSnHOOvgUs81ZSv1thqhbnkejcq5Pp5JaEZyOM7FA==
+nest-graphql-endpoint@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/nest-graphql-endpoint/-/nest-graphql-endpoint-0.6.2.tgz#fa1ff4fccdfaedba1bf9382f72b8f4c1bd649dd6"
+  integrity sha512-rguljXpzo2Uku7CPyvMaXGPrbcI+uE2Nzawrk60goIyXSAAtU+xkfZze+smIn5Wt1i5rIFGtLSQaaJhYQ+OWxg==
   dependencies:
     "@graphql-tools/schema" "^8.3.6"
     "@graphql-tools/wrap" "^8.4.10"


### PR DESCRIPTION
fix #6327
fix #6409

enableSAMLForDomain had some bugs in it:
- you could register a domain for multiple different clients
- you couldn't just update the domains without also including the metadata, or vice versa

Fixing this also exposed a bug in typescript not employing strictNullChecks, so that's fixed here, too.

TEST
- [ ] add a new SAML record locally & it works (you can copy valid metadata from staging)
- [ ] edit that record's domains by calling it again without metadata (e.g. `{name: 'foo.co', domains: ['example.co']}`)
- [ ] create a new SAML record & try to usurp that domain (e.g. `{name: 'test.co', domains: ['example.co']}`). it should fail because example.co is already owned by another SAML record