### PR TITLE
feat: remove auth identity

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -16,6 +16,7 @@
           "LoginsPayload": "./types/LoginsPayload#LoginsPayloadSource",
           "Organization": "../../database/types/Organization#default as Organization",
           "PingableServices": "./types/PingableServices#PingableServicesSource",
+          "RemoveAuthIdentitySuccess": "./types/RemoveAuthIdentitySuccess#RemoveAuthIdentitySuccessSource",
           "SignupsPayload": "./types/SignupsPayload#SignupsPayloadSource",
           "StripeFailPaymentPayload": "./mutations/stripeFailPayment#StripeFailPaymentPayloadSource",
           "User": "../../postgres/types/IUser#default as IUser"

--- a/packages/server/graphql/graphql.ts
+++ b/packages/server/graphql/graphql.ts
@@ -18,6 +18,7 @@ export interface GQLContext {
 export interface InternalContext {
   dataLoader: DataLoaderWorker
   authToken: AuthToken
+  ip: string
   // not present if called ad-hoc
   socketId?: string
 }

--- a/packages/server/graphql/mutations/helpers/processEmailPasswordReset.ts
+++ b/packages/server/graphql/mutations/helpers/processEmailPasswordReset.ts
@@ -1,0 +1,48 @@
+import base64url from 'base64url'
+import crypto from 'crypto'
+import {AuthenticationError} from 'parabol-client/types/constEnums'
+import {r} from 'rethinkdb-ts'
+import util from 'util'
+import AuthIdentity from '../../../database/types/AuthIdentity'
+import PasswordResetRequest from '../../../database/types/PasswordResetRequest'
+import getMailManager from '../../../email/getMailManager'
+import resetPasswordEmailCreator from '../../../email/resetPasswordEmailCreator'
+import updateUser from '../../../postgres/queries/updateUser'
+
+const randomBytes = util.promisify(crypto.randomBytes)
+
+const processEmailPasswordReset = async (
+  ip: string,
+  email: string,
+  identities: AuthIdentity[],
+  userId: string
+) => {
+  const tokenBuffer = await randomBytes(48)
+  const resetPasswordToken = base64url.encode(tokenBuffer)
+  // invalidate all other tokens for this email
+  await r
+    .table('PasswordResetRequest')
+    .getAll(email, {index: 'email'})
+    .filter({isValid: true})
+    .update({isValid: false})
+    .run()
+  await r
+    .table('PasswordResetRequest')
+    .insert(new PasswordResetRequest({ip, email, token: resetPasswordToken}))
+    .run()
+
+  await updateUser({identities}, userId)
+
+  const {subject, body, html} = resetPasswordEmailCreator({resetPasswordToken})
+  const success = await getMailManager().sendEmail({
+    to: email,
+    subject,
+    body,
+    html,
+    tags: ['type:resetPassword']
+  })
+  if (!success) return {error: {message: AuthenticationError.FAILED_TO_SEND}}
+  return {success}
+}
+
+export default processEmailPasswordReset

--- a/packages/server/graphql/private/mutations/removeAuthIdentity.ts
+++ b/packages/server/graphql/private/mutations/removeAuthIdentity.ts
@@ -1,0 +1,19 @@
+import {getUserId} from '../../../utils/authorization'
+import {MutationResolvers} from '../../public/resolverTypes'
+
+const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
+  _source,
+  {},
+  {authToken, dataLoader, socketId: mutatorId}
+) => {
+  const viewerId = getUserId(authToken)
+  const now = new Date()
+
+  // VALIDATION
+
+  // RESOLUTION
+  const data = {}
+  return data
+}
+
+export default removeAuthIdentity

--- a/packages/server/graphql/private/mutations/removeAuthIdentity.ts
+++ b/packages/server/graphql/private/mutations/removeAuthIdentity.ts
@@ -1,42 +1,78 @@
+import base64url from 'base64url'
 import bcrypt from 'bcrypt'
+import crypto from 'crypto'
 import {AuthIdentityTypeEnum, Security} from 'parabol-client/types/constEnums'
