### PR TITLE
refactor: handle default value for isOnboardTeam in checkTeamEq

### DIFF
--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -9,15 +9,15 @@ const alwaysDefinedFields: (keyof Team)[] = [
   'isArchived',
   'isPaid',
   'tier',
-  'orgId',
-  'isOnboardTeam'
+  'orgId'
 ]
 const ignoredFields: (keyof Team)[] = ['updatedAt']
 
 const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: unknown} = {
   jiraDimensionFields: [],
   lastMeetingType: 'retrospective',
-  createdBy: null
+  createdBy: null,
+  isOnboardTeam: false
 }
 
 const checkTeamEq = async (maxErrors = 10) => {


### PR DESCRIPTION
# Description

Partially Fixes #6239  / Part of #6239
See https://github.com/ParabolInc/parabol/pull/6239#issuecomment-1130326877

## Testing scenarios
- Run an equality check on the production database.
- Team records with the default value of `isOnboardTeam` should be successfully compared.

## Final checklist

- [x] I checked the [code review guidelines](../../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
