### PR TITLE
fix(SDL): Resolve subscription payload type

### DIFF
--- a/packages/server/graphql/graphQLSubscriptionType.ts
+++ b/packages/server/graphql/graphQLSubscriptionType.ts
@@ -1,4 +1,10 @@
-import {GraphQLInterfaceType, GraphQLObjectType, GraphQLUnionType} from 'graphql'
+import {
+  GraphQLObjectType,
+  GraphQLUnionType,
+  isInterfaceType,
+  isObjectType,
+  isUnionType
+} from 'graphql'
 
 const graphQLSubscriptionType = (name: string, types: GraphQLObjectType[]) =>
   new GraphQLUnionType({
@@ -8,11 +14,19 @@ const graphQLSubscriptionType = (name: string, types: GraphQLObjectType[]) =>
       const {type} = data
       const concreteType = types.find((t) => t.toString() === type)
       if (concreteType) return concreteType
-      const abstractType = info.schema.getType(type) as GraphQLInterfaceType | GraphQLUnionType
-      if (abstractType.resolveType) {
-        return abstractType.resolveType(data, context, info, abstractType)
+      const unknownType = info.schema.getType(type)
+      if (isInterfaceType(unknownType) || isUnionType(unknownType)) {
+        if (unknownType.resolveType) {
+          return unknownType.resolveType(data, context, info, unknownType)
+        }
+        // should never happen, but that depends on using the resolveType pattern for all abstract types
+        return null
       }
-      // should never happen, but that depends on using the resolveType pattern for all abstract types
+      // added via SDL
+      if (isObjectType(unknownType)) {
+        return unknownType
+      }
+      // Should not happen, did we add non-object types as subscription payload?
       return null
     }
   })


### PR DESCRIPTION
When a subscription union is extended via SDL, it wasn't resolved
properly. Query the schema for non-abstract object types and return
those directly solves it for this use case.
