### PR TITLE
fix: emoji menu popups in a wrong place if : is the first character typed 

### DIFF
--- a/packages/client/components/ReflectionEditorWrapper.tsx
+++ b/packages/client/components/ReflectionEditorWrapper.tsx
@@ -69,8 +69,8 @@ const EditorStyles = styled('div')(({useFallback, userSelect, isClipped}: any) =
   width: '100%'
 })) as any
 
-const AndroidEditorFallback = lazyPreload(() =>
-  import(/* webpackChunkName: 'AndroidEditorFallback' */ './AndroidEditorFallback')
+const AndroidEditorFallback = lazyPreload(
+  () => import(/* webpackChunkName: 'AndroidEditorFallback' */ './AndroidEditorFallback')
 )
 
 class ReflectionEditorWrapper extends PureComponent<Props> {
@@ -210,7 +210,7 @@ class ReflectionEditorWrapper extends PureComponent<Props> {
       removeModal()
     }
   }
-
+  //TODO investigate component why EmojiMenuContainer is initially on the top left of the dashbaord
   render() {
     const {
       isClipped,


### PR DESCRIPTION
# Description

- Create a new retro meeting
- Try to add a new reflection but start typing it from the `:` character
- See the emoji menu has appeared at the top left corner of the browser window



Fixes/Partially Fixes #6421 
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
