### PR TITLE
feat: retro template search filter

### DIFF
--- a/packages/client/clientSchema.graphql
+++ b/packages/client/clientSchema.graphql
@@ -60,6 +60,7 @@ extend type PokerMeetingSettings {
 
 extend type RetrospectiveMeetingSettings {
   activeTemplate: ReflectTemplate!
+  templateSearchQuery: String
 }
 
 extend type User {

--- a/packages/client/components/TypeAheadLabel.tsx
+++ b/packages/client/components/TypeAheadLabel.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import {PALETTE} from '~/styles/paletteV3'
 import getSafeRegex from '~/utils/getSafeRegex'
 
 interface Props {
   query: string
   label: string
+  highlight?: boolean
 }
 
 const Span = styled('span')({
@@ -14,11 +16,12 @@ const Span = styled('span')({
 })
 
 const TypeAheadLabel = (props: Props) => {
-  const {query, label} = props
+  const {query, label, highlight} = props
+  const html = highlight ? `<mark style="background: ${PALETTE.SKY_300}">$&</mark>` : `<b>$&</b>`
   return (
     <Span
       dangerouslySetInnerHTML={{
-        __html: query ? label.replace(getSafeRegex(query, 'gi'), `<b>$&</b>`) : label
+        __html: query ? label.replace(getSafeRegex(query, 'gi'), html) : label
       }}
     />
   )

--- a/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
+import TypeAheadLabel from '~/components/TypeAheadLabel'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useScrollIntoView from '../../../hooks/useScrollIntoVIew'
 import {DECELERATE} from '../../../styles/animation'
@@ -54,10 +55,11 @@ interface Props {
   teamId: string
   template: ReflectTemplateItem_template
   lowestScope: 'TEAM' | 'ORGANIZATION' | 'PUBLIC'
+  templateSearchQuery: string
 }
 
 const ReflectTemplateItem = (props: Props) => {
-  const {lowestScope, isActive, teamId, template} = props
+  const {lowestScope, isActive, teamId, template, templateSearchQuery} = props
   const {id: templateId, name: templateName} = template
   const description = makeTemplateDescription(lowestScope, template)
   const atmosphere = useAtmosphere()
@@ -69,7 +71,9 @@ const ReflectTemplateItem = (props: Props) => {
   return (
     <TemplateItem ref={ref} isActive={isActive} onClick={selectTemplate}>
       <TemplateItemDetails>
-        <TemplateTitle>{templateName}</TemplateTitle>
+        <TemplateTitle>
+          <TypeAheadLabel highlight query={templateSearchQuery} label={templateName} />
+        </TemplateTitle>
         <TemplateDescription>{description}</TemplateDescription>
       </TemplateItemDetails>
       <TemplateItemAction></TemplateItemAction>

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -38,7 +38,6 @@ const Label = styled('div')({
 })
 
 const StyledTabsBar = styled(Tabs)({
-  // boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`,
   flexShrink: 0
 })
 
@@ -97,6 +96,7 @@ const ReflectTemplateList = (props: Props) => {
     graphql`
       fragment ReflectTemplateList_settings on RetrospectiveMeetingSettings {
         ...ReflectTemplateSearchBar_settings
+        ...ReflectTemplateListTeam_settings
         id
         team {
           id
@@ -108,7 +108,6 @@ const ReflectTemplateList = (props: Props) => {
           orgId
         }
         teamTemplates {
-          ...ReflectTemplateListTeam_teamTemplates
           ...AddNewReflectTemplate_reflectTemplates
           id
         }
@@ -191,7 +190,7 @@ const ReflectTemplateList = (props: Props) => {
           <ReflectTemplateListTeam
             activeTemplateId={activeTemplateId}
             showPublicTemplates={() => goToTab('PUBLIC')}
-            teamTemplates={teamTemplates}
+            settingsRef={settings}
             teamId={teamId}
             isActive={activeIdx === 0}
           />

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -89,6 +89,7 @@ const ReflectTemplateList = (props: Props) => {
   const {id: teamId} = team
   const activeTemplateId = settings.activeTemplate?.id ?? '-tmp'
   const readyToScrollSmooth = useReadyToSmoothScroll(activeTemplateId)
+  // const atmosphere = useAtmosphere()
   const slideStyle = {scrollBehavior: readyToScrollSmooth ? 'smooth' : undefined}
 
   const gotoTeamTemplates = () => {
@@ -97,11 +98,16 @@ const ReflectTemplateList = (props: Props) => {
   const gotoPublicTemplates = () => {
     setActiveIdx(2)
   }
-  const onChangeIdx = (idx, _fromIdx, props: {reason: string}) => {
+  const onChangeIdx = (idx: number, _fromIdx, props: {reason: string}) => {
     //very buggy behavior, probably linked to the vertical scrolling.
     // to repro, go from team > org > team > org by clicking tabs & see this this get called for who knows why
     if (props.reason === 'focus') return
     setActiveIdx(idx)
+    // commitLocalUpdate(atmosphere, (store) => {
+    //   const settings = store.get(settingsId)
+    //   if (!settings) return
+    //   settings.setValue('', 'templateSearchQuery')
+    // })
   }
 
   return (
@@ -133,7 +139,7 @@ const ReflectTemplateList = (props: Props) => {
           onClick={gotoPublicTemplates}
         />
       </StyledTabsBar>
-      <ReflectTemplateSearchBar settingsId={settingsId} />
+      <ReflectTemplateSearchBar settingsRef={settings} />
       <AddNewReflectTemplate
         teamId={teamId}
         reflectTemplates={teamTemplates}
@@ -171,6 +177,7 @@ const ReflectTemplateList = (props: Props) => {
 export default createFragmentContainer(ReflectTemplateList, {
   settings: graphql`
     fragment ReflectTemplateList_settings on RetrospectiveMeetingSettings {
+      ...ReflectTemplateSearchBar_settings
       id
       team {
         id

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -122,6 +122,9 @@ const ReflectTemplateList = (props: Props) => {
   const readyToScrollSmooth = useReadyToSmoothScroll(activeTemplateId)
   const atmosphere = useAtmosphere()
   const slideStyle = {scrollBehavior: readyToScrollSmooth ? 'smooth' : undefined}
+  const templateType = Object.keys(templateIdxs).find(
+    (key) => templateIdxs[key] === activeIdx
+  ) as SharingScopeEnum
 
   const clearSearch = () => {
     commitLocalUpdate(atmosphere, (store) => {
@@ -174,7 +177,7 @@ const ReflectTemplateList = (props: Props) => {
         />
       </StyledTabsBar>
       <ReflectTemplateSearchBar
-        activeIdx={activeIdx}
+        templateType={templateType}
         clearSearch={clearSearch}
         settingsRef={settings}
       />

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -38,6 +38,7 @@ const Label = styled('div')({
 })
 
 const StyledTabsBar = styled(Tabs)({
+  boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`,
   flexShrink: 0
 })
 
@@ -172,7 +173,7 @@ const ReflectTemplateList = (props: Props) => {
           onClick={() => goToTab('PUBLIC')}
         />
       </StyledTabsBar>
-      <ReflectTemplateSearchBar settingsRef={settings} />
+      <ReflectTemplateSearchBar clearSearch={clearSearch} settingsRef={settings} />
       <AddNewReflectTemplate
         teamId={teamId}
         reflectTemplates={teamTemplates}

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {ChangeEvent, useEffect, useRef} from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import React, {useEffect, useRef} from 'react'
+import {createFragmentContainer} from 'react-relay'
 import SwipeableViews from 'react-swipeable-views'
-import useAtmosphere from '~/hooks/useAtmosphere'
 import Icon from '../../../components/Icon'
 import Tab from '../../../components/Tab/Tab'
 import Tabs from '../../../components/Tabs/Tabs'
@@ -14,6 +13,7 @@ import AddNewReflectTemplate from './AddNewReflectTemplate'
 import ReflectTemplateListOrgRoot from './ReflectTemplateListOrgRoot'
 import ReflectTemplateListPublicRoot from './ReflectTemplateListPublicRoot'
 import ReflectTemplateListTeam from './ReflectTemplateListTeam'
+import ReflectTemplateSearchBar from './ReflectTemplateSearchBar'
 
 const WIDTH = 360
 const TemplateSidebar = styled('div')({
@@ -36,7 +36,7 @@ const Label = styled('div')({
 })
 
 const StyledTabsBar = styled(Tabs)({
-  boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`,
+  // boxShadow: `inset 0 -1px 0 ${PALETTE.SLATE_300}`,
   flexShrink: 0
 })
 
@@ -89,7 +89,6 @@ const ReflectTemplateList = (props: Props) => {
   const {id: teamId} = team
   const activeTemplateId = settings.activeTemplate?.id ?? '-tmp'
   const readyToScrollSmooth = useReadyToSmoothScroll(activeTemplateId)
-  const atmosphere = useAtmosphere()
   const slideStyle = {scrollBehavior: readyToScrollSmooth ? 'smooth' : undefined}
 
   const gotoTeamTemplates = () => {
@@ -104,14 +103,7 @@ const ReflectTemplateList = (props: Props) => {
     if (props.reason === 'focus') return
     setActiveIdx(idx)
   }
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    commitLocalUpdate(atmosphere, (store) => {
-      const settings = store.get(settingsId)
-      if (!settings) return
-      const normalizedSearch = e.target.value.toLowerCase().trim()
-      settings.setValue(normalizedSearch, 'templateSearchQuery')
-    })
-  }
+
   return (
     <TemplateSidebar>
       <Label>Retro Templates</Label>
@@ -141,7 +133,7 @@ const ReflectTemplateList = (props: Props) => {
           onClick={gotoPublicTemplates}
         />
       </StyledTabsBar>
-      <input placeholder='Search templates...' onChange={onChange} />
+      <ReflectTemplateSearchBar settingsId={settingsId} />
       <AddNewReflectTemplate
         teamId={teamId}
         reflectTemplates={teamTemplates}

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -85,7 +85,7 @@ const useReadyToSmoothScroll = (activeTemplateId: string) => {
   return oldActiveTemplateId !== activeTemplateId && oldActiveTemplateId !== '-tmp'
 }
 
-const templateIdxs = {
+export const templateIdxs = {
   TEAM: 0,
   ORGANIZATION: 1,
   PUBLIC: 2
@@ -173,7 +173,11 @@ const ReflectTemplateList = (props: Props) => {
           onClick={() => goToTab('PUBLIC')}
         />
       </StyledTabsBar>
-      <ReflectTemplateSearchBar clearSearch={clearSearch} settingsRef={settings} />
+      <ReflectTemplateSearchBar
+        activeIdx={activeIdx}
+        clearSearch={clearSearch}
+        settingsRef={settings}
+      />
       <AddNewReflectTemplate
         teamId={teamId}
         reflectTemplates={teamTemplates}

--- a/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import useFilteredItems from '~/hooks/useFilteredItems'
 import useActiveTopTemplate from '../../../hooks/useActiveTopTemplate'
 import {PALETTE} from '../../../styles/paletteV3'
 import {ReflectTemplateListOrgQuery} from '../../../__generated__/ReflectTemplateListOrgQuery.graphql'
@@ -25,6 +26,10 @@ const Message = styled('div')({
 })
 interface Props {
   queryRef: PreloadedQuery<ReflectTemplateListOrgQuery>
+}
+
+const getValue = (item: {node: {id: string; name: string}}) => {
+  return item.node.name.toLowerCase()
 }
 
 const query = graphql`
@@ -67,9 +72,7 @@ const ReflectTemplateListOrg = (props: Props) => {
   const {templateSearchQuery, organizationTemplates, activeTemplate} = meetingSettings
   const activeTemplateId = activeTemplate?.id ?? '-tmp'
   const {edges} = organizationTemplates!
-  const filteredEdges = edges.filter(({node}) =>
-    node.name.toLowerCase().includes(templateSearchQuery ?? '')
-  )
+  const filteredEdges = useFilteredItems(templateSearchQuery ?? '', edges, getValue)
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
 
   if (edges.length === 0) {

--- a/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
@@ -70,9 +70,10 @@ const ReflectTemplateListOrg = (props: Props) => {
   const team = viewer.team!
   const {id: teamId, meetingSettings} = team
   const {templateSearchQuery, organizationTemplates, activeTemplate} = meetingSettings
+  const searchQuery = templateSearchQuery ?? ''
   const activeTemplateId = activeTemplate?.id ?? '-tmp'
   const {edges} = organizationTemplates!
-  const filteredEdges = useFilteredItems(templateSearchQuery ?? '', edges, getValue)
+  const filteredEdges = useFilteredItems(searchQuery, edges, getValue)
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
 
   if (edges.length === 0) {
@@ -80,7 +81,7 @@ const ReflectTemplateListOrg = (props: Props) => {
   }
   if (filteredEdges.length === 0) {
     return (
-      <Message>{`No template names in your organization match your search query "${templateSearchQuery}"`}</Message>
+      <Message>{`No template names in your organization match your search query "${searchQuery}"`}</Message>
     )
   }
   return (
@@ -93,6 +94,7 @@ const ReflectTemplateListOrg = (props: Props) => {
             isActive={template.id === activeTemplateId}
             lowestScope={'ORGANIZATION'}
             teamId={teamId}
+            templateSearchQuery={searchQuery}
           />
         )
       })}

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {PALETTE} from '~/styles/paletteV3'
 import useActiveTopTemplate from '../../../hooks/useActiveTopTemplate'
 import {ReflectTemplateListPublicQuery} from '../../../__generated__/ReflectTemplateListPublicQuery.graphql'
 import ReflectTemplateItem from './ReflectTemplateItem'
@@ -10,6 +11,17 @@ const TemplateList = styled('ul')({
   listStyle: 'none',
   paddingLeft: 0,
   marginTop: 0
+})
+
+const Message = styled('div')({
+  border: `1px dashed ${PALETTE.SLATE_400}`,
+  borderRadius: 4,
+  color: PALETTE.SLATE_600,
+  fontSize: 14,
+  fontStyle: 'italic',
+  lineHeight: '20px',
+  margin: 'auto 32px',
+  padding: '8px 16px'
 })
 
 interface Props {
@@ -60,6 +72,11 @@ const ReflectTemplateListPublic = (props: Props) => {
     node.name.toLowerCase().includes(templateSearchQuery ?? '')
   )
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
+  if (filteredEdges.length === 0) {
+    return (
+      <Message>{`No public templates match your search query "${templateSearchQuery}"`}</Message>
+    )
+  }
   return (
     <TemplateList>
       {filteredEdges.map(({node: template}) => {

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -71,14 +71,13 @@ const ReflectTemplateListPublic = (props: Props) => {
   const team = viewer.team!
   const {id: teamId, meetingSettings} = team
   const {templateSearchQuery, publicTemplates, activeTemplate} = meetingSettings
+  const searchQuery = templateSearchQuery ?? ''
   const activeTemplateId = activeTemplate?.id ?? '-tmp'
   const {edges} = publicTemplates!
-  const filteredEdges = useFilteredItems(templateSearchQuery ?? '', edges, getValue)
+  const filteredEdges = useFilteredItems(searchQuery, edges, getValue)
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
   if (filteredEdges.length === 0) {
-    return (
-      <Message>{`No public templates match your search query "${templateSearchQuery}"`}</Message>
-    )
+    return <Message>{`No public templates match your search query "${searchQuery}"`}</Message>
   }
   return (
     <TemplateList>
@@ -90,6 +89,7 @@ const ReflectTemplateListPublic = (props: Props) => {
             isActive={template.id === activeTemplateId}
             lowestScope={'PUBLIC'}
             teamId={teamId}
+            templateSearchQuery={searchQuery}
           />
         )
       })}

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import useFilteredItems from '~/hooks/useFilteredItems'
 import {PALETTE} from '~/styles/paletteV3'
 import useActiveTopTemplate from '../../../hooks/useActiveTopTemplate'
 import {ReflectTemplateListPublicQuery} from '../../../__generated__/ReflectTemplateListPublicQuery.graphql'
@@ -26,6 +27,10 @@ const Message = styled('div')({
 
 interface Props {
   queryRef: PreloadedQuery<ReflectTemplateListPublicQuery>
+}
+
+const getValue = (item: {node: {id: string; name: string}}) => {
+  return item.node.name.toLowerCase()
 }
 
 const query = graphql`
@@ -68,9 +73,7 @@ const ReflectTemplateListPublic = (props: Props) => {
   const {templateSearchQuery, publicTemplates, activeTemplate} = meetingSettings
   const activeTemplateId = activeTemplate?.id ?? '-tmp'
   const {edges} = publicTemplates!
-  const filteredEdges = edges.filter(({node}) =>
-    node.name.toLowerCase().includes(templateSearchQuery ?? '')
-  )
+  const filteredEdges = useFilteredItems(templateSearchQuery ?? '', edges, getValue)
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
   if (filteredEdges.length === 0) {
     return (

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -24,12 +24,14 @@ const query = graphql`
         id
         meetingSettings(meetingType: retrospective) {
           ... on RetrospectiveMeetingSettings {
+            templateSearchQuery
             publicTemplates(first: 50)
               @connection(key: "ReflectTemplateListPublic_publicTemplates") {
               edges {
                 node {
                   ...ReflectTemplateItem_template
                   id
+                  name
                 }
               }
             }
@@ -51,13 +53,16 @@ const ReflectTemplateListPublic = (props: Props) => {
   const {viewer} = data
   const team = viewer.team!
   const {id: teamId, meetingSettings} = team
-  const publicTemplates = meetingSettings.publicTemplates!
-  const activeTemplateId = meetingSettings.activeTemplate?.id ?? '-tmp'
-  const {edges} = publicTemplates
+  const {templateSearchQuery, publicTemplates, activeTemplate} = meetingSettings
+  const activeTemplateId = activeTemplate?.id ?? '-tmp'
+  const {edges} = publicTemplates!
+  const filteredEdges = edges.filter(({node}) =>
+    node.name.toLowerCase().includes(templateSearchQuery ?? '')
+  )
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
   return (
     <TemplateList>
-      {edges.map(({node: template}) => {
+      {filteredEdges.map(({node: template}) => {
         return (
           <ReflectTemplateItem
             key={template.id}

--- a/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
@@ -2,9 +2,13 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import useFilteredItems from '~/hooks/useFilteredItems'
 import useActiveTopTemplate from '../../../hooks/useActiveTopTemplate'
 import {PALETTE} from '../../../styles/paletteV3'
-import {ReflectTemplateListTeam_settings$key} from '../../../__generated__/ReflectTemplateListTeam_settings.graphql'
+import {
+  ReflectTemplateListTeam_settings,
+  ReflectTemplateListTeam_settings$key
+} from '../../../__generated__/ReflectTemplateListTeam_settings.graphql'
 import ReflectTemplateItem from './ReflectTemplateItem'
 
 const TemplateList = styled('ul')({
@@ -41,6 +45,10 @@ interface Props {
   settingsRef: ReflectTemplateListTeam_settings$key
 }
 
+const getValue = (item: ReflectTemplateListTeam_settings['teamTemplates'][0]) => {
+  return item.name.toLowerCase()
+}
+
 const ReflectTemplateListTeam = (props: Props) => {
   const {isActive, activeTemplateId, showPublicTemplates, teamId, settingsRef} = props
   const settings = useFragment(
@@ -59,9 +67,7 @@ const ReflectTemplateListTeam = (props: Props) => {
   const {teamTemplates, templateSearchQuery} = settings
   const edges = teamTemplates.map((t) => ({node: {id: t.id}})) as readonly {node: {id: string}}[]
   useActiveTopTemplate(edges, activeTemplateId, teamId, isActive, 'retrospective')
-  const filteredTemplates = teamTemplates.filter(({name}) =>
-    name.toLowerCase().includes(templateSearchQuery ?? '')
-  )
+  const filteredTemplates = useFilteredItems(templateSearchQuery ?? '', teamTemplates, getValue)
   if (teamTemplates.length === 0) {
     return (
       <Message>

--- a/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
@@ -65,9 +65,10 @@ const ReflectTemplateListTeam = (props: Props) => {
     settingsRef
   )
   const {teamTemplates, templateSearchQuery} = settings
+  const searchQuery = templateSearchQuery ?? ''
   const edges = teamTemplates.map((t) => ({node: {id: t.id}})) as readonly {node: {id: string}}[]
   useActiveTopTemplate(edges, activeTemplateId, teamId, isActive, 'retrospective')
-  const filteredTemplates = useFilteredItems(templateSearchQuery ?? '', teamTemplates, getValue)
+  const filteredTemplates = useFilteredItems(searchQuery, teamTemplates, getValue)
   if (teamTemplates.length === 0) {
     return (
       <Message>
@@ -77,7 +78,7 @@ const ReflectTemplateListTeam = (props: Props) => {
     )
   }
   if (filteredTemplates.length === 0) {
-    return <Message>{`No team templates match your search query "${templateSearchQuery}"`}</Message>
+    return <Message>{`No team templates match your search query "${searchQuery}"`}</Message>
   }
   return (
     <TemplateList>
@@ -89,6 +90,7 @@ const ReflectTemplateListTeam = (props: Props) => {
             isActive={template.id === activeTemplateId}
             lowestScope={'TEAM'}
             teamId={teamId}
+            templateSearchQuery={searchQuery}
           />
         )
       })}

--- a/packages/client/modules/meeting/components/ReflectTemplateModal.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateModal.tsx
@@ -46,7 +46,7 @@ const ReflectTemplateModal = (props: Props) => {
   return (
     <StyledDialogContainer>
       <ReflectTemplateList
-        settings={retroMeetingSettings}
+        settingsRef={retroMeetingSettings}
         activeIdx={activeIdx}
         setActiveIdx={setActiveIdx}
       />

--- a/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled'
+import React, {ChangeEvent, useRef} from 'react'
+import {commitLocalUpdate} from 'react-relay'
+import Atmosphere from '../../../Atmosphere'
+import Icon from '../../../components/Icon'
+import MenuItemComponentAvatar from '../../../components/MenuItemComponentAvatar'
+import MenuItemLabel from '../../../components/MenuItemLabel'
+import useAtmosphere from '../../../hooks/useAtmosphere'
+import {PALETTE} from '../../../styles/paletteV3'
+import {ICON_SIZE} from '../../../styles/typographyV2'
+
+const Search = styled(MenuItemLabel)({
+  overflow: 'visible',
+  padding: 0,
+  display: 'flex',
+  position: 'relative'
+})
+
+const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
+  position: 'absolute',
+  left: 8,
+  top: 8
+})
+
+const SearchIcon = styled(Icon)({
+  color: PALETTE.SLATE_600,
+  fontSize: ICON_SIZE.MD24
+})
+
+const SearchInput = styled('input')({
+  border: `1px solid ${PALETTE.SKY_500}`,
+  boxShadow: `inset 0px 0px 1px ${PALETTE.SKY_500}`,
+  color: PALETTE.SLATE_700,
+  display: 'block',
+  fontSize: 14,
+  lineHeight: '24px',
+  outline: 'none',
+  padding: '6px 0 6px 40px',
+  width: '100%',
+  '::placeholder': {
+    color: PALETTE.SLATE_600
+  }
+})
+
+const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: string) => {
+  commitLocalUpdate(atmosphere, (store) => {
+    const settings = store.get(settingsId)
+    if (!settings) return
+    const normalizedSearch = value.toLowerCase().trim()
+    settings.setValue(normalizedSearch, 'templateSearchQuery')
+  })
+}
+
+interface Props {
+  settingsId: string
+}
+
+const SpotlightSearchBar = (props: Props) => {
+  const {settingsId} = props
+  const atmosphere = useAtmosphere()
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setTemplateSearch(atmosphere, settingsId, e.currentTarget.value)
+  }
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && inputRef.current) {
+      e.stopPropagation()
+      e.preventDefault()
+      inputRef.current.blur()
+    }
+  }
+
+  return (
+    <Search>
+      <StyledMenuItemIcon>
+        <SearchIcon>search</SearchIcon>
+      </StyledMenuItemIcon>
+      <SearchInput
+        onKeyDown={onKeyDown}
+        autoComplete='off'
+        name='search'
+        placeholder='Search templates...'
+        type='text'
+        onChange={onChange}
+        ref={inputRef}
+      />
+    </Search>
+  )
+}
+
+export default SpotlightSearchBar

--- a/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
@@ -50,13 +50,12 @@ const InputWrapper = styled('div')({
   alignItems: 'center',
   display: 'flex',
   flex: 1,
-  paddingLeft: 18
+  paddingLeft: 8
 })
 
 const SearchInput = styled('input')({
   appearance: 'none',
   border: 'none',
-  borderLeft: `1px solid ${PALETTE.SLATE_400}`,
   color: PALETTE.SLATE_700,
   fontSize: 16,
   margin: 0,
@@ -71,7 +70,7 @@ const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: st
   commitLocalUpdate(atmosphere, (store) => {
     const settings = store.get(settingsId)
     if (!settings) return
-    const normalizedSearch = value.toLowerCase().trim()
+    const normalizedSearch = value.toLowerCase()
     settings.setValue(normalizedSearch, 'templateSearchQuery')
   })
 }

--- a/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
@@ -10,6 +10,7 @@ import MenuItemLabel from '../../../components/MenuItemLabel'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import {PALETTE} from '../../../styles/paletteV3'
 import {ICON_SIZE} from '../../../styles/typographyV2'
+import {templateIdxs} from './ReflectTemplateList'
 
 const SearchBarWrapper = styled('div')({
   padding: '16px 16px 0 16px'
@@ -42,7 +43,7 @@ const ClearSearchIcon = styled(Icon)<{isEmpty: boolean}>(({isEmpty}) => ({
   color: PALETTE.SLATE_500,
   cursor: 'pointer',
   padding: 8,
-  visibility: isEmpty ? 'hidden' : undefined
+  display: isEmpty ? 'none' : 'flex'
 }))
 
 const InputWrapper = styled('div')({
@@ -76,12 +77,13 @@ const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: st
 }
 
 interface Props {
-  settingsRef: ReflectTemplateSearchBar_settings$key
+  activeIdx: number
   clearSearch: () => void
+  settingsRef: ReflectTemplateSearchBar_settings$key
 }
 
 const ReflectTemplateSearchBar = (props: Props) => {
-  const {clearSearch, settingsRef} = props
+  const {activeIdx, clearSearch, settingsRef} = props
   const atmosphere = useAtmosphere()
   const settings = useFragment(
     graphql`
@@ -93,6 +95,8 @@ const ReflectTemplateSearchBar = (props: Props) => {
     settingsRef
   )
   const {id: settingsId, templateSearchQuery} = settings
+  const templateType = Object.keys(templateIdxs).find((key) => templateIdxs[key] === activeIdx)
+  const normalizedTempType = templateType === 'ORGANIZATION' ? 'org' : templateType?.toLowerCase()
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setTemplateSearch(atmosphere, settingsId, e.currentTarget.value)
@@ -118,7 +122,7 @@ const ReflectTemplateSearchBar = (props: Props) => {
             onKeyDown={onKeyDown}
             autoComplete='off'
             name='search'
-            placeholder='Search templates...'
+            placeholder={`Search ${normalizedTempType} templates...`}
             type='text'
             onChange={onChange}
             ref={inputRef}

--- a/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
 import React, {ChangeEvent, useRef} from 'react'
-import {commitLocalUpdate} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
+import {ReflectTemplateSearchBar_settings$key} from '~/__generated__/ReflectTemplateSearchBar_settings.graphql'
 import Atmosphere from '../../../Atmosphere'
 import Icon from '../../../components/Icon'
 import MenuItemComponentAvatar from '../../../components/MenuItemComponentAvatar'
@@ -52,12 +54,22 @@ const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: st
 }
 
 interface Props {
-  settingsId: string
+  settingsRef: ReflectTemplateSearchBar_settings$key
 }
 
-const SpotlightSearchBar = (props: Props) => {
-  const {settingsId} = props
+const ReflectTemplateSearchBar = (props: Props) => {
+  const {settingsRef} = props
   const atmosphere = useAtmosphere()
+  const settings = useFragment(
+    graphql`
+      fragment ReflectTemplateSearchBar_settings on RetrospectiveMeetingSettings {
+        id
+        templateSearchQuery
+      }
+    `,
+    settingsRef
+  )
+  const {id: settingsId, templateSearchQuery} = settings
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setTemplateSearch(atmosphere, settingsId, e.currentTarget.value)
@@ -85,9 +97,10 @@ const SpotlightSearchBar = (props: Props) => {
         type='text'
         onChange={onChange}
         ref={inputRef}
+        value={templateSearchQuery ?? ''}
       />
     </Search>
   )
 }
 
-export default SpotlightSearchBar
+export default ReflectTemplateSearchBar

--- a/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
@@ -11,16 +11,25 @@ import useAtmosphere from '../../../hooks/useAtmosphere'
 import {PALETTE} from '../../../styles/paletteV3'
 import {ICON_SIZE} from '../../../styles/typographyV2'
 
+const SearchBarWrapper = styled('div')({
+  padding: '16px 16px 0 16px'
+})
+
 const Search = styled(MenuItemLabel)({
-  overflow: 'visible',
-  padding: 0,
+  alignItems: 'center',
+  border: `1px solid ${PALETTE.SLATE_400}`,
+  borderRadius: '40px',
   display: 'flex',
-  position: 'relative'
+  height: 40,
+  overflow: 'visible',
+  paddingLeft: 20,
+  position: 'relative',
+  width: '100%'
 })
 
 const StyledMenuItemIcon = styled(MenuItemComponentAvatar)({
   position: 'absolute',
-  left: 8,
+  left: 10,
   top: 8
 })
 
@@ -29,19 +38,32 @@ const SearchIcon = styled(Icon)({
   fontSize: ICON_SIZE.MD24
 })
 
+const ClearSearchIcon = styled(Icon)<{isEmpty: boolean}>(({isEmpty}) => ({
+  color: PALETTE.SLATE_500,
+  cursor: 'pointer',
+  padding: 8,
+  visibility: isEmpty ? 'hidden' : undefined
+}))
+
+const InputWrapper = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  flex: 1,
+  paddingLeft: 18
+})
+
 const SearchInput = styled('input')({
-  border: `1px solid ${PALETTE.SKY_500}`,
-  boxShadow: `inset 0px 0px 1px ${PALETTE.SKY_500}`,
+  appearance: 'none',
+  border: 'none',
+  borderLeft: `1px solid ${PALETTE.SLATE_400}`,
   color: PALETTE.SLATE_700,
-  display: 'block',
-  fontSize: 14,
-  lineHeight: '24px',
-  outline: 'none',
-  padding: '6px 0 6px 40px',
-  width: '100%',
-  '::placeholder': {
-    color: PALETTE.SLATE_600
-  }
+  fontSize: 16,
+  margin: 0,
+  padding: 12,
+  height: 40,
+  outline: 0,
+  backgroundColor: 'transparent',
+  width: '100%'
 })
 
 const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: string) => {
@@ -55,10 +77,11 @@ const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: st
 
 interface Props {
   settingsRef: ReflectTemplateSearchBar_settings$key
+  clearSearch: () => void
 }
 
 const ReflectTemplateSearchBar = (props: Props) => {
-  const {settingsRef} = props
+  const {clearSearch, settingsRef} = props
   const atmosphere = useAtmosphere()
   const settings = useFragment(
     graphql`
@@ -85,21 +108,28 @@ const ReflectTemplateSearchBar = (props: Props) => {
   }
 
   return (
-    <Search>
-      <StyledMenuItemIcon>
-        <SearchIcon>search</SearchIcon>
-      </StyledMenuItemIcon>
-      <SearchInput
-        onKeyDown={onKeyDown}
-        autoComplete='off'
-        name='search'
-        placeholder='Search templates...'
-        type='text'
-        onChange={onChange}
-        ref={inputRef}
-        value={templateSearchQuery ?? ''}
-      />
-    </Search>
+    <SearchBarWrapper>
+      <Search>
+        <StyledMenuItemIcon>
+          <SearchIcon>search</SearchIcon>
+        </StyledMenuItemIcon>
+        <InputWrapper>
+          <SearchInput
+            onKeyDown={onKeyDown}
+            autoComplete='off'
+            name='search'
+            placeholder='Search templates...'
+            type='text'
+            onChange={onChange}
+            ref={inputRef}
+            value={templateSearchQuery ?? ''}
+          />
+        </InputWrapper>
+        <ClearSearchIcon isEmpty={!templateSearchQuery} onClick={clearSearch}>
+          close
+        </ClearSearchIcon>
+      </Search>
+    </SearchBarWrapper>
   )
 }
 

--- a/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateSearchBar.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ChangeEvent, useRef} from 'react'
 import {commitLocalUpdate, useFragment} from 'react-relay'
+import {SharingScopeEnum} from '~/__generated__/ReflectTemplateItem_template.graphql'
 import {ReflectTemplateSearchBar_settings$key} from '~/__generated__/ReflectTemplateSearchBar_settings.graphql'
 import Atmosphere from '../../../Atmosphere'
 import Icon from '../../../components/Icon'
@@ -10,7 +11,6 @@ import MenuItemLabel from '../../../components/MenuItemLabel'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import {PALETTE} from '../../../styles/paletteV3'
 import {ICON_SIZE} from '../../../styles/typographyV2'
-import {templateIdxs} from './ReflectTemplateList'
 
 const SearchBarWrapper = styled('div')({
   padding: '16px 16px 0 16px'
@@ -76,13 +76,13 @@ const setTemplateSearch = (atmosphere: Atmosphere, settingsId: string, value: st
 }
 
 interface Props {
-  activeIdx: number
+  templateType: SharingScopeEnum
   clearSearch: () => void
   settingsRef: ReflectTemplateSearchBar_settings$key
 }
 
 const ReflectTemplateSearchBar = (props: Props) => {
-  const {activeIdx, clearSearch, settingsRef} = props
+  const {templateType, clearSearch, settingsRef} = props
   const atmosphere = useAtmosphere()
   const settings = useFragment(
     graphql`
@@ -94,7 +94,6 @@ const ReflectTemplateSearchBar = (props: Props) => {
     settingsRef
   )
   const {id: settingsId, templateSearchQuery} = settings
-  const templateType = Object.keys(templateIdxs).find((key) => templateIdxs[key] === activeIdx)
   const normalizedTempType = templateType === 'ORGANIZATION' ? 'org' : templateType?.toLowerCase()
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -108,6 +107,11 @@ const ReflectTemplateSearchBar = (props: Props) => {
       e.preventDefault()
       inputRef.current.blur()
     }
+  }
+
+  const handleClear = () => {
+    inputRef.current?.focus()
+    clearSearch()
   }
 
   return (
@@ -128,7 +132,7 @@ const ReflectTemplateSearchBar = (props: Props) => {
             value={templateSearchQuery ?? ''}
           />
         </InputWrapper>
-        <ClearSearchIcon isEmpty={!templateSearchQuery} onClick={clearSearch}>
+        <ClearSearchIcon isEmpty={!templateSearchQuery} onClick={handleClear}>
           close
         </ClearSearchIcon>
       </Search>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6791

This PR implements a search filter so users can quickly find the template they're looking for. The UI does not sparkle on mobile as there are existing template UI bugs as outlined in: https://github.com/ParabolInc/parabol/issues/5978

<details>

![template-filter](https://user-images.githubusercontent.com/39854876/174806795-610bb5ee-7425-4af1-9b50-4995692eae70.png)

</details>


### To test

- [ ] Typing in the search bar filters templates in Team, Organization, and Public
- [ ] If you begin typing in one tab, e.g. Public, and switch to the Team tab, the search query is removed