### PR TITLE
feat(insights): usage snack nag

### DIFF
--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -9,6 +9,7 @@ import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 import {PALETTE} from '~/styles/paletteV3'
 import {Breakpoint} from '~/types/constEnums'
 import useSidebar from '../hooks/useSidebar'
+import useUsageSnackNag from '../hooks/useUsageSnackNag'
 import {DashboardQuery} from '../__generated__/DashboardQuery.graphql'
 import DashSidebar from './Dashboard/DashSidebar'
 import MobileDashSidebar from './Dashboard/MobileDashSidebar'
@@ -102,6 +103,9 @@ const Dashboard = (props: Props) => {
           ...MobileDashSidebar_viewer
           ...DashSidebar_viewer
           overLimitCopy
+          featureFlags {
+            insights
+          }
           teams {
             activeMeetings {
               ...useSnacksForNewMeetings_meetings
@@ -114,13 +118,15 @@ const Dashboard = (props: Props) => {
     {UNSTABLE_renderPolicy: 'full'}
   )
   const {viewer} = data
-  const {teams} = viewer
+  const {teams, featureFlags} = viewer
   const activeMeetings = teams.flatMap((team) => team.activeMeetings).filter(Boolean)
   const {isOpen, toggle, handleMenuClick} = useSidebar()
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const overLimitCopy = viewer?.overLimitCopy
   const meetingsDashRef = useRef<HTMLDivElement>(null)
+  console.log('🚀  ~ featureFlags', featureFlags)
   useSnackNag(overLimitCopy)
+  useUsageSnackNag(featureFlags.insights)
   useSnacksForNewMeetings(activeMeetings)
   return (
     <DashLayout>

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -119,14 +119,14 @@ const Dashboard = (props: Props) => {
   )
   const {viewer} = data
   const {teams, featureFlags} = viewer
+  const {insights} = featureFlags
   const activeMeetings = teams.flatMap((team) => team.activeMeetings).filter(Boolean)
   const {isOpen, toggle, handleMenuClick} = useSidebar()
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const overLimitCopy = viewer?.overLimitCopy
   const meetingsDashRef = useRef<HTMLDivElement>(null)
-  console.log('🚀  ~ featureFlags', featureFlags)
   useSnackNag(overLimitCopy)
-  useUsageSnackNag(featureFlags.insights)
+  useUsageSnackNag(insights)
   useSnacksForNewMeetings(activeMeetings)
   return (
     <DashLayout>

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -139,19 +139,19 @@ const query = graphql`
 `
 
 const NewMeeting = (props: Props) => {
-  const {teamId} = props
-  const {queryRef} = props
+  const {teamId, queryRef} = props
   const data = usePreloadedQuery<NewMeetingQuery>(query, queryRef, {
     UNSTABLE_renderPolicy: 'full'
   })
   const {viewer} = data
   const {teams, featureFlags} = viewer
+  const {insights} = featureFlags
   const newMeetingOrder = useMemo(() => createMeetingOrder(featureFlags), [featureFlags])
 
   const {history} = useRouter()
   const innerWidth = useInnerWidth()
   const [idx, setIdx] = useState(0)
-  useUsageSnackNag(featureFlags.insights)
+  useUsageSnackNag(insights)
   const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)] as MeetingTypeEnum
   const sendToMeRef = useRef(false)
   useEffect(() => {

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -4,6 +4,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {mod} from 'react-swipeable-views-core'
 import WaveSVG from 'static/images/wave.svg'
+import useUsageSnackNag from '~/hooks/useUsageSnackNag'
 import {NonEmptyArray} from '~/types/generics'
 import {MeetingTypeEnum, NewMeetingQuery} from '~/__generated__/NewMeetingQuery.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
@@ -121,6 +122,7 @@ const query = graphql`
     viewer {
       featureFlags {
         standups
+        insights
       }
       teams {
         ...NewMeetingTeamPicker_selectedTeam
@@ -149,6 +151,7 @@ const NewMeeting = (props: Props) => {
   const {history} = useRouter()
   const innerWidth = useInnerWidth()
   const [idx, setIdx] = useState(0)
+  useUsageSnackNag(featureFlags.insights)
   const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)] as MeetingTypeEnum
   const sendToMeRef = useRef(false)
   useEffect(() => {

--- a/packages/client/hooks/useUsageSnackNag.ts
+++ b/packages/client/hooks/useUsageSnackNag.ts
@@ -1,8 +1,12 @@
+import graphql from 'babel-plugin-relay/macro'
 import ms from 'ms'
 import {useEffect} from 'react'
+import {useLazyLoadQuery} from 'react-relay'
 import {RouterProps, useHistory} from 'react-router'
 import Atmosphere from '../Atmosphere'
 import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
+import {TierEnum} from './../__generated__/NewTeamOrgPicker_organizations.graphql'
+import {useUsageSnackNagQuery} from './../__generated__/useUsageSnackNagQuery.graphql'
 import useAtmosphere from './useAtmosphere'
 
 const NAG_EVERY = ms('3m')
@@ -11,6 +15,13 @@ const getIsNaggingPath = (history: RouterProps['history']) => {
   const {location} = history
   const {pathname} = location
   return !(pathname.includes('/usage') || pathname.includes('/meet/'))
+}
+
+const shouldNag = (tier: TierEnum, suggestedTier: TierEnum | null) => {
+  if (!suggestedTier) return false
+  const suggestPro = suggestedTier === 'pro' && tier === 'personal'
+  const suggestEnterprise = suggestedTier === 'enterprise' && tier !== 'enterprise'
+  return suggestPro || suggestEnterprise
 }
 
 const emitNag = (atmosphere: Atmosphere, history: RouterProps['history']) => {
@@ -41,10 +52,26 @@ const useUsageSnackNag = (insights: boolean) => {
   const atmosphere = useAtmosphere()
   const history = useHistory()
   const isNaggingPath = getIsNaggingPath(history)
+  const isUserNaggable = isNaggingPath && insights
+  const {viewer} = useLazyLoadQuery<useUsageSnackNagQuery>(
+    graphql`
+      query useUsageSnackNagQuery($isUserNaggable: Boolean!) {
+        viewer {
+          domains @include(if: $isUserNaggable) {
+            tier
+            suggestedTier
+          }
+        }
+      }
+    `,
+    {isUserNaggable}
+  )
+  const {domains} = viewer
+  const nag = domains?.find(({tier, suggestedTier}) => shouldNag(tier, suggestedTier))
   useEffect(() => {
-    if (!isNaggingPath || !insights) return
+    if (!nag) return
     emitNag(atmosphere, history)
-  }, [isNaggingPath, insights])
+  }, [nag])
 }
 
 export default useUsageSnackNag

--- a/packages/client/hooks/useUsageSnackNag.ts
+++ b/packages/client/hooks/useUsageSnackNag.ts
@@ -1,0 +1,50 @@
+import ms from 'ms'
+import {useEffect} from 'react'
+import {RouterProps, useHistory} from 'react-router'
+import Atmosphere from '../Atmosphere'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
+import useAtmosphere from './useAtmosphere'
+
+const NAG_EVERY = ms('3m')
+
+const getIsNaggingPath = (history: RouterProps['history']) => {
+  const {location} = history
+  const {pathname} = location
+  return !(pathname.includes('/usage') || pathname.includes('/meet/'))
+}
+
+const emitNag = (atmosphere: Atmosphere, history: RouterProps['history']) => {
+  atmosphere.eventEmitter.emit('addSnackbar', {
+    key: 'usage',
+    message: 'View your usage stats',
+    autoDismiss: 0,
+    onDismiss: () => {
+      setTimeout(() => {
+        const isNaggingPath = getIsNaggingPath(history)
+        if (!isNaggingPath) return
+        emitNag(atmosphere, history)
+      }, NAG_EVERY)
+    },
+    action: {
+      label: 'View Usage',
+      callback: () => {
+        atmosphere.eventEmitter.emit('removeSnackbar', ({key}) => key === 'usage')
+        history.push(`/usage`)
+        SendClientSegmentEventMutation(atmosphere, 'Clicked usage snackbar CTA')
+      }
+    }
+  })
+  SendClientSegmentEventMutation(atmosphere, 'Sent usage snackbar')
+}
+
+const useUsageSnackNag = (insights: boolean) => {
+  const atmosphere = useAtmosphere()
+  const history = useHistory()
+  const isNaggingPath = getIsNaggingPath(history)
+  useEffect(() => {
+    if (!isNaggingPath || !insights) return
+    emitNag(atmosphere, history)
+  }, [isNaggingPath, insights])
+}
+
+export default useUsageSnackNag


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6762

This PR shows a nagging snackbar to users who have the `insights` feature flag turned on and whose `tier` is less than their `suggestedTier`, e.g. `tier` is `personal` and `suggestedTier` is `pro`.

### To test

- [ ] Change `NAG_EVERY` to `2s` in `useUsageSnackNag`
- [ ] See that the snackbar pops up throughout the dashboard and meeting selector but not in a meeting
- [ ] If you dismiss the snackbar by clicking on it (not on the CTA), it reappears after `NAG_EVERY` 
- [ ] Sends an event to Segment when the snackbar has been emitted and when the CTA has been clicked on

Note: if you refresh the page or dismiss the snackbar and proceed to the meeting selector, it'll show up right away rather than after 3 minutes. I could add some logic to prevent this, but as [the idea](https://github.com/ParabolInc/parabol/issues/6762#issuecomment-1157976095) is for the snackbar to be essentially persistent, I think that logic would be unnecessary.  