### PR TITLE
feat: increase locking restrictions

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -17,6 +17,8 @@ import handleAddTeamMembers from './handlers/handleAddTeamMembers'
 import handleAddTeams from './handlers/handleAddTeams'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
 
+export const LOCKED_OVERDUE_MSG = `Sorry! You're unable to join this team because one of your teams has an overdue payment`
+
 graphql`
   fragment AcceptTeamInvitationMutation_team on AcceptTeamInvitationPayload {
     teamMember {
@@ -190,10 +192,13 @@ const AcceptTeamInvitationMutation: StandardMutation<
             autoDismiss: 0,
             key: `acceptTeamInvitation:${message}`,
             message,
-            action: {
-              label: 'OK',
-              callback: () => history.push(`/me`)
-            }
+            action:
+              message === LOCKED_OVERDUE_MSG
+                ? {
+                    label: 'Contact Sales',
+                    callback: () => window.open('mailto:love@parabol.co?subject=Overdue Payment')
+                  }
+                : undefined
           })
         }
         if (!ignoreApproval) return

--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -144,15 +144,13 @@ export const handleAcceptTeamInvitationErrors = (
 ) => {
   if (acceptTeamInvitation?.error) {
     const {message} = acceptTeamInvitation.error
-    if (message === InvitationTokenError.ALREADY_ACCEPTED) return true
+    if (message === InvitationTokenError.ALREADY_ACCEPTED) return
     atmosphere.eventEmitter.emit('addSnackbar', {
       autoDismiss: 0,
       key: `acceptTeamInvitation:${message}`,
       message
     })
-    return false
   }
-  return true
 }
 
 const AcceptTeamInvitationMutation: StandardMutation<

--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {InvitationTokenError} from '~/types/constEnums'
+import {InvitationTokenError, LOCKED_MESSAGE} from '~/types/constEnums'
 import {AcceptTeamInvitationMutation_notification} from '~/__generated__/AcceptTeamInvitationMutation_notification.graphql'
 import Atmosphere from '../Atmosphere'
 import {
@@ -16,8 +16,6 @@ import {AcceptTeamInvitationMutation_team} from '../__generated__/AcceptTeamInvi
 import handleAddTeamMembers from './handlers/handleAddTeamMembers'
 import handleAddTeams from './handlers/handleAddTeams'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
-
-export const LOCKED_OVERDUE_MSG = `Sorry! You're unable to join this team because one of your teams has an overdue payment`
 
 graphql`
   fragment AcceptTeamInvitationMutation_team on AcceptTeamInvitationPayload {
@@ -193,7 +191,7 @@ const AcceptTeamInvitationMutation: StandardMutation<
             key: `acceptTeamInvitation:${message}`,
             message,
             action:
-              message === LOCKED_OVERDUE_MSG
+              message === LOCKED_MESSAGE.TEAM_INVITE
                 ? {
                     label: 'Contact Sales',
                     callback: () => window.open('mailto:love@parabol.co?subject=Overdue Payment')

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -198,6 +198,10 @@ export const enum LocalStorageKey {
   ERROR_PRONE_AT = 'errorProneAt'
 }
 
+export const enum LOCKED_MESSAGE {
+  TEAM_INVITE = `Sorry! You're unable to join this team because one of your teams has an overdue payment`
+}
+
 export const enum AuthenticationError {
   FAILED_TO_SEND = 'failedToSend',
   MISSING_HASH = 'missingHash',

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -4,13 +4,15 @@ import {DataLoaderWorker} from '../../graphql'
 const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   const {lockMessageHTML, orgId, tier} = team
-  const orgTeams = await dataLoader.get('teamsByOrgIds').load(orgId)
-  const anyOrgTeamIsLocked = orgTeams.some((team) => !team.isPaid)
-  if (tier !== 'personal' && anyOrgTeamIsLocked) {
-    // if this team was manually locked, be mean because they called this by hiding the modal
-    return lockMessageHTML
-      ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
-      : 'Sorry! We are unable to start your meeting because your organization has an overdue payment'
+  // if this team was manually locked, be mean because they called this by hiding the modal
+  if (lockMessageHTML)
+    return 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
+  if (tier !== 'personal') {
+    const orgTeams = await dataLoader.get('teamsByOrgIds').load(orgId)
+    const anyOrgTeamIsLocked = orgTeams.some((team) => !team.isPaid)
+    return anyOrgTeamIsLocked
+      ? 'Sorry! We are unable to start your meeting because your organization has an overdue payment'
+      : null
   }
   // if this team wasn't manually locked, see if any of its members are on locked teams
   const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -11,7 +11,7 @@ const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker
     // if this team was manually locked, be mean because they called this by hiding the modal
     return lockMessageHTML
       ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
-      : 'Sorry! We are unable to start your meeting because one or more of the teams in your org has an overdue payment'
+      : 'Sorry! We are unable to start your meeting because your organization has an overdue payment'
   }
   // if this team wasn't manually locked, see if any of its members are on locked teams
   const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -1,17 +1,18 @@
 import isValid from '../../../graphql/isValid'
+import getTeamsByOrgIds from '../../../postgres/queries/getTeamsByOrgIds'
 import {DataLoaderWorker} from '../../graphql'
 
 const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const team = await dataLoader.get('teams').loadNonNull(teamId)
-  const {isPaid, lockMessageHTML, tier} = team
-  if (tier !== 'personal') {
-    return isPaid
-      ? null
-      : 'Sorry! We are unable to start your meeting because your team has an overdue payment'
+  const {lockMessageHTML, orgId, tier} = team
+  const orgTeams = await getTeamsByOrgIds([orgId])
+  const anyOrgTeamIsLocked = orgTeams.some((team) => !team.isPaid)
+  if (tier !== 'personal' && anyOrgTeamIsLocked) {
+    // if this team was manually locked, be mean because they called this by hiding the modal
+    return lockMessageHTML
+      ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
+      : 'Sorry! We are unable to start your meeting because one or more of the teams in your org has an overdue payment'
   }
-  // if this team was manually locked, be mean because they called this by hiding the modal
-  if (lockMessageHTML)
-    return 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
   // if this team wasn't manually locked, see if any of its members are on locked teams
   const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)
   const userIds = teamMembers.map(({userId}) => userId)
@@ -20,11 +21,9 @@ const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker
     .flat()
   const teamIds = [...new Set(allTeamMembers.map(({teamId}) => teamId))]
   const allRelatedTeams = (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
-  const anyTeamIsLocked = allRelatedTeams.some(
-    (team) => team.tier !== 'personal' && team.isPaid === false
-  )
+  const anyTeamIsLocked = allRelatedTeams.some((team) => team.isPaid === false)
   return anyTeamIsLocked
-    ? 'One or more of your team members is over the usage limit. Please contact sales.'
+    ? 'One or more of your team members is over the usage limit. Please contact sales'
     : null
 }
 

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -22,7 +22,7 @@ const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker
     .flat()
   const teamIds = [...new Set(allTeamMembers.map(({teamId}) => teamId))]
   const allRelatedTeams = (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
-  const anyTeamIsLocked = allRelatedTeams.some((team) => team.isPaid === false)
+  const anyTeamIsLocked = allRelatedTeams.some((team) => team.isPaid === false && !team.isArchived)
   return anyTeamIsLocked
     ? 'One or more of your team members is over the usage limit. Please contact sales'
     : null

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -1,12 +1,31 @@
+import isValid from '../../../graphql/isValid'
 import {DataLoaderWorker} from '../../graphql'
 
 const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const team = await dataLoader.get('teams').loadNonNull(teamId)
-  const {isPaid, lockMessageHTML} = team
-  if (isPaid) return null
-  return lockMessageHTML
-    ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
-    : 'Sorry! We are unable to start your meeting because your team has an overdue payment'
+  const {isPaid, lockMessageHTML, tier} = team
+  if (tier !== 'personal') {
+    return isPaid
+      ? null
+      : 'Sorry! We are unable to start your meeting because your team has an overdue payment'
+  }
+  // if this team was manually locked, be mean because they called this by hiding the modal
+  if (lockMessageHTML)
+    return 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
+  // if this team wasn't manually locked, see if any of its members are on locked teams
+  const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)
+  const userIds = teamMembers.map(({userId}) => userId)
+  const allTeamMembers = (await dataLoader.get('teamMembersByUserId').loadMany(userIds))
+    .filter(isValid)
+    .flat()
+  const teamIds = [...new Set(allTeamMembers.map(({teamId}) => teamId))]
+  const allRelatedTeams = (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
+  const anyTeamIsLocked = allRelatedTeams.some(
+    (team) => team.tier !== 'personal' && team.isPaid === false
+  )
+  return anyTeamIsLocked
+    ? 'One or more of your team members is over the usage limit. Please contact sales.'
+    : null
 }
 
 export default isStartMeetingLocked

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -1,31 +1,12 @@
-import isValid from '../../../graphql/isValid'
 import {DataLoaderWorker} from '../../graphql'
 
 const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const team = await dataLoader.get('teams').loadNonNull(teamId)
-  const {lockMessageHTML, orgId, tier} = team
-  // if this team was manually locked, be mean because they called this by hiding the modal
-  if (lockMessageHTML)
-    return 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
-  if (tier !== 'personal') {
-    const orgTeams = await dataLoader.get('teamsByOrgIds').load(orgId)
-    const anyOrgTeamIsLocked = orgTeams.some((team) => !team.isPaid)
-    return anyOrgTeamIsLocked
-      ? 'Sorry! We are unable to start your meeting because your organization has an overdue payment'
-      : null
-  }
-  // if this team wasn't manually locked, see if any of its members are on locked teams
-  const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)
-  const userIds = teamMembers.map(({userId}) => userId)
-  const allTeamMembers = (await dataLoader.get('teamMembersByUserId').loadMany(userIds))
-    .filter(isValid)
-    .flat()
-  const teamIds = [...new Set(allTeamMembers.map(({teamId}) => teamId))]
-  const allRelatedTeams = (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
-  const anyTeamIsLocked = allRelatedTeams.some((team) => team.isPaid === false && !team.isArchived)
-  return anyTeamIsLocked
-    ? 'One or more of your team members is over the usage limit. Please contact sales'
-    : null
+  const {isPaid, lockMessageHTML} = team
+  if (isPaid) return null
+  return lockMessageHTML
+    ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
+    : 'Sorry! We are unable to start your meeting because your team has an overdue payment'
 }
 
 export default isStartMeetingLocked

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -1,11 +1,10 @@
 import isValid from '../../../graphql/isValid'
