### PR TITLE
feat(Onboarding): Added video tutorial to empty meetings dash

### DIFF
--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -12,6 +12,7 @@ import DemoMeetingCard from './DemoMeetingCard'
 import MeetingCard from './MeetingCard'
 import MeetingsDashEmpty from './MeetingsDashEmpty'
 import StartMeetingFAB from './StartMeetingFAB'
+import TutorialMeetingCard from './TutorialMeetingCard'
 
 interface Props {
   meetingsDashRef: RefObject<HTMLDivElement>
@@ -78,6 +79,7 @@ const MeetingsDash = (props: Props) => {
           <MeetingsDashEmpty name={preferredName} />
           <Wrapper maybeTabletPlus={maybeTabletPlus}>
             <DemoMeetingCard />
+            <TutorialMeetingCard />
           </Wrapper>
         </EmptyContainer>
       )}

--- a/packages/client/components/MeetingsDashTutorialModal.tsx
+++ b/packages/client/components/MeetingsDashTutorialModal.tsx
@@ -32,9 +32,9 @@ const StyledDialogContent = styled(DialogContent)({
   }
 })
 
-const URL = 'https://www.loom.com/embed/<SOME_ID>'
+const URL = 'https://www.youtube.com/embed/X_i60AMxPBU?modestbranding=1&rel=0'
 
