### PR TITLE
fix: increase initial page size for archived tasks

### DIFF
--- a/packages/client/components/ArchiveTaskRoot.tsx
+++ b/packages/client/components/ArchiveTaskRoot.tsx
@@ -17,7 +17,7 @@ const ArchiveTaskRoot = ({teamIds, team, userIds, returnToTeamId}: Props) => {
   const queryRef = useQueryLoaderNow<TeamArchiveQuery>(teamArchiveQuery, {
     userIds,
     teamIds,
-    first: 10
+    first: 40
   })
 
   return (

--- a/packages/client/components/ArchiveTaskUserRoot.tsx
+++ b/packages/client/components/ArchiveTaskUserRoot.tsx
@@ -13,7 +13,7 @@ const ArchiveTaskUserRoot = ({teamIds, userIds}: Props) => {
   const queryRef = useQueryLoaderNow<TeamArchiveQuery>(teamArchiveQuery, {
     userIds,
     teamIds,
-    first: 10
+    first: 40
   })
 
   return (


### PR DESCRIPTION
By default, the system loads only the first 10 archived tasks, which is quite small even for the first screen without scrolling (related to #6536).

<a href="https://www.loom.com/share/25d04129fbc44d16b899b29c15d3a551">
    <p>Archived tasks- 13 May 2022 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/25d04129fbc44d16b899b29c15d3a551-with-play.gif">
  </a>
