### PR TITLE
feat(standups): Basic editable prompt

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -31,6 +31,7 @@
           "CreateImposterTokenPayload": "./types/CreateImposterTokenPayload#CreateImposterTokenPayloadSource",
           "LoginWithGooglePayload": "./types/LoginWithGooglePayload#LoginWithGooglePayloadSource",
           "NewMeeting": "../../postgres/types/Meeting#AnyMeeting",
+          "TeamPromptMeeting": "../../database/types/MeetingTeamPrompt#default as MeetingTeamPromptDB",
           "Organization": "../../database/types/Organization#default as Organization",
           "PokerMeeting": "../../database/types/MeetingPoker#default as MeetingPoker",
           "Team": "../../postgres/queries/getTeamsByIds#Team",

--- a/codegen.json
+++ b/codegen.json
@@ -38,6 +38,7 @@
           "TimelineEventTeamPromptComplete": "./types/TimelineEventTeamPromptComplete#TimelineEventTeamPromptCompleteSource",
           "UpdateDimensionFieldSuccess": "./types/UpdateDimensionFieldSuccess#UpdateDimensionFieldSuccessSource",
           "UpdateGitLabDimensionFieldSuccess": "./types/UpdateGitLabDimensionFieldSuccess#UpdateGitLabDimensionFieldSuccessSource",
+          "UpdateMeetingPromptSuccess": "./types/UpdateMeetingPromptSuccess#UpdateMeetingPromptSuccessSource",
           "UpsertTeamPromptResponseSuccess": "./types/UpsertTeamPromptResponseSuccess#UpsertTeamPromptResponseSuccessSource",
           "User": "../../postgres/types/IUser#default as IUser"
         }
