### PR TITLE
fix: display search on archived tasks page

### DIFF
--- a/packages/client/components/TopBarSearch.tsx
+++ b/packages/client/components/TopBarSearch.tsx
@@ -19,6 +19,11 @@ const getShowSearch = (location: NonNullable<RouteProps['location']>) => {
       path: '/team/:teamId',
       exact: true,
       strict: false
+    }) ||
+    !!matchPath(pathname, {
+      path: '/team/:teamId/archive',
+      exact: true,
+      strict: false
     })
   )
 }


### PR DESCRIPTION
This is a first steps to fix: #6536 
Case: the search control disappears on the page for archived tasks, but still applies to them...

<a href="https://www.loom.com/share/f617869b1ab347d2ab8907c61538599d">
    <p>Disappearance of search control 🔍 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/f617869b1ab347d2ab8907c61538599d-with-play.gif">
  </a>
