### PR TITLE
fix(standups): Reduced list padding in standups response

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -10,6 +10,18 @@ const StyledEditor = styled('div')`
   .ProseMirror {
     min-height: 40px;
   }
+
+  .ProseMirror :is(ul, ol) {
+    list-style-position: outside;
+    padding-inline-start: 16px;
+    margin-block-start: 16px;
+    margin-block-end: 16px;
+  }
+
+  .ProseMirror :is(ol) {
+    margin-inline-start: 2px;
+  }
+
   .ProseMirror p.is-editor-empty:first-child::before {
     color: #adb5bd;
     content: attr(data-placeholder);
@@ -17,6 +29,7 @@ const StyledEditor = styled('div')`
     height: 0;
     pointer-events: none;
   }
+
   .ProseMirror-focused:focus {
     outline: none;
   }


### PR DESCRIPTION
# Description

Fixes #6702 

## Demo

![localhost_3000_meet_e4ms6U9Ow0_responses](https://user-images.githubusercontent.com/1017620/173754002-d9206e0a-c985-4020-b93a-d68a53186d08.png)

![CleanShot 2022-06-15 at 07 57 43](https://user-images.githubusercontent.com/1017620/173754018-0caa6e11-e78f-4914-855f-e28bc84059aa.gif)


## Testing scenarios

- [ ] check the ordered list style
- [ ] check the unordered list style

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
