### PR TITLE
feat(saml): support preferredName, enforce SAML over oauth

### DIFF
--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -51,15 +51,15 @@ const loginSAML: MutationResolvers['loginSAML'] = async (_source, {samlName, que
   const {isInvited} = relayState
   const {extract} = loginResponse
   const {attributes, nameID: name} = extract
-  const caseInsensitiveAtttributes = {} as Record<Lowercase<string>, Lowercase<string>>
+  const caseInsensitiveAtttributes = {} as Record<Lowercase<string>, string | undefined>
   Object.keys(attributes).forEach((key) => {
     const lowercaseKey = key.toLowerCase()
     const value = attributes[key]
-    const lowercaseValue = String(value).toLowerCase()
-    caseInsensitiveAtttributes[lowercaseKey] = lowercaseValue
+    caseInsensitiveAtttributes[lowercaseKey] = String(value)
   })
-  const {email: inputEmail, emailaddress} = caseInsensitiveAtttributes
-  const email = inputEmail || emailaddress
+  const {email: inputEmail, emailaddress, preferredname} = caseInsensitiveAtttributes
+  const preferredName = preferredname || name
+  const email = inputEmail?.toLowerCase() || emailaddress?.toLowerCase()
   if (!email) {
     return {error: {message: 'Email attribute was not included in SAML response'}}
   }
@@ -83,7 +83,7 @@ const loginSAML: MutationResolvers['loginSAML'] = async (_source, {samlName, que
   const newUser = new User({
     id: userId,
     email,
-    preferredName: name,
+    preferredName,
     tier: 'enterprise'
   })
 

--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -57,8 +57,8 @@ const loginSAML: MutationResolvers['loginSAML'] = async (_source, {samlName, que
     const value = attributes[key]
     caseInsensitiveAtttributes[lowercaseKey] = String(value)
   })
-  const {email: inputEmail, emailaddress, preferredname} = caseInsensitiveAtttributes
-  const preferredName = preferredname || name
+  const {email: inputEmail, emailaddress, displayname} = caseInsensitiveAtttributes
+  const preferredName = displayname || name
   const email = inputEmail?.toLowerCase() || emailaddress?.toLowerCase()
   if (!email) {
     return {error: {message: 'Email attribute was not included in SAML response'}}

--- a/packages/server/graphql/public/mutations/loginWithGoogle.ts
+++ b/packages/server/graphql/public/mutations/loginWithGoogle.ts
@@ -7,6 +7,7 @@ import {USER_PREFERRED_NAME_LIMIT} from '../../../postgres/constants'
 import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
 import updateUser from '../../../postgres/queries/updateUser'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
+import getSAMLURLFromEmail from '../../../utils/getSAMLURLFromEmail'
 import GoogleServerManager from '../../../utils/GoogleServerManager'
 import standardError from '../../../utils/standardError'
 import bootstrapNewUser from '../../mutations/helpers/bootstrapNewUser'
@@ -28,8 +29,14 @@ const loginWithGoogle: MutationResolvers['loginWithGoogle'] = async (
     return {error: {message: 'Email is too long'}}
   }
 
-  const existingUser = await getUserByEmail(email)
+  const [existingUser, samlURL] = await Promise.all([
+    getUserByEmail(email),
+    getSAMLURLFromEmail(email, false)
+  ])
 
+  if (samlURL) {
+    return {error: {message: 'Please login using SSO'}}
+  }
   if (existingUser) {
     const {id: viewerId, identities, rol} = existingUser
     let googleIdentity = identities.find(

--- a/packages/server/graphql/public/mutations/loginWithGoogle.ts
+++ b/packages/server/graphql/public/mutations/loginWithGoogle.ts
@@ -35,7 +35,12 @@ const loginWithGoogle: MutationResolvers['loginWithGoogle'] = async (
   ])
 
   if (samlURL) {
-    return {error: {message: 'Please login using SSO'}}
+    return {
+      error: {
+        message:
+          'our organization requires you to login with SSO. Reach out to support@parabol.co for more help!'
+      }
+    }
   }
   if (existingUser) {
     const {id: viewerId, identities, rol} = existingUser


### PR DESCRIPTION
# Description

fix #6668
fix #6930

Users can add a `preferredName` attribute to their SAML response payload & that will become their new `preferredName` _for new users_. This will not update the name for existing users.

Also, if a user signed up using Google OAuth2 and then their domain upgraded to SSO, we now force them to login with SSO. If they try logging in via Google OAuth2, they get an error telling them to login via SSO.
