### PR TITLE
fix: access more than 10 Jira projects in task footer

### DIFF
--- a/packages/client/components/GitHubScopingSearchResults.tsx
+++ b/packages/client/components/GitHubScopingSearchResults.tsx
@@ -48,7 +48,7 @@ const GitHubScopingSearchResults = (props: Props) => {
         viewer {
           ...NewGitHubIssueInput_viewer
           teamMember(teamId: $teamId) {
-            repoIntegrations(first: 10) {
+            repoIntegrations(first: 20) {
               items {
                 ... on _xGitHubRepository {
                   id

--- a/packages/client/components/GitHubScopingSearchResults.tsx
+++ b/packages/client/components/GitHubScopingSearchResults.tsx
@@ -48,7 +48,7 @@ const GitHubScopingSearchResults = (props: Props) => {
         viewer {
           ...NewGitHubIssueInput_viewer
           teamMember(teamId: $teamId) {
-            repoIntegrations {
+            repoIntegrations(first: 10) {
               items {
                 ... on _xGitHubRepository {
                   id

--- a/packages/client/components/TaskFooterIntegrateMenu.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenu.tsx
@@ -181,7 +181,7 @@ graphql`
 `
 graphql`
   fragment TaskFooterIntegrateMenuViewerRepoIntegrations on TeamMember {
-    repoIntegrations {
+    repoIntegrations(first: 50) {
       ...TaskFooterIntegrateMenuList_repoIntegrations
     }
   }

--- a/packages/server/graphql/queries/repoIntegrations.ts
+++ b/packages/server/graphql/queries/repoIntegrations.ts
@@ -1,16 +1,26 @@
-import {GraphQLNonNull, GraphQLResolveInfo} from 'graphql'
+import {GraphQLInt, GraphQLNonNull, GraphQLResolveInfo} from 'graphql'
 import {getUserId} from '../../utils/authorization'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
+import GraphQLISO8601Type from '../types/GraphQLISO8601Type'
 import RepoIntegrationQueryPayload from '../types/RepoIntegrationQueryPayload'
 import fetchAllRepoIntegrations from './helpers/fetchAllRepoIntegrations'
 
 export default {
   description: 'The integrations that the user would probably like to use',
   type: new GraphQLNonNull(RepoIntegrationQueryPayload),
+  args: {
+    first: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'the number of repo integrations to return'
+    },
+    after: {
+      type: GraphQLISO8601Type
+    }
+  },
   resolve: async (
     {teamId, userId}: {teamId: string; userId: string},
-    {first = 10}: {first?: number},
+    {first}: {first: number},
     context: GQLContext,
     info: GraphQLResolveInfo
   ) => {

--- a/packages/server/graphql/types/TeamMember.ts
+++ b/packages/server/graphql/types/TeamMember.ts
@@ -11,7 +11,6 @@ import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import {getUserId} from '../../utils/authorization'
 import {GQLContext} from '../graphql'
 import connectionFromTasks from '../queries/helpers/connectionFromTasks'
-import repoIntegrations from '../queries/repoIntegrations'
 import {resolveTeam} from '../resolvers'
 import GraphQLEmailType from './GraphQLEmailType'
 import GraphQLISO8601Type from './GraphQLISO8601Type'
@@ -94,7 +93,7 @@ const TeamMember = new GraphQLObjectType<any, GQLContext>({
       type: new GraphQLNonNull(GraphQLString),
       description: 'The name of the assignee'
     },
-    repoIntegrations,
+    repoIntegrations: require('../queries/repoIntegrations').default,
     tasks: {
       type: TaskConnection,
       description: 'Tasks owned by the team member',


### PR DESCRIPTION
Fix: https://github.com/ParabolInc/parabol/issues/6880

### To test

- [ ] Create 11 projects in Jira
- [ ] Open the menu footer in a Parabol task card
- [ ] When you search in the task footer, you can find all 11 projects
- [ ] GitHub's new issue menu continues to work as expected