### PR TITLE
fix(Sprint Poker): Remove padding in Discussion Drawer

### DIFF
--- a/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
+++ b/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
@@ -6,13 +6,14 @@ import {desktopSidebarShadow} from '~/styles/elevation'
 import {PALETTE} from '~/styles/paletteV3'
 import {ICON_SIZE} from '~/styles/typographyV2'
 import {EstimatePhaseDiscussionDrawer_meeting} from '~/__generated__/EstimatePhaseDiscussionDrawer_meeting.graphql'
-import {BezierCurve, DiscussionThreadEnum, ZIndex} from '../types/constEnums'
+import {BezierCurve, Breakpoint, DiscussionThreadEnum, ZIndex} from '../types/constEnums'
 import {DiscussionThreadables} from './DiscussionThreadList'
 import DiscussionThreadListEmptyState from './DiscussionThreadListEmptyState'
 import DiscussionThreadRoot from './DiscussionThreadRoot'
 import Icon from './Icon'
 import LabelHeading from './LabelHeading/LabelHeading'
 import PlainButton from './PlainButton/PlainButton'
+import mediaQueryforPoker from './mediaQueryforPoker'
 
 const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
   boxShadow: isDesktop ? desktopSidebarShadow : undefined,
@@ -29,7 +30,12 @@ const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop,
   transition: `all 200ms ${BezierCurve.DECELERATE}`,
   userSelect: 'none',
   width: isOpen || !isDesktop ? DiscussionThreadEnum.WIDTH : 0,
