### PR TITLE
Add UTM parameters to Team Invite email

### DIFF
--- a/packages/client/modules/email/components/TeamInvite.tsx
+++ b/packages/client/modules/email/components/TeamInvite.tsx
@@ -1,5 +1,6 @@
 import {ExternalLinks} from 'parabol-client/types/constEnums'
 import React from 'react'
+import makeAppURL from '../../../utils/makeAppURL'
 import {emailCopyStyle, emailLinkStyle, emailProductTeamSignature} from '../styles'
 import Button from './Button'
 import EmailBlock from './EmailBlock/EmailBlock'
@@ -37,6 +38,12 @@ const meetingCopyLabelLookup = {
   teamPrompt: 'an Async Standup Meeting'
 } as const
 
+const urlParams = {
+  utm_source: 'invite email',
+  utm_medium: 'email',
+  utm_campaign: 'invitations'
+}
+const options = {searchParams: urlParams}
 export interface TeamInviteProps {
   appOrigin: string
   inviteeName: string
@@ -119,7 +126,11 @@ const TeamInvite = (props: TeamInviteProps) => {
             'Parabol is software for remote teams to run online retrospective and check-in meetings. See the video and links below:'
           }
         </p>
-        <a href={ExternalLinks.GETTING_STARTED_RETROS} style={videoLinkStyle} title='Retro 101'>
+        <a
+          href={makeAppURL('https://www.parabol.co/', 'resources/retrospective-meetings', options)}
+          style={videoLinkStyle}
+          title='Retro 101'
+        >
           <img crossOrigin='' alt='' src={videoGraphicSrc} style={videoGraphicStyle} />
         </a>
         <EmptySpace height={24} />
@@ -127,7 +138,11 @@ const TeamInvite = (props: TeamInviteProps) => {
           {'Learn more about Parabol meetings:'}
           <br />
           <a
-            href={ExternalLinks.GETTING_STARTED_RETROS}
+            href={makeAppURL(
+              'https://www.parabol.co/',
+              'resources/retrospective-meetings',
+              options
+            )}
             style={emailLinkStyle}
             title='Getting Started: Retro 101'
           >
@@ -135,7 +150,7 @@ const TeamInvite = (props: TeamInviteProps) => {
           </a>
           <br />
           <a
-            href={ExternalLinks.GETTING_STARTED_CHECK_INS}
+            href={makeAppURL('https://www.parabol.co/', 'resources/check-in-meetings', options)}
             style={emailLinkStyle}
             title='Leveling Up: Check-in 101'
           >


### PR DESCRIPTION
Fixes #6498 

Tests:
1. Invite a user via email
2. Click the links and verify the URL contains `?utm_source=invite+email&utm_medium=email&utm_campaign=invitations`