### PR TITLE
fix(Sprint Poker): Remove padding in Discussion Drawer

### DIFF
--- a/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
+++ b/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
@@ -98,7 +98,7 @@ const EstimatePhaseDiscussionDrawer = (props: Props) => {
         <DiscussionThreadRoot
           allowedThreadables={allowedThreadables}
           discussionId={discussionId!}
-          width={'calc(100% - 16px)'}
+          width={'100%'}
           emptyState={
             <DiscussionThreadListEmptyState
               allowTasks={false}


### PR DESCRIPTION
# Description

#6433 Fixed the unrequired padding inside the Discussion Drawer

:star_struck: My First Contribution to Open-Source

## Demo

Before
![WhatsApp Image 2022-06-08 at 9 35 03 PM](https://user-images.githubusercontent.com/106697681/172665374-c06f3b55-edb0-4910-b0b6-677e37eeebdd.jpeg)



After
![After](https://user-images.githubusercontent.com/106697681/172665464-c7639a80-169f-44ca-b6db-999a0885a791.png)



## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [x] Check the discussion drawer on mobile Chrome/Safari
- [X] Check the discussion drawer on desktop Chrome/Safari



## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes, or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in the changelog