-import getTeamsByOrgIds from '../../../postgres/queries/getTeamsByOrgIds'
 import {DataLoaderWorker} from '../../graphql'
 
 const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   const {lockMessageHTML, orgId, tier} = team
-  const orgTeams = await getTeamsByOrgIds([orgId])
+  const orgTeams = await dataLoader.get('teamsByOrgIds').load(orgId)
   const anyOrgTeamIsLocked = orgTeams.some((team) => !team.isPaid)
   if (tier !== 'personal' && anyOrgTeamIsLocked) {
     // if this team was manually locked, be mean because they called this by hiding the modal

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -8,7 +8,6 @@ import {getUserId, isAuthenticated} from '../../../utils/authorization'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
 import publish from '../../../utils/publish'
 import RedisLock from '../../../utils/RedisLock'
-import segmentIo from '../../../utils/segmentIo'
 import activatePrevSlackAuth from '../../mutations/helpers/activatePrevSlackAuth'
 import handleInvitationToken from '../../mutations/helpers/handleInvitationToken'
 import {MutationResolvers} from '../resolverTypes'
@@ -72,11 +71,6 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
     return {error: {message: approvalError.message}}
   }
   if (isAnyViewerTeamLocked) {
-    segmentIo.track({
-      userId: viewerId,
-      event: 'Locked user attempted to join a team',
-      properties: {invitingOrgId: orgId}
-    })
     return {
       error: {
         message: LOCKED_OVERDUE_MSG

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -1,4 +1,5 @@
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
+import {LOCKED_OVERDUE_MSG} from '../../../../client/mutations/AcceptTeamInvitationMutation'
 import {InvitationTokenError, SubscriptionChannel} from '../../../../client/types/constEnums'
 import AuthToken from '../../../database/types/AuthToken'
 import acceptTeamInvitationSafe from '../../../safeMutations/acceptTeamInvitation'
@@ -78,7 +79,7 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
     })
     return {
       error: {
-        message: `Sorry! You're unable to join this team because one of your teams has an overdue payment`
+        message: LOCKED_OVERDUE_MSG
       }
     }
   }

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -7,6 +7,7 @@ import {getUserId, isAuthenticated} from '../../../utils/authorization'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
 import publish from '../../../utils/publish'
 import RedisLock from '../../../utils/RedisLock'