+import {r} from 'rethinkdb-ts'
+import util from 'util'
 import AuthIdentityLocal from '../../../database/types/AuthIdentityLocal'
+import PasswordResetRequest from '../../../database/types/PasswordResetRequest'
+import getMailManager from '../../../email/getMailManager'
+import resetPasswordEmailCreator from '../../../email/resetPasswordEmailCreator'
+import generateRandomString from '../../../generateRandomString'
 import getUsersByDomain from '../../../postgres/queries/getUsersByDomain'
 import updateUser from '../../../postgres/queries/updateUser'
-import {getUserId} from '../../../utils/authorization'
-import {MutationResolvers} from '../../public/resolverTypes'
+import {MutationResolvers} from '../../private/resolverTypes'
+
+const randomBytes = util.promisify(crypto.randomBytes)
 
 const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
   _source,
   {domain, identityType, addLocal},
-  {authToken}
+  {ip}
 ) => {
-  const viewerId = getUserId(authToken)
-  const now = new Date()
-
   // VALIDATION
+  const users = await getUsersByDomain(domain)
+  if (!users.length) {
+    return {error: {message: 'No user emails match that domain'}}
+  }
 
   // RESOLUTION
-  const users = await getUsersByDomain(domain)
-  const dummyPassword = 'dummy'
-  const dummyHashedPassword = await bcrypt.hash(dummyPassword, Security.SALT_ROUNDS)
-  const updateUsersPromises = users.map((user) => {
+  const updateUsersPromises = users.map(async (user) => {
     const {id: userId, identities} = user
     const filteredIdentities = identities.filter((identity) => identity.type !== identityType)
     if (!filteredIdentities.length || addLocal) {
       const identityId = `${userId}:${AuthIdentityTypeEnum.LOCAL}`
+      const dummyPassword = generateRandomString(Security.SALT_ROUNDS)
+      const dummyHashedPassword = await bcrypt.hash(dummyPassword, Security.SALT_ROUNDS)
       const newIdentity = new AuthIdentityLocal({
         hashedPassword: dummyHashedPassword,
         id: identityId,
         isEmailVerified: false
       })
       const newIdentities = [...filteredIdentities, newIdentity]
+      user.identities = newIdentities
       return updateUser({identities: newIdentities}, userId)
     } else {
+      user.identities = filteredIdentities
       return updateUser({identities: filteredIdentities}, userId)
     }
   })
-  const result = await Promise.all(updateUsersPromises)
+  await Promise.all(updateUsersPromises)
+
+  // send forgot password email
+  users.forEach(async ({email}) => {
+    const tokenBuffer = await randomBytes(48)
+    const resetPasswordToken = base64url.encode(tokenBuffer)
+    // invalidate all other tokens for this email
+    await r
+      .table('PasswordResetRequest')
+      .getAll(email, {index: 'email'})
+      .filter({isValid: true})
+      .update({isValid: false})
+      .run()
+    await r
+      .table('PasswordResetRequest')
+      .insert(new PasswordResetRequest({ip, email, token: resetPasswordToken}))
+      .run()
+    const {subject, body, html} = resetPasswordEmailCreator({resetPasswordToken})
+    await getMailManager().sendEmail({
+      to: email,
+      subject,
+      body,
+      html,
+      tags: ['type:resetPassword']
+    })
+  })
 
   const updatedUserIds = users.map(({id}) => id)
   const data = {userIds: updatedUserIds}

--- a/packages/server/graphql/private/mutations/removeAuthIdentity.ts
+++ b/packages/server/graphql/private/mutations/removeAuthIdentity.ts
@@ -21,7 +21,8 @@ const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
   {ip}
 ) => {
   // VALIDATION
-  const users = await getUsersByDomain(domain)
+  const normalizedDomain = domain.toLowerCase().trim()
+  const users = await getUsersByDomain(normalizedDomain)
   if (!users.length) {
     return {error: {message: 'No user emails match that domain'}}
   }
@@ -30,7 +31,10 @@ const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
   const updateUsersPromises = users.map(async (user) => {
     const {id: userId, identities} = user
     const filteredIdentities = identities.filter((identity) => identity.type !== identityType)
-    if (!filteredIdentities.length || addLocal) {
+    const localIdentity = identities.find(
+      (identity) => identity.type === AuthIdentityTypeEnum.LOCAL
+    )
+    if (!localIdentity && addLocal) {
       const identityId = `${userId}:${AuthIdentityTypeEnum.LOCAL}`
       const dummyPassword = generateRandomString(Security.SALT_ROUNDS)
       const dummyHashedPassword = await bcrypt.hash(dummyPassword, Security.SALT_ROUNDS)

--- a/packages/server/graphql/private/mutations/removeAuthIdentity.ts
+++ b/packages/server/graphql/private/mutations/removeAuthIdentity.ts
@@ -40,10 +40,8 @@ const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
         isEmailVerified: false
       })
       const newIdentities = [...filteredIdentities, newIdentity]
-      user.identities = newIdentities
       return updateUser({identities: newIdentities}, userId)
     } else {
-      user.identities = filteredIdentities
       return updateUser({identities: filteredIdentities}, userId)
     }
   })

--- a/packages/server/graphql/private/mutations/removeAuthIdentity.ts
+++ b/packages/server/graphql/private/mutations/removeAuthIdentity.ts
@@ -34,7 +34,8 @@ const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
   })
   const result = await Promise.all(updateUsersPromises)
 
