### PR TITLE
fix: Added dismiss button to snackbar messages

### DIFF
--- a/packages/client/components/Snackbar.tsx
+++ b/packages/client/components/Snackbar.tsx
@@ -46,6 +46,7 @@ export interface Snack {
   onDismiss?: () => void
   action?: SnackAction
   secondaryAction?: SnackAction
+  showDismissButton?: boolean
 }
 
 const Snackbar = React.memo(() => {
@@ -169,6 +170,7 @@ const Snackbar = React.memo(() => {
             dismissSnack={dismiss}
             onMouseEnter={onMouseEnter(child)}
             onMouseLeave={onMouseLeave}
+            showDismissButton={child.showDismissButton}
           />
         )
       })}

--- a/packages/client/components/SnackbarMessage.tsx
+++ b/packages/client/components/SnackbarMessage.tsx
@@ -19,6 +19,7 @@ interface Props {
   secondaryAction?: SnackAction
   onMouseEnter: () => void
   onMouseLeave: () => void
+  showDismissButton?: boolean
 }
 
 const Space = styled('div')({
@@ -85,23 +86,22 @@ const SnackbarMessage = (props: Props) => {
     onTransitionEnd,
     dismissSnack,
     onMouseEnter,
-    onMouseLeave
+    onMouseLeave,
+    showDismissButton
   } = props
   useTransitionEnd(300, status, onTransitionEnd)
-  //Currently do not need dismiss button
-  const displayDismissButton = false
   return (
     <Space>
       <MessageStyles
         status={status}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        onClick={displayDismissButton ? undefined : dismissSnack}
+        onClick={dismissSnack}
       >
         <Text>{message}</Text>
         <SnackbarMessageAction action={action} />
         <SnackbarMessageAction action={secondaryAction} />
-        {displayDismissButton && (
+        {showDismissButton && (
           <DismissButton onClick={dismissSnack}>
             <StyledIcon>close</StyledIcon>
           </DismissButton>

--- a/packages/client/components/SnackbarMessage.tsx
+++ b/packages/client/components/SnackbarMessage.tsx
@@ -7,6 +7,8 @@ import {PALETTE} from '../styles/paletteV3'
 import {Radius, ZIndex} from '../types/constEnums'
 import {SnackAction} from './Snackbar'
 import SnackbarMessageAction from './SnackbarMessageAction'
+import {ICON_SIZE} from '../styles/typographyV2'
+import Icon from './Icon'
 
 interface Props {
   onTransitionEnd: () => void
@@ -45,6 +47,22 @@ const MessageStyles = styled('div')<{status: TransitionStatus}>(({status}) => ({
   zIndex: ZIndex.SNACKBAR
 }))
 
+const DismissButton = styled('button')({
+  border: 'none',
+  backgroundColor: 'inherit',
+  marginLeft: '8px',
+  cursor: 'pointer',
+  padding: 5
+
+})
+
+const StyledIcon = styled (Icon)({
+  color: PALETTE.SLATE_500,
+  fontSize: ICON_SIZE.MD18,
+  '&:hover': {
+    opacity: 0.5
+  }
+})
 const useTransitionEnd = (
   timeout: number,
   status: TransitionStatus,
@@ -71,13 +89,15 @@ const SnackbarMessage = (props: Props) => {
     <Space>
       <MessageStyles
         status={status}
-        onClick={dismissSnack}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
         <Text>{message}</Text>
         <SnackbarMessageAction action={action} />
         <SnackbarMessageAction action={secondaryAction} />
+        <DismissButton onClick={dismissSnack}>
+          <StyledIcon>close</StyledIcon>
+        </DismissButton>
       </MessageStyles>
     </Space>
   )

--- a/packages/client/components/SnackbarMessage.tsx
+++ b/packages/client/components/SnackbarMessage.tsx
@@ -88,15 +88,24 @@ const SnackbarMessage = (props: Props) => {
     onMouseLeave
   } = props
   useTransitionEnd(300, status, onTransitionEnd)
+  //Currently do not need dismiss button
+  const displayDismissButton = false
   return (
     <Space>
-      <MessageStyles status={status} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+      <MessageStyles
+        status={status}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onClick={displayDismissButton ? undefined : dismissSnack}
+      >
         <Text>{message}</Text>
         <SnackbarMessageAction action={action} />
         <SnackbarMessageAction action={secondaryAction} />
-        <DismissButton onClick={dismissSnack}>
-          <StyledIcon>close</StyledIcon>
-        </DismissButton>
+        {displayDismissButton && (
+          <DismissButton onClick={dismissSnack}>
+            <StyledIcon>close</StyledIcon>
+          </DismissButton>
+        )}
       </MessageStyles>
     </Space>
   )

--- a/packages/client/components/SnackbarMessage.tsx
+++ b/packages/client/components/SnackbarMessage.tsx
@@ -4,11 +4,11 @@ import {TransitionStatus} from '../hooks/useTransition'
 import {DECELERATE} from '../styles/animation'
 import {snackbarShadow} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
+import {ICON_SIZE} from '../styles/typographyV2'
 import {Radius, ZIndex} from '../types/constEnums'
+import Icon from './Icon'
 import {SnackAction} from './Snackbar'
 import SnackbarMessageAction from './SnackbarMessageAction'
-import {ICON_SIZE} from '../styles/typographyV2'
-import Icon from './Icon'
 
 interface Props {
   onTransitionEnd: () => void
@@ -40,8 +40,9 @@ const MessageStyles = styled('div')<{status: TransitionStatus}>(({status}) => ({
   padding: 8,
   transition: `all 300ms ${DECELERATE}`,
   opacity: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : 1,
-  transform: `translateY(${status === TransitionStatus.MOUNTED ? 20 : status === TransitionStatus.EXITING ? -20 : 0
-    }px)`,
+  transform: `translateY(${
+    status === TransitionStatus.MOUNTED ? 20 : status === TransitionStatus.EXITING ? -20 : 0
+  }px)`,
   pointerEvents: 'auto',
   userSelect: 'none',
   zIndex: ZIndex.SNACKBAR
@@ -52,11 +53,13 @@ const DismissButton = styled('button')({
   backgroundColor: 'inherit',
   marginLeft: '8px',
   cursor: 'pointer',
-  padding: 5
-
+  padding: 5,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
 })
 
-const StyledIcon = styled (Icon)({
+const StyledIcon = styled(Icon)({
   color: PALETTE.SLATE_500,
   fontSize: ICON_SIZE.MD18,
   '&:hover': {
@@ -87,11 +90,7 @@ const SnackbarMessage = (props: Props) => {
   useTransitionEnd(300, status, onTransitionEnd)
   return (
     <Space>
-      <MessageStyles
-        status={status}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
+      <MessageStyles status={status} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
         <Text>{message}</Text>
         <SnackbarMessageAction action={action} />
         <SnackbarMessageAction action={secondaryAction} />

--- a/packages/client/components/SnackbarMessageAction.tsx
+++ b/packages/client/components/SnackbarMessageAction.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
-import {SnackAction} from './Snackbar'
 import styled from '@emotion/styled'
-import PlainButton from './PlainButton/PlainButton'
+import React from 'react'
+import {DECELERATE} from '../styles/animation'
 import {PALETTE} from '../styles/paletteV3'
 import {Radius} from '../types/constEnums'
+import PlainButton from './PlainButton/PlainButton'
+import {SnackAction} from './Snackbar'
 
 interface Props {
   action: SnackAction | null | undefined
@@ -16,7 +17,10 @@ const Action = styled(PlainButton)({
   fontWeight: 600,
   marginLeft: 8,
   padding: 8,
-  backgroundColor: '#ffffff0e'
+  transition: `background 100ms ${DECELERATE}`,
+  ':hover,:focus,:active': {
+    backgroundColor: '#ffffff0e'
+  }
 })
 
 const SnackbarMessageAction = (props: Props) => {

--- a/packages/client/components/SnackbarMessageAction.tsx
+++ b/packages/client/components/SnackbarMessageAction.tsx
@@ -19,7 +19,7 @@ const Action = styled(PlainButton)({
   padding: 8,
   transition: `background 100ms ${DECELERATE}`,
   ':hover,:focus,:active': {
-    backgroundColor: '#ffffff0e'
+    backgroundColor: '#ffffff1a'
   }
 })
 

--- a/packages/client/components/SnackbarMessageAction.tsx
+++ b/packages/client/components/SnackbarMessageAction.tsx
@@ -3,23 +3,20 @@ import {SnackAction} from './Snackbar'
 import styled from '@emotion/styled'
 import PlainButton from './PlainButton/PlainButton'
 import {PALETTE} from '../styles/paletteV3'
-import {DECELERATE} from '../styles/animation'
+import {Radius} from '../types/constEnums'
 
 interface Props {
   action: SnackAction | null | undefined
 }
 
 const Action = styled(PlainButton)({
-  borderRadius: 2,
+  borderRadius: Radius.SNACKBAR,
   color: PALETTE.ROSE_500,
   fontSize: 14,
   fontWeight: 600,
   marginLeft: 8,
   padding: 8,
-  transition: `background 100ms ${DECELERATE}`,
-  ':hover,:focus,:active': {
-    backgroundColor: '#ffffff0e'
-  }
+  backgroundColor: '#ffffff0e'
 })
 
 const SnackbarMessageAction = (props: Props) => {

--- a/packages/client/components/SnackbarMessageAction.tsx
+++ b/packages/client/components/SnackbarMessageAction.tsx
@@ -17,9 +17,10 @@ const Action = styled(PlainButton)({
   fontWeight: 600,
   marginLeft: 8,
   padding: 8,
+  backgroundColor: '#ffffff17',
   transition: `background 100ms ${DECELERATE}`,
   ':hover,:focus,:active': {
-    backgroundColor: '#ffffff1a'
+    backgroundColor: '#ffffff26'
   }
 })
 


### PR DESCRIPTION
# Description

fixes #6218

## Demo

![Screenshot 2022-06-22 140132](https://user-images.githubusercontent.com/106697681/174983368-801c771e-049c-4938-a894-48794c25ab00.png)

![Screenshot 2022-06-22 140046](https://user-images.githubusercontent.com/106697681/174982856-e0cb9b21-81d0-4659-a250-a0bf7d73b701.png)


## Testing scenarios

Try to generate different snackbar messages and verify the dismiss button and its functionality.

