### PR TITLE
feat(metrics): Add Segment event to track when onboarding user clicks the Demo Meeting Card

### DIFF
--- a/packages/client/components/DemoMeetingCard.tsx
+++ b/packages/client/components/DemoMeetingCard.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, {useCallback} from 'react'
 import {Link} from 'react-router-dom'
 import retrospective from '../../../static/images/illustrations/retrospective.png'
+import useAtmosphere from '../hooks/useAtmosphere'
 import useBreakpoint from '../hooks/useBreakpoint'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
 import {BezierCurve, Breakpoint, Card, ElementWidth} from '../types/constEnums'
@@ -102,9 +104,17 @@ const TopLine = styled('div')({
 
 const DemoMeetingCard = () => {
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
+  const atmospehere = useAtmosphere()
+  const {viewerId} = atmospehere
+
+  const onOpen = useCallback(() => {
+    SendClientSegmentEventMutation(atmospehere, 'Demo Meeting Card Clicked', {
+      viewerId
+    })
+  }, [])
 
   return (
-    <CardWrapper maybeTabletPlus={maybeTabletPlus}>
+    <CardWrapper maybeTabletPlus={maybeTabletPlus} onClick={onOpen}>
       <Link to={`/retrospective-demo`}>
         <MeetingImgWrapper>
           <MeetingImgBackground meetingType='retrospective' />


### PR DESCRIPTION
# Description

Fixes #6833 

## Demo
<img width="946" alt="Screen Shot 2022-06-24 at 2 33 31 PM" src="https://user-images.githubusercontent.com/1879975/175696528-f8244ebe-a419-41ae-82b3-3324362fba7b.png">


## Testing scenarios

- [ ] Scenario A
  - Create a new user
  - Click the demo meeting card
  - Verify the event was emitted in Segment

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
