### PR TITLE
feat(standups): Make response in discussion drawer scrollable

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -94,6 +94,10 @@ const StyledReactjis = styled(ReactjiSection)({
   paddingTop: '16px'
 })
 
+const DiscussionHeaderWrapper = styled('div')({
+  padding: '0px 12px 20px 12px'
+})
+
 interface Props {
   meetingRef: TeamPromptDiscussionDrawer_meeting$key
   isDesktop: boolean
@@ -207,14 +211,18 @@ const TeamPromptDiscussionDrawer = ({meetingRef, isDesktop}: Props) => {
               <CloseIcon>close</CloseIcon>
             </StyledCloseButton>
           </Header>
-          <PromptResponseEditor content={contentJSON} readOnly={true} />
-          <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
         </DiscussionResponseCard>
         <ThreadColumn>
           <DiscussionThreadRoot
             discussionId={discussionId}
             allowedThreadables={['comment', 'task']}
             width={'100%'}
+            header={
+              <DiscussionHeaderWrapper>
+                <PromptResponseEditor content={contentJSON} readOnly={true} />
+                <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
+              </DiscussionHeaderWrapper>
+            }
           />
         </ThreadColumn>
       </Drawer>


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6624

Move the response + reactjis to the header of the discussion thread, which is in the discussion scrollview.

## Demo
<img width="532" alt="Screen Shot 2022-06-14 at 6 23 01 PM" src="https://user-images.githubusercontent.com/9013217/173705251-3d2ba237-5592-4e0f-887e-8335fa7fb252.png">
<img width="490" alt="Screen Shot 2022-06-14 at 6 23 05 PM" src="https://user-images.githubusercontent.com/9013217/173705256-e486813d-2e79-4a62-8f4b-b4ffd2111cb8.png">

## Testing scenarios
- [ ] Type a short response
- [ ] Open the discussion drawer
- [ ] Type a reply
- [ ] Confirm that the reply appears at the bottom of the drawer
- [ ] Type a long response into a response card
- [ ] Confirm that you can scroll through the response down to the discussion
- [ ] Confirm that styling, etc. is sane.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
