### PR TITLE
feat: Add start meeting button to top bar

### DIFF
--- a/packages/client/components/DashTopBar.tsx
+++ b/packages/client/components/DashTopBar.tsx
@@ -15,6 +15,7 @@ import TopBarAvatar from './TopBarAvatar'
 import TopBarHelp from './TopBarHelp'
 import TopBarNotifications from './TopBarNotifications'
 import TopBarSearch from './TopBarSearch'
+import TopBarStartMeetingButton from './TopBarStartMeetingButton'
 
 const dashWidestBreakpoint = makeMinWidthMediaQuery(Breakpoint.DASH_BREAKPOINT_WIDEST)
 
@@ -107,6 +108,7 @@ const DashTopBar = (props: Props) => {
       <TopBarMain>
         <TopBarSearch viewer={viewer} />
         <TopBarIcons>
+          <TopBarStartMeetingButton />
           <TopBarHelp />
           <TopBarNotifications viewer={viewer || null} />
           <TopBarAvatar viewer={viewer || null} />

--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -36,6 +36,7 @@ const MeetingLabel = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
   fontSize: 16,
   fontWeight: 600,
   textAlign: 'start',
+  paddingTop: 4,
   transition: `all 300ms ${BezierCurve.DECELERATE}`,
   transform: `translateX(${isExpanded ? -4 : ElementWidth.NEW_MEETING_FAB}px)`,
   width: isExpanded ? ElementWidth.NEW_MEETING_FAB : 0
@@ -82,7 +83,7 @@ const StartMeetingFAB = (props: Props) => {
     }
   }
   const onClick = () => {
-    history.push(`/new-meeting/${teamId}`)
+    history.push(`/new-meeting/${teamId}?source=BottomFAB`)
   }
   return (
     <Block className={className}>

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import useRouter from '~/hooks/useRouter'
+import {PALETTE} from '~/styles/paletteV3'
+import getTeamIdFromPathname from '~/utils/getTeamIdFromPathname'
+import FloatingActionButton from './FloatingActionButton'
+
+const Button = styled(FloatingActionButton)({
+  color: '#fff',
+  backgroundImage: PALETTE.GRADIENT_TOMATO_600_ROSE_500,
+  height: 40,
+  overflow: 'hidden',
+  paddingLeft: 24,
+  paddingRight: 24,
+  marginRight: 32
+})
+
+const MeetingLabel = styled('div')({
+  fontSize: 16,
+  fontWeight: 600,
+  paddingTop: 4
+})
+
+const TopBarStartMeetingButton = () => {
+  const teamId = getTeamIdFromPathname()
+  const {history} = useRouter()
+
+  const onClick = () => {
+    history.push(`/new-meeting/${teamId}?source=TopBar`)
+  }
+  return (
+    <Button onClick={onClick}>
+      <MeetingLabel>Start Meeting</MeetingLabel>
+    </Button>
+  )
+}
+
+export default TopBarStartMeetingButton


### PR DESCRIPTION
# Description

Fixes #6635
For now the button is added in addition to the current one. If uptake is
big enough, we will eventually remove the bottom one for desktop.

## Demo
![Screenshot from 2022-06-09 12-23-51](https://user-images.githubusercontent.com/7331043/172825867-bbd6c3c9-b6c1-41b3-9078-8f7816fe6309.png)

## Testing scenarios

Start new meeting from the top bar from different views, including "Meetings", "Timeline" and a team view.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
