### PR TITLE
docs(codeReview): Decouple PRs from Issues

### DIFF
--- a/docs/codeReview.md
+++ b/docs/codeReview.md
@@ -12,8 +12,15 @@ A PR advances from self-review to reviewer-review and finally maintainer review 
 - It should be a reviewer’s goal to do the code review within 1 business day. If you’re unable to do it, leave a comment.
 - If you’re busy it’s ok to assign someone else as a reviewer.
 - When submitting a PR, provide context. What's the task? What's changed? Why? If you can, record a Loom to share why things are done that way. It'll be easier for a reviewer to understand what decision you've made and why.
-- When reviewing a PR and requesting changes, be mindful that the PR author won't always have the right background to understand what are you requesting. Make your comments meaningful, and record a Loom if needed.
+- When reviewing a PR and requesting changes, be mindful that the PR author won't always have the right background to understand what are you requesting. Make your comments meaningful, and record a Loom if needed. 
 - [The right balance](https://docs.gitlab.com/ee/development/code_review.html#the-right-balance)
+
+## Sprint Board
+
+- Issues can go in these columns: To Prioritize, Backlog, To Do, In Progress, Stuck.
+- Pull Requests can go in these columns: Stuck, Self Review, Reviewer Review, Maintainer Review.
+- A PR may correpsond to 0 or many issues. These issues shall stay "In Progress" and when the PR gets merged, they'll be moved to "Done" automatically.
+- The motivation for this structure is to relax the constraint that 1 issue has 1 PR. If a PR resolves 3 issues, we only have to update the status of the PR, not update all 3 issues as a group. If a PR fails to resolve 1 of the 3 issues, the remaining issue stays "In Progress" instead of being moved from "Maintainer Review" back to "In Progress".
 
 ## Reviewer
 

--- a/docs/codeReview.md
+++ b/docs/codeReview.md
@@ -20,7 +20,7 @@ A PR advances from self-review to reviewer-review and finally maintainer review 
 - Issues can go in these columns: To Prioritize, Backlog, To Do, In Progress, Stuck.
 - Pull Requests can go in these columns: Stuck, Self Review, Reviewer Review, Maintainer Review.
 - A PR may correpsond to 0 or many issues. These issues shall stay "In Progress" and when the PR gets merged, they'll be moved to "Done" automatically.
-- The motivation for this structure is to relax the constraint that 1 issue has 1 PR. If a PR resolves 3 issues, we only have to update the status of the PR, not update all 3 issues as a group. If a PR fails to resolve 1 of the 3 issues, the remaining issue stays "In Progress" instead of being moved from "Maintainer Review" back to "In Progress".
+- The motivation for this structure is to relax the constraint that 1 issue has 1 PR. If a PR resolves 3 issues, we only have to update the status of the PR, not update all 3 issues as a group. If a PR fails to resolve 1 of the 3 issues, the remaining issue stays "In Progress" instead of being moved from "Maintainer Review" back to "In Progress". If an issue has multiple PRs, the issue can stay "In Progress" while the PRs move through the process.
 
 ## Reviewer
 


### PR DESCRIPTION
# Description

Today, our sprint board implicitly couples 1 issue to 1 PR.
For example, we might see an issue in the "reviewer review" column.
It's not actually the _issue_ that is under review, rather it is the PR that fixes that issue.
This is important because 1 PR might resolve multiple issues.
if a PR resolves 3 issues, would all 3 issues have to go under "reviewer review"? If it fails to resolve 1 of the issues, does that single issue get moved back to "In Progress" after the PR is merged?
What if 2 PRs are required to resolve 1 issue? Would we merge the PR & move that issue back to "In Progress"? That's not an accurate representation of the work that's being accomplished.
By making sure only PRs go in the "Review" columns, we know 1 card = 1 review needed.

