### PR TITLE
chore: fix delete team migration

### DIFF
--- a/packages/server/postgres/generatedMigrationHelpers.ts
+++ b/packages/server/postgres/generatedMigrationHelpers.ts
@@ -486,3 +486,28 @@ const updateUserTiersQueryIR: any = {
  * ```
  */
 export const updateUserTiersQuery = new PreparedQuery(updateUserTiersQueryIR)
+
+const getTeamsByIdsQueryIR: any = {
+  name: 'getTeamsByIdsQuery',
+  params: [
+    {
+      name: 'ids',
+      codeRefs: {
+        defined: {a: 39, b: 41, line: 3, col: 9},
+        used: [{a: 89, b: 91, line: 6, col: 13}]
+      },
+      transform: {type: 'array_spread'}
+    }
+  ],
+  usedParamSet: {ids: true},
+  statement: {body: 'SELECT * FROM "Team"\nWHERE id IN :ids', loc: {a: 55, b: 91, line: 5, col: 0}}
+}
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * FROM "Team"
+ * WHERE id IN :ids
+ * ```
+ */
+export const getTeamsByIdsQuery = new PreparedQuery(getTeamsByIdsQueryIR)

--- a/packages/server/postgres/utils/checkTeamEq.ts
+++ b/packages/server/postgres/utils/checkTeamEq.ts
@@ -1,6 +1,7 @@
 import getRethink from '../../database/rethinkDriver'
 import Team from '../../database/types/Team'
-import getTeamsByIds from '../queries/getTeamsByIds'
+import {getTeamsByIdsQuery} from '../generatedMigrationHelpers'
+import getPg from '../getPg'
 import {checkTableEq} from './checkEqBase'
 
 const alwaysDefinedFields: (keyof Team)[] = [
@@ -12,6 +13,11 @@ const alwaysDefinedFields: (keyof Team)[] = [
   'orgId'
 ]
 const ignoredFields: (keyof Team)[] = ['updatedAt']
+
+const getTeamsByIds = async (teamIds: string[] | readonly string[]): Promise<any[]> => {
+  const teams = await getTeamsByIdsQuery.run({ids: teamIds} as any, getPg())
+  return teams
+}
 
 const maybeUndefinedFieldsDefaultValues: {[Property in keyof Partial<Team>]: unknown} = {
   jiraDimensionFields: [],


### PR DESCRIPTION
# Description

Fixes #6761 
The migration still used generated postgres queries. Added getTeamsByIds
to the static queries for migrations and changed `checkTeamEq` to use
it.

## Demo
no demo

## Testing scenarios
CI passes

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