+import segmentIo from '../../../utils/segmentIo'
 import activatePrevSlackAuth from '../../mutations/helpers/activatePrevSlackAuth'
 import handleInvitationToken from '../../mutations/helpers/handleInvitationToken'
 import {MutationResolvers} from '../resolverTypes'
@@ -70,6 +71,11 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
     return {error: {message: approvalError.message}}
   }
   if (isAnyViewerTeamLocked) {
+    segmentIo.track({
+      userId: viewerId,
+      event: 'Locked user attempted to join a team',
+      properties: {invitingOrgId: orgId}
+    })
     return {
       error: {
         message: `Sorry! You're unable to join this team because one of your teams has an overdue payment`

--- a/packages/server/graphql/public/mutations/helpers/getIsAnyViewerTeamLocked.ts
+++ b/packages/server/graphql/public/mutations/helpers/getIsAnyViewerTeamLocked.ts
@@ -1,0 +1,9 @@
+import {DataLoaderWorker} from '../../../graphql'
+import isValid from '../../../isValid'
+
+const getIsAnyViewerTeamLocked = async (tms: string[], dataLoader: DataLoaderWorker) => {
+  const viewerTeams = await dataLoader.get('teams').loadMany(tms)
+  return viewerTeams.filter(isValid).some(({isPaid}) => !isPaid)
+}
+
+export default getIsAnyViewerTeamLocked


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6897

This PR prevents a user from creating a meeting if any of the members of that team belong to a locked team. It largely uses the logic shared [here](https://github.com/ParabolInc/parabol/issues/6378#issuecomment-1185777575), with a few changes. I've added comments where the logic was changed to help with the CR.

### To test

- [ ] Teams that don't contain a user that belongs to a locked team can create a meeting successfully
- [ ] If the team is locked, the user can't start a meeting
- [ ] If a team in the org is locked, the user can't start a meeting
- [ ] If a team member in the team belongs to a team that is locked, the user can't start a meeting
- [ ] The user sees a helpful error message if they're locked & unable to start a meeting