-const LoomEmbed = styled('iframe')({
+const VideoEmbed = styled('iframe')({
   border: 'none',
   aspectRatio: '16/9',
   width: '100%',
@@ -44,9 +44,9 @@ const LoomEmbed = styled('iframe')({
 const MeetingsDashTutorialModal = () => {
   return (
     <StyledDialogContainer>
-      <StyledDialogTitle>How to start a meeting</StyledDialogTitle>
+      <StyledDialogTitle>Starting a Sprint Poker Meeting</StyledDialogTitle>
       <StyledDialogContent>
-        <LoomEmbed src={URL} />
+        <VideoEmbed src={URL} allow='fullscreen' />
       </StyledDialogContent>
     </StyledDialogContainer>
   )

--- a/packages/client/components/MeetingsDashTutorialModal.tsx
+++ b/packages/client/components/MeetingsDashTutorialModal.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import DialogContainer from './DialogContainer'
+import DialogContent from './DialogContent'
+import DialogTitle from './DialogTitle'
+
+const INVITE_DIALOG_BREAKPOINT = 864
+const INVITE_DIALOG_MEDIA_QUERY = `@media (min-width: ${INVITE_DIALOG_BREAKPOINT}px)`
+
+const StyledDialogContainer = styled(DialogContainer)({
+  width: 480,
+  [INVITE_DIALOG_MEDIA_QUERY]: {
+    width: 816
+  }
+})
+
+const StyledDialogTitle = styled(DialogTitle)({
+  [INVITE_DIALOG_MEDIA_QUERY]: {
+    fontSize: 24,
+    lineHeight: '32px',
+    marginBottom: 8,
+    paddingLeft: 32,
+    paddingTop: 24
+  }
+})
+
+const StyledDialogContent = styled(DialogContent)({
+  [INVITE_DIALOG_MEDIA_QUERY]: {
+    alignItems: 'center',
+    display: 'flex',
+    padding: '16px 32px 32px'
+  }
+})
+
+const URL = 'https://www.loom.com/embed/<SOME_ID>'
+
+const LoomEmbed = styled('iframe')({
+  border: 'none',
+  aspectRatio: '16/9',
+  width: '100%',
+  height: '100%'
+})
+
+const MeetingsDashTutorialModal = () => {
+  return (
+    <StyledDialogContainer>
+      <StyledDialogTitle>How to start a meeting</StyledDialogTitle>
+      <StyledDialogContent>
+        <LoomEmbed src={URL} />
+      </StyledDialogContent>
+    </StyledDialogContainer>
+  )
+}
+
+export default MeetingsDashTutorialModal

--- a/packages/client/components/TutorialMeetingCard.tsx
+++ b/packages/client/components/TutorialMeetingCard.tsx
@@ -1,0 +1,124 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import useBreakpoint from '../hooks/useBreakpoint'
+import useModal from '../hooks/useModal'
+import {Elevation} from '../styles/elevation'
+import {PALETTE} from '../styles/paletteV3'
+import {BezierCurve, Breakpoint, Card, ElementWidth} from '../types/constEnums'
+import MeetingsDashTutorialModal from './MeetingsDashTutorialModal'
+
+const CardWrapper = styled('div')<{
+  maybeTabletPlus: boolean
+}>(({maybeTabletPlus}) => ({
+  background: Card.BACKGROUND_COLOR,
+  borderRadius: Card.BORDER_RADIUS,
+  boxShadow: Elevation.CARD_SHADOW,
+  flexShrink: 0,
+  maxWidth: '100%',
+  transition: `box-shadow 100ms ${BezierCurve.DECELERATE}, opacity 300ms ${BezierCurve.DECELERATE}`,
+  marginBottom: maybeTabletPlus ? 0 : 16,
+  margin: 8,
+  width: maybeTabletPlus ? ElementWidth.MEETING_CARD : '100%',
+  userSelect: 'none',
+  cursor: 'pointer',
+  ':hover': {
+    boxShadow: Elevation.CARD_SHADOW_HOVER
+  }
+}))
+
+const MeetingInfo = styled('div')({
+  // tighter padding for options, meta, avatars
+  // keep a nice left edge
+  padding: '4px 8px 12px 16px'
+})
+
+const Name = styled('span')({
+  color: PALETTE.SLATE_700,
+  display: 'block',
+  fontSize: 20,
+  lineHeight: '24px',
+  // add right padding to keep a long name from falling under the options button
+  // add top and bottom padding to keep a single line at 32px to match the options button
+  padding: '4px 32px 4px 0',
+  wordBreak: 'break-word'
+})
+
+const Meta = styled('span')({
+  color: PALETTE.SLATE_600,
+  display: 'block',
+  fontSize: 14,
+  // partial grid bottom padding accounts for maybe avatar whitespace and offset
+  paddingBottom: '4px',
+  wordBreak: 'break-word'
+})
+
+const MeetingImgBackground = styled('div')({
+  background: PALETTE.FUSCIA_400,
+  borderRadius: `${Card.BORDER_RADIUS}px ${Card.BORDER_RADIUS}px 0 0`,
+  display: 'block',
+  position: 'absolute',
+  top: 0,
+  bottom: '0px',
+  width: '100%'
+})
+
+const MeetingImgWrapper = styled('div')({
+  borderRadius: `${Card.BORDER_RADIUS}px ${Card.BORDER_RADIUS}px 0 0`,
+  display: 'block',
+  position: 'relative',
+  bottom: 0,
+  marginBottom: '6px'
+})
+
+const MeetingTypeLabel = styled('span')({
+  color: PALETTE.WHITE,
+  fontSize: 12,
+  fontWeight: 600,
+  position: 'absolute',
+  left: 8,
+  top: 8
+})
+
+const MeetingImg = styled('img')({
+  borderRadius: `${Card.BORDER_RADIUS}px ${Card.BORDER_RADIUS}px 0 0`,
+  position: 'relative',
+  display: 'block',
+  overflow: 'hidden',
+  paddingTop: 24,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  height: '174px'
+})
+
+const TopLine = styled('div')({
+  position: 'relative',
+  display: 'flex'
+})
+
+const THUMBNAIL = 'https://cdn.loom.com/sessions/thumbnails/SOME_ID-with-play.gif'
+
+const TutorialMeetingCard = () => {
+  const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
+  const {togglePortal: toggleModal, modalPortal} = useModal()
+
+  return (
+    <>
+      <CardWrapper maybeTabletPlus={maybeTabletPlus} onClick={toggleModal}>
+        <MeetingImgWrapper>
+          <MeetingImgBackground />
+          <MeetingTypeLabel>Tutorial</MeetingTypeLabel>
+          <MeetingImg src={THUMBNAIL} alt='' />
+        </MeetingImgWrapper>
+        <MeetingInfo>
+          <TopLine>
+            <Name>How to start a meeting</Name>
+          </TopLine>
+          <Meta>Video tutorial</Meta>
+        </MeetingInfo>
+      </CardWrapper>
+      {modalPortal(<MeetingsDashTutorialModal />)}
+    </>
+  )
+}
+
+export default TutorialMeetingCard

--- a/packages/client/components/TutorialMeetingCard.tsx
+++ b/packages/client/components/TutorialMeetingCard.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, {useCallback} from 'react'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
+import useAtmosphere from '../hooks/useAtmosphere'
 import useBreakpoint from '../hooks/useBreakpoint'
 import useModal from '../hooks/useModal'
 import {Elevation} from '../styles/elevation'
@@ -95,11 +97,25 @@ const TopLine = styled('div')({
   display: 'flex'
 })
 
-const THUMBNAIL = 'https://cdn.loom.com/sessions/thumbnails/SOME_ID-with-play.gif'
+const THUMBNAIL = 'http://i.ytimg.com/vi/X_i60AMxPBU/maxresdefault.jpg'
 
 const TutorialMeetingCard = () => {
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
-  const {togglePortal: toggleModal, modalPortal} = useModal()
+  const atmospehere = useAtmosphere()
+  const {viewerId} = atmospehere
+
+  const onOpen = useCallback(() => {
+    SendClientSegmentEventMutation(atmospehere, 'Tutorial Meeting Card Opened', {
+      viewerId
+    })
+  }, [])
+  const onClose = useCallback(() => {
+    SendClientSegmentEventMutation(atmospehere, 'Tutorial Meeting Card Closed', {
+      viewerId
+    })
+  }, [])
+
+  const {togglePortal: toggleModal, modalPortal} = useModal({onOpen, onClose})
 
   return (
     <>
@@ -111,7 +127,7 @@ const TutorialMeetingCard = () => {
         </MeetingImgWrapper>
         <MeetingInfo>
           <TopLine>
-            <Name>How to start a meeting</Name>
+            <Name>Starting a Sprint Poker Meeting</Name>
           </TopLine>
           <Meta>Video tutorial</Meta>
         </MeetingInfo>


### PR DESCRIPTION
# Description

Fixes #6652 
Add a video tutorial link to the empty meetings dash experience.

TODO: Final links are missing

## Demo
![meeting dash demo](https://user-images.githubusercontent.com/7331043/172799443-9fa29d76-b613-4467-9950-b5c2d2441e90.gif)


## Testing scenarios

Open meeting dash without any active meetings, click the tutorial card.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
