### PR TITLE
feat(standups): Update relative `createdAt` automatically

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptLastUpdatedTime.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptLastUpdatedTime.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import {MenuPosition} from '../../hooks/useCoords'
 import useTooltip from '../../hooks/useTooltip'
 import {PALETTE} from '../../styles/paletteV3'
@@ -20,7 +20,19 @@ interface Props {
   updatedAt: string | Date
 }
 
+const UPDATE_INTERVAL_MS = 1000
+
 export default function TeamPromptLastUpdatedTime({updatedAt, createdAt}: Props) {
+  const [relativeCreatedAt, setRelativeCreatedAt] = useState(() => relativeDate(createdAt))
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setRelativeCreatedAt(relativeDate(createdAt))
+    }, UPDATE_INTERVAL_MS)
+
+    return () => clearInterval(intervalId)
+  }, [createdAt])
+
   const {
     tooltipPortal: createdTimePortal,
     openTooltip: showCreatedTime,
@@ -38,7 +50,7 @@ export default function TeamPromptLastUpdatedTime({updatedAt, createdAt}: Props)
   return (
     <Timestamp>
       <Hover onMouseEnter={showCreatedTime} onMouseLeave={closeCreatedTime} ref={createdTimeRef}>
-        {relativeDate(createdAt)}
+        {relativeCreatedAt}
         {createdTimePortal(absoluteDate(createdAt))}
       </Hover>
       {isEdited && (

--- a/packages/client/components/TeamPrompt/TeamPromptLastUpdatedTime.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptLastUpdatedTime.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
-import React, {useEffect, useState} from 'react'
+import React from 'react'
+import useRefreshInterval from '~/hooks/useRefreshInterval'
 import {MenuPosition} from '../../hooks/useCoords'
 import useTooltip from '../../hooks/useTooltip'
 import {PALETTE} from '../../styles/paletteV3'
@@ -20,18 +21,10 @@ interface Props {
   updatedAt: string | Date
 }
 
-const UPDATE_INTERVAL_MS = 1000
+const RELATIVE_DATES_UPDATE_INTERVAL_MS = 1000
 
 export default function TeamPromptLastUpdatedTime({updatedAt, createdAt}: Props) {
-  const [relativeCreatedAt, setRelativeCreatedAt] = useState(() => relativeDate(createdAt))
-
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      setRelativeCreatedAt(relativeDate(createdAt))
-    }, UPDATE_INTERVAL_MS)
-
-    return () => clearInterval(intervalId)
-  }, [createdAt])
+  useRefreshInterval(RELATIVE_DATES_UPDATE_INTERVAL_MS)
 
   const {
     tooltipPortal: createdTimePortal,
@@ -50,7 +43,7 @@ export default function TeamPromptLastUpdatedTime({updatedAt, createdAt}: Props)
   return (
     <Timestamp>
       <Hover onMouseEnter={showCreatedTime} onMouseLeave={closeCreatedTime} ref={createdTimeRef}>
-        {relativeCreatedAt}
+        {relativeDate(createdAt)}
         {createdTimePortal(absoluteDate(createdAt))}
       </Hover>
       {isEdited && (


### PR DESCRIPTION
# Description

Fixes #6628 

## Demo
No demo

## Testing scenarios

- [ ] Open a standup meeting, add a response wait for more than 1min, and see if `createdAt` is updated automatically (ie. from  `Just now` to `1 minute ago` 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
