### PR TITLE
docs: Fix code policy link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ Fixes/Partially Fixes #[issue number]
 
 ## Final checklist
 
-- [ ] I checked the [code review guidelines](../../docs/codeReview.md)
+- [ ] I checked the [code review guidelines](../docs/codeReview.md)
 - [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
 - [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
 - [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way


### PR DESCRIPTION
Path wasn't adapted after the template was moved.