### PR TITLE
chore: Hide bottom start meeting FAB on desktop

### DIFF
--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -84,6 +84,10 @@ const StartMeetingFAB = (props: Props) => {
   const onClick = () => {
     history.push(`/new-meeting/${teamId}?source=BottomFAB`)
   }
+  // We use the TopBarStartMeetingButton in this case
+  if (isDesktop) {
+    return null
+  }
   return (
     <Block className={className}>
       <Button onClick={onClick} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -29,7 +29,7 @@ const TopBarStartMeetingButton = () => {
   }
   return (
     <Button onClick={onClick}>
-      <MeetingLabel>Start Meeting</MeetingLabel>
+      <MeetingLabel>Add Meeting</MeetingLabel>
     </Button>
   )
 }


### PR DESCRIPTION
# Description

Relates-To:
* #6707 

Hide the bottom start meeting button on desktop so only one button is visible at any time

## Demo
![Peek 2022-06-22 09-32](https://user-images.githubusercontent.com/7331043/174972534-d7061248-e2d0-46ce-87b9-47b7c09c9edf.gif)

## Testing scenarios

Go to different dashboards in the app and verify the correct start meeting button is visible. Change the screen size and see the button change.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
