### PR TITLE
fix(Retrospective): Fix refleciton prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.62.1 2022-June-10
+
+### Fixed
+
+- Fixed some retrospective prompts for existing meetings
+
 ## 6.62.0 2022-June-9
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "6.62.0",
+  "version": "6.62.1-rc.1",
   "useWorkspaces": true
 }

--- a/packages/gql-executor/package.json
+++ b/packages/gql-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-executor",
-  "version": "6.62.0",
+  "version": "6.62.1-rc.1",
   "description": "A Stateless GraphQL Executor",
   "author": "Matt Krick <matt.krick@gmail.com>",
   "homepage": "https://github.com/ParabolInc/parabol/tree/master/packages/gqlExecutor#readme",
@@ -29,6 +29,6 @@
   "dependencies": {
     "dd-trace": "^2.2.0",
     "parabol-client": "^6.62.0",
-    "parabol-server": "^6.62.0"
+    "parabol-server": "^6.62.1-rc.1"
   }
 }

--- a/packages/server/database/migrations/20220610093935-fixRetroPromptIds.ts
+++ b/packages/server/database/migrations/20220610093935-fixRetroPromptIds.ts
@@ -1,0 +1,52 @@
+import {reflectPrompts} from './20220124600507-addMoreRetroTemplates'
+
+// fix promptId fields of existing reflections
+const promptIdMapping = reflectPrompts
+  // filter out prompts which were missing since the old id belongs to different template
+  .filter(({id}) => !['keepPrompt', 'moreOfPrompt', 'lessOfPrompt'].includes(id))
+  .map(({id, templateId}) => ({
+    oldId: id,
+    newId: `${templateId}:${id}`
+  }))
+
+// There is some prompt filtering happening based on template creation date
+const newIds = reflectPrompts.map(({id, templateId}) => `${templateId}:${id}`)
+const createdAt = new Date('2022-01-28')
+
+export const up = async function (r) {
+  await r.table('ReflectPrompt').getAll(r.args(newIds)).update({createdAt}).run()
+
+  const renames = Object.fromEntries(
+    promptIdMapping.flatMap(({oldId, newId}) => {
+      return [
+        [
+          `${oldId}-RetroReflection`,
+          r.table('RetroReflection').filter({promptId: oldId}).update({promptId: newId})
+        ],
+        [
+          `${oldId}-RetroReflectionGroup`,
+          r.table('RetroReflectionGroup').filter({promptId: oldId}).update({promptId: newId})
+        ]
+      ]
+    })
+  )
+  await r(renames).run()
+}
+
+export const down = async function (r) {
+  const renames = Object.fromEntries(
+    promptIdMapping.flatMap(({oldId, newId}) => {
+      return [
+        [
+          `${oldId}-RetroReflection`,
+          r.table('RetroReflection').filter({promptId: newId}).update({promptId: oldId})
+        ],
+        [
+          `${oldId}-RetroReflectionGroup`,
+          r.table('RetroReflectionGroup').filter({promptId: newId}).update({promptId: oldId})
+        ]
+      ]
+    })
+  )
+  await r(renames).run()
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.62.0",
+  "version": "6.62.1-rc.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"


### PR DESCRIPTION
# Description

Fixes #6714 
The updated reflection prompts got a new id which was not updated in the
reflections themselves. Also there is some filtering happening based on
the template creation date which messed up pre-release retrospectives.

## Testing scenarios

Without this PR on master do
* create a meeting before running the migration `packages/server/database/migrations/20220602164119-fixRetroTemplates.ts`
  This can be done by clearing the db, running all up migrations and then one down migration
  ```
  yarn db:stop
  docker volume rm docker_postgres-data docker_rethink-data
  yarn db:start
  yarn dev
  #stop after migrations ran
  yarn db:migrate down
  ```
* Make sure you're not running up migrations when starting the server by commenting out
  https://github.com/ParabolInc/parabol/blob/8fa20a5509c889b86da2de4a059478b76899af51/scripts/runMigrations.js#L30
* run `yarn dev`
* create an account and start a retrospective meeting from above migration (e.g. "WARP", "Questions, Comments, Concerns")
* add some reflections
* run `yarn db:migrate up`
* run `yarn dev`
* check the retrospective again, no prompts are shown
* check out PR and run `yarn db:migrate up`
* [ ] prompts are shown correctly in the retrospective and reflections appear

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
