### PR TITLE
fix: github repos filter menu shows limited selection

### DIFF
--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -111,10 +111,6 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
   const contributionsCollection =
     query?.viewer?.teamMember?.integrations.github?.api?.query?.viewer?.contributionsCollection
-  // const contributionsByRepo =
-  //   query?.viewer?.teamMember?.integrations.github?.api?.query?.viewer?.contributionsCollection
-  //     ?.commitContributionsByRepository ?? []
-  // const contributionsByRepo = contributionsCollection?.commitContributionsByRepository
   const repoContributions = useMemo(() => {
     const repoContributions =
       contributionsCollection?.commitContributionsByRepository?.map((contributionByRepo) =>
@@ -155,10 +151,6 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
     )
     return Array.from(new Set([...selectedRepos, ...repos])).slice(0, adjustedMax)
   }, [filteredRepoContributions])
-  console.log('🚀  ~ selectedAndFilteredRepos', {
-    selectedAndFilteredRepos,
-    filteredRepoContributions
-  })
 
   const {portalStatus, isDropdown} = menuProps
   return (

--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -118,8 +118,8 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
       ) ?? []
     const issueContributions =
       contributionsCollection?.issueContributionsByRepository.map((contributionByRepo) => {
-        const repository = contributionByRepo.repository
-        const edges = contributionByRepo.contributions.edges ?? []
+        const {repository, contributions} = contributionByRepo
+        const edges = contributions.edges ?? []
         const occurredAt = edges[0]?.node?.occurredAt
         return {
           repository,

--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -119,9 +119,8 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
     const issueContributions =
       contributionsCollection?.issueContributionsByRepository.map((contributionByRepo) => {
         const repository = contributionByRepo.repository
-        const edges = contributionByRepo.contributions.edges
-        const edge = edges![0]
-        const occurredAt = edge?.node?.occurredAt
+        const edges = contributionByRepo.contributions.edges ?? []
+        const occurredAt = edges[0]?.node?.occurredAt
         return {
           repository,
           occurredAt


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6465

The original GitHub filter menu query gets the repos that the user has recently pushed a commit to - `commitContributionsByRepository`. The intention is to show repos that are relevant to the user.

However, it's possible that a scrum master leading a Poker meeting does not commit code to the repo but does create issues. Therefore, I think we should show repos where the viewer has contributed an issue.

Alternatively, we could show all repos and search through them, but I think it's OK to only show repos that they've contributed to as they still have the option of updating the main search query with `repo: nameWithOwner` if they want.

### To test

- Open the GitHub repo filter menu 
- See repos that the viewer has committed code to
- See repos that the viewer has not committed code to, but has created an issue for. If you don't have any repos matching this description in your GitHub account, you can create a new repo and add an issue. 