### PR TITLE
feat(standups): Decrease top/bottom list margins in standup response editor

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -42,8 +42,8 @@ const StyledEditor = styled('div')`
   .ProseMirror :is(ul, ol) {
     list-style-position: outside;
     padding-inline-start: 16px;
-    margin-block-start: 16px;
-    margin-block-end: 16px;
+    margin-block-start: 4px;
+    margin-block-end: 4px;
   }
 
   .ProseMirror :is(ol) {


### PR DESCRIPTION
# Description

This PR improves list styles in standups response editor by decreasing top/bottom margins a little.

## Demo

**Before**
![localhost_3000_meet_epTh68UyUE_responses (1)](https://user-images.githubusercontent.com/1017620/175317189-bfe29ac9-09e8-418c-be61-ea285d419fdb.png)

**After**
![localhost_3000_meet_epTh68UyUE_responses (2)](https://user-images.githubusercontent.com/1017620/175317232-bf40c848-6862-4f74-9751-3cecf32feecb.png)


## Testing scenarios

- [ ] Check the ordered list style
- [ ] Check the unordered list style

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
