### PR TITLE
feat: mattermost info icon

### DIFF
--- a/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {FormEvent} from 'react'
 import {useFragment} from 'react-relay'
+import Icon from '~/components/Icon'
 import {MenuPosition} from '~/hooks/useCoords'
 import useForm from '~/hooks/useForm'
 import useTooltip from '~/hooks/useTooltip'
@@ -25,6 +26,14 @@ interface Props {
   viewerRef: MattermostPanel_viewer$key
   teamId: string
 }
+
+const StyledIcon = styled(Icon)({
+  color: PALETTE.SLATE_600,
+  paddingLeft: '4px',
+  ':hover': {
+    cursor: 'pointer'
+  }
+})
 
 const MattermostPanelStyles = styled('div')({
   borderTop: `1px solid ${PALETTE.SLATE_300}`,
@@ -50,7 +59,10 @@ const Row = styled('div')({
 const Label = styled('span')({
   fontSize: 14,
   marginRight: 16,
-  width: '100%'
+  width: '100%',
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center'
 })
 
 const StyledButton = styled(FlatButton)({
@@ -170,7 +182,7 @@ const MattermostPanel = (props: Props) => {
   }
 
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
-    MenuPosition.LOWER_LEFT
+    MenuPosition.LOWER_CENTER
   )
 
   return (
@@ -180,8 +192,11 @@ const MattermostPanel = (props: Props) => {
       </ConnectionGroup>
       <form onSubmit={onSubmit}>
         <Row>
-          <Label onMouseOver={openTooltip} onMouseOut={closeTooltip} ref={originRef}>
+          <Label>
             Mattermost Webhook
+            <StyledIcon onMouseOver={openTooltip} onMouseOut={closeTooltip} ref={originRef}>
+              {'info'}
+            </StyledIcon>
           </Label>
           {tooltipPortal('Configure in Mattermost: Main Menu > Integrations > Incoming Webhook')}
           <BasicInput

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
@@ -61,8 +61,8 @@ const Label = styled('span')({
   marginRight: 16,
   width: '100%',
   position: 'relative',
-  display: 'flex',
-  alignItems: 'center'
+  alignItems: 'center',
+  display: 'flex'
 })
 
 const StyledButton = styled(FlatButton)({


### PR DESCRIPTION
Currently, you need to hover over the "Mattermost Webhook" text to see the tooltip which explains how to get the webhook URL:

![before](https://user-images.githubusercontent.com/39854876/180196537-d72705bd-62e1-4d28-b2c0-15c07b5eb0b3.png)

In this PR, I'm adding an info icon to make it clearer for users that there's a tooltip with instructions:

![mattermost-after](https://user-images.githubusercontent.com/39854876/180196652-fd3eb47c-4ebe-4099-b7dc-8374bc468754.png)

