### PR TITLE
fix(dd-trace): enabled comes from env var

### DIFF
--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -8,7 +8,6 @@ import '../server/initSentry'
 import RedisStream from './RedisStream'
 
 tracer.init({
-  enabled: process.env.DD_TRACE_ENABLED === 'true',
   service: `GQLExecutor ${process.env.SERVER_ID}`,
   appsec: process.env.DD_APPSEC_ENABLED === 'true',
   plugins: false

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -24,7 +24,6 @@ import staticFileHandler from './staticFileHandler'
 import SAMLHandler from './utils/SAMLHandler'
 
 tracer.init({
-  enabled: process.env.DD_TRACE_ENABLED === 'true',
   service: `Web ${process.env.SERVER_ID}`,
   appsec: process.env.DD_APPSEC_ENABLED === 'true',
   plugins: false


### PR DESCRIPTION
Signed-off-by: Matt Krick <matt.krick@gmail.com>

# Description

`process.env.DD_TRACE_ENABLED`  is now the only way to set enabled for dd-trace.
this PR fixes the typescript error, but no change to runtime.
this happened when i bumped dd-trace to fix a security vuln