-  const data = {}
+  const updatedUserIds = users.map(({id}) => id)
+  const data = {userIds: updatedUserIds}
   return data
 }
 

--- a/packages/server/graphql/private/mutations/removeAuthIdentity.ts
+++ b/packages/server/graphql/private/mutations/removeAuthIdentity.ts
@@ -1,10 +1,15 @@
+import bcrypt from 'bcrypt'
+import {AuthIdentityTypeEnum, Security} from 'parabol-client/types/constEnums'
+import AuthIdentityLocal from '../../../database/types/AuthIdentityLocal'
+import getUsersByDomain from '../../../postgres/queries/getUsersByDomain'
+import updateUser from '../../../postgres/queries/updateUser'
 import {getUserId} from '../../../utils/authorization'
 import {MutationResolvers} from '../../public/resolverTypes'
 
 const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
   _source,
-  {},
-  {authToken, dataLoader, socketId: mutatorId}
+  {domain, identityType, addLocal},
+  {authToken}
 ) => {
   const viewerId = getUserId(authToken)
   const now = new Date()
@@ -12,6 +17,23 @@ const removeAuthIdentity: MutationResolvers['removeAuthIdentity'] = async (
   // VALIDATION
 
   // RESOLUTION
+  const users = await getUsersByDomain(domain)
+  const dummyPassword = 'dummy'
+  const dummyHashedPassword = await bcrypt.hash(dummyPassword, Security.SALT_ROUNDS)
+  const updateUsersPromises = users.map((user) => {
+    const {id: userId} = user
+    const identityId = `${userId}:${AuthIdentityTypeEnum.LOCAL}`
+    const newIdentity = new AuthIdentityLocal({
+      hashedPassword: dummyHashedPassword,
+      id: identityId,
+      isEmailVerified: false
+    })
+    const filteredIdentities = user.identities.filter((identity) => identity.type !== identityType)
+    const newIdentities = addLocal ? [...filteredIdentities, newIdentity] : filteredIdentities
+    return updateUser({identities: newIdentities}, userId)
+  })
+  const result = await Promise.all(updateUsersPromises)
+
   const data = {}
   return data
 }

--- a/packages/server/graphql/private/typeDefs/removeAuthIdentity.graphql
+++ b/packages/server/graphql/private/typeDefs/removeAuthIdentity.graphql
@@ -29,5 +29,5 @@ type RemoveAuthIdentitySuccess {
   """
   The users who had their auth identity removed
   """
-  users: [User]!
+  users: [User!]!
 }

--- a/packages/server/graphql/private/typeDefs/removeAuthIdentity.graphql
+++ b/packages/server/graphql/private/typeDefs/removeAuthIdentity.graphql
@@ -11,7 +11,7 @@ extend type Mutation {
     """
     The type of auth to remove
     """
-    identityType: AuthIdentityType!
+    identityType: AuthIdentityTypeEnum!
 
     """
     Add a local auth with a dummy hashed password

--- a/packages/server/graphql/private/typeDefs/removeAuthIdentity.graphql
+++ b/packages/server/graphql/private/typeDefs/removeAuthIdentity.graphql
@@ -1,0 +1,33 @@
+extend type Mutation {
+  """
+  Remove the auth identity for users with a specific domain. Example use case: signed up with Gmail but they're deleting their Google account
+  """
+  removeAuthIdentity(
+    """
+    Change the auth identity for users with this domain
+    """
+    domain: String!
+
+    """
+    The type of auth to remove
+    """
+    identityType: AuthIdentityType!
+
+    """
+    Add a local auth with a dummy hashed password
+    """
+    addLocal: Boolean!
+  ): RemoveAuthIdentityPayload!
+}
+
+"""
+Return value for removeAuthIdentity, which could be an error
+"""
+union RemoveAuthIdentityPayload = ErrorPayload | RemoveAuthIdentitySuccess
+
+type RemoveAuthIdentitySuccess {
+  """
+  The users who had their auth identity removed
+  """
+  users: [User]!
+}

--- a/packages/server/graphql/private/types/RemoveAuthIdentitySuccess.ts
+++ b/packages/server/graphql/private/types/RemoveAuthIdentitySuccess.ts
@@ -1,0 +1,13 @@
+import {RemoveAuthIdentitySuccessResolvers} from '../../public/resolverTypes'
+
+export type RemoveAuthIdentitySuccessSource = {
+  userIds: string[]
+}
+
+const RemoveAuthIdentitySuccess: RemoveAuthIdentitySuccessResolvers = {
+  users: async ({id}, _args, {dataLoader}) => {
+    return dataLoader.get('').load(id)
+  }
+}
+
+export default RemoveAuthIdentitySuccess

--- a/packages/server/graphql/private/types/RemoveAuthIdentitySuccess.ts
+++ b/packages/server/graphql/private/types/RemoveAuthIdentitySuccess.ts
@@ -1,3 +1,4 @@
+import isValid from '../../../graphql/isValid'
 import {RemoveAuthIdentitySuccessResolvers} from '../../private/resolverTypes'
 
 export type RemoveAuthIdentitySuccessSource = {
@@ -6,7 +7,8 @@ export type RemoveAuthIdentitySuccessSource = {
 
 const RemoveAuthIdentitySuccess: RemoveAuthIdentitySuccessResolvers = {
   users: async ({userIds}, _args, {dataLoader}) => {
-    return dataLoader.get('').loadMany(userIds)
+    const users = (await dataLoader.get('users').loadMany(userIds)).filter(isValid)
+    return users
   }
 }
 

--- a/packages/server/graphql/private/types/RemoveAuthIdentitySuccess.ts
+++ b/packages/server/graphql/private/types/RemoveAuthIdentitySuccess.ts
@@ -1,12 +1,12 @@
-import {RemoveAuthIdentitySuccessResolvers} from '../../public/resolverTypes'
+import {RemoveAuthIdentitySuccessResolvers} from '../../private/resolverTypes'
 
 export type RemoveAuthIdentitySuccessSource = {
   userIds: string[]
 }
 
 const RemoveAuthIdentitySuccess: RemoveAuthIdentitySuccessResolvers = {
-  users: async ({id}, _args, {dataLoader}) => {
-    return dataLoader.get('').load(id)
+  users: async ({userIds}, _args, {dataLoader}) => {
+    return dataLoader.get('').loadMany(userIds)
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6709

### To test

- [ ] Copy & paste the following mutation

```gql
mutation {
  removeAuthIdentity(domain: "parabol.co", identityType: GOOGLE, addLocal: true){
    ... on RemoveAuthIdentitySuccess {
      users {
        email
        identities {
          isEmailVerified
          type
        }
      }
    }
  }
}
```

- [ ] See that the `GOOGLE` auth identities have been removed from the `User` table
- [ ] You're no longer able to sign in with that Google login
- [ ] You receive a forgot password email and can reset your password
- [ ] You can login with the Parabol email & newly created password