### PR TITLE
feat(metrics): Add more Segment events to Standups

### DIFF
--- a/packages/server/graphql/mutations/addReactjiToReactable.ts
+++ b/packages/server/graphql/mutations/addReactjiToReactable.ts
@@ -11,6 +11,7 @@ import Reflection from '../../database/types/Reflection'
 import getPg from '../../postgres/getPg'
 import {appendTeamResponseReactji} from '../../postgres/queries/generated/appendTeamResponseReactjiQuery'
 import {removeTeamResponseReactji} from '../../postgres/queries/generated/removeTeamResponseReactjiQuery'
+import {analytics} from '../../utils/analytics/analytics'
 import {getUserId} from '../../utils/authorization'
 import emojiIds from '../../utils/emojiIds'
 import getGroupedReactjis from '../../utils/getGroupedReactjis'
@@ -39,7 +40,7 @@ const addReactjiToReactable = {
     },
     reactableType: {
       type: new GraphQLNonNull(ReactableEnum),
-      description: 'the type of the'
+      description: 'the type of the reactable'
     },
     reactji: {
       type: new GraphQLNonNull(GraphQLString),
@@ -162,6 +163,15 @@ const addReactjiToReactable = {
     }
 
     const data = {reactableId, reactableType}
+    const {meetingType} = await dataLoader.get('newMeetings').load(meetingId)
+    analytics.reactjiInteracted(
+      viewerId,
+      meetingId,
+      meetingType,
+      reactableId,
+      reactableType,
+      !!isRemove
+    )
     if (meetingId) {
       publish(
         SubscriptionChannel.MEETING,

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -4,6 +4,7 @@ import TeamPromptResponseId from 'parabol-client/shared/gqlIds/TeamPromptRespons
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {TeamPromptResponse} from '../../../postgres/queries/getTeamPromptResponsesByIds'
 import {upsertTeamPromptResponse as upsertTeamPromptResponseQuery} from '../../../postgres/queries/upsertTeamPromptResponses'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId, isTeamMember} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
@@ -75,6 +76,7 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
     meetingId,
     teamPromptResponseId
   }
+  analytics.responseAdded(viewerId, meetingId, teamPromptResponseId, !!inputTeamPromptResponseId)
   publish(
     SubscriptionChannel.MEETING,
     meetingId,

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -23,6 +23,7 @@ export type AnalyticsEvent =
   | 'Meeting Started'
   | 'Meeting Joined'
   | 'Meeting Completed'
+  | 'Comment Added'
   // team
   | 'Integration Added'
   | 'Integration Removed'
@@ -119,6 +120,17 @@ class Analytics {
       teamMembersPresentCount: meetingMembers.length,
       teamId,
       ...meetingSpecificProperties
+    })
+  }
+
+  commentAdded = (userId: string, meeting: Meeting, isAnonymous, isAsync, isReply) => {
+    this.track(userId, 'Comment Added', {
+      meetingId: meeting.id,
+      meetingType: meeting.meetingType,
+      teamId: meeting.teamId,
+      isAnonymous,
+      isAsync,
+      isReply
     })
   }
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -24,6 +24,7 @@ export type AnalyticsEvent =
   | 'Meeting Joined'
   | 'Meeting Completed'
   | 'Comment Added'
+  | 'Response Added'
   // team
   | 'Integration Added'
   | 'Integration Removed'
@@ -131,6 +132,19 @@ class Analytics {
       isAnonymous,
       isAsync,
       isReply
+    })
+  }
+
+  responseAdded = (
+    userId: string,
+    meetingId: string,
+    teamPromptResponseId: string,
+    isUpdate: boolean
+  ) => {
+    this.track(userId, 'Response Added', {
+      meetingId,
+      teamPromptResponseId,
+      isUpdate
     })
   }
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -2,9 +2,10 @@ import {NewMeetingPhaseTypeEnum} from '../../database/types/GenericMeetingPhase'
 import Meeting from '../../database/types/Meeting'
 import MeetingMember from '../../database/types/MeetingMember'
 import MeetingTemplate from '../../database/types/MeetingTemplate'
+import {ReactableEnum} from '../../database/types/Reactable'
 import {IntegrationProviderServiceEnumType} from '../../graphql/types/IntegrationProviderServiceEnum'
 import {TeamPromptResponse} from '../../postgres/queries/getTeamPromptResponsesByIds'
-import {AnyMeeting} from '../../postgres/types/Meeting'
+import {AnyMeeting, MeetingTypeEnum} from '../../postgres/types/Meeting'
 import segment from '../segmentIo'
 import {createMeetingTemplateAnalyticsParams} from './helpers'
 import {SegmentAnalytics} from './segment/SegmentAnalytics'
@@ -25,6 +26,7 @@ export type AnalyticsEvent =
   | 'Meeting Completed'
   | 'Comment Added'
   | 'Response Added'
+  | 'Reactji Interacted'
   // team
   | 'Integration Added'
   | 'Integration Removed'
@@ -145,6 +147,23 @@ class Analytics {
       meetingId,
       teamPromptResponseId,
       isUpdate
+    })
+  }
+
+  reactjiInteracted = (
+    userId: string,
+    meetingId: string,
+    meetingType: MeetingTypeEnum,
+    reactableId: string,
+    reactableType: ReactableEnum,
+    isRemove: boolean
+  ) => {
+    this.track(userId, 'Reactji Interacted', {
+      meetingId,
+      meetingType,
+      reactableId,
+      reactableType,
+      isRemove
     })
   }
 


### PR DESCRIPTION
# Description

Implements #6902 

## Demo

Comment Added:
<img width="447" alt="Screen Shot 2022-07-20 at 10 41 33 AM" src="https://user-images.githubusercontent.com/1879975/180083925-0182937b-6b6d-4c84-891b-f763cc76767d.png">

Response Added:
<img width="427" alt="Screen Shot 2022-07-20 at 10 56 18 AM" src="https://user-images.githubusercontent.com/1879975/180083956-a27bebf0-e95a-4a49-a3b0-877959e902eb.png">

Reactji Interacted:
<img width="445" alt="Screen Shot 2022-07-20 at 2 17 58 PM" src="https://user-images.githubusercontent.com/1879975/180083975-616a0a1e-f623-4830-b4cd-8c3ae21de58a.png">

## Testing scenarios
- [ ] When user adds a response in a stand up meeting, a `Response Added` event is emitted to Segment
- [ ] When user updates a response in a stand up meeting, a `Response Added` event is emitted to Segment, with `isUpdate` attribute set to true
- [ ] When user add a comment to a response in a stand up meeting, the `Comment Added` event is emitted to Segment, with `meetingType` set to `teamPrompt`
- [ ] When user add a Reactji in a stand up meeting, a `Reactji Interacted` event is emitted to Segment with `isRemove` set to false. If the Reactji is removed, `isRemove` should be set to true.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
