### PR TITLE
fix(poker): Fix wrong controls when estimating Parabol tasks

### DIFF
--- a/packages/client/components/PokerDimensionValueControl.tsx
+++ b/packages/client/components/PokerDimensionValueControl.tsx
@@ -161,15 +161,18 @@ const PokerDimensionValueControl = (props: Props) => {
           />
         </MiniPokerCard>
         {!isFacilitator && <Label>{label}</Label>}
-        <PokerDimensionFinalScorePicker
-          canUpdate={isStale}
-          stageRef={stage}
-          error={errorStr}
-          submitScore={onSubmitScore}
-          clearError={onCompleted}
-          inputRef={inputRef}
-          isFacilitator={isFacilitator}
-        />
+
+        {hasIntegration && (
+          <PokerDimensionFinalScorePicker
+            canUpdate={isStale}
+            stageRef={stage}
+            error={errorStr}
+            submitScore={onSubmitScore}
+            clearError={onCompleted}
+            inputRef={inputRef}
+            isFacilitator={isFacilitator}
+          />
+        )}
 
         {!hasIntegration && isFacilitator && (
           <>


### PR DESCRIPTION
Fixes #6710

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/466991/173051530-6a24d74f-6158-4a06-8008-99c6f586e46f.png">

How to test:

- Try to estimate Parabol tasks in poker meeting
- See no additional label controls appeared