### PR TITLE
DRAFT: move subscriptions to gqlExecutor

### DIFF
--- a/packages/server/graphql/ResponseStream.ts
+++ b/packages/server/graphql/ResponseStream.ts
@@ -1,6 +1,6 @@
 import {ExecutionResult} from 'graphql'
-import {getUserId} from '../utils/authorization'
-import getGraphQLExecutor from '../utils/getGraphQLExecutor'
+//import {getUserId} from '../utils/authorization'
+//import getGraphQLExecutor from '../utils/getGraphQLExecutor'
 import sendToSentry from '../utils/sendToSentry'
 import SubscriptionIterator from '../utils/SubscriptionIterator'
 import {SubscribeRequest} from './subscribeGraphQL'
@@ -20,10 +20,13 @@ export default class ResponseStream implements AsyncIterableIterator<ExecutionRe
   async next(): Promise<IteratorResult<ExecutionResult>> {
     const sourceIter = await this.sourceStream.next()
     if (sourceIter.done) return sourceIter
+
+    const result = sourceIter.value
+    /*
     const {mutatorId, operationId: dataLoaderId, rootValue, executorServerId} = sourceIter.value
     const {connectionContext, query, variables, docId} = this.req
     const {id: socketId, authToken, ip} = connectionContext
-    if (mutatorId === socketId) return this.next()
+    if (mutatorId === socketId) return this.next() // Why do we filter out self?
     try {
       const result = await getGraphQLExecutor().publish({
         docId,
@@ -36,17 +39,20 @@ export default class ResponseStream implements AsyncIterableIterator<ExecutionRe
         socketId,
         executorServerId
       })
+      */
       if (result.errors) {
         sendToSentry(new Error(result.errors[0]?.message))
         return this.next()
       }
       return {done: false, value: result}
+    /*
     } catch (e) {
       const error =
         e instanceof Error ? e : new Error(`GQL executor failed to publish. docId: ${docId}`)
       sendToSentry(error, {userId: getUserId(authToken)})
       return this.next()
     }
+    */
   }
   return() {
     this.sourceStream.return()

--- a/packages/server/graphql/subscriptions/meetingSubscription.ts
+++ b/packages/server/graphql/subscriptions/meetingSubscription.ts
@@ -16,7 +16,7 @@ export default {
   subscribe: async (
     _source: unknown,
     {meetingId}: {meetingId: string},
-    {authToken}: GQLContext
+    {authToken, socketId}: GQLContext
   ) => {
     // AUTH
     const r = await getRethink()
@@ -32,6 +32,6 @@ export default {
 
     // RESOLUTION
     const channelName = `${SubscriptionChannel.MEETING}.${meetingId}`
-    return getPubSub().subscribe([channelName])
+    return getPubSub().subscribe([channelName], socketId)
   }
 }

--- a/packages/server/graphql/subscriptions/notificationSubscription.ts
+++ b/packages/server/graphql/subscriptions/notificationSubscription.ts
@@ -7,7 +7,7 @@ import NotificationSubscriptionPayload from '../types/NotificationSubscriptionPa
 
 export default {
   type: new GraphQLNonNull(NotificationSubscriptionPayload),
-  subscribe: (_source: unknown, _args: unknown, {authToken}: GQLContext) => {
+  subscribe: (_source: unknown, _args: unknown, {authToken, socketId}: GQLContext) => {
     // AUTH
     if (!isAuthenticated(authToken)) {
       throw new Error('Not authenticated')
@@ -17,6 +17,6 @@ export default {
     const viewerId = getUserId(authToken)
     const channelName = `${SubscriptionChannel.NOTIFICATION}.${viewerId}`
 
-    return getPubSub().subscribe([channelName])
+    return getPubSub().subscribe([channelName], socketId)
   }
 }

--- a/packages/server/graphql/subscriptions/organizationSubscription.ts
+++ b/packages/server/graphql/subscriptions/organizationSubscription.ts
@@ -8,7 +8,7 @@ import OrganizationSubscriptionPayload from '../types/OrganizationSubscriptionPa
 
 export default {
   type: new GraphQLNonNull(OrganizationSubscriptionPayload),
-  subscribe: async (_source: unknown, _args: unknown, {authToken}: GQLContext) => {
+  subscribe: async (_source: unknown, _args: unknown, {authToken, socketId}: GQLContext) => {
     // AUTH
     const viewerId = getUserId(authToken)
     const r = await getRethink()
@@ -23,6 +23,6 @@ export default {
     const channelNames = orgIds
       .concat(viewerId)
       .map((id) => `${SubscriptionChannel.ORGANIZATION}.${id}`)
-    return getPubSub().subscribe(channelNames)
+    return getPubSub().subscribe(channelNames, socketId)
   }
 }

--- a/packages/server/graphql/subscriptions/taskSubscription.ts
+++ b/packages/server/graphql/subscriptions/taskSubscription.ts
@@ -7,7 +7,7 @@ import TaskSubscriptionPayload from '../types/TaskSubscriptionPayload'
 
 const taskSubscription = {
   type: new GraphQLNonNull(TaskSubscriptionPayload),
-  subscribe: async (_source: unknown, _args: unknown, {authToken}: GQLContext) => {
+  subscribe: async (_source: unknown, _args: unknown, {authToken, socketId}: GQLContext) => {
     // AUTH
     if (!isAuthenticated(authToken)) {
       throw new Error('Not authenticated')
@@ -16,7 +16,7 @@ const taskSubscription = {
     // RESOLUTION
     const viewerId = getUserId(authToken)
     const channelName = `${SubscriptionChannel.TASK}.${viewerId}`
-    return getPubSub().subscribe([channelName])
+    return getPubSub().subscribe([channelName], socketId)
   }
 }
 

--- a/packages/server/graphql/subscriptions/teamSubscription.ts
+++ b/packages/server/graphql/subscriptions/teamSubscription.ts
@@ -7,7 +7,7 @@ import TeamSubscriptionPayload from '../types/TeamSubscriptionPayload'
 
 export default {
   type: new GraphQLNonNull(TeamSubscriptionPayload),
-  subscribe: (_source: unknown, _args: unknown, {authToken}: GQLContext) => {
+  subscribe: (_source: unknown, _args: unknown, {authToken, socketId}: GQLContext) => {
     // AUTH
     if (!isAuthenticated(authToken)) {
       throw new Error('Not authenticated')
@@ -17,6 +17,6 @@ export default {
     const userId = getUserId(authToken)
     const {tms: teamIds} = authToken
     const channelNames = teamIds.concat(userId).map((id) => `${SubscriptionChannel.TEAM}.${id}`)
-    return getPubSub().subscribe(channelNames)
+    return getPubSub().subscribe(channelNames, socketId)
   }
 }

--- a/packages/server/utils/GraphQLRedisPubSub.ts
+++ b/packages/server/utils/GraphQLRedisPubSub.ts
@@ -36,19 +36,20 @@ export default class GraphQLRedisPubSub {
     return this.publisher.publish(channel, JSON.stringify(payload))
   }
 
-  subscribe = (channels: string[], options: SubscribeOptions = {}) => {
-    this.subscriber.subscribe(...channels)
+  subscribe = (channels: string[], socketId: string, options: SubscribeOptions = {}) => {
     const onStart = (listener: SubscriptionListener) => {
       channels.forEach((channel) => {
-        this.listenersByChannel[channel] = this.listenersByChannel[channel] || []
-        this.listenersByChannel[channel]!.push(listener)
+        const chan = `${socketId}:${channel}`
+        this.subscriber.subscribe(chan)
+        this.listenersByChannel[chan] = this.listenersByChannel[chan] || []
+        this.listenersByChannel[chan]!.push(listener)
       })
     }
     const onCompleted = (listener: SubscriptionListener) => {
       options?.onCompleted?.()
       this.unsubscribe(channels, listener)
     }
-    return new SubscriptionIterator({onStart, onCompleted, transform: options?.transform})
+    return new SubscriptionIterator({onStart, onCompleted, transform: options?.transform, channels})
   }
 
   unsubscribe = (channels: string[], listener: SubscriptionListener) => {

--- a/packages/server/utils/SubscriptionIterator.ts
+++ b/packages/server/utils/SubscriptionIterator.ts
@@ -5,6 +5,7 @@ interface Handlers {
   onStart?: (listener: SubscriptionListener) => void
   onCompleted?: (listener: SubscriptionListener) => void
   transform?: SubscriptionTransform
+  channels: string[]
 }
 
 export default class SubscriptionIterator<T = any> implements AsyncIterator<T> {
@@ -13,6 +14,7 @@ export default class SubscriptionIterator<T = any> implements AsyncIterator<T> {
   private pullQueue = [] as ((resolvedValue?: any) => void)[]
   private transform?: SubscriptionTransform
   private onCompleted?: (listener: SubscriptionListener) => void
+  channels: string[]
   private pushValue: SubscriptionListener = async (input) => {
     const value = this.transform ? await this.transform(input) : input
     if (value !== undefined) {
@@ -25,9 +27,10 @@ export default class SubscriptionIterator<T = any> implements AsyncIterator<T> {
     }
   }
 
-  constructor({onStart, onCompleted, transform}: Handlers) {
+  constructor({onStart, onCompleted, transform, channels}: Handlers) {
     this.transform = transform
     this.onCompleted = onCompleted
+    this.channels = channels
     onStart?.(this.pushValue)
   }
 


### PR DESCRIPTION
# Description

Unsubscribing does not work yet and the source/response streams need
cleanup/merging.

Fixes #6622 
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
