### PR TITLE
fix(Retro Templates): Added missing prompts

### DIFF
--- a/packages/server/database/migrations/20210602120505-addAdditionalRetroTemplates.ts
+++ b/packages/server/database/migrations/20210602120505-addAdditionalRetroTemplates.ts
@@ -42,6 +42,7 @@ const makePrompt = (promptInfo: PromptInfo) => {
     createdAt,
     description,
     groupColor,
+    // FIXME this may create duplicated ids
     id: nameToId(question, false),
     isActive: true,
     question,
@@ -150,38 +151,24 @@ const promptsInfo = [
 const templates = templateNames.map((templateName) => makeTemplate(templateName))
 const reflectPrompts = promptsInfo.map((promptInfo: PromptInfo) => makePrompt(promptInfo))
 
-export const up = async function(r: R) {
+export const up = async function (r: R) {
   try {
     await Promise.all([
-      r
-        .table('MeetingTemplate')
-        .insert(templates)
-        .run(),
-      r
-        .table('ReflectPrompt')
-        .insert(reflectPrompts)
-        .run()
+      r.table('MeetingTemplate').insert(templates).run(),
+      r.table('ReflectPrompt').insert(reflectPrompts).run()
     ])
   } catch (e) {
     console.log(e)
   }
 }
 
-export const down = async function(r: R) {
+export const down = async function (r: R) {
   const templateIds = templates.map(({id}) => id)
   const promptIds = reflectPrompts.map(({id}) => id)
   try {
     await Promise.all([
-      r
-        .table('MeetingTemplate')
-        .getAll(r.args(templateIds))
-        .delete()
-        .run(),
-      r
-        .table('ReflectPrompt')
-        .getAll(r.args(promptIds))
-        .delete()
-        .run()
+      r.table('MeetingTemplate').getAll(r.args(templateIds)).delete().run(),
+      r.table('ReflectPrompt').getAll(r.args(promptIds)).delete().run()
     ])
   } catch (e) {
     console.log(e)

--- a/packages/server/database/migrations/20220124600507-addMoreRetroTemplates.ts
+++ b/packages/server/database/migrations/20220124600507-addMoreRetroTemplates.ts
@@ -626,6 +626,7 @@ const makePrompt = (promptInfo: PromptInput, idx: number) => {
   const {question, description, promptColor, promptId, templateId, sortOrder} = promptInfo
   const paletteIdx = idx > promptColors.length - 1 ? idx % promptColors.length : idx
   const groupColor = promptColor ? promptColor : promptColors[paletteIdx]
+  // FIXME this creates duplicated ids
   const id = promptId ? promptId : nameToId(question, false)
   return {
     createdAt,
@@ -642,8 +643,8 @@ const makePrompt = (promptInfo: PromptInput, idx: number) => {
   }
 }
 
-const templates = templateNames.map((templateName) => makeTemplate(templateName))
-const reflectPrompts = promptsInfo.map((promptInfo, idx) => makePrompt(promptInfo, idx))
+export const templates = templateNames.map((templateName) => makeTemplate(templateName))
+export const reflectPrompts = promptsInfo.map((promptInfo, idx) => makePrompt(promptInfo, idx))
 
 export const up = async function (r: R) {
   try {

--- a/packages/server/database/migrations/20220602164119-fixRetroTemplates.ts
+++ b/packages/server/database/migrations/20220602164119-fixRetroTemplates.ts
@@ -1,0 +1,37 @@
+import {
+  down as faultyDown,
+  reflectPrompts,
+  templates,
+  up as faultyUp
+} from './20220124600507-addMoreRetroTemplates'
+
+const fixedReflectPrompts = reflectPrompts.map((prompt) => ({
+  ...prompt,
+  id: `${prompt.templateId}:${prompt.id}`
+}))
+
+export const up = async function (r) {
+  try {
+    await faultyDown(r)
+    await Promise.all([
+      r.table('MeetingTemplate').insert(templates).run(),
+      r.table('ReflectPrompt').insert(fixedReflectPrompts).run()
+    ])
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export const down = async function (r) {
+  const templateIds = templates.map(({id}) => id)
+  const promptIds = fixedReflectPrompts.map(({id}) => id)
+  try {
+    await Promise.all([
+      r.table('MeetingTemplate').getAll(r.args(templateIds)).delete().run(),
+      r.table('ReflectPrompt').getAll(r.args(promptIds)).delete().run()
+    ])
+    await faultyUp(r)
+  } catch (e) {
+    console.log(e)
+  }
+}


### PR DESCRIPTION
# Description

Fixes #6666

Some prompts were missing because of an `id` clash with existing
prompts because the `id` was purely generated from the question itself.
Changed it to be generated including the `templateId`.

## Demo

![Screenshot from 2022-06-03 00-11-27](https://user-images.githubusercontent.com/7331043/171746920-e583ed40-1c31-4387-a64d-2e0219ed214f.png)
![Screenshot from 2022-06-03 00-10-58](https://user-images.githubusercontent.com/7331043/171746925-f3761cf5-9c1b-41e3-9490-0c33f93b89fd.png)

## Testing scenarios

New meeting dialog, choose Retro and switch template. "SaMoLo" and "Keep, Problem, Try" have 3 prompts each matching their name.