### PR TITLE
fix(jira): Handle a case with a huge number of Jira projects and avoid timeout error when trying to fix Jira field automatically

### DIFF
--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -748,9 +748,9 @@ export default abstract class AtlassianManager {
     throw res
   }
 
-  async getScreens(cloudId: string, maxResults: number) {
+  async getScreens(cloudId: string, maxResults: number, startAt = 0) {
     return this.get<JiraScreensResponse>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens?maxResults=${maxResults}`
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens?maxResults=${maxResults}&startAt=${startAt}`
     )
   }
 

--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -748,9 +748,9 @@ export default abstract class AtlassianManager {
     throw res
   }
 
-  async getScreens(cloudId: string) {
+  async getScreens(cloudId: string, maxResults: number) {
     return this.get<JiraScreensResponse>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens`
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens?maxResults=${maxResults}`
     )
   }
 

--- a/packages/server/graphql/mutations/addMissingJiraField.ts
+++ b/packages/server/graphql/mutations/addMissingJiraField.ts
@@ -95,8 +95,7 @@ const addMissingJiraField = {
     const screensResponse = await manager.getScreens(cloudId, batchSize)
     const screens: JiraScreen[] = []
     if (screensResponse instanceof Error || screensResponse instanceof RateLimitError) {
-      console.log('Unable to fetch screens for cloudId:', cloudId)
-      return {error: {message: screensResponse.message}}
+      return standardError(screensResponse)
     }
 
     console.log(`Total screens count: ${screensResponse.total}, batch size: ${batchSize}`)
@@ -114,8 +113,7 @@ const addMissingJiraField = {
       const screenResponses = await Promise.all(promises)
       for (const response of screenResponses) {
         if (response instanceof Error || response instanceof RateLimitError) {
-          console.log('Unable to fetch screens for cloudId:', cloudId)
-          return {error: {message: response.message}}
+          return standardError(response)
         }
         screens.push(...response.values)
       }

--- a/packages/server/graphql/mutations/addMissingJiraField.ts
+++ b/packages/server/graphql/mutations/addMissingJiraField.ts
@@ -87,12 +87,19 @@ const addMissingJiraField = {
     }
     const {fieldType, fieldId} = dimensionField
 
-    const screensResponse = await manager.getScreens(cloudId)
+    console.log(`Adding missing Jira field, fieldId: ${fieldId}, cloudId: ${cloudId}, projectKey: ${projectKey}`)
+
+    const maxResults = 2000
+    const screensResponse = await manager.getScreens(cloudId, maxResults)
     if (screensResponse instanceof Error || screensResponse instanceof RateLimitError) {
+      console.log('Unable to fetch screens for cloudId:', cloudId)
       return {error: {message: screensResponse.message}}
     }
 
     const {values: screens} = screensResponse
+
+    console.log(`Screens fetched: ${screens.length}`)
+
     // we're trying to guess what's the probability that given screen is assigned to an issue project
     const evaluateProbability = (screen: JiraScreen) => {
       if (screen.name.startsWith(projectKey) && screen.name.includes('Default')) return 1
@@ -101,21 +108,17 @@ const addMissingJiraField = {
 
       return 0.5
     }
-    const possibleScreens = (
-      await Promise.all(
-        screens.map(async (screen) => {
-          const screenTabsResponse = await manager.getScreenTabs(cloudId, screen.id)
-          if (screenTabsResponse instanceof Error || screenTabsResponse instanceof RateLimitError) {
-            return null
-          }
 
-          const tabId = screenTabsResponse[0]?.id
-          return {screenId: screen.id, tabId, probability: evaluateProbability(screen)}
-        })
-      )
-    )
+    const possibleScreens = screens.map((screen) => {
+      return {screenId: screen.id, probability: evaluateProbability(screen), name: screen.name}
+    })
       .filter(isNotNull)
+      .filter((screen) => screen.probability >= 0.9)
       .sort((screen1, screen2) => screen2.probability - screen1.probability)
+
+    console.log(`Possible screens count: ${possibleScreens.length}`)
+    console.log('Possible screens:', JSON.stringify(possibleScreens))
+
     if (possibleScreens.length === 0) {
       return {error: {message: 'No screens available to modify!'}}
     }
@@ -123,21 +126,33 @@ const addMissingJiraField = {
     const dummyValues = {number: 0, string: '0'}
     const dummyValue = dummyValues[fieldType]
 
-    let updatedScreen: {screenId: string; tabId: string} | null = null
+    let updatedScreen: {screenId: string;} | null = null
     const screensToCleanup: Array<{screenId: string; tabId: string}> = []
     // iterate over all the screens sorted by probability, try to update the given field
     for (let i = 0; i < possibleScreens.length; i++) {
       const screen = possibleScreens[i]!
-      const {screenId, tabId} = screen
-      const addFieldResponse = await manager.addFieldToScreenTab(cloudId, screenId, tabId, fieldId)
-      if (addFieldResponse instanceof Error) {
+      const {screenId} = screen
+
+      const screenTabsResponse = await manager.getScreenTabs(cloudId, screenId)
+      if (screenTabsResponse instanceof Error || screenTabsResponse instanceof RateLimitError) {
+        console.log(`Unable to fetch screen tabs for screenId: ${screenId}`)
         continue
       }
+      const tabId = screenTabsResponse[0]?.id
+
+      const addFieldResponse = await manager.addFieldToScreenTab(cloudId, screenId, tabId, fieldId)
+      if (addFieldResponse instanceof Error) {
+        console.log(`Unable to add fields to screen tab ${tabId}`)
+        continue
+      }
+
+      console.log(`Field ${fieldId} added to screen ${screenId} and tab ${tabId}`)
 
       try {
         // if we can update the field that was previously missing it means we've added it to the right screen
         await manager.updateStoryPoints(cloudId, issueKey, dummyValue, fieldId)
         updatedScreen = screen
+        console.log(`Tested story points update for the issue: ${issueKey}, fieldId: ${fieldId}`)
         break
       } catch (e) {
         // save a screen for a later cleanup, continue looking for a proper screen
@@ -147,6 +162,7 @@ const addMissingJiraField = {
 
     // remove field from all the unused screens
     if (screensToCleanup.length > 0) {
+      console.log('Cleanup screens count:', screensToCleanup.length)
       await Promise.all(
         screensToCleanup.map(({screenId, tabId}) => {
           return manager.removeFieldFromScreenTab(cloudId, screenId, tabId, fieldId)
@@ -155,6 +171,7 @@ const addMissingJiraField = {
     }
 
     if (updatedScreen === null) {
+      console.log('No screens updated for cloudId:', cloudId)
       return standardError(new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR))
     }
 


### PR DESCRIPTION
Fixes #6675

In this PR:
- I increased number of screens we fetching to 2000 as it is not possible to filter them by `projectId` using API
- I'm trying to fix only screens with high probability, to avoid possible timeout errors while iterating everything
- I request screen tabs as we go, to reduce potential number of API requests. 
- I assume that required screen will be fixed first in most cases, otherwise I suggest it is better to show a meaningful error instead of timeout
- Added more logging

How to test:

- Create a new company-managed project in Jira
- Try to estimate any issue with Story points
- See that Fix field dialog works fine and fixes the field