### PR TITLE
feat(Retrospective): Updated voting buttons to be clearer

### DIFF
--- a/packages/client/components/ReflectionGroupVoting.tsx
+++ b/packages/client/components/ReflectionGroupVoting.tsx
@@ -51,7 +51,7 @@ const UpvoteButton = styled(FlatButton)<{isExpanded: boolean; disabled: boolean}
   })
 )
 
-const VoteCount = styled('span')<{voteCount: number; isExpanded: boolean}>(
+const Votes = styled('span')<{voteCount: number; isExpanded: boolean}>(
   ({voteCount, isExpanded}) => ({
     color: isExpanded
       ? voteCount === 0
@@ -132,14 +132,10 @@ const ReflectionGroupVoting = (props: Props) => {
         >
           <Icon>remove</Icon>
         </UpvoteButton>
-        <VoteCount
-          isExpanded={isExpanded}
-          voteCount={viewerVoteCount}
-          data-cy={`completed-vote-count`}
-        >
+        <Votes isExpanded={isExpanded} voteCount={viewerVoteCount}>
           <ThumbUpIcon>{'thumb_up'}</ThumbUpIcon>
-          {viewerVoteCount}
-        </VoteCount>
+          <span data-cy={`completed-vote-count`}>{viewerVoteCount}</span>
+        </Votes>
         <UpvoteButton
           aria-label={`Add vote`}
           isExpanded={isExpanded}

--- a/packages/client/components/ReflectionGroupVoting.tsx
+++ b/packages/client/components/ReflectionGroupVoting.tsx
@@ -13,6 +13,7 @@ import isTempId from '../utils/relay/isTempId'
 import withMutationProps, {WithMutationProps} from '../utils/relay/withMutationProps'
 import {ReflectionGroupVoting_meeting} from '../__generated__/ReflectionGroupVoting_meeting.graphql'
 import {ReflectionGroupVoting_reflectionGroup} from '../__generated__/ReflectionGroupVoting_reflectionGroup.graphql'
+import FlatButton from './FlatButton'
 import Icon from './Icon'
 
 interface Props extends WithMutationProps {
@@ -36,22 +37,17 @@ const ThumbUpIcon = styled(Icon)({
   width: 24
 })
 
-const UpvoteIcon = styled(Icon)<{isExpanded: boolean; isEnabled: boolean}>(
-  ({isExpanded, isEnabled}) => ({
-    color: isExpanded
-      ? isEnabled
-        ? '#fff'
-        : 'rgba(255, 255, 255, .25)'
-      : isEnabled
-      ? PALETTE.SLATE_600
-      : PALETTE.SLATE_400,
-    cursor: isEnabled ? 'pointer' : undefined,
-    fontSize: ICON_SIZE.MD18,
+const UpvoteButton = styled(FlatButton)<{isExpanded: boolean; disabled: boolean}>(
+  ({isExpanded, disabled}) => ({
+    color: isExpanded ? '#fff' : PALETTE.SLATE_600,
     height: 24,
     lineHeight: '24px',
-    textAlign: 'center',
-    userSelect: 'none',
-    width: 24
+    padding: 0,
+    width: 24,
+    ':hover,:focus,:active': {
+      backgroundColor: !disabled ? (isExpanded ? PALETTE.SLATE_500 : PALETTE.SLATE_200) : undefined,
+      boxShadow: 'none'
+    }
   })
 )
 
@@ -127,15 +123,15 @@ const ReflectionGroupVoting = (props: Props) => {
   return (
     <UpvoteColumn>
       <UpvoteRow data-cy='reflection-vote-row'>
-        <UpvoteIcon
+        <UpvoteButton
           aria-label={`Remove vote`}
           isExpanded={isExpanded}
-          isEnabled={canDownvote}
+          disabled={!canDownvote}
           color={isExpanded ? PALETTE.SKY_400 : PALETTE.SKY_500}
           onClick={downvote}
         >
-          {'remove'}
-        </UpvoteIcon>
+          <Icon>remove</Icon>
+        </UpvoteButton>
         <VoteCount
           isExpanded={isExpanded}
           voteCount={viewerVoteCount}
@@ -144,15 +140,15 @@ const ReflectionGroupVoting = (props: Props) => {
           <ThumbUpIcon>{'thumb_up'}</ThumbUpIcon>
           {viewerVoteCount}
         </VoteCount>
-        <UpvoteIcon
+        <UpvoteButton
           aria-label={`Add vote`}
           isExpanded={isExpanded}
-          isEnabled={canUpvote}
+          disabled={!canUpvote}
           color={isExpanded ? 'rgba(255, 255, 255, .65)' : PALETTE.SLATE_600}
           onClick={vote}
         >
-          {'add'}
-        </UpvoteIcon>
+          <Icon>add</Icon>
+        </UpvoteButton>
       </UpvoteRow>
     </UpvoteColumn>
   )

--- a/packages/client/components/ReflectionGroupVoting.tsx
+++ b/packages/client/components/ReflectionGroupVoting.tsx
@@ -27,6 +27,15 @@ const UpvoteRow = styled('div')({
   justifyContent: 'flex-end'
 })
 
+const ThumbUpIcon = styled(Icon)({
+  fontSize: ICON_SIZE.MD18,
+  height: 24,
+  lineHeight: '24px',
+  textAlign: 'center',
+  userSelect: 'none',
+  width: 24
+})
+
 const UpvoteIcon = styled(Icon)<{isExpanded: boolean; isEnabled: boolean}>(
   ({isExpanded, isEnabled}) => ({
     color: isExpanded
@@ -57,6 +66,8 @@ const VoteCount = styled('span')<{voteCount: number; isExpanded: boolean}>(
       : PALETTE.SKY_500,
     fontWeight: 600,
     padding: '0 4px',
+    display: 'flex',
+    alignItems: 'center',
     userSelect: 'none'
   })
 )
@@ -123,13 +134,14 @@ const ReflectionGroupVoting = (props: Props) => {
           color={isExpanded ? PALETTE.SKY_400 : PALETTE.SKY_500}
           onClick={downvote}
         >
-          {'thumb_down'}
+          {'remove'}
         </UpvoteIcon>
         <VoteCount
           isExpanded={isExpanded}
           voteCount={viewerVoteCount}
           data-cy={`completed-vote-count`}
         >
+          <ThumbUpIcon>{'thumb_up'}</ThumbUpIcon>
           {viewerVoteCount}
         </VoteCount>
         <UpvoteIcon
@@ -139,7 +151,7 @@ const ReflectionGroupVoting = (props: Props) => {
           color={isExpanded ? 'rgba(255, 255, 255, .65)' : PALETTE.SLATE_600}
           onClick={vote}
         >
-          {'thumb_up'}
+          {'add'}
         </UpvoteIcon>
       </UpvoteRow>
     </UpvoteColumn>

--- a/packages/client/components/VoteSettingsMenu.tsx
+++ b/packages/client/components/VoteSettingsMenu.tsx
@@ -75,6 +75,7 @@ const VoteSettingsMenu = (props: Props) => {
       <VoteOption>
         <Label>Votes per participant</Label>
         <VoteStepper
+          aria-label='Votes per participant'
           value={totalVotes}
           increase={increaseTotalVotes}
           decrease={decreaseTotalVotes}
@@ -84,6 +85,7 @@ const VoteSettingsMenu = (props: Props) => {
       <VoteOption>
         <Label>Votes per topic</Label>
         <VoteStepper
+          aria-label='Votes per topic'
           value={maxVotesPerGroup}
           increase={increaseMaxVotesPerGroup}
           decrease={decreaseMaxVotesPerGroup}

--- a/packages/client/components/VoteSettingsStepper.tsx
+++ b/packages/client/components/VoteSettingsStepper.tsx
@@ -10,6 +10,7 @@ interface Props {
   increase(): void
   decrease(): void
   value: number
+  'aria-label'?: string
 }
 
 const Wrapper = styled('div')({
@@ -48,7 +49,7 @@ const VoteStepper = (props: Props) => {
       <Stepper isDisabled={!canDecrease} aria-label={'Decrease'} onClick={decrease}>
         <StyledIcon>remove</StyledIcon>
       </Stepper>
-      <Value>{value}</Value>
+      <Value aria-label={props['aria-label']}>{value}</Value>
       <Stepper isDisabled={!canIncrease} aria-label={'Increase'} onClick={increase}>
         <StyledIcon>add</StyledIcon>
       </Stepper>

--- a/packages/integration-tests/tests/retrospective-demo/step3-vote.test.ts
+++ b/packages/integration-tests/tests/retrospective-demo/step3-vote.test.ts
@@ -40,7 +40,8 @@ test.describe('retrospective-demo / vote page', () => {
     await expect(voteCount).toHaveText('2')
     await addVote.click()
     await expect(voteCount).toHaveText('3')
-    await addVote.click()
+    // button should be disabled, force click anyways in case this changes in the future
+    await addVote.click({force: true})
     await expect(voteCount).toHaveText('3') // 3 is the default maximum per-topic
   })
 
@@ -66,7 +67,8 @@ test.describe('retrospective-demo / vote page', () => {
     const group1AddVote = page.locator(`[data-cy="Start-group-1"] [aria-label="Add vote"]`)
     await group1AddVote.click()
     await group1AddVote.click()
-    await group1AddVote.click()
+    // button should be disabled, force click anyways in case this changes in the future
+    await group1AddVote.click({force: true})
     await expect(group1VoteCount).toHaveText('2') // Even though you clicked 3 times, you're out of votes
   })
 
@@ -75,7 +77,8 @@ test.describe('retrospective-demo / vote page', () => {
     const voteCount = page.locator(`[data-cy="Start-group-0"] [data-cy="completed-vote-count"]`)
     await expect(voteCount).toHaveText('0')
     const removeVote = page.locator(`[data-cy="Start-group-0"] [aria-label="Remove vote"]`)
-    await removeVote.click()
+    // button should be disabled, force click anyways in case this changes in the future
+    await removeVote.click({force: true})
     await expect(voteCount).toHaveText('0')
   })
 
@@ -136,7 +139,7 @@ test.describe('retrospective-demo / vote page', () => {
     await page.locator('text=Vote Settings').click()
 
     // Increase the maximum from 3 to 4
-    const votesPerTopic = page.locator('span:right-of(:text("Votes per topic")) >> nth=0')
+    const votesPerTopic = page.locator('[aria-label="Votes per topic"]')
     await expect(votesPerTopic).toHaveText('3')
     await page
       .locator('[aria-label="Increase"]:right-of(:text("Votes per topic")) >> nth=0')
@@ -156,7 +159,7 @@ test.describe('retrospective-demo / vote page', () => {
     await expect(voteCount).toHaveText('3')
     await addVote.click()
     await expect(voteCount).toHaveText('4')
-    await addVote.click()
+    await addVote.click({force: true})
     await expect(voteCount).toHaveText('4') // 4 is the new maximum
   })
 


### PR DESCRIPTION
# Description

Fixes #6750 
Replace thumbs up/thumbs down with + and - buttons for voting so it's less confusing.

## Demo
![Peek 2022-06-23 17-45](https://user-images.githubusercontent.com/7331043/175340643-392d8250-2411-4be6-b53b-c957a0fa1386.gif)
![Peek 2022-06-23 17-45-1](https://user-images.githubusercontent.com/7331043/175340657-8452338c-c185-4dc5-bd2d-15c1226c2855.gif)

## Testing scenarios

* Start a Retrospective, create some reflections and at least 1 group
* vote + and - on single reflections
* vote + and - on opened reflection group

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
