### PR TITLE
feat(insights): usage stats analytics

### DIFF
--- a/packages/client/components/Insights.tsx
+++ b/packages/client/components/Insights.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
 import {InsightsQuery} from '../__generated__/InsightsQuery.graphql'
@@ -44,6 +46,12 @@ const Insights = (props: Props) => {
   )
   const {viewer} = data
   const {domains} = viewer
+  const atmosphere = useAtmosphere()
+  domains.forEach(({id: domainId}) => {
+    SendClientSegmentEventMutation(atmosphere, 'Viewed domain stats', {
+      domainId
+    })
+  })
 
   return (
     <div>

--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 import useModal from '../hooks/useModal'
 import CreditCardModal from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
 import {PALETTE} from '../styles/paletteV3'
@@ -85,10 +86,10 @@ const InsightsDomainNudge = (props: Props) => {
     } else if (suggestEnterprise) {
       window.open('mailto:love@parabol.co?subject=Increase Usage Limits')
     }
-    // SendClientSegmentEventMutation(atmosphere, 'Clicked Domain Stats CTA', {
-    //   CTAType,
-    //   domainId
-    // })
+    SendClientSegmentEventMutation(atmosphere, 'Clicked Domain Stats CTA', {
+      CTAType,
+      domainId
+    })
   }
   const {togglePortal, closePortal, modalPortal} = useModal()
   return (

--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import useAtmosphere from '~/hooks/useAtmosphere'
 import useModal from '../hooks/useModal'
 import CreditCardModal from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
 import {PALETTE} from '../styles/paletteV3'
@@ -66,6 +67,7 @@ const InsightsDomainNudge = (props: Props) => {
     `,
     domainRef
   )
+  const atmosphere = useAtmosphere()
   const {id: domainId, suggestedTier, tier, organizations} = domain
   const personalOrganizations = organizations
     .filter((org) => org.tier === 'personal')
@@ -76,12 +78,17 @@ const InsightsDomainNudge = (props: Props) => {
   const suggestEnterprise = suggestedTier === 'enterprise' && tier !== 'enterprise'
   const showNudge = suggestPro || suggestEnterprise
   const CTACopy = suggestPro ? `Upgrade ${organizationName} to Pro` : 'Contact Us'
+  const CTAType = suggestPro ? 'pro' : 'enterprise'
   const onClickCTA = () => {
     if (suggestPro) {
       togglePortal()
     } else if (suggestEnterprise) {
       window.open('mailto:love@parabol.co?subject=Increase Usage Limits')
     }
+    // SendClientSegmentEventMutation(atmosphere, 'Clicked Domain Stats CTA', {
+    //   CTAType,
+    //   domainId
+    // })
   }
   const {togglePortal, closePortal, modalPortal} = useModal()
   return (

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -8,6 +8,7 @@ import {
 } from 'graphql'
 import NewMeetingPhaseTypeEnum from './NewMeetingPhaseTypeEnum'
 import TaskServiceEnum from './TaskServiceEnum'
+import TierEnum from './TierEnum'
 
 const SegmentEventTrackOptions = new GraphQLInputObjectType({
   name: 'SegmentEventTrackOptions',
@@ -27,7 +28,9 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     service: {type: TaskServiceEnum},
     searchQueryFilters: {type: GraphQLList(GraphQLID)},
     projectId: {type: GraphQLID},
-    selectedAll: {type: GraphQLBoolean}
+    selectedAll: {type: GraphQLBoolean},
+    domainId: {type: GraphQLID},
+    CTAType: {type: TierEnum}
   })
 })
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6681

This PR sends an event to Segment when the viewer visits the /usage page and when they click the domain stats CTA.

I got a bunch of bad merge conflicts in https://github.com/ParabolInc/parabol/pull/6764 after https://github.com/ParabolInc/parabol/issues/6681 was merged to master, so I closed that PR and created a fresh one as there aren't too many changes. 

### To test

- [ ] Copy & paste the SEGMENT_WRITE_KEY and SEGMENT_FN_KEY from production in the devops repo
- [ ] Comment out the PRODUCTION check in Analytics.ts
- [ ] Visit the /usage page and click on the CTA
- [ ] Check the network tab of the dev tools and see that the SendClientSegmentEventMutation was executed
- [ ] Visit Amplitude, search for your viewerId, and see that the events were recorded