### PR TITLE
fix: Ensure all meeting types have a mapped icon

### DIFF
--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -147,6 +147,8 @@ export const CREATE_ACCOUNT_SLUG = 'create-account'
 /* Meeting Types */
 export const ACTION = 'action'
 export const RETROSPECTIVE = 'retrospective'
+export const POKER = 'poker'
+export const TEAM_PROMPT = 'teamPrompt'
 
 /* Spotlight */
 export const MAX_REDUCTION_PERCENTAGE = 1

--- a/packages/client/utils/meetings/lookups.ts
+++ b/packages/client/utils/meetings/lookups.ts
@@ -1,6 +1,8 @@
+import React from 'react'
+import {MeetingTypeEnum} from '~/../server/postgres/types/Meeting'
 import {NewMeetingPhaseTypeEnum} from '~/__generated__/ActionMeetingSidebar_meeting.graphql'
 import CardsSVG from '../../components/CardsSVG'
-import {ACTION, RETROSPECTIVE} from '../constants'
+import {ACTION, POKER, RETROSPECTIVE, TEAM_PROMPT} from '../constants'
 
 /* Used by the server! cannot convert to enums yet */
 
@@ -40,8 +42,9 @@ export const phaseImageLookup = {
 export const meetingTypeToIcon = {
   [RETROSPECTIVE]: 'history',
   [ACTION]: 'change_history',
-  poker: CardsSVG
-} as const
+  [POKER]: CardsSVG,
+  [TEAM_PROMPT]: 'group_work'
+} as Record<MeetingTypeEnum, string | React.ComponentType>
 
 export const phaseTypeToSlug = {
   checkin: 'checkin',


### PR DESCRIPTION
# Description
Fixes https://github.com/ParabolInc/parabol/issues/6608.
Caused by a missing meeting icon mapping for the `teamPrompt` meeting type.  Enforce mapping completeness for `meetingTypeToIcon`, and add the `teamPrompt` meeting type to the mapping.  Confirmed that excluding `teamPrompt` from the mapping shows a type error with the added typing.

## Demo
<img width="512" alt="Screen Shot 2022-05-20 at 5 13 37 PM" src="https://user-images.githubusercontent.com/9013217/169619127-bb565d4d-2469-485c-b2e5-7471af1ffad0.png">

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
