### PR TITLE
chore: Fix browser translation

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -129,20 +129,25 @@ const AnalyticsPage = () => {
   }, [isSegmentLoaded])
 
   useEffect(() => {
-    if (!isSegmentLoaded || !window.analytics) return
+    if (!isSegmentLoaded || !window.analytics || typeof window.analytics.page !== 'function') return
     const prevPathname = pathnameRef.current
     pathnameRef.current = pathname
     setTimeout(() => {
       const title = document.title || ''
       // This is the magic. Ignore everything after hitting the pipe
       const [pageName] = title.split(' | ')
+      // Detect browser translations, see https://www.ctrl.blog/entry/detect-machine-translated-webpages.html
+      const translated = !!document.querySelector(
+        'html.translated-ltr, html.translated-rtl, ya-tr-span, *[_msttexthash], *[x-bergamot-translated]'
+      )
       window.analytics.page(
         pageName,
         {
           referrer: makeHref(prevPathname),
           title,
           path: pathname,
-          url: href
+          url: href,
+          translated
         },
         // See: segmentIo.ts:28 for more information on the next line
         {integrations: {'Google Analytics': {clientId: getAnonymousId()}}}

--- a/packages/client/components/Icon.tsx
+++ b/packages/client/components/Icon.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
+import React from 'react'
 import {ICON_SIZE} from '../styles/typographyV2'
 
-const Icon = styled('i')({
+const StyledIcon = styled('i')({
   flexShrink: 0,
   fontFamily: 'Material Icons',
   fontWeight: 'normal',
@@ -24,5 +25,11 @@ const Icon = styled('i')({
   // Support for IE
   fontFeatureSettings: 'liga'
 })
+
+const Icon = (props: Parameters<typeof StyledIcon>[0]) => {
+  // add notranslate class so it's skipped by Chrome translate website
+  const className = `notranslate ${props.className ?? ''}`
+  return <StyledIcon {...props} className={className} />
+}
 
 export default Icon


### PR DESCRIPTION
# Description

Relates to: #6062
When translating the app in Chrome it would break all the material ui font icons. To fix this the CSS class 'notranslate' was added to the `Icon` component.

## Demo

Before (page translated to German by Chromium):
![Screenshot from 2022-07-25 12-05-33](https://user-images.githubusercontent.com/7331043/180799877-4ac5fac9-cd01-4545-abfb-eebc3147ac67.png)
After:
![Screenshot from 2022-07-25 16-21-56](https://user-images.githubusercontent.com/7331043/180799914-dd63420e-17ea-4a49-9bb0-7599b02e2922.png)

## Testing scenarios

Load the app in Chrome and translate to a non-English language.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
