### PR TITLE
feat(standups): Response submission UX redesign

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -258,7 +258,7 @@ const TeamPromptResponseCard = (props: Props) => {
               readOnly={!isCurrentViewer}
               placeholder={'Share your response...'}
             />
-            {!!contentJSON && (
+            {!!plaintextContent && (
               <ResponseCardFooter>
                 <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
                 <ReplyButton onClick={() => onSelectDiscussion()}>

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -258,19 +258,21 @@ const TeamPromptResponseCard = (props: Props) => {
               readOnly={!isCurrentViewer}
               placeholder={'Share your response...'}
             />
-            <ResponseCardFooter>
-              <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
-              <ReplyButton onClick={() => onSelectDiscussion()}>
-                {replyCount > 0 ? (
-                  <>
-                    <TeamPromptRepliesAvatarList edgesRef={discussionEdges} />
-                    {replyCount} {plural(replyCount, 'Reply', 'Replies')}
-                  </>
-                ) : (
-                  'Reply'
-                )}
-              </ReplyButton>
-            </ResponseCardFooter>
+            {!!contentJSON && (
+              <ResponseCardFooter>
+                <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
+                <ReplyButton onClick={() => onSelectDiscussion()}>
+                  {replyCount > 0 ? (
+                    <>
+                      <TeamPromptRepliesAvatarList edgesRef={discussionEdges} />
+                      {replyCount} {plural(replyCount, 'Reply', 'Replies')}
+                    </>
+                  ) : (
+                    'Reply'
+                  )}
+                </ReplyButton>
+              </ResponseCardFooter>
+            )}
           </>
         )}
       </ResponseCard>

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -84,11 +84,11 @@ interface Props {
 
 const PromptResponseEditor = (props: Props) => {
   const {autoFocus: autoFocusProp, content, handleSubmit, readOnly, placeholder} = props
-  const [_isEditing, setIsEditing] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
   const [autoFocus, setAutoFocus] = useState(autoFocusProp)
 
-  const setEditing = (isEditing: boolean) => {
-    setIsEditing(isEditing)
+  const setEditing = (newIsEditing: boolean) => {
+    setIsEditing(newIsEditing)
     setAutoFocus(false)
   }
 
@@ -130,12 +130,12 @@ const PromptResponseEditor = (props: Props) => {
         <EditorContent editor={editor} />
       </StyledEditor>
       <SubmissionButtonWrapper>
-        {!!content && _isEditing && (
+        {!!content && isEditing && (
           <CancelButton onClick={() => editor && onCancel(editor)} size='medium'>
             Cancel
           </CancelButton>
         )}
-        {(!content || _isEditing) && (
+        {(!content || isEditing) && (
           <SubmitButton
             onClick={() => editor && onSubmit(editor)}
             size='medium'

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -1,10 +1,31 @@
 import styled from '@emotion/styled'
 import {Editor as EditorState} from '@tiptap/core'
 import Placeholder from '@tiptap/extension-placeholder'
-import {EditorContent, EditorEvents, JSONContent, useEditor} from '@tiptap/react'
+import {EditorContent, JSONContent, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import areEqual from 'fbjs/lib/areEqual'
 import React, {useState} from 'react'
+import {PALETTE} from '~/styles/paletteV3'
+import RaisedButton from '../RaisedButton'
+
+const SubmissionButtonWrapper = styled('div')({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center'
+})
+
+const SubmitButton = styled(RaisedButton)({
+  marginTop: 12,
+  padding: '4px 12px 4px 12px',
+  fontSize: 14,
+  lineHeight: '20px',
+  fontWeight: 400
+})
+
+const CancelButton = styled(SubmitButton)({
+  marginRight: 12,
+  color: PALETTE.SLATE_700
+})
 
 const StyledEditor = styled('div')`
   .ProseMirror {
@@ -68,7 +89,7 @@ const PromptResponseEditor = (props: Props) => {
     setEditing(true)
   }
 
-  const onSubmit = ({editor: newEditorState}: EditorEvents['blur']) => {
+  const onSubmit = (newEditorState: EditorState) => {
     setEditing(false)
     const newContent = newEditorState.getJSON()
 
@@ -80,22 +101,45 @@ const PromptResponseEditor = (props: Props) => {
     handleSubmit?.(newEditorState)
   }
 
+  const onCancel = (editor: EditorState) => {
+    setEditing(false)
+    editor?.commands.setContent(content)
+  }
+
   const editor = useEditor(
     {
       content,
       extensions: createEditorExtensions(placeholder),
       autofocus: autoFocus,
       onUpdate,
-      onBlur: onSubmit,
       editable: !readOnly
     },
     [content]
   )
 
   return (
-    <StyledEditor>
-      <EditorContent editor={editor} />
-    </StyledEditor>
+    <>
+      <StyledEditor>
+        <EditorContent editor={editor} />
+      </StyledEditor>
+      <SubmissionButtonWrapper>
+        {!!content && _isEditing && (
+          <CancelButton onClick={() => editor && onCancel(editor)} size='medium' palette={'gray'}>
+            Cancel
+          </CancelButton>
+        )}
+        {(!content || _isEditing) && (
+          <SubmitButton
+            onClick={() => editor && onSubmit(editor)}
+            size='medium'
+            palette={!editor?.isEmpty ? 'blue' : 'gray'}
+            disabled={!editor || editor.isEmpty}
+          >
+            {!content ? 'Submit' : 'Update'}
+          </SubmitButton>
+        )}
+      </SubmissionButtonWrapper>
+    </>
   )
 }
 export default PromptResponseEditor

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -129,22 +129,26 @@ const PromptResponseEditor = (props: Props) => {
       <StyledEditor>
         <EditorContent editor={editor} />
       </StyledEditor>
-      <SubmissionButtonWrapper>
-        {!!content && isEditing && (
-          <CancelButton onClick={() => editor && onCancel(editor)} size='medium'>
-            Cancel
-          </CancelButton>
-        )}
-        {(!content || isEditing) && (
-          <SubmitButton
-            onClick={() => editor && onSubmit(editor)}
-            size='medium'
-            disabled={!editor || editor.isEmpty}
-          >
-            {!content ? 'Submit' : 'Update'}
-          </SubmitButton>
-        )}
-      </SubmissionButtonWrapper>
+      {!readOnly && (
+        // The render conditions for these buttons *should* only be true when 'readOnly' is false, but let's be explicit
+        // about it.
+        <SubmissionButtonWrapper>
+          {!!content && isEditing && (
+            <CancelButton onClick={() => editor && onCancel(editor)} size='medium'>
+              Cancel
+            </CancelButton>
+          )}
+          {(!content || isEditing) && (
+            <SubmitButton
+              onClick={() => editor && onSubmit(editor)}
+              size='medium'
+              disabled={!editor || editor.isEmpty}
+            >
+              {!content ? 'Submit' : 'Update'}
+            </SubmitButton>
+          )}
+        </SubmissionButtonWrapper>
+      )}
     </>
   )
 }

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -6,7 +6,8 @@ import StarterKit from '@tiptap/starter-kit'
 import areEqual from 'fbjs/lib/areEqual'
 import React, {useState} from 'react'
 import {PALETTE} from '~/styles/paletteV3'
-import RaisedButton from '../RaisedButton'
+import {Radius} from '~/types/constEnums'
+import BaseButton from '../BaseButton'
 
 const SubmissionButtonWrapper = styled('div')({
   display: 'flex',
@@ -14,15 +15,21 @@ const SubmissionButtonWrapper = styled('div')({
   alignItems: 'center'
 })
 
-const SubmitButton = styled(RaisedButton)({
+const SubmitButton = styled(BaseButton)<{disabled?: boolean}>(({disabled}) => ({
+  backgroundColor: disabled ? PALETTE.SLATE_200 : PALETTE.SKY_500,
+  opacity: 1,
+  borderRadius: Radius.BUTTON_PILL,
+  color: disabled ? PALETTE.SLATE_600 : '#FFFFFF',
+  outline: 0,
   marginTop: 12,
   padding: '4px 12px 4px 12px',
   fontSize: 14,
   lineHeight: '20px',
   fontWeight: 400
-})
+}))
 
 const CancelButton = styled(SubmitButton)({
+  backgroundColor: PALETTE.SLATE_200,
   marginRight: 12,
   color: PALETTE.SLATE_700
 })
@@ -124,7 +131,7 @@ const PromptResponseEditor = (props: Props) => {
       </StyledEditor>
       <SubmissionButtonWrapper>
         {!!content && _isEditing && (
-          <CancelButton onClick={() => editor && onCancel(editor)} size='medium' palette={'gray'}>
+          <CancelButton onClick={() => editor && onCancel(editor)} size='medium'>
             Cancel
           </CancelButton>
         )}
@@ -132,7 +139,6 @@ const PromptResponseEditor = (props: Props) => {
           <SubmitButton
             onClick={() => editor && onSubmit(editor)}
             size='medium'
-            palette={!editor?.isEmpty ? 'blue' : 'gray'}
             disabled={!editor || editor.isEmpty}
           >
             {!content ? 'Submit' : 'Update'}


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6688
Update the UX for response submission from onBlur to explicit "submit"/"update", and allow users to undo any in-progress edits with a "cancel" button.

Recommend reviewer sets "ignore whitespace" for the change in `packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx`

## Demo

https://www.loom.com/share/8f09c3adb3ec42089de0b05831cc984f

## Testing scenarios
(check that this matches designs for each step)
- [ ] Start a new meeting
- [ ] Type out a new response
- [ ] Click "Submit"
- [ ] Refresh the page to confirm that the mutation was persisted
- [ ] Click into the response (should have no buttons)
- [ ] Make a minor edit (buttons should appear)
- [ ] Click "cancel" - content should revert to original submission, with no edit timestamp
- [ ] Try to delete the entire response - "update" should be disabled.  Then click cancel.
- [ ] Make a minor edit, and click update - the card should show as edited, and refreshing should show that the mutation persisted.
- [ ] Sign in as a different user - confirm that buttons do not appear on non-viewer cards

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
