### PR TITLE
feat(pg): reduce max pg connections to 30

### DIFF
--- a/packages/server/postgres/getPgConfig.ts
+++ b/packages/server/postgres/getPgConfig.ts
@@ -6,7 +6,7 @@ const getPgConfig = () => ({
   database: process.env.POSTGRES_DB,
   host: process.env.POSTGRES_HOST,
   port: Number(process.env.POSTGRES_PORT),
-  max: PROD ? 40 : 5
+  max: PROD ? 30 : 5
 })
 
 export default getPgConfig


### PR DESCRIPTION
Reduce connections to 30 for the application.
Things that connect directly to the DB (e.g. pgadmin, analytics, psql) will still take up a connection, so we'll need to keep those pinned at < 15, but that should be pretty easy to do.