### PR TITLE
feat(metrics): merge 'Upgrade to Pro' and 'Enterprise invoice draft' events together

### DIFF
--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -9,6 +9,15 @@ import segment from '../segmentIo'
 import {createMeetingTemplateAnalyticsParams} from './helpers'
 import {SegmentAnalytics} from './segment/SegmentAnalytics'
 
+export type UpgradeEventProperties = {
+  orgId: string
+  domain?: string
+  orgName: string
+  oldTier: string
+  newTier: string
+  billingLeaderEmail: string
+}
+
 export type AnalyticsEvent =
   // meeting
   | 'Meeting Started'
@@ -17,6 +26,8 @@ export type AnalyticsEvent =
   // team
   | 'Integration Added'
   | 'Integration Removed'
+  // org
+  | 'Organization Upgraded'
   // task
   | 'Task Created'
   | 'Task Published'
@@ -171,6 +182,10 @@ class Analytics {
       isReply,
       service
     })
+  }
+
+  organizationUpgraded = (userId: string, upgradeEventProperties: UpgradeEventProperties) => {
+    this.track(userId, 'Organization Upgraded', upgradeEventProperties)
   }
 
   private track = (userId: string, event: AnalyticsEvent, properties?: any) =>


### PR DESCRIPTION
# Description

Fixes #6699 

Today when upgrade happens, for pro we emit the event 'Upgrade to pro' and for enterprise we emit the event 'Enterprise invoice draft'. This PR:
1. merges these two events into one
2. add more attributes

## Demo

<img width="943" alt="Screen Shot 2022-06-13 at 3 42 02 PM" src="https://user-images.githubusercontent.com/1879975/173459447-f7db9e4f-4d5b-473c-9b4e-3835a8c306ff.png">


## Testing scenarios

Before testing, copy the [`SEGMENT_WRITE_KEY`](https://github.com/ParabolInc/action-devops/blob/master/environments/local#L59) to your `.env`

- [ ] Upgrade from personal to pro
  - Upgrade a personal org to pro
  - Go to [Segment Debugger](https://app.segment.com/parabol-jordan/sources/actiondevelopment/debugger) and search for `Organization Upgraded` events and verify `oldTier` is `personal` and `newTier` is `pro`

- [ ] Upgrade from personal to enterprise
  - Upgrade a personal org to enterprise
  - Go to [Segment Debugger](https://app.segment.com/parabol-jordan/sources/actiondevelopment/debugger) and search for `Organization Upgraded` events and verify `oldTier` is `personal` and `newTier` is `enterprise`

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
