### PR TITLE
fix(metrics): activeTeamCount resolver in Company GraphQL type should not count inactive teams

### DIFF
--- a/packages/server/graphql/types/Company.ts
+++ b/packages/server/graphql/types/Company.ts
@@ -31,7 +31,7 @@ const Company = new GraphQLObjectType<any, GQLContext>({
         const teams = teamsByOrgId.flat().filter(({isArchived}: Team) => !isArchived)
         const teamIds = teams.map(({id}: Team) => id)
 
-        const AreTeamActive = await Promise.all(
+        const AreTeamsActive = await Promise.all(
           teamIds.map(async (teamId) => {
             const activeMeetings = await dataLoader.get('activeMeetingsByTeamId').load(teamId)
             if (activeMeetings.length > 0) {
@@ -47,7 +47,7 @@ const Company = new GraphQLObjectType<any, GQLContext>({
             }
           })
         )
-        return AreTeamActive.filter(Boolean).length
+        return AreTeamsActive.filter(Boolean).length
       }
     },
     activeUserCount: {


### PR DESCRIPTION
Fixes #6225 

Test steps:

1.  Create a new org and 2 new teams under it
2.  In RethinkDB, manually update the org's domain to something else: `r.db('actionDevelopment').table('Organization').get('xxx').update({activeDomain: "abcd.com"})`
3.  Run a meeting in one of the new team
4.  Run GraphQL query in admin console and observe the count should be 1 (in `master` branch this will return 2):

```graphql
query {
  company(domain: "abcd.com") {
    activeTeamCount
  }
}
```