### PR TITLE
feat(Azure DevOps): Add SaaS url to sprint poker estimation

### DIFF
--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -520,11 +520,14 @@ export const getMappedAzureDevOpsWorkItem = async (
   instanceId: string,
   returnedWorkItem: WorkItem
 ) => {
+  const mappedUrl = returnedWorkItem._links['html']
+    ? returnedWorkItem._links['html'].href
+    : returnedWorkItem.url
   const azureDevOpsWorkItem = {
     id: returnedWorkItem.id.toString(),
     title: returnedWorkItem.fields['System.Title'],
     teamProject: getProjectId(new URL(returnedWorkItem.url)),
-    url: returnedWorkItem.url,
+    url: mappedUrl,
     state: returnedWorkItem.fields['System.State'],
     type: returnedWorkItem.fields['System.WorkItemType'],
     descriptionHTML: returnedWorkItem.fields['System.Description']

--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -520,9 +520,7 @@ export const getMappedAzureDevOpsWorkItem = async (
   instanceId: string,
   returnedWorkItem: WorkItem
 ) => {
-  const mappedUrl = returnedWorkItem._links['html']
-    ? returnedWorkItem._links['html'].href
-    : returnedWorkItem.url
+  const mappedUrl = returnedWorkItem._links['html']?.href ?? returnedWorkItem.url
   const azureDevOpsWorkItem = {
     id: returnedWorkItem.id.toString(),
     title: returnedWorkItem.fields['System.Title'],

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -305,7 +305,9 @@ class AzureDevOpsServerManager {
     const workItems = [] as WorkItem[]
     let firstError: Error | undefined
     const uri = `https://${instanceId}/_apis/wit/workitemsbatch?api-version=7.1-preview.1`
-    const payload = !!fields ? {ids: workItemIds, fields: fields} : {ids: workItemIds}
+    const payload = !!fields
+      ? {ids: workItemIds, fields: fields}
+      : {ids: workItemIds, $expand: 'All'}
     const res = await this.post<WorkItemBatchResponse>(uri, payload)
     if (res instanceof Error) {
       if (!firstError) {

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -307,7 +307,7 @@ class AzureDevOpsServerManager {
     const uri = `https://${instanceId}/_apis/wit/workitemsbatch?api-version=7.1-preview.1`
     const payload = !!fields
       ? {ids: workItemIds, fields: fields}
-      : {ids: workItemIds, $expand: 'All'}
+      : {ids: workItemIds, $expand: 'Links'}
     const res = await this.post<WorkItemBatchResponse>(uri, payload)
     if (res instanceof Error) {
       if (!firstError) {

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -393,7 +393,6 @@ class AzureDevOpsServerManager {
     const {error: accessibleError, accessibleOrgs} = await this.getAccessibleOrgs(id)
     if (!!accessibleError) return {error: accessibleError, projects: null}
 
-    // this forEach is not returning
     for (const resource of accessibleOrgs) {
       const {accountName} = resource
       const instanceId = `dev.azure.com/${accountName}`


### PR DESCRIPTION
# Description

Fixes #6891
Changes include:

1. Adding the $expand property to the Azure DevOps Rest API to return hypermedia links
2. Changing the mapping function of the returned work item to retrieve html url

## Demo

When you are in a sprint poker meeting and are in the process of providing estimates, after importing the work item, you will see
![Screen Shot 2022-07-17 at 6 39 33 PM](https://user-images.githubusercontent.com/1582053/179427637-813091fd-972d-43ec-bcd7-c00f84973f07.png)

If you click on the link of the work item at the top of the screen (in this case the #3 link), you will currently be linked incorrectly to the JSON representation and see something like:
![Screen Shot 2022-07-17 at 6 39 52 PM](https://user-images.githubusercontent.com/1582053/179427684-054f7204-9942-4027-bc04-f77d250a8160.png)

This change fixes that issue by providing the html url.  You will now see:
![Screen Shot 2022-07-17 at 6 39 43 PM](https://user-images.githubusercontent.com/1582053/179427697-2f186be0-7c4f-4e2e-b4b6-99daf73243a6.png)


## Testing scenarios

- [ ] Scenario A - Click link to see the work item in Azure DevOps
  - Import the work items that you want to estimate into a sprint poker meeting
  - During the estimate phase, click on the link at the top of the screen and verify it takes you to the Azure DevOps SaaS instance and displays the work item.


