### PR TITLE
feat(standups): Removed standups feature flag

### DIFF
--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -4,7 +4,6 @@ import React, {useEffect, useRef, useState} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import useUsageSnackNag from '~/hooks/useUsageSnackNag'
 import {PALETTE} from '~/styles/paletteV3'
-import {NonEmptyArray} from '~/types/generics'
 import {MeetingTypeEnum, NewMeetingQuery} from '~/__generated__/NewMeetingQuery.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
 import useRouter from '../hooks/useRouter'
@@ -77,23 +76,10 @@ const NewMeetingInner = styled('div')({
   }
 })
 
-const createMeetingOrder = ({standups}: {standups: boolean}) => {
-  const meetingOrder: NonEmptyArray<MeetingTypeEnum> = ['retrospective']
-
-  if (standups) {
-    meetingOrder.push('teamPrompt')
-  }
-
-  meetingOrder.push('poker', 'action')
-
-  return meetingOrder
-}
-
 const query = graphql`
   query NewMeetingQuery {
     viewer {
       featureFlags {
-        standups
         insights
       }
       teams {
@@ -118,9 +104,12 @@ const NewMeeting = (props: Props) => {
   const {viewer} = data
   const {teams, featureFlags} = viewer
   const {insights} = featureFlags
-  const [meetingOrder, setMeetingOrder] = useState<MeetingTypeEnum[]>(
-    createMeetingOrder(featureFlags)
-  )
+  const [meetingOrder, setMeetingOrder] = useState<MeetingTypeEnum[]>([
+    'retrospective',
+    'teamPrompt',
+    'poker',
+    'action'
+  ])
 
   const {history, location} = useRouter()
   const [idx, setIdx] = useState(0)

--- a/packages/client/modules/demo/DemoUser.ts
+++ b/packages/client/modules/demo/DemoUser.ts
@@ -8,9 +8,8 @@ export default class DemoUser {
   createdAt = new Date().toJSON()
   email: string
   featureFlags = {
-    gitlab: false,
-    spotlight: true,
-    standups: true
+    azureDevOps: false,
+    msTeams: false
   }
   facilitatorUserId: string
   facilitatorName: string

--- a/packages/server/__tests__/addFeatureFlag.test.ts
+++ b/packages/server/__tests__/addFeatureFlag.test.ts
@@ -12,7 +12,7 @@ const ADD_FEATURE_FLAG = `
       users {
         id
         featureFlags {
-          standups
+          azureDevOps
         }
       }
     }
@@ -27,7 +27,7 @@ test('Add feature flag by email', async () => {
     query: ADD_FEATURE_FLAG,
     variables: {
       emails: [email],
-      flag: 'standups'
+      flag: 'azureDevOps'
     },
     authToken
   })
@@ -40,7 +40,7 @@ test('Add feature flag by email', async () => {
           {
             id: userId,
             featureFlags: {
-              standups: true
+              azureDevOps: true
             }
           }
         ]

--- a/packages/server/graphql/public/types/UserFeatureFlags.ts
+++ b/packages/server/graphql/public/types/UserFeatureFlags.ts
@@ -1,7 +1,6 @@
 import {UserFeatureFlagsResolvers} from '../resolverTypes'
 
 const UserFeatureFlags: UserFeatureFlagsResolvers = {
-  standups: ({standups}) => !!standups,
   azureDevOps: ({azureDevOps}) => !!azureDevOps,
   msTeams: ({msTeams}) => !!msTeams,
   insights: ({insights}) => !!insights

--- a/packages/server/graphql/types/UserFlagEnum.ts
+++ b/packages/server/graphql/types/UserFlagEnum.ts
@@ -1,12 +1,11 @@
 import {GraphQLEnumType} from 'graphql'
 
-export type UserFeatureFlagEnum = 'standups' | 'azureDevOps' | 'msTeams'
+export type UserFeatureFlagEnum = 'azureDevOps' | 'msTeams'
 
 const UserFlagEnum = new GraphQLEnumType({
   name: 'UserFlagEnum',
   description: 'A flag to give an individual user super powers',
   values: {
-    standups: {},
     azureDevOps: {},
     msTeams: {}
   }


### PR DESCRIPTION
# Description

This PR removes the standups feature flag and is meant to finish the https://github.com/ParabolInc/parabol/milestone/129 milestone.

## Testing scenarios

- [ ] Register new user, check if standups are available on the new meeting screen

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
