### PR TITLE
fix: reuse invite link

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -36,6 +36,7 @@ graphql`
     }
   }
 `
+
 graphql`
   fragment AcceptTeamInvitationMutation_notification on AcceptTeamInvitationPayload {
     # this is just for the user that accepted the invitation

--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -143,6 +143,7 @@ export const handleAcceptTeamInvitationErrors = (
 ) => {
   if (acceptTeamInvitation?.error) {
     const {message} = acceptTeamInvitation.error
+    if (message === InvitationTokenError.ALREADY_ACCEPTED) return true
     atmosphere.eventEmitter.emit('addSnackbar', {
       autoDismiss: 0,
       key: `acceptTeamInvitation:${message}`,
@@ -175,10 +176,6 @@ const AcceptTeamInvitationMutation: StandardMutation<
         onCompleted(data, errors)
       }
       const {acceptTeamInvitation} = data
-      const isOK = ignoreApproval
-        ? true
-        : handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
-      if (!isOK) return
       const {authToken, team} = acceptTeamInvitation
       const serverError = getGraphQLError(data, errors)
       if (serverError) {
@@ -191,6 +188,10 @@ const AcceptTeamInvitationMutation: StandardMutation<
         }
         return
       }
+      const isOK = ignoreApproval
+        ? true
+        : handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
+      if (!isOK) return
       atmosphere.setAuthToken(authToken)
       if (!team) return
       const {id: teamId, name: teamName} = team


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6793

### To test

- In prod/master, copy the team invitation link
- Go to a new window and create a new account
- Paste the invitation link into the URL and see that you're successfully added to the team 
- Now paste the URL for a second time and see the loading screen (see screenshot in issue)
- Checkout this branch and see that you can use the same invitation link as many times as you wish