### PR TITLE
fix(sprint-poker): Prevent kicking facilitator off the meeting while modifying the scope

### DIFF
--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -56,6 +56,7 @@ graphql`
       }
     }
     meeting {
+      ...PokerMeeting_meeting
       ...useInitialSafeRoute_meeting
       ...useUpdatedSafeRoute_meeting
       gitlabSearchQuery {

--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -56,6 +56,8 @@ graphql`
       }
     }
     meeting {
+      ...useInitialSafeRoute_meeting
+      ...useUpdatedSafeRoute_meeting
       gitlabSearchQuery {
         queryString
         selectedProjectsIds


### PR DESCRIPTION
# Description

Fixes #6231 

The bug itself was caused by meeting subscription updating the relay store with no fully populated data. `UpdatePokerScopeMutation` didn't include data needed for `useInitialSafeRoute` and `useUpdatedSafeRoute` hooks to work. `facilitatorStageId` was undefined after the update and as a result, the facilitator was kicked off the meeting. 

## Demo

https://user-images.githubusercontent.com/1017620/171653362-24ce2b37-cc41-4028-b9cd-4bfa97568678.mp4

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Alice creates the sprint poker and adds some issues to the scope. Bob joins the meeting and removes the issues added by Alice. Alice is still in the meeting and wasn't kicked off the meeting.

Doesn't really matter what integration is used, the scenario described in #6231 was true for all existing integrations. 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
