### PR TITLE
feat(standups): Improved standups options button size

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -4,18 +4,20 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
+import {PALETTE} from '~/styles/paletteV3'
 import {TeamPromptOptions_meeting$key} from '~/__generated__/TeamPromptOptions_meeting.graphql'
-import {PALETTE} from '../../styles/paletteV3'
-import CardButton from '../CardButton'
+import FlatButton from '../FlatButton'
 import IconLabel from '../IconLabel'
 import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
 
-const Options = styled(CardButton)({
-  color: PALETTE.SLATE_700,
-  height: 32,
-  width: 32,
-  opacity: 1,
-  ':hover': {
+const OptionsButton = styled(FlatButton)({
+  color: PALETTE.SLATE_600,
+  height: '100%',
+  width: 'auto',
+  aspectRatio: '1/1',
+  borderRadius: '100%',
+  ':hover, :focus, :active': {
+    color: PALETTE.SLATE_700,
     backgroundColor: PALETTE.SLATE_300
   }
 })
@@ -40,9 +42,9 @@ const TeamPromptOptions = (props: Props) => {
 
   return (
     <>
-      <Options ref={originRef} onClick={togglePortal}>
-        <IconLabel ref={originRef} icon='more_vert' />
-      </Options>
+      <OptionsButton ref={originRef} onClick={togglePortal}>
+        <IconLabel ref={originRef} icon='more_vert' iconLarge />
+      </OptionsButton>
       {menuPortal(<TeamPromptOptionsMenu meetingRef={meeting} menuProps={menuProps} />)}
     </>
   )

--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -6,16 +6,17 @@ import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import {PALETTE} from '~/styles/paletteV3'
 import {TeamPromptOptions_meeting$key} from '~/__generated__/TeamPromptOptions_meeting.graphql'
-import FlatButton from '../FlatButton'
+import BaseButton from '../BaseButton'
 import IconLabel from '../IconLabel'
 import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
 
-const OptionsButton = styled(FlatButton)({
+const OptionsButton = styled(BaseButton)({
   color: PALETTE.SLATE_600,
   height: '100%',
-  width: 'auto',
-  aspectRatio: '1/1',
+  aspectRatio: '1 / 1',
+  opacity: 1,
   borderRadius: '100%',
+  padding: 0,
   ':hover, :focus, :active': {
     color: PALETTE.SLATE_700,
     backgroundColor: PALETTE.SLATE_300


### PR DESCRIPTION
# Description

Fixes #6616 

Changes:
1. Added support for `active` and `focus` styles so it's easier to navigate using the keyboard
2. Changed the styles to match the back button used in the top bar 
3. Increased icon size

Note: I didn't add any breakpoints for icon size as I wanted to make it work the same way as the existing back button. The size of the icon was increased, IMO it looks good on both mobile and desktop. 

## Demo

https://user-images.githubusercontent.com/1017620/170276983-c6b9e653-13cc-4295-b370-be91255d1de1.mp4

## Testing scenarios

- [ ] Navigate all focusable elements on standups and make sure `active` and `focus` styles work correctly
- [ ] Hover style works correctly
- [ ] Resize the browser to see if the button is centered correctly all the time

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
