### PR TITLE
fix(Sprint Poker): An exception could occur when modifying the scope in fast succession

### DIFF
--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -134,12 +134,13 @@ const UpdatePokerScopeMutation: StandardMutation<TUpdatePokerScopeMutation, Hand
         const stagesForTaskId = stages.filter(
           (stage) => stage.getValue('taskId') === firstStageTaskId
         )
-        const prevDimensionRefIds = stagesForTaskId.map((stage) => {
+        stagesForTaskId.forEach((stage) => {
           const dimensionRef = stage.getLinkedRecord('dimensionRef')
-          return dimensionRef?.getValue('id') ?? ''
-        }) as string[]
-        dimensionRefIds.push(...prevDimensionRefIds)
-      } else {
+          const dimensionRefId = dimensionRef?.getValue('id') as string | null
+          dimensionRefId && dimensionRefIds.push(dimensionRefId)
+        })
+      }
+      if (dimensionRefIds.length === 0) {
         const value = createProxyRecord(store, 'TemplateScaleValue', {
           color: PALETTE.SLATE_600,
           label: '#'

--- a/packages/server/graphql/mutations/updatePokerScope.ts
+++ b/packages/server/graphql/mutations/updatePokerScope.ts
@@ -55,139 +55,144 @@ const updatePokerScope = {
     const redisLock = new RedisLockQueue(`meeting:${meetingId}`, 3000)
     await redisLock.lock(10000)
 
-    //AUTH
-    const meeting = (await dataLoader.get('newMeetings').load(meetingId)) as MeetingPoker
-    if (!meeting) {
-      return {error: {message: `Meeting not found`}}
-    }
+    // Wrap everything in try catch to ensure the lock is released
+    try {
+      //AUTH
+      const meeting = (await dataLoader.get('newMeetings').load(meetingId)) as MeetingPoker
+      if (!meeting) {
+        return {error: {message: `Meeting not found`}}
+      }
 
-    const {endedAt, teamId, phases, meetingType, templateRefId, facilitatorStageId} = meeting
-    if (!isTeamMember(authToken, teamId)) {
-      // bad actors could be naughty & just lock meetings that they don't own. Limit bad actors to team members
-      await redisLock.unlock()
-      return {error: {message: `Not on team`}}
-    }
-    if (endedAt) {
-      return {error: {message: `Meeting already ended`}}
-    }
+      const {endedAt, teamId, phases, meetingType, templateRefId, facilitatorStageId} = meeting
+      if (!isTeamMember(authToken, teamId)) {
+        // bad actors could be naughty & just lock meetings that they don't own. Limit bad actors to team members
+        return {error: {message: `Not on team`}}
+      }
+      if (endedAt) {
+        return {error: {message: `Meeting already ended`}}
+      }
 
-    if (meetingType !== 'poker') {
-      return {error: {message: 'Not a poker meeting'}}
-    }
+      if (meetingType !== 'poker') {
+        return {error: {message: 'Not a poker meeting'}}
+      }
 
-    // RESOLUTION
+      // RESOLUTION
 
-    const estimatePhase = getPhase(phases, 'ESTIMATE')
-    let stages = estimatePhase.stages
+      const estimatePhase = getPhase(phases, 'ESTIMATE')
+      let stages = estimatePhase.stages
 
-    // delete stages
-    const subtractiveUpdates = updates.filter((update) => {
-      const {action, serviceTaskId} = update
-      return action === 'DELETE' && !!stages.find((stage) => stage.serviceTaskId === serviceTaskId)
-    })
-    subtractiveUpdates.forEach((update) => {
-      const {serviceTaskId} = update
-      const stagesToRemove = stages.filter((stage) => stage.serviceTaskId === serviceTaskId)
-      const removingTatorStage = stagesToRemove.find((stage) => stage.id === facilitatorStageId)
-      if (removingTatorStage) {
-        const nextStage = getNextFacilitatorStageAfterStageRemoved(
-          facilitatorStageId,
-          removingTatorStage.id,
-          phases
+      // delete stages
+      const subtractiveUpdates = updates.filter((update) => {
+        const {action, serviceTaskId} = update
+        return (
+          action === 'DELETE' && !!stages.find((stage) => stage.serviceTaskId === serviceTaskId)
         )
-        nextStage.startAt = now
-        meeting.facilitatorStageId = nextStage.id
-      }
-      if (stagesToRemove.length > 0) {
-        // MUTATIVE
-        stages = stages.filter((stage) => stage.serviceTaskId !== serviceTaskId)
-        estimatePhase.stages = stages
-        const writes = stagesToRemove.map((stage) => {
-          return ['del', `pokerHover:${stage.id}`]
-        })
-        redis.multi(writes).exec()
-      }
-    })
-
-    // add stages
-    const templateRef = await dataLoader.get('templateRefs').loadNonNull(templateRefId)
-    const {dimensions} = templateRef
-    const firstDimensionName = dimensions[0].name
-    const newDiscussions = [] as Writeable<InputDiscussions>
-    const additiveUpdates = updates.filter((update) => {
-      const {action, serviceTaskId} = update
-      return action === 'ADD' && !stages.find((stage) => stage.serviceTaskId === serviceTaskId)
-    })
-
-    const requiredJiraMappers = additiveUpdates
-      .filter((update) => update.service === 'jira')
-      .map((update) => {
-        const {cloudId, issueKey, projectKey} = JiraIssueId.split(update.serviceTaskId)
-        return {
-          cloudId,
-          issueKey,
-          projectKey,
-          dimensionName: firstDimensionName
-        } as JiraDimensionField
       })
-    await ensureJiraDimensionField(requiredJiraMappers, teamId, viewerId, dataLoader)
-
-    const additiveUpdatesWithTaskIds = await importTasksForPoker(
-      additiveUpdates,
-      teamId,
-      viewerId,
-      meetingId
-    )
-
-    const newStageIds = [] as string[]
-    additiveUpdatesWithTaskIds.forEach((update) => {
-      const {serviceTaskId, taskId} = update
-      const lastSortOrder = stages[stages.length - 1]?.sortOrder ?? -1
-      const newStages = dimensions.map(
-        (_, idx) =>
-          new EstimateStage({
-            creatorUserId: viewerId,
-            // integrationHash if integrated, else taskId
-            serviceTaskId,
-            sortOrder: lastSortOrder + ESTIMATE_TASK_SORT_ORDER + idx,
-            taskId,
-            durations: undefined,
-            dimensionRefIdx: idx
+      subtractiveUpdates.forEach((update) => {
+        const {serviceTaskId} = update
+        const stagesToRemove = stages.filter((stage) => stage.serviceTaskId === serviceTaskId)
+        const removingTatorStage = stagesToRemove.find((stage) => stage.id === facilitatorStageId)
+        if (removingTatorStage) {
+          const nextStage = getNextFacilitatorStageAfterStageRemoved(
+            facilitatorStageId,
+            removingTatorStage.id,
+            phases
+          )
+          nextStage.startAt = now
+          meeting.facilitatorStageId = nextStage.id
+        }
+        if (stagesToRemove.length > 0) {
+          // MUTATIVE
+          stages = stages.filter((stage) => stage.serviceTaskId !== serviceTaskId)
+          estimatePhase.stages = stages
+          const writes = stagesToRemove.map((stage) => {
+            return ['del', `pokerHover:${stage.id}`]
           })
-      )
-      const discussions = newStages.map((stage) => ({
-        id: stage.discussionId,
-        meetingId,
-        teamId,
-        discussionTopicId: taskId,
-        discussionTopicType: 'task' as const
-      }))
-      // MUTATIVE
-      newDiscussions.push(...discussions)
-      stages.push(...newStages)
-      const newIds = newStages.map(({id}) => id)
-      newStageIds.push(...newIds)
-    })
-
-    if (stages.length > Threshold.MAX_POKER_STORIES * dimensions.length) {
-      return {error: {message: 'Story limit reached'}}
-    }
-    await r
-      .table('NewMeeting')
-      .get(meetingId)
-      .update({
-        facilitatorStageId: meeting.facilitatorStageId,
-        phases,
-        updatedAt: now
+          redis.multi(writes).exec()
+        }
       })
-      .run()
-    if (newDiscussions.length > 0) {
-      await insertDiscussions(newDiscussions)
+
+      // add stages
+      const templateRef = await dataLoader.get('templateRefs').loadNonNull(templateRefId)
+      const {dimensions} = templateRef
+      const firstDimensionName = dimensions[0].name
+      const newDiscussions = [] as Writeable<InputDiscussions>
+      const additiveUpdates = updates.filter((update) => {
+        const {action, serviceTaskId} = update
+        return action === 'ADD' && !stages.find((stage) => stage.serviceTaskId === serviceTaskId)
+      })
+
+      const requiredJiraMappers = additiveUpdates
+        .filter((update) => update.service === 'jira')
+        .map((update) => {
+          const {cloudId, issueKey, projectKey} = JiraIssueId.split(update.serviceTaskId)
+          return {
+            cloudId,
+            issueKey,
+            projectKey,
+            dimensionName: firstDimensionName
+          } as JiraDimensionField
+        })
+      await ensureJiraDimensionField(requiredJiraMappers, teamId, viewerId, dataLoader)
+
+      const additiveUpdatesWithTaskIds = await importTasksForPoker(
+        additiveUpdates,
+        teamId,
+        viewerId,
+        meetingId
+      )
+
+      const newStageIds = [] as string[]
+      additiveUpdatesWithTaskIds.forEach((update) => {
+        const {serviceTaskId, taskId} = update
+        const lastSortOrder = stages[stages.length - 1]?.sortOrder ?? -1
+        const newStages = dimensions.map(
+          (_, idx) =>
+            new EstimateStage({
+              creatorUserId: viewerId,
+              // integrationHash if integrated, else taskId
+              serviceTaskId,
+              sortOrder: lastSortOrder + ESTIMATE_TASK_SORT_ORDER + idx,
+              taskId,
+              durations: undefined,
+              dimensionRefIdx: idx
+            })
+        )
+        const discussions = newStages.map((stage) => ({
+          id: stage.discussionId,
+          meetingId,
+          teamId,
+          discussionTopicId: taskId,
+          discussionTopicType: 'task' as const
+        }))
+        // MUTATIVE
+        newDiscussions.push(...discussions)
+        stages.push(...newStages)
+        const newIds = newStages.map(({id}) => id)
+        newStageIds.push(...newIds)
+      })
+
+      if (stages.length > Threshold.MAX_POKER_STORIES * dimensions.length) {
+        return {error: {message: 'Story limit reached'}}
+      }
+      await r
+        .table('NewMeeting')
+        .get(meetingId)
+        .update({
+          facilitatorStageId: meeting.facilitatorStageId,
+          phases,
+          updatedAt: now
+        })
+        .run()
+      if (newDiscussions.length > 0) {
+        await insertDiscussions(newDiscussions)
+      }
+      const data = {meetingId, newStageIds}
+      publish(SubscriptionChannel.MEETING, meetingId, 'UpdatePokerScopeSuccess', data, subOptions)
+      return data
+    } finally {
+      await redisLock.unlock()
     }
-    const data = {meetingId, newStageIds}
-    publish(SubscriptionChannel.MEETING, meetingId, 'UpdatePokerScopeSuccess', data, subOptions)
-    await redisLock.unlock()
-    return data
   }
 }
 


### PR DESCRIPTION
# Description

Fixes #6334 

Minified exception occured on production because all exception messages are stripped out. When adding and removing issues in fast succession, it could happen that the optimistic updater throws an error because the store is in a weird state. This fix just works around this particular case but does not fix the root cause.

## Demo

This is how I was able to reproduce it before the fix:
https://www.loom.com/share/f2990f1feab448bca0d50190e67a16d5
I needed to repeat this a couple of times, it was not easily reproducible.
I tested with Jira as GitHub was probably bottlenecked by the server which resulted in different server side errors.

## Testing scenarios

- [ ] See loom, Sprint Poker with Jira
  - Add and remove tasks in quick succession
  - No error is shown

- [ ] Conclude the sprint poker and then modify the scope
  - Add remove more than 5 items in 10s (individual operations)
  - The server will not print an error like
    ```
11:08:09 1|GraphQL Executor | Error: Could not achieve lock for lock:queue:meeting:dtVNSO7Av6 after 10000ms
    ```

## Final checklist

- [ ] I checked the [code review guidelines](../../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