-  zIndex: ZIndex.SIDEBAR
+  zIndex: ZIndex.SIDEBAR,
+  [mediaQueryforPoker(Breakpoint.POKER_DISCUSSION_DRAWER)]: {
+    width: '100vw',
+    position: 'fixed',
+    right: isOpen ? '-360px' : '-100vw'
+  }
 }))
 
 const ThreadColumn = styled('div')({
@@ -98,7 +104,7 @@ const EstimatePhaseDiscussionDrawer = (props: Props) => {
         <DiscussionThreadRoot
           allowedThreadables={allowedThreadables}
           discussionId={discussionId!}
-          width={'calc(100% - 16px)'}
+          width={'100%'}
           emptyState={
             <DiscussionThreadListEmptyState
               allowTasks={false}

--- a/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
+++ b/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
@@ -13,7 +13,6 @@ import DiscussionThreadRoot from './DiscussionThreadRoot'
 import Icon from './Icon'
 import LabelHeading from './LabelHeading/LabelHeading'
 import PlainButton from './PlainButton/PlainButton'
-import mediaQueryforPoker from './mediaQueryforPoker'
 
 const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
   boxShadow: isDesktop ? desktopSidebarShadow : undefined,
@@ -31,10 +30,10 @@ const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop,
   userSelect: 'none',
   width: isOpen || !isDesktop ? DiscussionThreadEnum.WIDTH : 0,
   zIndex: ZIndex.SIDEBAR,
-  [mediaQueryforPoker(Breakpoint.POKER_DISCUSSION_DRAWER)]: {
+  [`@media screen and (max-width: ${Breakpoint.POKER_DISCUSSION_FULLSCREEN_DRAWER}px)`]: {
     width: '100vw',
     position: 'fixed',
-    right: isOpen ? '-360px' : '-100vw'
+    right: isOpen ? `-${DiscussionThreadEnum.WIDTH}px` : '-100vw'
   }
 }))
 

--- a/packages/client/components/PokerEstimatePhase.tsx
+++ b/packages/client/components/PokerEstimatePhase.tsx
@@ -19,10 +19,14 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PokerEstimateHeaderCard from './PokerEstimateHeaderCard'
 import {PokerMeetingPhaseProps} from './PokerMeeting'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
+import mediaQueryforPoker from './mediaQueryforPoker'
 
 const StyledMeetingHeaderAndPhase = styled(MeetingHeaderAndPhase)<{isOpen: boolean}>(
   ({isOpen}) => ({
-    width: isOpen ? `calc(100% - ${DiscussionThreadEnum.WIDTH}px)` : '100%'
+    width: isOpen ? `calc(100% - ${DiscussionThreadEnum.WIDTH}px)` : '100%',
+    [mediaQueryforPoker(Breakpoint.POKER_DISCUSSION_DRAWER)]: {
+      width: '100%'
+    }
   })
 )
 

--- a/packages/client/components/PokerEstimatePhase.tsx
+++ b/packages/client/components/PokerEstimatePhase.tsx
@@ -19,12 +19,11 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PokerEstimateHeaderCard from './PokerEstimateHeaderCard'
 import {PokerMeetingPhaseProps} from './PokerMeeting'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
-import mediaQueryforPoker from './mediaQueryforPoker'
 
 const StyledMeetingHeaderAndPhase = styled(MeetingHeaderAndPhase)<{isOpen: boolean}>(
   ({isOpen}) => ({
     width: isOpen ? `calc(100% - ${DiscussionThreadEnum.WIDTH}px)` : '100%',
-    [mediaQueryforPoker(Breakpoint.POKER_DISCUSSION_DRAWER)]: {
+    [`@media screen and (max-width: ${Breakpoint.POKER_DISCUSSION_FULLSCREEN_DRAWER}px)`]: {
       width: '100%'
     }
   })

--- a/packages/client/components/mediaQueryforPoker.tsx
+++ b/packages/client/components/mediaQueryforPoker.tsx
@@ -1,0 +1,3 @@
+export default function mediaQueryforPoker(breakpoint: number) {
+  return `@media screen and (max-width: ${breakpoint}px)`
+}

--- a/packages/client/components/mediaQueryforPoker.tsx
+++ b/packages/client/components/mediaQueryforPoker.tsx
@@ -1,3 +1,0 @@
-export default function mediaQueryforPoker(breakpoint: number) {
-  return `@media screen and (max-width: ${breakpoint}px)`
-}

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -37,7 +37,7 @@ export const enum Breakpoint {
   SIDEBAR_LEFT = 1024,
   NEW_MEETING_GRID = 1112,
   NEW_MEETING_SELECTOR = 500,
-  POKER_DISCUSSION_DRAWER = 660,
+  POKER_DISCUSSION_FULLSCREEN_DRAWER = 660,
   SINGLE_REFLECTION_COLUMN = 704, // (ReflectionWith + 16) * 2,
   DASH_BREAKPOINT_WIDEST = 1816, // (4*296) + (5*24) + (256*2) = 4 card cols, 4 col gutters, 2 sidebars
   VOTE_PHASE = 800,

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -37,6 +37,7 @@ export const enum Breakpoint {
   SIDEBAR_LEFT = 1024,
   NEW_MEETING_GRID = 1112,
   NEW_MEETING_SELECTOR = 500,
+  POKER_DISCUSSION_DRAWER = 660,
   SINGLE_REFLECTION_COLUMN = 704, // (ReflectionWith + 16) * 2,
   DASH_BREAKPOINT_WIDEST = 1816, // (4*296) + (5*24) + (256*2) = 4 card cols, 4 col gutters, 2 sidebars
   VOTE_PHASE = 800,


### PR DESCRIPTION
# Description

fix #6433 Remove the padding in the discussion Drawer


:star_struck: My first Open-Source Contribution

## Demo
Before
![WhatsApp Image 2022-06-08 at 9 35 03 PM](https://user-images.githubusercontent.com/106697681/172693582-e9e6b7f2-f584-4f74-943d-73fd3b1fca53.jpeg)



After
![After](https://user-images.githubusercontent.com/106697681/172693703-ea18b1dc-1fbd-4007-a4ea-755c5ba55c17.png)


## Testing scenarios

- [x] Check the discussion drawer on mobile Chrome/Safari
- [X] Check the discussion drawer on desktop Chrome/Safari

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes, or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in the changelog
