### PR TITLE
fix: hardDeleteUser failed because readyToAdvance is undefined

### DIFF
--- a/packages/server/database/types/GenericMeetingStage.ts
+++ b/packages/server/database/types/GenericMeetingStage.ts
@@ -46,7 +46,7 @@ export default class GenericMeetingStage {
   suggestedEndTime: Date | undefined
   suggestedTimeLimit: number | undefined
   viewCount: number
-  readyToAdvance = [] as string[]
+  readyToAdvance: string[] | undefined = []
   phaseType: string
   constructor(input: GenericMeetingStageInput) {
     const {durations, phaseType, id, isNavigable, isNavigableByFacilitator, startAt, viewCount} =

--- a/packages/server/graphql/mutations/helpers/removeUserFromMeetingStages.ts
+++ b/packages/server/graphql/mutations/helpers/removeUserFromMeetingStages.ts
@@ -30,9 +30,9 @@ const removeUserFromMeetingStages = async (
         for (let i = 0; i < stages.length; i++) {
           const stage = stages[i]!
           const {readyToAdvance} = stage
-          const userIdIdx = readyToAdvance.indexOf(userId)
+          const userIdIdx = readyToAdvance?.indexOf(userId) ?? -1
           if (userIdIdx !== -1) {
-            readyToAdvance.splice(userIdIdx, 1)
+            readyToAdvance?.splice(userIdIdx, 1)
             isChanged = true
           }
           if (isEstimateStage(stage)) {

--- a/packages/server/graphql/types/NewMeetingStage.ts
+++ b/packages/server/graphql/types/NewMeetingStage.ts
@@ -94,7 +94,7 @@ export const newMeetingStageFields = () => ({
     type: new GraphQLNonNull(GraphQLBoolean),
     description: 'true if the viewer is ready to advance, else false',
     resolve: (
-      {readyToAdvance}: {readyToAdvance: string[]},
+      {readyToAdvance}: {readyToAdvance?: string[]},
       _args: any,
       {authToken}: {authToken: AuthToken}
     ) => {
@@ -106,7 +106,7 @@ export const newMeetingStageFields = () => ({
     type: new GraphQLNonNull(GraphQLInt),
     description: 'the number of meeting members ready to advance, excluding the facilitator',
     resolve: async (
-      {meetingId, readyToAdvance}: {meetingId: string; readyToAdvance: string[]},
+      {meetingId, readyToAdvance}: {meetingId: string; readyToAdvance?: string[]},
       _args: any,
       {dataLoader}: GQLContext,
       ref: any


### PR DESCRIPTION
`readyToAdvance` field of `GenericMeetingStage` can be undefined. This
was already checked in multiple parts of the codebase. Fixed the type
accordingly and `removeUserFromMeetingStages`.

I'm not perfectly clear how the `readyToAdvance` field gets lost, but we have such data in Rethink, thus it's better to have the code prepared for it.