### PR TITLE
chore: added PR labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: labeler
+
+on: [pull_request]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: "size/xs"
+          xs_max_size: "10"
+          s_label: "size/s"
+          s_max_size: "100"
+          m_label: "size/m"
+          m_max_size: "500"
+          l_label: "size/l"
+          l_max_size: "1000"
+          xl_label: "size/xl"
+          fail_if_xl: "false"
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR will be delayed and might be rejected due to its size.
+          github_api_url: "api.github.com"
+          files_to_ignore: "generated/**"


### PR DESCRIPTION
As we agreed here it'd be good to add size labels to our PRs. This PR adds usage of [Pull Request size labeler workflow](https://github.com/marketplace/actions/pull-request-size-labeler). Feel free to comment on the config, ie. what we consider a big PR etc. thank you! 