### PR TITLE
fix(saml): write to url field

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -36,6 +36,7 @@ graphql`
     }
   }
 `
+
 graphql`
   fragment AcceptTeamInvitationMutation_notification on AcceptTeamInvitationPayload {
     # this is just for the user that accepted the invitation

--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -143,6 +143,7 @@ export const handleAcceptTeamInvitationErrors = (
 ) => {
   if (acceptTeamInvitation?.error) {
     const {message} = acceptTeamInvitation.error
+    if (message === InvitationTokenError.ALREADY_ACCEPTED) return true
     atmosphere.eventEmitter.emit('addSnackbar', {
       autoDismiss: 0,
       key: `acceptTeamInvitation:${message}`,
@@ -175,10 +176,6 @@ const AcceptTeamInvitationMutation: StandardMutation<
         onCompleted(data, errors)
       }
       const {acceptTeamInvitation} = data
-      const isOK = ignoreApproval
-        ? true
-        : handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
-      if (!isOK) return
       const {authToken, team} = acceptTeamInvitation
       const serverError = getGraphQLError(data, errors)
       if (serverError) {
@@ -191,6 +188,10 @@ const AcceptTeamInvitationMutation: StandardMutation<
         }
         return
       }
+      const isOK = ignoreApproval
+        ? true
+        : handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
+      if (!isOK) return
       atmosphere.setAuthToken(authToken)
       if (!team) return
       const {id: teamId, name: teamName} = team

--- a/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
@@ -100,7 +100,12 @@ const enableSAMLForDomain: MutationResolvers['enableSAMLForDomain'] = async (
     if (!metadata || !signOnURL) return {error: {message: 'Invalid metadata'}}
     await r
       .table('SAML')
-      .insert({id: slugName, domains: normalizedDomains, metadata: metadata, signOnURL})
+      .insert({
+        id: slugName,
+        domains: normalizedDomains,
+        metadata: metadata,
+        url: signOnURL
+      })
       .run()
   }
 


### PR DESCRIPTION
# Description

I introduced this bug during the Org Approvals PR.
It wrote to the wrong field & typescript didn't catch it.
I still haven't figured out why typescript didn't catch it.
