### PR TITLE
feat(standups): Display standups as active instead of started

### DIFF
--- a/packages/client/utils/meetings/lookups.ts
+++ b/packages/client/utils/meetings/lookups.ts
@@ -20,7 +20,7 @@ export const phaseLabelLookup = {
   SUMMARY: 'Summary',
   SCOPE: 'Scope',
   ESTIMATE: 'Estimate',
-  RESPONSES: 'Started'
+  RESPONSES: 'Active'
 } as Record<NewMeetingPhaseTypeEnum, string>
 
 export const phaseIconLookup = {


### PR DESCRIPTION
# Description

This PR changes the label shown on the meeting card for standups. Instead of `Started` now, we'll display `Active`

## Demo

![localhost_3000_meetings](https://user-images.githubusercontent.com/1017620/178750436-da80725c-9adc-4a3d-b997-dd6df0775643.png)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
