### PR TITLE
fix(standups): Allow reactjis to be added after initial response submission

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -185,7 +185,7 @@ const TeamPromptResponseCard = (props: Props) => {
     [response]
   )
   const plaintextContent = response?.plaintextContent ?? ''
-  const reactjis = response?.reactjis
+  const reactjis = response?.reactjis ?? []
 
   const discussionEdges = discussion.thread.edges
   const replyCount = discussionEdges.length
@@ -209,7 +209,7 @@ const TeamPromptResponseCard = (props: Props) => {
   })
 
   const onToggleReactji = (emojiId: string) => {
-    if (submitting || !reactjis) return
+    if (submitting || !response) return
     const isRemove = !!reactjis.find((reactji) => {
       return reactji.isViewerReactji && ReactjiId.split(reactji.id).name === emojiId
     })
@@ -259,7 +259,7 @@ const TeamPromptResponseCard = (props: Props) => {
               placeholder={'Share your response...'}
             />
             <ResponseCardFooter>
-              <StyledReactjis reactjis={reactjis || []} onToggle={onToggleReactji} />
+              <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
               <ReplyButton onClick={() => onSelectDiscussion()}>
                 {replyCount > 0 ? (
                   <>


### PR DESCRIPTION
# Description

Currently, the add reactji mutation often doesn't happen when attempted immediately after the viewer submits their response.  The current workaround is to just refresh the page, but that's annoying.

## Testing scenarios

- [ ] Create a new standup meeting
- [ ] Add a response
- [ ] Add an emoji successfully

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
