### PR TITLE
chore: Refresh HubSpot chat widget on page changes

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -25,6 +25,11 @@ const query = graphql`
 declare global {
   interface Window {
     analytics: SegmentAnalytics.AnalyticsJS
+    HubSpotConversations?: {
+      widget?: {
+        refresh?: () => void
+      }
+    }
   }
 }
 
@@ -144,6 +149,11 @@ const AnalyticsPage = () => {
       )
     }, TIME_TO_RENDER_TREE)
   }, [isSegmentLoaded, pathname])
+
+  // We need to refresh the chat widget so it can recheck the URL
+  useEffect(() => {
+    window.HubSpotConversations?.widget?.refresh?.()
+  }, [pathname])
 
   useEffect(() => {
     if (!datadogEnabled) {


### PR DESCRIPTION
Fixes #6718 

HubSpot matches the URL to decide which chat to show. For SPAs it needs
manual refreshing on page change.

## Demo
https://www.loom.com/share/21d239c305fa4791b4d130dc4bd96333


## Testing scenarios

- Add Hubspot to your local [devTemplate.html](https://github.com/ParabolInc/parabol/blob/4f1c9d807d01ca027f9f300af114a67a2f2992af/devTemplate.html#L7)
  (see #6718)
- Remove non-production return from Analytics page
  https://github.com/ParabolInc/parabol/blob/4f1c9d807d01ca027f9f300af114a67a2f2992af/packages/client/components/AnalyticsPage.tsx#L83-L85
- [ ] load a meeting summary on 'localhost:3000/new-summary' which shows a chat bot as configured on HubSpot
- [ ] switching to another page which changes the URL also makes the chat disappear

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
