### PR TITLE
feat: New meeting dialog is now a modal

### DIFF
--- a/packages/client/components/AuthenticationPage.tsx
+++ b/packages/client/components/AuthenticationPage.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled'
 import React from 'react'
 import useCanonical from '~/hooks/useCanonical'
 import useAtmosphere from '../hooks/useAtmosphere'
@@ -6,7 +7,6 @@ import useRouter from '../hooks/useRouter'
 import getValidRedirectParam from '../utils/getValidRedirectParam'
 import GenericAuthentication, {AuthPageSlug, GotoAuthPage} from './GenericAuthentication'
 import TeamInvitationWrapper from './TeamInvitationWrapper'
-import styled from '@emotion/styled'
 
 const CopyBlock = styled('div')({
   marginBottom: 48,

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
+import {Location} from 'history'
 import React, {lazy, useRef} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {Route, Switch} from 'react-router'
+import {Route, Switch, useLocation} from 'react-router'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import useSnackNag from '~/hooks/useSnackNag'
 import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
@@ -37,6 +38,9 @@ const NewTeam = lazy(
     import(
       /* webpackChunkName: 'NewTeamRoot' */ '../modules/newTeam/containers/NewTeamForm/NewTeamRoot'
     )
+)
+const NewMeetingRoot = lazy(
+  () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
 )
 
 interface Props {
@@ -128,6 +132,10 @@ const Dashboard = (props: Props) => {
   useSnackNag(overLimitCopy)
   useUsageSnackNag(insights)
   useSnacksForNewMeetings(activeMeetings)
+
+  const location = useLocation<{backgroundLocation?: Location}>()
+  const state = location.state
+
   return (
     <DashLayout>
       <SkipLink href='#main'>Skip to content</SkipLink>
@@ -145,9 +153,9 @@ const Dashboard = (props: Props) => {
           </SwipeableDashSidebar>
         )}
         <DashMain id='main' ref={meetingsDashRef}>
-          <Switch>
+          <Switch location={state?.backgroundLocation || location}>
             <Route
-              path='/meetings'
+              path='(/meetings|/new-meeting)'
               render={(routeProps) => (
                 <MeetingsDash {...routeProps} meetingsDashRef={meetingsDashRef} viewer={viewer} />
               )}
@@ -156,6 +164,9 @@ const Dashboard = (props: Props) => {
             <Route path='/team/:teamId' component={TeamRoot} />
             <Route path='/newteam/:defaultOrgId?' component={NewTeam} />
             <Route path='/usage' component={InsightsRoot} />
+          </Switch>
+          <Switch>
+            <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
           </Switch>
         </DashMain>
       </DashPanel>

--- a/packages/client/components/FlatPrimaryButton.tsx
+++ b/packages/client/components/FlatPrimaryButton.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled'
+import React, {forwardRef} from 'react'
+import {PALETTE} from '~/styles/paletteV3'
+import {Radius} from '~/types/constEnums'
+import BaseButton, {BaseButtonProps} from './BaseButton'
+
+const StyledBaseButton = styled(BaseButton)((props: BaseButtonProps) => {
+  const {disabled, waiting} = props
+  const visuallyDisabled = disabled || waiting
+  return {
+    backgroundImage: visuallyDisabled
+      ? PALETTE.GRADIENT_TOMATO_400_ROSE_300
+      : PALETTE.GRADIENT_TOMATO_600_ROSE_500,
+    borderRadius: Radius.BUTTON_PILL,
+    color: '#FFFFFF',
+    fontWeight: 600,
+    opacity: visuallyDisabled ? 1 : undefined,
+    outline: 0,
+    ':hover,:focus,:active': {
+      backgroundImage: visuallyDisabled
+        ? PALETTE.GRADIENT_TOMATO_400_ROSE_300
+        : PALETTE.GRADIENT_TOMATO_700_ROSE_600,
+      opacity: visuallyDisabled ? 1 : undefined
+    }
+  }
+})
+
+interface Props extends BaseButtonProps {}
+
+const FlatPrimaryButton = forwardRef((props: Props, ref: any) => {
+  const {children, className} = props
+  return (
+    <StyledBaseButton {...props} ref={ref} className={className}>
+      {children}
+    </StyledBaseButton>
+  )
+})
+
+export default FlatPrimaryButton

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -31,10 +31,11 @@ interface Props {
 
 const MEDIA_QUERY_VERTICAL_CENTERING = '@media screen and (min-height: 840px)'
 
-const IllustrationAndSelector = styled('div')({
+const IllustrationAndSelector = styled('div')<{isDesktop}>(({isDesktop}) => ({
   gridArea: 'picker',
-  width: '100%'
-})
+  width: '100%',
+  paddingBottom: isDesktop ? 0 : 32
+}))
 
 const TeamAndSettings = styled('div')<{isDesktop}>(({isDesktop}) => ({
   alignItems: 'center',
@@ -167,7 +168,7 @@ const NewMeeting = (props: Props) => {
         </CloseButton>
       </Title>
       <NewMeetingInner isDesktop={isDesktop}>
-        <IllustrationAndSelector>
+        <IllustrationAndSelector isDesktop={isDesktop}>
           <NewMeetingIllustration idx={idx} setIdx={setIdx} newMeetingOrder={newMeetingOrder} />
           <NewMeetingMeetingSelector meetingType={meetingType} idx={idx} setIdx={setIdx} />
         </IllustrationAndSelector>

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -65,8 +65,11 @@ const Title = styled(DialogTitle)({
 })
 
 const CloseButton = styled(FlatButton)({
-  padding: 8,
-  color: PALETTE.SLATE_600
+  position: 'absolute',
+  top: 8,
+  right: 8,
+  color: PALETTE.SLATE_600,
+  padding: 0
 })
 
 const NewMeetingInner = styled('div')<{isDesktop: boolean}>(

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -3,8 +3,8 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {useEffect, useMemo, useRef, useState} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {mod} from 'react-swipeable-views-core'
-import WaveSVG from 'static/images/wave.svg'
 import useUsageSnackNag from '~/hooks/useUsageSnackNag'
+import {PALETTE} from '~/styles/paletteV3'
 import {NonEmptyArray} from '~/types/generics'
 import {MeetingTypeEnum, NewMeetingQuery} from '~/__generated__/NewMeetingQuery.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
@@ -12,8 +12,11 @@ import useRouter from '../hooks/useRouter'
 import {Elevation} from '../styles/elevation'
 import {Breakpoint} from '../types/constEnums'
 import sortByTier from '../utils/sortByTier'
+import DialogContainer from './DialogContainer'
+import DialogTitle from './DialogTitle'
+import FlatButton from './FlatButton'
+import IconLabel from './IconLabel'
 import NewMeetingActions from './NewMeetingActions'
-import NewMeetingBackButton from './NewMeetingBackButton'
 import NewMeetingHowTo from './NewMeetingHowTo'
 import NewMeetingIllustration from './NewMeetingIllustration'
 import NewMeetingMeetingSelector from './NewMeetingMeetingSelector'
@@ -23,6 +26,7 @@ import NewMeetingTeamPicker from './NewMeetingTeamPicker'
 interface Props {
   teamId?: string | null
   queryRef: PreloadedQuery<NewMeetingQuery>
+  onClose: () => void
 }
 
 const MEDIA_QUERY_VERTICAL_CENTERING = '@media screen and (min-height: 840px)'
@@ -48,27 +52,24 @@ const TeamAndSettingsInner = styled('div')({
   boxShadow: Elevation.Z1
 })
 
-const NewMeetingBlock = styled('div')<{innerWidth: number; isDesktop: boolean}>(
-  {
-    alignItems: 'flex-start',
-    backgroundImage: 'linear-gradient(0deg, #F1F0FA 25%, #FFFFFF 50%)',
-    backgroundRepeat: 'no-repeat',
-    display: 'flex',
-    flexDirection: 'column',
-    justifyItems: 'center',
-    minHeight: '100%'
-  },
-  ({innerWidth, isDesktop}) =>
-    isDesktop && {
-      backgroundImage: `url('${WaveSVG}'), linear-gradient(0deg, #F1F0FA 50%, #FFFFFF 50%)`,
-      backgroundSize: '100%',
-      // the wave is 2560x231, so to figure out the offset from the center, we need to find how much scaling there was
-      backgroundPositionY: `calc(50% - ${Math.floor(((innerWidth / 2560) * 231) / 2 - 1)}px), 0`,
-      height: '100%',
-      minHeight: 0,
-      overflow: 'auto'
-    }
-)
+const NewMeetingDialog = styled(DialogContainer)({
+  width: '800px',
+  maxHeight: 'unset'
+})
+
+const Title = styled(DialogTitle)({
+  fontSize: 24,
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  paddingBottom: 16
+})
+
+const CloseButton = styled(FlatButton)({
+  padding: 8,
+  color: PALETTE.SLATE_600
+})
 
 const NewMeetingInner = styled('div')<{isDesktop: boolean}>(
   {
@@ -92,20 +93,6 @@ const NewMeetingInner = styled('div')<{isDesktop: boolean}>(
       padding: '0 32px 16px 64px'
     }
 )
-
-const useInnerWidth = () => {
-  const [innerWidth, setInnerWidth] = useState(() => window.innerWidth)
-  useEffect(() => {
-    const resizeWindow = () => {
-      setInnerWidth(window.innerWidth)
-    }
-    window.addEventListener('resize', resizeWindow, {passive: true})
-    return () => {
-      window.removeEventListener('resize', resizeWindow)
-    }
-  }, [])
-  return innerWidth
-}
 
 const createMeetingOrder = ({standups}: {standups: boolean}) => {
   const meetingOrder: NonEmptyArray<MeetingTypeEnum> = ['poker', 'retrospective', 'action']
@@ -139,7 +126,7 @@ const query = graphql`
 `
 
 const NewMeeting = (props: Props) => {
-  const {teamId, queryRef} = props
+  const {teamId, queryRef, onClose} = props
   const data = usePreloadedQuery<NewMeetingQuery>(query, queryRef, {
     UNSTABLE_renderPolicy: 'full'
   })
@@ -148,8 +135,7 @@ const NewMeeting = (props: Props) => {
   const {insights} = featureFlags
   const newMeetingOrder = useMemo(() => createMeetingOrder(featureFlags), [featureFlags])
 
-  const {history} = useRouter()
-  const innerWidth = useInnerWidth()
+  const {history, location} = useRouter()
   const [idx, setIdx] = useState(0)
   useUsageSnackNag(insights)
   const meetingType = newMeetingOrder[mod(idx, newMeetingOrder.length)] as MeetingTypeEnum
@@ -159,7 +145,7 @@ const NewMeeting = (props: Props) => {
       sendToMeRef.current = true
       const [firstTeam] = sortByTier(teams)
       const nextPath = firstTeam ? `/new-meeting/${firstTeam.id}` : '/newteam'
-      history.replace(nextPath)
+      history.replace(nextPath, location.state)
     }
   }, [])
   const isDesktop = useBreakpoint(Breakpoint.NEW_MEETING_GRID)
@@ -172,8 +158,13 @@ const NewMeeting = (props: Props) => {
   }, [])
   if (!teamId || !selectedTeam) return null
   return (
-    <NewMeetingBlock innerWidth={innerWidth} isDesktop={isDesktop}>
-      <NewMeetingBackButton teamId={teamId} sendToMe={sendToMeRef.current} />
+    <NewMeetingDialog>
+      <Title>
+        New meeting
+        <CloseButton onClick={onClose}>
+          <IconLabel icon='close' iconLarge />
+        </CloseButton>
+      </Title>
       <NewMeetingInner isDesktop={isDesktop}>
         <IllustrationAndSelector>
           <NewMeetingIllustration idx={idx} setIdx={setIdx} newMeetingOrder={newMeetingOrder} />
@@ -186,9 +177,9 @@ const NewMeeting = (props: Props) => {
             <NewMeetingSettings selectedTeam={selectedTeam} meetingType={meetingType} />
           </TeamAndSettingsInner>
         </TeamAndSettings>
-        <NewMeetingActions team={selectedTeam} meetingType={meetingType} />
       </NewMeetingInner>
-    </NewMeetingBlock>
+      <NewMeetingActions team={selectedTeam} meetingType={meetingType} onClose={onClose} />
+    </NewMeetingDialog>
   )
 }
 

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -42,9 +42,7 @@ const TeamAndSettings = styled('div')<{isDesktop}>(({isDesktop}) => ({
   flexDirection: 'column',
   gridArea: 'settings',
   marginTop: isDesktop ? 32 : undefined,
-  [MEDIA_QUERY_VERTICAL_CENTERING]: {
-    minHeight: isDesktop ? undefined : 166
-  }
+  minHeight: 166
 }))
 
 const TeamAndSettingsInner = styled('div')({
@@ -63,7 +61,7 @@ const Title = styled(DialogTitle)({
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'space-between',
-  paddingBottom: 16
+  paddingBottom: 24
 })
 
 const CloseButton = styled(FlatButton)({
@@ -90,7 +88,7 @@ const NewMeetingInner = styled('div')<{isDesktop: boolean}>(
       margin: 'auto',
       maxHeight: 640,
       maxWidth: 1400,
-      padding: '0 32px 16px 64px'
+      padding: '0 64px 16px 64px'
     }
 )
 

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -12,7 +12,6 @@ import useMutationProps from '../hooks/useMutationProps'
 import useRouter from '../hooks/useRouter'
 import StartSprintPokerMutation from '../mutations/StartSprintPokerMutation'
 import {Breakpoint} from '../types/constEnums'
-import FlatButton from './FlatButton'
 import FlatPrimaryButton from './FlatPrimaryButton'
 import NewMeetingActionsCurrentMeetings from './NewMeetingActionsCurrentMeetings'
 import StyledError from './StyledError'
@@ -53,16 +52,8 @@ const StartButton = styled(FlatPrimaryButton)({
   height: 50,
   [narrowScreenMediaQuery]: {
     paddingLeft: 16,
-    paddingRight: 16
-  }
-})
-
-const CancelButton = styled(FlatButton)({
-  fontSize: 20,
-  height: 50,
-  [narrowScreenMediaQuery]: {
-    paddingLeft: 16,
-    paddingRight: 16
+    paddingRight: 16,
+    marginLeft: 'auto'
   }
 })
 
@@ -73,7 +64,7 @@ interface Props {
 }
 
 const NewMeetingActions = (props: Props) => {
-  const {team, meetingType, onClose} = props
+  const {team, meetingType} = props
   const {id: teamId} = team
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
@@ -99,7 +90,6 @@ const NewMeetingActions = (props: Props) => {
         {error && <StyledError>{error.message}</StyledError>}
       </ActiveMeetingsBlock>
       <ButtonBlock>
-        <CancelButton onClick={onClose}>Cancel</CancelButton>
         <StartButton onClick={onStartMeetingClick} waiting={submitting}>
           Start Meeting
         </StartButton>

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -26,7 +26,7 @@ const ActionRow = styled('div')({
   justifyContent: 'space-between',
   flexWrap: 'wrap',
   padding: 24,
-  paddingBottom: 16
+  paddingTop: 16
 })
 
 const ActiveMeetingsBlock = styled('div')({
@@ -35,7 +35,7 @@ const ActiveMeetingsBlock = styled('div')({
   flexDirection: 'row',
   flexWrap: 'nowrap',
   flexGrow: 10,
-  paddingBottom: 8
+  paddingTop: 8
 })
 
 const ButtonBlock = styled('div')({
@@ -45,7 +45,7 @@ const ButtonBlock = styled('div')({
   flexWrap: 'nowrap',
   justifyContent: 'space-between',
   flexGrow: 1,
-  paddingBottom: 8
+  paddingTop: 8
 })
 
 const StartButton = styled(FlatPrimaryButton)({

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -52,8 +52,8 @@ const StartButton = styled(FlatPrimaryButton)({
   fontSize: 20,
   height: 50,
   [narrowScreenMediaQuery]: {
-    paddingLeft: '1em',
-    paddingRight: '1em'
+    paddingLeft: 16,
+    paddingRight: 16
   }
 })
 
@@ -61,8 +61,8 @@ const CancelButton = styled(FlatButton)({
   fontSize: 20,
   height: 50,
   [narrowScreenMediaQuery]: {
-    paddingLeft: '1em',
-    paddingRight: '1em'
+    paddingLeft: 16,
+    paddingRight: 16
   }
 })
 

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -8,61 +8,76 @@ import StartTeamPromptMutation from '~/mutations/StartTeamPromptMutation'
 import {NewMeetingActions_team} from '~/__generated__/NewMeetingActions_team.graphql'
 import {MeetingTypeEnum} from '~/__generated__/NewMeetingQuery.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
-import useBreakpoint from '../hooks/useBreakpoint'
 import useMutationProps from '../hooks/useMutationProps'
 import useRouter from '../hooks/useRouter'
 import StartSprintPokerMutation from '../mutations/StartSprintPokerMutation'
 import {Breakpoint} from '../types/constEnums'
-import Icon from './Icon'
+import FlatButton from './FlatButton'
+import FlatPrimaryButton from './FlatPrimaryButton'
 import NewMeetingActionsCurrentMeetings from './NewMeetingActionsCurrentMeetings'
-import PrimaryButton from './PrimaryButton'
 import StyledError from './StyledError'
 
-const newMeetingGridMediaQuery = `@media screen and (min-width: ${Breakpoint.NEW_MEETING_GRID}px)`
+const narrowScreenMediaQuery = `@media screen and (max-width: ${Breakpoint.FUZZY_TABLET}px)`
 
-const ButtonBlock = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
+const ActionRow = styled('div')({
   alignItems: 'center',
   display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
-  justifyContent: isDesktop ? 'flex-start' : 'flex-end',
-  gridArea: 'actions',
-  padding: '24px 8px',
-  width: '100%',
-  [newMeetingGridMediaQuery]: {
-    padding: '32px 8px'
-  }
-}))
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  flexWrap: 'wrap',
+  padding: 24,
+  paddingBottom: 16
+})
 
-const StartButton = styled(PrimaryButton)({
-  fontSize: 18,
-  width: 320,
-  maxWidth: '100%',
-  [newMeetingGridMediaQuery]: {
-    fontSize: 24,
-    height: 64
+const ActiveMeetingsBlock = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+  flexGrow: 10,
+  paddingBottom: 8
+})
+
+const ButtonBlock = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
+  justifyContent: 'space-between',
+  flexGrow: 1,
+  paddingBottom: 8
+})
+
+const StartButton = styled(FlatPrimaryButton)({
+  fontSize: 20,
+  height: 50,
+  [narrowScreenMediaQuery]: {
+    paddingLeft: '1em',
+    paddingRight: '1em'
   }
 })
 
-const ForwardIcon = styled(Icon)({
-  paddingLeft: 16,
-  [newMeetingGridMediaQuery]: {
-    fontSize: 36 // MD 1.5x
+const CancelButton = styled(FlatButton)({
+  fontSize: 20,
+  height: 50,
+  [narrowScreenMediaQuery]: {
+    paddingLeft: '1em',
+    paddingRight: '1em'
   }
 })
 
 interface Props {
   meetingType: MeetingTypeEnum
   team: NewMeetingActions_team
+  onClose: () => void
 }
 
 const NewMeetingActions = (props: Props) => {
-  const {team, meetingType} = props
+  const {team, meetingType, onClose} = props
   const {id: teamId} = team
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   const {submitMutation, error, submitting, onError, onCompleted} = useMutationProps()
-  const isDesktop = useBreakpoint(Breakpoint.NEW_MEETING_SELECTOR)
   const onStartMeetingClick = () => {
     if (submitting) return
     submitMutation()
@@ -78,14 +93,18 @@ const NewMeetingActions = (props: Props) => {
   }
 
   return (
-    <ButtonBlock isDesktop={isDesktop}>
-      <NewMeetingActionsCurrentMeetings team={team} />
-      {error && <StyledError>{error.message}</StyledError>}
-      <StartButton size={'large'} onClick={onStartMeetingClick} waiting={submitting}>
-        Start Meeting
-        <ForwardIcon>arrow_forward</ForwardIcon>
-      </StartButton>
-    </ButtonBlock>
+    <ActionRow>
+      <ActiveMeetingsBlock>
+        <NewMeetingActionsCurrentMeetings team={team} />
+        {error && <StyledError>{error.message}</StyledError>}
+      </ActiveMeetingsBlock>
+      <ButtonBlock>
+        <CancelButton onClick={onClose}>Cancel</CancelButton>
+        <StartButton onClick={onStartMeetingClick} waiting={submitting}>
+          Start Meeting
+        </StartButton>
+      </ButtonBlock>
+    </ActionRow>
   )
 }
 

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -2,12 +2,10 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
-import useBreakpoint from '~/hooks/useBreakpoint'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 import {PALETTE} from '~/styles/paletteV3'
-import {Breakpoint} from '~/types/constEnums'
 import plural from '~/utils/plural'
 import {NewMeetingActionsCurrentMeetings_team} from '~/__generated__/NewMeetingActionsCurrentMeetings_team.graphql'
 import FlatButton from './FlatButton'
@@ -18,7 +16,7 @@ const CurrentButton = styled(FlatButton)<{hasMeetings: boolean}>(({hasMeetings})
   color: PALETTE.ROSE_500,
   fontSize: 16,
   fontWeight: 600,
-  height: 50,
+  height: hasMeetings ? 50 : 0,
   visibility: hasMeetings ? undefined : 'hidden'
 }))
 
@@ -32,16 +30,17 @@ interface Props {
 
 const NewMeetingActionsCurrentMeetings = (props: Props) => {
   const {team} = props
-  const isDesktop = useBreakpoint(Breakpoint.NEW_MEETING_GRID)
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu<HTMLButtonElement>(
     MenuPosition.LOWER_RIGHT,
-    {isDropdown: true}
+    {
+      parentId: 'newMeetingRoot',
+      isDropdown: true
+    }
   )
   const {activeMeetings} = team
   useSnacksForNewMeetings(activeMeetings)
   const meetingCount = activeMeetings.length
   const label = `${meetingCount} Active ${plural(meetingCount, 'Meeting')}`
-  if (meetingCount === 0 && !isDesktop) return null
   return (
     <>
       <CurrentButton

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -5,7 +5,7 @@ import {createFragmentContainer} from 'react-relay'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
-import {Elevation} from '~/styles/elevation'
+import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 import {PALETTE} from '~/styles/paletteV3'
 import {Breakpoint} from '~/types/constEnums'
 import plural from '~/utils/plural'
@@ -13,18 +13,12 @@ import {NewMeetingActionsCurrentMeetings_team} from '~/__generated__/NewMeetingA
 import FlatButton from './FlatButton'
 import Icon from './Icon'
 import SelectMeetingDropdown from './SelectMeetingDropdown'
-import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 
 const CurrentButton = styled(FlatButton)<{hasMeetings: boolean}>(({hasMeetings}) => ({
   color: PALETTE.ROSE_500,
-  fontSize: 14,
+  fontSize: 16,
   fontWeight: 600,
-  padding: '4px 16px',
-  marginBottom: 24,
-  ':hover': {
-    backgroundColor: '#fff',
-    boxShadow: Elevation.BUTTON_RAISED
-  },
+  height: 50,
   visibility: hasMeetings ? undefined : 'hidden'
 }))
 

--- a/packages/client/components/NewMeetingHowTo.tsx
+++ b/packages/client/components/NewMeetingHowTo.tsx
@@ -1,59 +1,30 @@
 import styled from '@emotion/styled'
-import React, {useRef, useState} from 'react'
+import React from 'react'
 import {MeetingTypeEnum} from '~/__generated__/NewMeetingQuery.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
-import {BezierCurve, Breakpoint} from '../types/constEnums'
-import ExpansionPanelSummary from './ExpansionPanelSummary'
+import {Breakpoint} from '../types/constEnums'
 import NewMeetingHowToSteps from './NewMeetingHowToSteps'
 
 interface Props {
   meetingType: MeetingTypeEnum
 }
 
-const Parent = styled('div')<{isDesktop?: boolean}>(({isDesktop}) => ({
+const Parent = styled('div')({
   gridArea: 'howto',
-  maxWidth: isDesktop ? undefined : 424,
-  margin: isDesktop ? undefined : '0 auto',
-  paddingLeft: isDesktop ? '32px' : undefined
-}))
-
-const ExpansionPanelBody = styled('div')<{bodyHeight: number}>(({bodyHeight}) => ({
-  height: bodyHeight,
-  justifyContent: 'center',
-  overflow: 'hidden',
-  padding: '0 16px',
-  transition: `height 600ms ${BezierCurve.DECELERATE}`,
-  width: '100%'
-}))
+  paddingLeft: '32px'
+})
 
 const NewMeetingHowTo = (props: Props) => {
   const {meetingType} = props
   const isDesktop = useBreakpoint(Breakpoint.NEW_MEETING_GRID)
-  const [bodyHeight, setBodyHeight] = useState(0)
-  const ref = useRef<HTMLDivElement>(null)
-  const toggleExpansionPanel = () => {
-    const nextHeight = (bodyHeight === 0 && ref.current?.scrollHeight) || 0
-    setBodyHeight(nextHeight)
-  }
   if (isDesktop) {
     return (
-      <Parent isDesktop>
+      <Parent>
         <NewMeetingHowToSteps meetingType={meetingType} showTitle />
       </Parent>
     )
   }
-  return (
-    <Parent>
-      <ExpansionPanelSummary
-        label={'How to Run'}
-        onClick={toggleExpansionPanel}
-        isExpanded={bodyHeight > 0}
-      />
-      <ExpansionPanelBody bodyHeight={bodyHeight} ref={ref}>
-        <NewMeetingHowToSteps meetingType={meetingType} />
-      </ExpansionPanelBody>
-    </Parent>
-  )
+  return null
 }
 
 export default NewMeetingHowTo

--- a/packages/client/components/NewMeetingHowTo.tsx
+++ b/packages/client/components/NewMeetingHowTo.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import React, {useRef, useState} from 'react'
 import {MeetingTypeEnum} from '~/__generated__/NewMeetingQuery.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
-import {BezierCurve, Breakpoint, NewMeeting} from '../types/constEnums'
+import {BezierCurve, Breakpoint} from '../types/constEnums'
 import ExpansionPanelSummary from './ExpansionPanelSummary'
 import NewMeetingHowToSteps from './NewMeetingHowToSteps'
 
@@ -12,8 +12,6 @@ interface Props {
 
 const Parent = styled('div')<{isDesktop?: boolean}>(({isDesktop}) => ({
   gridArea: 'howto',
-  // make it wider than any child so there's no movement between changes
-  minWidth: isDesktop ? NewMeeting.ILLUSTRATION_WIDTH : undefined,
   maxWidth: isDesktop ? undefined : 424,
   margin: isDesktop ? undefined : '0 auto'
 }))

--- a/packages/client/components/NewMeetingHowTo.tsx
+++ b/packages/client/components/NewMeetingHowTo.tsx
@@ -13,7 +13,8 @@ interface Props {
 const Parent = styled('div')<{isDesktop?: boolean}>(({isDesktop}) => ({
   gridArea: 'howto',
   maxWidth: isDesktop ? undefined : 424,
-  margin: isDesktop ? undefined : '0 auto'
+  margin: isDesktop ? undefined : '0 auto',
+  paddingLeft: isDesktop ? '32px' : undefined
 }))
 
 const ExpansionPanelBody = styled('div')<{bodyHeight: number}>(({bodyHeight}) => ({

--- a/packages/client/components/NewMeetingHowToSteps.tsx
+++ b/packages/client/components/NewMeetingHowToSteps.tsx
@@ -65,9 +65,9 @@ const HowToBlock = styled('div')({
 const HowToTitle = styled('div')({
   color: PALETTE.SLATE_700,
   gridColumnStart: 2,
-  fontSize: 24,
+  fontSize: 18,
   fontWeight: 600,
-  paddingBottom: 4
+  paddingBottom: 24
 })
 
 interface Props {
@@ -81,15 +81,20 @@ const NewMeetingHowToSteps = (props: Props) => {
   const learnMore = LINKS[meetingType]
 
   return (
-    <HowToBlock>
+    <>
       {showTitle && <HowToTitle>{TITLES[meetingType]}</HowToTitle>}
-      {steps.map((step, idx) => {
-        return <HowToStepItem key={idx} number={idx + 1} step={step} />
-      })}
-      <LearnMoreLink palette='blue' onClick={() => window.open(learnMore, '_blank', 'noreferrer')}>
-        <IconLabel icon='open_in_new' iconAfter label='Learn More' />
-      </LearnMoreLink>
-    </HowToBlock>
+      <HowToBlock>
+        {steps.map((step, idx) => {
+          return <HowToStepItem key={idx} number={idx + 1} step={step} />
+        })}
+        <LearnMoreLink
+          palette='blue'
+          onClick={() => window.open(learnMore, '_blank', 'noreferrer')}
+        >
+          <IconLabel icon='open_in_new' iconAfter label='Learn More' />
+        </LearnMoreLink>
+      </HowToBlock>
+    </>
   )
 }
 

--- a/packages/client/components/NewMeetingIllustration.tsx
+++ b/packages/client/components/NewMeetingIllustration.tsx
@@ -53,7 +53,7 @@ const ImageWithPadding = styled.div<{meetingType: keyof typeof BACKGROUND_COLORS
   ({meetingType}) => ({
     background: BACKGROUND_COLORS[meetingType],
     boxShadow: Elevation.Z12,
-    borderRadius: '12px',
+    borderRadius: '4px',
     display: 'flex',
     height: 300,
     padding: '0 64px'

--- a/packages/client/components/NewMeetingMeetingSelector.tsx
+++ b/packages/client/components/NewMeetingMeetingSelector.tsx
@@ -4,7 +4,7 @@ import {MeetingTypeEnum} from '~/__generated__/NewMeetingQuery.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
-import {Breakpoint, NewMeeting} from '../types/constEnums'
+import {Breakpoint, NewMeeting, ZIndex} from '../types/constEnums'
 import FloatingActionButton from './FloatingActionButton'
 import Icon from './Icon'
 
@@ -26,7 +26,8 @@ const SelectArrow = styled(FloatingActionButton)({
   color: '#fff',
   height: ICON_SIZE.MD40,
   padding: 0,
-  width: ICON_SIZE.MD40
+  width: ICON_SIZE.MD40,
+  zIndex: ZIndex.FAB
 })
 
 const MeetingTitle = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({

--- a/packages/client/components/NewMeetingRoot.tsx
+++ b/packages/client/components/NewMeetingRoot.tsx
@@ -1,5 +1,7 @@
-import React, {Suspense} from 'react'
+import React, {Suspense, useCallback, useEffect} from 'react'
+import {useHistory, useLocation} from 'react-router'
 import newMeetingQuery, {NewMeetingQuery} from '~/__generated__/NewMeetingQuery.graphql'
+import useModal from '../hooks/useModal'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
 import useRouter from '../hooks/useRouter'
 import useSubscription from '../hooks/useSubscription'
@@ -19,9 +21,27 @@ const NewMeetingRoot = () => {
   useSubscription('NewMeetingRoot', TaskSubscription)
   useSubscription('NewMeetingRoot', TeamSubscription)
   const queryRef = useQueryLoaderNow<NewMeetingQuery>(newMeetingQuery, {teamId})
-  return (
+
+  const location = useLocation<{backgroundLocation?: Location}>()
+  const history = useHistory()
+
+  const onClose = useCallback(() => {
+    const state = location.state
+    history.push(state?.backgroundLocation ?? '/meetings')
+  }, [location])
+
+  const {openPortal, closePortal, modalPortal} = useModal({onClose})
+
+  useEffect(() => {
+    openPortal()
+    return () => {
+      closePortal()
+    }
+  }, [])
+
+  return modalPortal(
     <Suspense fallback={renderLoader()}>
-      {queryRef && <NewMeeting teamId={teamId} queryRef={queryRef} />}
+      {queryRef && <NewMeeting teamId={teamId} queryRef={queryRef} onClose={closePortal} />}
     </Suspense>
   )
 }

--- a/packages/client/components/NewMeetingRoot.tsx
+++ b/packages/client/components/NewMeetingRoot.tsx
@@ -27,7 +27,7 @@ const NewMeetingRoot = () => {
 
   const onClose = useCallback(() => {
     const state = location.state
-    history.push(state?.backgroundLocation ?? '/meetings')
+    history.replace(state?.backgroundLocation ?? '/meetings')
   }, [location])
 
   const {openPortal, closePortal, modalPortal} = useModal({

--- a/packages/client/components/NewMeetingRoot.tsx
+++ b/packages/client/components/NewMeetingRoot.tsx
@@ -30,7 +30,10 @@ const NewMeetingRoot = () => {
     history.push(state?.backgroundLocation ?? '/meetings')
   }, [location])
 
-  const {openPortal, closePortal, modalPortal} = useModal({onClose})
+  const {openPortal, closePortal, modalPortal} = useModal({
+    id: 'newMeetingRoot',
+    onClose
+  })
 
   useEffect(() => {
     openPortal()

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -1,20 +1,21 @@
+import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
-import graphql from 'babel-plugin-relay/macro'
-import lazyPreload from '../utils/lazyPreload'
+import {NewMeetingTeamPicker_selectedTeam} from '~/__generated__/NewMeetingTeamPicker_selectedTeam.graphql'
+import {NewMeetingTeamPicker_teams} from '~/__generated__/NewMeetingTeamPicker_teams.graphql'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
 import useRouter from '../hooks/useRouter'
-import {NewMeetingTeamPicker_teams} from '~/__generated__/NewMeetingTeamPicker_teams.graphql'
-import {NewMeetingTeamPicker_selectedTeam} from '~/__generated__/NewMeetingTeamPicker_selectedTeam.graphql'
+import lazyPreload from '../utils/lazyPreload'
 import NewMeetingDropdown from './NewMeetingDropdown'
-import styled from '@emotion/styled'
 
-const SelectTeamDropdown = lazyPreload(() =>
-  import(
-    /* webpackChunkName: 'SelectTeamDropdown' */
-    './SelectTeamDropdown'
-  )
+const SelectTeamDropdown = lazyPreload(
+  () =>
+    import(
+      /* webpackChunkName: 'SelectTeamDropdown' */
+      './SelectTeamDropdown'
+    )
 )
 
 interface Props {
@@ -32,6 +33,7 @@ const NewMeetingTeamPicker = (props: Props) => {
   const {togglePortal, menuPortal, originRef, menuProps} = useMenu<HTMLDivElement>(
     MenuPosition.LOWER_RIGHT,
     {
+      parentId: 'newMeetingRoot',
       isDropdown: true
     }
   )

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -29,9 +29,6 @@ const Signout = lazy(
 )
 const NotFound = lazy(() => import(/* webpackChunkName: 'NotFound' */ './NotFound/NotFound'))
 const DashboardRoot = lazy(() => import(/* webpackChunkName: 'DashboardRoot' */ './DashboardRoot'))
-const NewMeetingRoot = lazy(
-  () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
-)
 const MeetingRoot = lazy(() => import(/* webpackChunkName: 'MeetingRoot' */ './MeetingRoot'))
 const ViewerNotOnTeamRoot = lazy(
   () => import(/* webpackChunkName: 'ViewerNotOnTeamRoot' */ './ViewerNotOnTeamRoot')
@@ -42,10 +39,9 @@ const PrivateRoutes = () => {
   useNoIndex()
   return (
     <Switch>
-      <Route path='(/meetings|/me|/newteam|/team|/usage)' component={DashboardRoot} />
+      <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/invoice/:invoiceId' component={Invoice} />
-      <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
       <Route path='/new-summary/:meetingId/:urlAction?' component={NewMeetingSummary} />
       <Route path='/admin/graphql' component={Graphql} />
       <Route path='/admin/impersonate' component={Impersonate} />

--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import React, {useEffect, useRef, useState} from 'react'
+import {useLocation} from 'react-router'
 import useRouter from '~/hooks/useRouter'
 import {PALETTE} from '~/styles/paletteV3'
 import getTeamIdFromPathname from '~/utils/getTeamIdFromPathname'
@@ -46,6 +47,7 @@ interface Props {
 }
 
 const StartMeetingFAB = (props: Props) => {
+  const location = useLocation()
   const {className} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const teamId = getTeamIdFromPathname()
@@ -82,7 +84,7 @@ const StartMeetingFAB = (props: Props) => {
     }
   }
   const onClick = () => {
-    history.push(`/new-meeting/${teamId}?source=BottomFAB`)
+    history.push(`/new-meeting/${teamId}?source=BottomFAB`, {backgroundLocation: location})
   }
   // We use the TopBarStartMeetingButton in this case
   if (isDesktop) {

--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -84,7 +84,7 @@ const StartMeetingFAB = (props: Props) => {
     }
   }
   const onClick = () => {
-    history.replace(`/new-meeting/${teamId}?source=BottomFAB`, {backgroundLocation: location})
+    history.replace(`/new-meeting/${teamId}`, {backgroundLocation: location})
   }
   // We use the TopBarStartMeetingButton in this case
   if (isDesktop) {

--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -84,7 +84,7 @@ const StartMeetingFAB = (props: Props) => {
     }
   }
   const onClick = () => {
-    history.push(`/new-meeting/${teamId}?source=BottomFAB`, {backgroundLocation: location})
+    history.replace(`/new-meeting/${teamId}?source=BottomFAB`, {backgroundLocation: location})
   }
   // We use the TopBarStartMeetingButton in this case
   if (isDesktop) {

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import {useLocation} from 'react-router'
 import useRouter from '~/hooks/useRouter'
 import {PALETTE} from '~/styles/paletteV3'
 import getTeamIdFromPathname from '~/utils/getTeamIdFromPathname'
@@ -21,11 +22,12 @@ const MeetingLabel = styled('div')({
 })
 
 const TopBarStartMeetingButton = () => {
+  const location = useLocation()
   const teamId = getTeamIdFromPathname()
   const {history} = useRouter()
 
   const onClick = () => {
-    history.push(`/new-meeting/${teamId}?source=TopBar`)
+    history.push(`/new-meeting/${teamId}?source=TopBar`, {backgroundLocation: location})
   }
   return (
     <Button onClick={onClick}>

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -24,7 +24,7 @@ const TopBarStartMeetingButton = () => {
   const {history} = useRouter()
 
   const onClick = () => {
-    history.push(`/new-meeting/${teamId}?source=TopBar`, {backgroundLocation: location})
+    history.replace(`/new-meeting/${teamId}?source=TopBar`, {backgroundLocation: location})
   }
   return (
     <Button onClick={onClick}>

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -2,13 +2,10 @@ import styled from '@emotion/styled'
 import React from 'react'
 import {useLocation} from 'react-router'
 import useRouter from '~/hooks/useRouter'
-import {PALETTE} from '~/styles/paletteV3'
 import getTeamIdFromPathname from '~/utils/getTeamIdFromPathname'
-import FloatingActionButton from './FloatingActionButton'
+import FlatPrimaryButton from './FlatPrimaryButton'
 
-const Button = styled(FloatingActionButton)({
-  color: '#fff',
-  backgroundImage: PALETTE.GRADIENT_TOMATO_600_ROSE_500,
+const Button = styled(FlatPrimaryButton)({
   height: 40,
   overflow: 'hidden',
   paddingLeft: 24,

--- a/packages/client/components/TopBarStartMeetingButton.tsx
+++ b/packages/client/components/TopBarStartMeetingButton.tsx
@@ -24,7 +24,7 @@ const TopBarStartMeetingButton = () => {
   const {history} = useRouter()
 
   const onClick = () => {
-    history.replace(`/new-meeting/${teamId}?source=TopBar`, {backgroundLocation: location})
+    history.replace(`/new-meeting/${teamId}`, {backgroundLocation: location})
   }
   return (
     <Button onClick={onClick}>

--- a/packages/client/hooks/useModalPortal.tsx
+++ b/packages/client/hooks/useModalPortal.tsx
@@ -1,13 +1,13 @@
-import React, {ReactElement, ReactPortal, Ref, Suspense, useEffect} from 'react'
 import styled from '@emotion/styled'
+import React, {ReactElement, ReactPortal, Ref, Suspense, useEffect} from 'react'
 import ErrorBoundary from '../components/ErrorBoundary'
 import LoadingComponent from '../components/LoadingComponent/LoadingComponent'
 import ModalError from '../components/ModalError'
-import {LoadingDelayRef} from './useLoadingDelay'
-import usePortal, {PortalStatus} from './usePortal'
 import {DECELERATE} from '../styles/animation'
 import {PALETTE} from '../styles/paletteV3'
 import {Duration, ZIndex} from '../types/constEnums'
+import {LoadingDelayRef} from './useLoadingDelay'
+import usePortal, {PortalStatus} from './usePortal'
 
 const ModalBlock = styled('div')({
   alignItems: 'center',
@@ -19,7 +19,8 @@ const ModalBlock = styled('div')({
   position: 'absolute',
   top: 0,
   width: '100%',
-  zIndex: ZIndex.DIALOG
+  zIndex: ZIndex.DIALOG,
+  overflow: 'scroll'
 })
 
 const backdropStyles = {
@@ -80,6 +81,8 @@ const ModalContents = styled('div')<{portalStatus: PortalStatus}>(({portalStatus
   flex: '0 1 auto',
   flexDirection: 'column',
   position: 'relative',
+  marginTop: 'auto',
+  marginBottom: 'auto',
   ...modalStyles[portalStatus]
 }))
 

--- a/packages/client/hooks/usePortal.tsx
+++ b/packages/client/hooks/usePortal.tsx
@@ -31,6 +31,7 @@ export type PortalId =
   | 'StageTimerMinutePicker'
   | 'taskFooterTeamAssigneeAddIntegration'
   | 'taskFooterTeamAssigneeMenu'
+  | 'newMeetingRoot'
 
 export interface UsePortalOptions {
   onOpen?: (el: HTMLElement) => void

--- a/packages/client/modules/meeting/components/PokerTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplatePicker.tsx
@@ -11,11 +11,12 @@ interface Props {
   settings: PokerTemplatePicker_settings
 }
 
-const PokerTemplateModal = lazyPreload(() =>
-  import(
-    /* webpackChunkName: 'PokerTemplateModal' */
-    './PokerTemplateModal'
-  )
+const PokerTemplateModal = lazyPreload(
+  () =>
+    import(
+      /* webpackChunkName: 'PokerTemplateModal' */
+      './PokerTemplateModal'
+    )
 )
 
 const Dropdown = styled(NewMeetingDropdown)({
@@ -27,7 +28,10 @@ const PokerTemplatePicker = (props: Props) => {
   const {settings} = props
   const {selectedTemplate} = settings
   const {name: templateName} = selectedTemplate
-  const {togglePortal, modalPortal, closePortal} = useModal({id: 'templateModal'})
+  const {togglePortal, modalPortal, closePortal} = useModal({
+    id: 'templateModal',
+    parentId: 'newMeetingRoot'
+  })
 
   return (
     <>
@@ -38,7 +42,9 @@ const PokerTemplatePicker = (props: Props) => {
         onClick={togglePortal}
         onMouseEnter={PokerTemplateModal.preload}
       />
-      {modalPortal(<PokerTemplateModal closePortal={closePortal} pokerMeetingSettings={settings} />)}
+      {modalPortal(
+        <PokerTemplateModal closePortal={closePortal} pokerMeetingSettings={settings} />
+      )}
     </>
   )
 }

--- a/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
@@ -11,11 +11,12 @@ interface Props {
   settings: RetroTemplatePicker_settings
 }
 
-const ReflectTemplateModal = lazyPreload(() =>
-  import(
-    /* webpackChunkName: 'ReflectTemplateModal' */
-    './ReflectTemplateModal'
-  )
+const ReflectTemplateModal = lazyPreload(
+  () =>
+    import(
+      /* webpackChunkName: 'ReflectTemplateModal' */
+      './ReflectTemplateModal'
+    )
 )
 
 const Dropdown = styled(NewMeetingDropdown)({
@@ -27,7 +28,10 @@ const RetroTemplatePicker = (props: Props) => {
   const {settings} = props
   const {selectedTemplate} = settings
   const {name: templateName} = selectedTemplate
-  const {togglePortal, modalPortal, closePortal} = useModal({id: 'templateModal'})
+  const {togglePortal, modalPortal, closePortal} = useModal({
+    id: 'templateModal',
+    parentId: 'newMeetingRoot'
+  })
 
   return (
     <>
@@ -38,7 +42,9 @@ const RetroTemplatePicker = (props: Props) => {
         onClick={togglePortal}
         onMouseEnter={ReflectTemplateModal.preload}
       />
-      {modalPortal(<ReflectTemplateModal closePortal={closePortal} retroMeetingSettings={settings} />)}
+      {modalPortal(
+        <ReflectTemplateModal closePortal={closePortal} retroMeetingSettings={settings} />
+      )}
     </>
   )
 }


### PR DESCRIPTION
# Description

Fixes #5602 

This is the first step in redesigning the dialog. The dialog still uses
the same route as before. If the route is hit directly, the meetings
dashboard is rendered in the background. If it's reached by pressing the
"Add meeting" button, then the current page is put into the location
state to be rendered as background.

## Demo

https://www.loom.com/share/eba28320ed6f4c67806042a440ac1b9f

<img width="1742" alt="image" src="https://user-images.githubusercontent.com/466991/178493589-6fb24836-b852-4b09-8c05-adfa1c13e46c.png">

## Testing scenarios

* Create at least 2 teams
  * team 1 with some active meetings
  * team 2 with no active meetings
* [ ] Open the new meeting dialog by the "Add meeting" button from different dashboards
  * [ ] see that the dashboard is still in the background
* [ ] Open the new meeting dialog by hitting the URL directly
  * [ ] meetings dash is in the background
* [ ] test all meeting dialog buttons, including all drop downs
* [ ] check layout on mobile
  * [ ] with active meetings
  * [ ] with no active meetings
  * [ ] with opening the description
* [ ] smoke test some other dialogs
  * [ ] create teams
  * [ ] credit card information
  * [ ] invite members
