### PR TITLE
fix(standups): Discussion thread drawer is cut off on mobile

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -29,7 +29,6 @@ const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop,
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
-  height: '100%',
   justifyContent: 'stretch',
   overflow: 'hidden',
   position: isDesktop ? 'fixed' : 'static',
@@ -40,7 +39,11 @@ const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop,
   userSelect: 'none',
   transform: `translateX(${isOpen ? 0 : DiscussionThreadEnum.WIDTH}px)`,
   width: DiscussionThreadEnum.WIDTH,
-  zIndex: ZIndex.SIDEBAR
+  zIndex: ZIndex.SIDEBAR,
+  height: '100%',
+  '@supports (height: 1svh) and (height: 1lvh)': {
+    height: isDesktop ? '100lvh' : '100svh'
+  }
 }))
 
 const ThreadColumn = styled('div')({


### PR DESCRIPTION
# Description

Partially Fixes `Standups: Improve mobile experience #6601`

The issue is caused by mobile browser not taking into account the top/bottom bars of their UI into calculating units like `vh`.
The quickest fix is to use `lvh` on mobile as it fixes exactly that problem.  More info: https://css-tricks.com/the-large-small-and-dynamic-viewports/. The support isn't great right now but it works on the new mobile browsers. For everything else, the behavior will stay as it is now. 

## Demo

Before
![IMG_9936](https://user-images.githubusercontent.com/1017620/172651365-c96e6d70-4254-468e-a04a-3a457536fbc4.PNG)

After
![IMG_9935](https://user-images.githubusercontent.com/1017620/172651397-9d955b0f-d517-4a95-9e3c-3fe08e274f87.PNG)


## Testing scenarios

- [ ] Check standups discussion thread drawer on mobile safari
- [ ] Check standups discussion thread drawer on mobile chrome 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
