### PR TITLE
feat(standups): Display active users and invite button in standup meeting

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -11,9 +11,6 @@ import IconLabel from '../IconLabel'
 import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
 
 const Options = styled(CardButton)({
-  position: 'absolute',
-  top: 0,
-  right: 0,
   color: PALETTE.SLATE_700,
   height: 32,
   width: 32,

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -2,10 +2,11 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import NewMeetingAvatarGroup from '~/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
 import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
 import {meetingAvatarMediaQueries} from '../../styles/meeting'
 import BackButton from '../BackButton'
-import {HeadingBlock, IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
+import {IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
 import TeamPromptOptions from './TeamPromptOptions'
 
 const TeamPromptHeaderTitle = styled('h1')({
@@ -16,6 +17,7 @@ const TeamPromptHeaderTitle = styled('h1')({
 })
 
 const TeamPromptHeader = styled('div')({
+  margin: 'auto 0',
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
@@ -24,11 +26,9 @@ const TeamPromptHeader = styled('div')({
 
 const ButtonContainer = styled('div')({
   alignItems: 'center',
-  alignContent: 'center',
+  justifyContent: 'center',
   display: 'flex',
   height: 32,
-  marginLeft: 11,
-  position: 'relative',
   [meetingAvatarMediaQueries[0]]: {
     height: 48,
     marginLeft: 10
@@ -50,6 +50,7 @@ const TeamPromptTopBar = (props: Props) => {
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         name
         ...TeamPromptOptions_meeting
+        ...NewMeetingAvatarGroup_meeting
       }
     `,
     meetingRef
@@ -59,14 +60,12 @@ const TeamPromptTopBar = (props: Props) => {
 
   return (
     <MeetingTopBarStyles>
-      <HeadingBlock>
-        <TeamPromptHeader>
-          <BackButton ariaLabel='Back to Meetings' to='/meetings' />
-          <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
-        </TeamPromptHeader>
-      </HeadingBlock>
+      <TeamPromptHeader>
+        <BackButton ariaLabel='Back to Meetings' to='/meetings' />
+        <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
+      </TeamPromptHeader>
       <IconGroupBlock>
-        {/* :TODO: (jmtaber129): Add avatars, etc. */}
+        <NewMeetingAvatarGroup meeting={meeting} />
         <ButtonContainer>
           <TeamPromptOptions meetingRef={meeting} />
         </ButtonContainer>


### PR DESCRIPTION
# Description

Fixes #6583 

## Demo

Widest breakpoint
![localhost_3000_meet_dAmG9lFXI4_responses (1)](https://user-images.githubusercontent.com/1017620/169852012-f8de51f7-c3fc-4304-9297-a0beb168ca96.png)

Medium breakpoint
![localhost_3000_meet_dAmG9lFXI4_responses](https://user-images.githubusercontent.com/1017620/169852027-02bf7460-49c1-4ea6-8bb2-3162c6a5a5b2.png)

Mobile
![localhost_3000_meet_dAmG9lFXI4_responses(iPhone SE)](https://user-images.githubusercontent.com/1017620/169852032-0fc86fe0-4509-41a0-ae43-5aa498a1727c.png)


## Testing scenarios

- [ ] Make sure the avatar group is visible on various screen sizes, including mobile
- [ ] Invite button opens the invite modal, the same as in other meetings
- [ ] After successfully inviting someone, meeting view will automatically refresh and show the card for the newly invited team member
- [ ] Avatar list is updated correctly when someone joins/leaves the meeting

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
 