### PR TITLE
fix(retro): Give users feedback that they need to vote in Vote phase

### DIFF
--- a/packages/client/components/BottomControlBarReady.tsx
+++ b/packages/client/components/BottomControlBarReady.tsx
@@ -159,17 +159,15 @@ const BottomControlBarReady = (props: Props) => {
     return false
   }
   const disabled = getDisabled()
+  const onMouseOver = () => {
+    if (phaseType === 'vote' && disabled) {
+      openErrorTooltip()
+    }
+  }
+
   return (
     <>
-      <div
-        onMouseOver={() => {
-          if (phaseType === 'vote' && disabled) {
-            openErrorTooltip()
-          }
-        }}
-        onMouseLeave={closeErrorTooltip}
-        ref={errorTooltipRef}
-      >
+      <div onMouseOver={onMouseOver} onMouseLeave={closeErrorTooltip} ref={errorTooltipRef}>
         <BottomNavControl
           dataCy={`next-phase`}
           disabled={disabled}

--- a/packages/client/components/BottomControlBarReady.tsx
+++ b/packages/client/components/BottomControlBarReady.tsx
@@ -44,6 +44,26 @@ const CheckIcon = styled(Icon)<{progress: number; isNext: boolean; isViewerReady
   })
 )
 
+// Disabled button does not fire mouse events, this is a workaround for showing a tooltip
+// `pointer-events: none` required to be set on underlying button
+const BottomNavContorlWrapper = styled('div')<{
+  disabled?: boolean
+}>((props) => {
+  const {disabled} = props
+
+  if (disabled)
+    return {
+      cursor: 'not-allowed',
+      opacity: 1,
+      transition: `all 300ms ${BezierCurve.DECELERATE}`,
+      ':hover': {
+        opacity: 0.5
+      }
+    }
+
+  return {}
+})
+
 const PHASE_REQUIRES_CONFIRM = new Set<NewMeetingPhaseTypeEnum>(['reflect', 'group', 'vote'])
 
 const BottomControlBarReady = (props: Props) => {
@@ -167,10 +187,8 @@ const BottomControlBarReady = (props: Props) => {
 
   return (
     <>
-      <div
-        style={{
-          cursor: disabled ? 'not-allowed' : undefined
-        }}
+      <BottomNavContorlWrapper
+        disabled={disabled}
         onMouseOver={onMouseOver}
         onMouseLeave={closeErrorTooltip}
         ref={errorTooltipRef}
@@ -192,7 +210,7 @@ const BottomControlBarReady = (props: Props) => {
             </CheckIcon>
           </BottomNavIconLabel>
         </BottomNavControl>
-      </div>
+      </BottomNavContorlWrapper>
       {tooltipPortal(`Tap 'Next' again to Confirm`)}
       {errorTooltipPortal(`At least one vote required`)}
     </>

--- a/packages/client/components/BottomControlBarReady.tsx
+++ b/packages/client/components/BottomControlBarReady.tsx
@@ -167,7 +167,14 @@ const BottomControlBarReady = (props: Props) => {
 
   return (
     <>
-      <div onMouseOver={onMouseOver} onMouseLeave={closeErrorTooltip} ref={errorTooltipRef}>
+      <div
+        style={{
+          cursor: disabled ? 'not-allowed' : undefined
+        }}
+        onMouseOver={onMouseOver}
+        onMouseLeave={closeErrorTooltip}
+        ref={errorTooltipRef}
+      >
         <BottomNavControl
           dataCy={`next-phase`}
           disabled={disabled}

--- a/packages/client/components/BottomNavControl.tsx
+++ b/packages/client/components/BottomNavControl.tsx
@@ -23,12 +23,11 @@ const BottomNavControl = styled(FlatButton)<Props>((props) => {
       status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
         ? 0
         : ElementWidth.CONTROL_BAR_BUTTON,
-    opacity:
-      confirming || disabled
-        ? 0.5
-        : status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
-        ? 0
-        : 1,
+    opacity: confirming
+      ? 0.5
+      : status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
+      ? 0
+      : 1,
     padding: 0,
     transformOrigin: 'center bottom',
     transition: `all 300ms ${BezierCurve.DECELERATE}`,

--- a/packages/client/components/BottomNavControl.tsx
+++ b/packages/client/components/BottomNavControl.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import {TransitionStatus} from '~/hooks/useTransition'
 import {BezierCurve, ElementWidth} from '~/types/constEnums'
-import FlatButton, {FlatButtonProps} from './FlatButton'
 import {PALETTE} from '../styles/paletteV3'
+import FlatButton, {FlatButtonProps} from './FlatButton'
 
 interface Props extends FlatButtonProps {
   confirming?: boolean
@@ -15,13 +15,18 @@ const BottomNavControl = styled(FlatButton)<Props>((props) => {
   const {confirming, disabled, status, waiting} = props
   const visuallyDisabled = disabled || waiting
   return {
+    pointerEvents: disabled ? 'none' : undefined,
     border: 0,
     borderRadius: 0,
     minHeight: 56,
-    width: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : ElementWidth.CONTROL_BAR_BUTTON,
-    opacity: confirming
-      ? 0.5
-      : status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
+    width:
+      status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
+        ? 0
+        : ElementWidth.CONTROL_BAR_BUTTON,
+    opacity:
+      confirming || disabled
+        ? 0.5
+        : status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING
         ? 0
         : 1,
     padding: 0,

--- a/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
+++ b/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
@@ -33,6 +33,7 @@ graphql`
           viewerVoteCount
         }
       }
+      ...MeetingControlBar_meeting
     }
   }
 `


### PR DESCRIPTION
Fixes #6631



https://user-images.githubusercontent.com/466991/179980001-24b8e29e-cdca-4c23-8607-127019bfcee2.mov



_Please let me know if I need to change tooltip text_

**How to test:**

- Create a retro, go to vote phase
- See you can't click next until some votes appeared
- See a tooltip with a hint
- Smoke test another meeting type