@@ -46,17 +47,13 @@
       "schema": "packages/server/graphql/public/schema.graphql"
     },
     "packages/server/types/githubTypes.ts": {
-      "config": {
-        "assumeValidSDL": true
-      },
+      "config": {"assumeValidSDL": true},
       "documents": "packages/server/utils/githubQueries/*.graphql",
       "plugins": ["typescript", "typescript-operations", "add"],
       "schema": "packages/server/utils/githubSchema.graphql"
     },
     "packages/server/types/gitlabTypes.ts": {
-      "config": {
-        "assumeValidSDL": true
-      },
+      "config": {"assumeValidSDL": true},
       "documents": [
         "packages/server/graphql/nestedSchema/GitLab/queries/*.graphql",
         "packages/server/graphql/nestedSchema/GitLab/mutations/*.graphql"

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -62,6 +62,7 @@ const TeamPromptMeeting = (props: Props) => {
         ...TeamPromptDiscussionDrawer_meeting
         id
         isRightDrawerOpen
+        meetingPrompt
         phases {
           ... on TeamPromptResponsesPhase {
             __typename
@@ -82,7 +83,7 @@ const TeamPromptMeeting = (props: Props) => {
     `,
     meetingRef
   )
-  const {phases} = meeting
+  const {phases, meetingPrompt} = meeting
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
   const {viewerId} = useAtmosphere()
 
@@ -132,7 +133,7 @@ const TeamPromptMeeting = (props: Props) => {
               hideBottomBar={true}
             >
               <TeamPromptTopBar meetingRef={meeting} />
-              <Prompt>What are you working on today? Stuck on anything?</Prompt>
+              <Prompt>{meetingPrompt}</Prompt>
               <ErrorBoundary>
                 <ResponsesGridContainer maybeTabletPlus={maybeTabletPlus}>
                   <ResponsesGrid>

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -8,6 +8,7 @@ import useEventCallback from '~/hooks/useEventCallback'
 import useMeeting from '~/hooks/useMeeting'
 import useMutationProps from '~/hooks/useMutationProps'
 import useTransition from '~/hooks/useTransition'
+import UpdateMeetingPromptMutation from '~/mutations/UpdateMeetingPromptMutation'
 import {Breakpoint, DiscussionThreadEnum} from '~/types/constEnums'
 import {isNotNull} from '~/utils/predicates'
 import sortByISO8601Date from '~/utils/sortByISO8601Date'
@@ -23,7 +24,6 @@ import MeetingStyles from './MeetingStyles'
 import TeamPromptDiscussionDrawer from './TeamPrompt/TeamPromptDiscussionDrawer'
 import TeamPromptResponseCard from './TeamPrompt/TeamPromptResponseCard'
 import TeamPromptTopBar from './TeamPrompt/TeamPromptTopBar'
-import UpdateMeetingPromptMutation from '~/mutations/UpdateMeetingPromptMutation'
 
 const Prompt = styled('h1')({
   textAlign: 'center',
@@ -142,7 +142,7 @@ const TeamPromptMeeting = (props: Props) => {
   const validate = (rawMeetingPrompt: string) => {
     const res = new Legitity(rawMeetingPrompt)
       .trim()
-      .required('Standups need names')
+      .required('Standups need prompts')
       .min(2, 'Standups need good prompts')
 
     if (res.error) {

--- a/packages/client/mutations/UpdateMeetingPromptMutation.ts
+++ b/packages/client/mutations/UpdateMeetingPromptMutation.ts
@@ -1,0 +1,50 @@
+import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
+import {StandardMutation} from '../types/relayMutations'
+import {UpdateMeetingPromptMutation as TUpdateMeetingPromptMutation} from '../__generated__/UpdateMeetingPromptMutation.graphql'
+
+graphql`
+  fragment UpdateMeetingPromptMutation_meeting on UpdateMeetingPromptSuccess {
+    meeting {
+      id
+      meetingPrompt
+    }
+  }
+`
+
+const mutation = graphql`
+  mutation UpdateMeetingPromptMutation($meetingId: ID!, $newPrompt: String!) @raw_response_type {
+    updateMeetingPrompt(meetingId: $meetingId, newPrompt: $newPrompt) {
+      ... on ErrorPayload {
+        error {
+          message
+        }
+      }
+      ...UpdateMeetingPromptMutation_meeting @relay(mask: false)
+    }
+  }
+`
+
+const UpdateMeetingPromptMutation: StandardMutation<TUpdateMeetingPromptMutation> = (
+  atmosphere,
+  variables,
+  {onError, onCompleted}
+) => {
+  return commitMutation<TUpdateMeetingPromptMutation>(atmosphere, {
+    mutation,
+    variables,
+    optimisticResponse: {
+      updateMeetingPrompt: {
+        __typename: 'UpdateMeetingPromptSuccess',
+        meeting: {
+          id: variables.meetingId,
+          meetingPrompt: variables.newPrompt
+        }
+      }
+    },
+    onCompleted,
+    onError
+  })
+}
+
+export default UpdateMeetingPromptMutation

--- a/packages/client/subscriptions/MeetingSubscription.ts
+++ b/packages/client/subscriptions/MeetingSubscription.ts
@@ -28,6 +28,7 @@ const subscription = graphql`
   subscription MeetingSubscription($meetingId: ID!) {
     meetingSubscription(meetingId: $meetingId) {
       __typename
+      ...UpdateMeetingPromptMutation_meeting @relay(mask: false)
       ...SetTaskEstimateMutation_meeting @relay(mask: false)
       ...SetPokerSpectateMutation_team @relay(mask: false)
       ...JoinMeetingMutation_meeting @relay(mask: false)

--- a/packages/server/database/migrations/20220524131406-addPromptToTeamPrompt.ts
+++ b/packages/server/database/migrations/20220524131406-addPromptToTeamPrompt.ts
@@ -1,0 +1,25 @@
+export const up = async function (r) {
+  try {
+    await r
+      .table('NewMeeting')
+      .filter({meetingType: 'teamPrompt'})
+      .update({
+        meetingPrompt: 'What are you working on today? Stuck on anything?'
+      })
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function (r) {
+  try {
+    await r
+      .table('NewMeeting')
+      .filter({meetingType: 'teamPrompt'})
+      .replace(r.row.without('meetingPrompt'))
+      .run()
+  } catch (e) {
+    console.log(e)
+  }
+}

--- a/packages/server/database/types/MeetingTeamPrompt.ts
+++ b/packages/server/database/types/MeetingTeamPrompt.ts
@@ -8,6 +8,7 @@ interface Input {
   id?: string
   teamId: string
   meetingCount: number
+  meetingPrompt: string
   name?: string
   phases: [TeamPromptPhase, ...TeamPromptPhase[]]
   facilitatorUserId: string
@@ -19,9 +20,10 @@ export function isMeetingTeamPrompt(meeting: Meeting): meeting is MeetingTeamPro
 
 export default class MeetingTeamPrompt extends Meeting {
   meetingType!: 'teamPrompt'
+  meetingPrompt: string
 
   constructor(input: Input) {
-    const {id, teamId, meetingCount, name, phases, facilitatorUserId} = input
+    const {id, teamId, meetingCount, meetingPrompt, name, phases, facilitatorUserId} = input
     super({
       id,
       teamId,
@@ -31,5 +33,6 @@ export default class MeetingTeamPrompt extends Meeting {
       meetingType: 'teamPrompt',
       name: name ?? `Async Standup #${meetingCount + 1}`
     })
+    this.meetingPrompt = meetingPrompt
   }
 }

--- a/packages/server/graphql/mutations/startTeamPrompt.ts
+++ b/packages/server/graphql/mutations/startTeamPrompt.ts
@@ -74,7 +74,8 @@ const startTeamPrompt = {
       teamId,
       meetingCount,
       phases,
-      facilitatorUserId: viewerId
+      facilitatorUserId: viewerId,
+      meetingPrompt: 'What are you working on today? Stuck on anything?' // :TODO: (jmtaber129): Get this from meeting settings.
     })
     await r.table('NewMeeting').insert(meeting).run()
 

--- a/packages/server/graphql/public/mutations/updateMeetingPrompt.ts
+++ b/packages/server/graphql/public/mutations/updateMeetingPrompt.ts
@@ -31,7 +31,7 @@ const updateMeetingPrompt: MutationResolvers['updateMeetingPrompt'] = async (
   }
 
   // VALIDATION
-  if (newPrompt.length < 2) {
+  if (newPrompt.length < 2 || newPrompt.length > 500) {
     return standardError(new Error('Invalid meeting prompt'), {userId: viewerId})
   }
 

--- a/packages/server/graphql/public/mutations/updateMeetingPrompt.ts
+++ b/packages/server/graphql/public/mutations/updateMeetingPrompt.ts
@@ -1,0 +1,51 @@
+import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import getRethink from '../../../database/rethinkDriver'
+import {getUserId} from '../../../utils/authorization'
+import publish from '../../../utils/publish'
+import {MutationResolvers} from '../resolverTypes'
+
+const updateMeetingPrompt: MutationResolvers['updateMeetingPrompt'] = async (
+  _source,
+  {meetingId, newPrompt},
+  {authToken, dataLoader, socketId: mutatorId}
+) => {
+  const r = await getRethink()
+  const viewerId = getUserId(authToken)
+  const operationId = dataLoader.share()
+  const subOptions = {mutatorId, operationId}
+
+  // AUTH
+  const meeting = await dataLoader.get('newMeetings').load(meetingId)
+  if (!meeting) {
+    return {error: {message: 'Meeting not found'}}
+  }
+  if (meeting.meetingType !== 'teamPrompt') {
+    return {error: {message: 'Meeting is not a team prompt meeting'}}
+  }
+  const {facilitatorUserId} = meeting
+  if (viewerId !== facilitatorUserId) {
+    return {error: {message: 'Only the facilitator can change the meeting prompt'}}
+  }
+
+  // VALIDATION
+  if (newPrompt.length < 2) {
+    return {error: {message: 'Invalid meeting prompt'}}
+  }
+
+  // RESOLUTION
+  await r
+    .table('NewMeeting')
+    .get(meetingId)
+    .update({
+      meetingPrompt: newPrompt
+    })
+    .run()
+  dataLoader.get('newMeetings').clear(meetingId)
+
+  // RESOLUTION
+  const data = {meetingId}
+  publish(SubscriptionChannel.MEETING, meetingId, 'UpdateMeetingPromptSuccess', data, subOptions)
+  return data
+}
+
+export default updateMeetingPrompt

--- a/packages/server/graphql/public/mutations/updateMeetingPrompt.ts
+++ b/packages/server/graphql/public/mutations/updateMeetingPrompt.ts
@@ -2,6 +2,7 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import getRethink from '../../../database/rethinkDriver'
 import {getUserId} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
+import standardError from '../../../utils/standardError'
 import {MutationResolvers} from '../resolverTypes'
 
 const updateMeetingPrompt: MutationResolvers['updateMeetingPrompt'] = async (
@@ -17,19 +18,21 @@ const updateMeetingPrompt: MutationResolvers['updateMeetingPrompt'] = async (
   // AUTH
   const meeting = await dataLoader.get('newMeetings').load(meetingId)
   if (!meeting) {
-    return {error: {message: 'Meeting not found'}}
+    return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
   if (meeting.meetingType !== 'teamPrompt') {
-    return {error: {message: 'Meeting is not a team prompt meeting'}}
+    return standardError(new Error('Meeting is not a team prompt meeting'), {userId: viewerId})
   }
   const {facilitatorUserId} = meeting
   if (viewerId !== facilitatorUserId) {
-    return {error: {message: 'Only the facilitator can change the meeting prompt'}}
+    return standardError(new Error('Only the facilitator can change the meeting prompt'), {
+      userId: viewerId
+    })
   }
 
   // VALIDATION
   if (newPrompt.length < 2) {
-    return {error: {message: 'Invalid meeting prompt'}}
+    return standardError(new Error('Invalid meeting prompt'), {userId: viewerId})
   }
 
   // RESOLUTION

--- a/packages/server/graphql/public/typeDefs/updateMeetingPrompt.graphql
+++ b/packages/server/graphql/public/typeDefs/updateMeetingPrompt.graphql
@@ -1,0 +1,32 @@
+extend type Mutation {
+  """
+  Describe the mutation here
+  """
+  updateMeetingPrompt(
+    """
+    The meeting to update the prompt
+    """
+    meetingId: ID!
+
+    """
+    The updated prompt
+    """
+    newPrompt: String!
+  ): UpdateMeetingPromptPayload!
+}
+
+"""
+Return value for updateMeetingPrompt, which could be an error
+"""
+union UpdateMeetingPromptPayload = UpdateMeetingPromptSuccess | ErrorPayload
+
+type UpdateMeetingPromptSuccess {
+  meetingId: ID!
+
+  """
+  the updated meeting
+  """
+  meeting: TeamPromptMeeting
+}
+
+extend union MeetingSubscriptionPayload = UpdateMeetingPromptSuccess

--- a/packages/server/graphql/public/typeDefs/updateMeetingPrompt.graphql
+++ b/packages/server/graphql/public/typeDefs/updateMeetingPrompt.graphql
@@ -26,7 +26,7 @@ type UpdateMeetingPromptSuccess {
   """
   the updated meeting
   """
-  meeting: TeamPromptMeeting
+  meeting: TeamPromptMeeting!
 }
 
 extend union MeetingSubscriptionPayload = UpdateMeetingPromptSuccess

--- a/packages/server/graphql/public/types/UpdateMeetingPromptSuccess.ts
+++ b/packages/server/graphql/public/types/UpdateMeetingPromptSuccess.ts
@@ -1,4 +1,5 @@
-import {Maybe, ResolversTypes, UpdateMeetingPromptSuccessResolvers} from '../resolverTypes'
+import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
+import {UpdateMeetingPromptSuccessResolvers} from '../resolverTypes'
 
 export type UpdateMeetingPromptSuccessSource = {
   meetingId: string
@@ -7,10 +8,7 @@ export type UpdateMeetingPromptSuccessSource = {
 const UpdateMeetingPromptSuccess: UpdateMeetingPromptSuccessResolvers = {
   meeting: async (source, _args, {dataLoader}) => {
     const {meetingId} = source
-    const meeting = await dataLoader.get('newMeetings').load(meetingId)
-    return (meeting.meetingType !== 'teamPrompt' ? null : meeting) as Maybe<
-      ResolversTypes['TeamPromptMeeting']
-    >
+    return dataLoader.get('newMeetings').load(meetingId) as Promise<MeetingTeamPrompt>
   }
 }
 

--- a/packages/server/graphql/public/types/UpdateMeetingPromptSuccess.ts
+++ b/packages/server/graphql/public/types/UpdateMeetingPromptSuccess.ts
@@ -1,0 +1,17 @@
+import {Maybe, ResolversTypes, UpdateMeetingPromptSuccessResolvers} from '../resolverTypes'
+
+export type UpdateMeetingPromptSuccessSource = {
+  meetingId: string
+}
+
+const UpdateMeetingPromptSuccess: UpdateMeetingPromptSuccessResolvers = {
+  meeting: async (source, _args, {dataLoader}) => {
+    const {meetingId} = source
+    const meeting = await dataLoader.get('newMeetings').load(meetingId)
+    return (meeting.meetingType !== 'teamPrompt' ? null : meeting) as Maybe<
+      ResolversTypes['TeamPromptMeeting']
+    >
+  }
+}
+
+export default UpdateMeetingPromptSuccess

--- a/packages/server/graphql/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/types/TeamPromptMeeting.ts
@@ -1,4 +1,4 @@
-import {GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql'
+import {GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'graphql'
 import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import {getTeamPromptResponsesByMeetingId} from '../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 import {getUserId} from '../../utils/authorization'
@@ -14,6 +14,10 @@ const TeamPromptMeeting = new GraphQLObjectType<any, GQLContext>({
   description: 'A team prompt meeting',
   fields: () => ({
     ...newMeetingFields(),
+    meetingPrompt: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The name of the meeting'
+    },
     settings: {
       type: new GraphQLNonNull(TeamPromptMeetingSettings),
       description: 'The settings that govern the team prompt meeting',


### PR DESCRIPTION
# Description
refs https://github.com/ParabolInc/parabol/issues/6584
Full "update prompt" mutation w/ basic UI.  The proper UI (full modal w/ static suggestions) will come in a follow-on PR.

In an effort to get this feature partially landed by the next release, and because this is still behind a feature flag, anything related to a "good" UI is outside the scope of this PR.  As a result, while the non-facilitator view should be unchanged, the facilitator's view of the prompt may seem a bit janky.  Additionally, most (all?) of the changes to `packages/client/components/TeamPromptMeeting.tsx` will be short-lived (only until the UI PR lands).

See https://github.com/ParabolInc/parabol/pull/6625/commits/993d027785be822e39b41a506fd61878e2d73e1f and later commits for context on how the UI will change to match designs.

## Demo
https://www.loom.com/share/55bf3227b9c844fcbe52e4c0c44c1efc

## Testing scenarios
- [ ] Facilitator can update prompt from within meeting
- [ ] Meeting prompt changes on other users' views when the facilitator changes the prompt

## Final checklist
- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
