### PR TITLE
feat(Retrospective): Add more prominent enter to submit hint

### DIFF
--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -7,6 +7,7 @@ import usePortal from '../../hooks/usePortal'
 import CreateReflectionMutation from '../../mutations/CreateReflectionMutation'
 import EditReflectionMutation from '../../mutations/EditReflectionMutation'
 import {Elevation} from '../../styles/elevation'
+import {PALETTE} from '../../styles/paletteV3'
 import {BezierCurve, ZIndex} from '../../types/constEnums'
 import convertToTaskContent from '../../utils/draftjs/convertToTaskContent'
 import ReflectionCardRoot from '../ReflectionCard/ReflectionCardRoot'
@@ -25,6 +26,16 @@ const CardInFlightStyles = styled(ReflectionCardRoot)<{transform: string; isStar
     zIndex: ZIndex.REFLECTION_IN_FLIGHT
   })
 )
+
+const EnterHint = styled('div')({
+  color: PALETTE.SLATE_600,
+  fontSize: 14,
+  fontStyle: 'italic',
+  fontWeight: 400,
+  lineHeight: '20px',
+  paddingLeft: 16,
+  cursor: 'pointer'
+})
 
 interface Props {
   cardsInFlightRef: MutableRefObject<ReflectColumnCardInFlight[]>
@@ -183,6 +194,11 @@ const PhaseItemEditor = (props: Props) => {
           setEditorState={setEditorState}
           readOnly={readOnly}
         />
+        {!isEditing && editorState.getCurrentContent().hasText() && (
+          <EnterHint onClick={handleKeydown}>
+            press enter after writing or click here to add
+          </EnterHint>
+        )}
       </ReflectionCardRoot>
       {portal(
         <>


### PR DESCRIPTION
Fixes: #6792 
This should help with onboarding new users. The hint appears after a timeout (same which is used for typing notifications) or after blurring the input.

## Demo
![Peek 2022-06-21 22-43](https://user-images.githubusercontent.com/7331043/174894122-33f6e087-197a-45ed-82c4-b1a2f1b18c10.gif)

## Testing scenarios

- Start Retrospective and go to reflect phase
- [ ] Enter text in a reflection and wait -> hint appears
- [ ] Start typing again -> hint disappears
- [ ] Blur a reflection with text -> hint appears
- [ ] Blur a reflection without text -> hint does not appear
- [ ] Blur reflection by moving focus to another window and then refocus window -> correct copy text appears
- [ ] Press the hint to submit a reflection

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
