### PR TITLE
feat(Azure DevOps):  Correctly format Sprint Poker comments as HTML

### DIFF
--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -528,7 +528,7 @@ class AzureDevOpsServerManager {
     remoteIssueId: string,
     projectKey: string
   ) {
-    const comment = `<div>*${dimensionName}: ${finalScore}*</div>
+    const comment = `<div><b>${dimensionName}: ${finalScore}</b></div>
     <div>See the <a href='${discussionURL}'>discussion</a> in ${meetingName}</div>
 
     <div>Powered by <a href='${ExternalLinks.GETTING_STARTED_SPRINT_POKER}'>Parabol</a></div>`

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -528,10 +528,10 @@ class AzureDevOpsServerManager {
     remoteIssueId: string,
     projectKey: string
   ) {
-    const comment = `*${dimensionName}: ${finalScore}*
-    \n[See the discussion | ${discussionURL}] in ${meetingName}
+    const comment = `<div>*${dimensionName}: ${finalScore}*</div>
+    <div>See the <a href='${discussionURL}'>discussion</a> in ${meetingName}</div>
 
-    \n_Powered by [Parabol | ${ExternalLinks.GETTING_STARTED_SPRINT_POKER}]_`
+    <div>Powered by <a href='${ExternalLinks.GETTING_STARTED_SPRINT_POKER}'>Parabol</a></div>`
 
     const res = await this.post<WorkItemAddCommentResponse>(
       `https://${instanceId}/${projectKey}/_apis/wit/workItems/${remoteIssueId}/comments?api-version=7.1-preview.3`,


### PR DESCRIPTION
# Description

Fixes #[6509]
Modifies the AzureDevOpsServerManager to send html formatted comments to Azure DevOps instead of markdown.  This has a better user experience in Azure DevOps.


## Testing scenarios

- [ ] Start a new sprint poker meeting
  - Import any Azure DevOps work item
  - Add a story point estimate value
  - Set the dropdown to a "Comment" to push the value of the story point to the work item's comment section in Azure DevOps
  - Navigate to the work item in Azure DevOps and open it.  Make sure that a comment was created from the Parabol client in html format.


