### PR TITLE
fix: Center add/start meeting button content

### DIFF
--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -36,7 +36,6 @@ const MeetingLabel = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
   fontSize: 16,
   fontWeight: 600,
   textAlign: 'start',
-  paddingTop: 4,
   transition: `all 300ms ${BezierCurve.DECELERATE}`,
   transform: `translateX(${isExpanded ? -4 : ElementWidth.NEW_MEETING_FAB}px)`,
   width: isExpanded ? ElementWidth.NEW_MEETING_FAB : 0

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -17,8 +17,7 @@ const Button = styled(FloatingActionButton)({
 
 const MeetingLabel = styled('div')({
   fontSize: 16,
-  fontWeight: 600,
-  paddingTop: 4
+  fontWeight: 600
 })
 
 const TopBarStartMeetingButton = () => {


### PR DESCRIPTION
# Description

Fixes #6730 

## Demo

![localhost_3000_meetings](https://user-images.githubusercontent.com/1017620/173403836-9d0d5084-9868-4203-894e-f078ccc3669a.png)

## Testing scenarios

- [ ] Start meeting button's content is centered
- [ ] Add meeting button's content is centered

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
