### PR TITLE
feat(standups): Beta badge within meeting

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -58,10 +58,11 @@ const BetaBadge = styled('div')({
 
 interface Props {
   meetingRef: TeamPromptTopBar_meeting$key
+  isDesktop: boolean
 }
 
 const TeamPromptTopBar = (props: Props) => {
-  const {meetingRef} = props
+  const {meetingRef, isDesktop} = props
 
   const meeting = useFragment(
     graphql`
@@ -100,7 +101,7 @@ const TeamPromptTopBar = (props: Props) => {
         )}
       </TeamPromptHeader>
       <IconGroupBlock>
-        <BetaBadge>BETA</BetaBadge>
+        {isDesktop && <BetaBadge>BETA</BetaBadge>}
         <NewMeetingAvatarGroup meeting={meeting} />
         <ButtonContainer>
           <TeamPromptOptions meetingRef={meeting} />

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -5,6 +5,7 @@ import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {useRenameMeeting} from '~/hooks/useRenameMeeting'
 import NewMeetingAvatarGroup from '~/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
+import {PALETTE} from '~/styles/paletteV3'
 import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
 import {meetingAvatarMediaQueries} from '../../styles/meeting'
 import BackButton from '../BackButton'
@@ -42,6 +43,17 @@ const ButtonContainer = styled('div')({
   [meetingAvatarMediaQueries[1]]: {
     height: 56
   }
+})
+
+const BetaBadge = styled('div')({
+  borderRadius: 44,
+  backgroundColor: PALETTE.GRAPE_500,
+  color: PALETTE.SLATE_100,
+  fontWeight: 600,
+  fontSize: 12,
+  lineHeight: '11px',
+  marginRight: 53,
+  padding: '8px 16px 8px 16px'
 })
 
 interface Props {
@@ -88,6 +100,7 @@ const TeamPromptTopBar = (props: Props) => {
         )}
       </TeamPromptHeader>
       <IconGroupBlock>
+        <BetaBadge>BETA</BetaBadge>
         <NewMeetingAvatarGroup meeting={meeting} />
         <ButtonContainer>
           <TeamPromptOptions meetingRef={meeting} />

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -132,7 +132,7 @@ const TeamPromptMeeting = (props: Props) => {
               isOpen={isRightDrawerOpen && isDesktop}
               hideBottomBar={true}
             >
-              <TeamPromptTopBar meetingRef={meeting} />
+              <TeamPromptTopBar meetingRef={meeting} isDesktop={isDesktop} />
               <TeamPromptEditablePrompt meetingRef={meeting} />
               <ErrorBoundary>
                 <ResponsesGridContainer>


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6899

Adds a beta badge to the standups meeting

## Demo
Appears on desktop
<img width="1414" alt="Screen Shot 2022-07-25 at 4 29 29 PM" src="https://user-images.githubusercontent.com/9013217/180816832-4ddb2656-d2f9-4e65-adda-1d5883c43bb2.png">

Does not appear on mobile (since the top bar doesn't have enough real estate)
<img width="444" alt="Screen Shot 2022-07-25 at 4 33 32 PM" src="https://user-images.githubusercontent.com/9013217/180817593-8662b3c8-fe7f-4d07-94b4-c2545f7b9606.png">


## Testing scenarios
- [ ] Beta badge appears on larger viewports
- [ ] Beta badge doesn't interfere with styling on smaller viewports

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
