### PR TITLE
style: Increased active phase color contrast

### DIFF
--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -18,7 +18,7 @@ interface ItemRootProps {
 const ItemRoot = styled('div')<ItemRootProps>(
   ({isActive, isComplete, isDisabled, isDragging, onClick}) => ({
     alignItems: 'center',
-    backgroundColor: isActive ? PALETTE.SLATE_100 : isDragging ? PALETTE.SLATE_100 : 'transparent',
+    backgroundColor: isActive ? PALETTE.SLATE_200 : isDragging ? PALETTE.SLATE_200 : 'transparent',
     borderRadius: '0 4px 4px 0',
     color: PALETTE.SLATE_700,
     display: 'flex',
@@ -32,7 +32,7 @@ const ItemRoot = styled('div')<ItemRootProps>(
     userSelect: 'none',
     width: '100%',
     '&:hover': {
-      backgroundColor: onClick && !isActive ? PALETTE.SLATE_100 : undefined,
+      backgroundColor: onClick && !isActive ? PALETTE.SLATE_200 : undefined,
       cursor: !isActive && onClick ? 'pointer' : undefined,
       opacity: !isDisabled ? 1 : undefined
     }


### PR DESCRIPTION
# Description

Fixes #6176
- MeetingSubnavItem background color changed from Slate 100 > Slate 200 for improved contrast. Impacts active, hover, and dragging states.

## Demo
<img width="255" alt="Screen Shot 2022-07-27 at 1 28 36 PM" src="https://user-images.githubusercontent.com/18582225/181311353-001ad938-a14c-45a5-bcca-1813f80e91b0.png">



## Testing scenarios

Test in various browsers to ensure contrast between the background and text is comfortable.
[ ] Chrome
[ ] Firefox
[ ] Safari

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
