### PR TITLE
fix:  Emoji menu popups in a wrong place if `:` is the first character typed 

### DIFF
--- a/packages/client/components/TaskEditor/withEmojis.tsx
+++ b/packages/client/components/TaskEditor/withEmojis.tsx
@@ -76,16 +76,20 @@ const withEmojis = (ComposedComponent) => {
     renderModal = () => {
       const {query} = this.state
       const {editorState} = this.props
-      this.cachedCoords = getDraftCoords() || this.cachedCoords
+      this.cachedCoords = getDraftCoords()
       return (
-        <EmojiMenuContainer
-          removeModal={this.removeModal}
-          menuItemClickFactory={this.menuItemClickFactory}
-          query={query}
-          menuRef={this.menuRef}
-          editorState={editorState}
-          originCoords={this.cachedCoords}
-        />
+        <>
+          {this.cachedCoords && (
+            <EmojiMenuContainer
+              removeModal={this.removeModal}
+              menuItemClickFactory={this.menuItemClickFactory}
+              query={query}
+              menuRef={this.menuRef}
+              editorState={editorState}
+              originCoords={this.cachedCoords}
+            />
+          )}
+        </>
       )
     }
 


### PR DESCRIPTION
# Description
Emoji menu popups in a wrong place if : is the first character typed

- `EmogiMenuContainer`  is rendered out of position  because the `draft-js`'s `getVisibleSelectionRect` responsible for calculating and returns the correct page coordinates instead returns undefined when we input `:` at the start of input. 

Partially Fixes  [issue](https://github.com/ParabolInc/parabol/issues/6421)
- Conditionally render `EmojiMenuContainer` if we have the page `coordinates` provided

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
