### PR TITLE
docs: Added general rules to code review policy

### DIFF
--- a/docs/codeReview.md
+++ b/docs/codeReview.md
@@ -5,6 +5,16 @@ Review progress is tracked in the [Sprint Board](https://github.com/orgs/Parabol
 If there is no issue belonging to the PR, then the PR itself should be added to the board.
 A PR advances from self-review to reviewer-review and finally maintainer review before it can get merged.
 
+## General rules
+
+- Once you're assigned to a task, it's your responsibility to split it the way you can submit reasonably sized PRs. It’s ok to have multiple PRs for a single issue.
+- Use draft PRs to ask for early feedback.
+- It should be a reviewer’s goal to do the code review within 1 business day. If you’re unable to do it, leave a comment.
+- If you’re busy it’s ok to assign someone else as a reviewer.
+- When submitting a PR, provide context. What's the task? What's changed? Why? If you can, record a Loom to share why things are done that way. It'll be easier for a reviewer to understand what decision you've made and why.
+- When reviewing a PR and requesting changes, be mindful that the PR author won't always have the right background to understand what are you requesting. Make your comments meaningful, and record a Loom if needed.
+- [The right balance](https://docs.gitlab.com/ee/development/code_review.html#the-right-balance)
+
 ## Reviewer
 
 - Prefix each comment with a label. The labels are not points and will not be summed up or similar.
@@ -23,6 +33,7 @@ A PR advances from self-review to reviewer-review and finally maintainer review 
     - Approved? Move the associated issue to maintainer-review.
 
 ## Maintainer
+
 - Maintainer follows the same process of Reviewers
 - Approved by the maintainer?
   - If there are +1 comments, the issue the PR belongs to goes back to self-review to give the author a chance to react to the comments.


### PR DESCRIPTION
This PR is a result of code review brainstorming sessions with @nickoferrall and @Dschoordsch.

The changes introduced here add more explicit statements about what's ok when doing the code review or when submitting a PR etc. I believe it's beneficial to have things written down explicitly. 

Let's discuss! 