### PR TITLE
fix: ignore updateAt field in checkTableEq for Teams

### DIFF
--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -1,7 +1,7 @@
-import Team from '../../database/types/Team'
 import getRethink from '../../database/rethinkDriver'
-import {checkTableEq} from './checkEqBase'
+import Team from '../../database/types/Team'
 import getTeamsByIds from '../queries/getTeamsByIds'
+import {checkTableEq} from './checkEqBase'
 
 const alwaysDefinedFields: (keyof Partial<Team>)[] = [
   'name',
@@ -9,8 +9,7 @@ const alwaysDefinedFields: (keyof Partial<Team>)[] = [
   'isArchived',
   'isPaid',
   'tier',
-  'orgId',
-  'updatedAt'
+  'orgId'
 ]
 
 const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: any} = {

--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -3,14 +3,17 @@ import Team from '../../database/types/Team'
 import getTeamsByIds from '../queries/getTeamsByIds'
 import {checkTableEq} from './checkEqBase'
 
-const alwaysDefinedFields: (keyof Partial<Team>)[] = [
+const alwaysDefinedFields: (keyof Team)[] = [
   'name',
   'createdAt',
   'isArchived',
   'isPaid',
   'tier',
-  'orgId'
+  'orgId',
+  'createdBy',
+  'isOnboardTeam'
 ]
+const ignoredFields: (keyof Team)[] = ['updatedAt']
 
 const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: any} = {
   jiraDimensionFields: [],
@@ -24,7 +27,7 @@ const checkTeamEq = async (maxErrors = 10) => {
     'Team',
     rethinkQuery,
     getTeamsByIds,
-    alwaysDefinedFields,
+    alwaysDefinedFields.filter((field) => !ignoredFields.includes(field)),
     maybeUndefinedFieldsDefaultValues,
     {},
     maxErrors

--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -12,11 +12,12 @@ const alwaysDefinedFields: (keyof Team)[] = [
   'orgId',
   'isOnboardTeam'
 ]
-const ignoredFields: (keyof Team)[] = ['updatedAt', 'createdBy']
+const ignoredFields: (keyof Team)[] = ['updatedAt']
 
-const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: any} = {
+const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: unknown} = {
   jiraDimensionFields: [],
-  lastMeetingType: 'retrospective'
+  lastMeetingType: 'retrospective',
+  createdBy: null
 }
 
 const checkTeamEq = async (maxErrors = 10) => {

--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -10,10 +10,9 @@ const alwaysDefinedFields: (keyof Team)[] = [
   'isPaid',
   'tier',
   'orgId',
-  'createdBy',
   'isOnboardTeam'
 ]
-const ignoredFields: (keyof Team)[] = ['updatedAt']
+const ignoredFields: (keyof Team)[] = ['updatedAt', 'createdBy']
 
 const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: any} = {
   jiraDimensionFields: [],


### PR DESCRIPTION
As part of #6239 struggle, we encountered the fact that Postgres & RethinkDB store "Team" records with `updatedAt` that differ by about a year. 

This appears to be because the system does not always update the `updatedAt` field of Postgres or RethinkDB in some cases. This will be fixed in a separate PR.

Therefore, we can skip checking the `updateAt` field for the time being when comparing records.
https://github.com/ParabolInc/parabol/pull/6239#discussion_r863572037