### PR TITLE
feat(standups): Added beta badge to standups on new meeting view

### DIFF
--- a/packages/client/components/NewMeetingCarousel.tsx
+++ b/packages/client/components/NewMeetingCarousel.tsx
@@ -57,9 +57,23 @@ const Card = styled('div')<{isActive: boolean; meetingType: keyof typeof BACKGRO
     transition: `all 200ms ${BezierCurve.DECELERATE}`,
     transform: isActive ? `scale(1.1)` : 'scale(1)',
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'column',
+    position: 'relative'
   })
 )
+
+const Badge = styled('div')({
+  position: 'absolute',
+  top: -8,
+  right: -8,
+  background: PALETTE.GRAPE_500,
+  color: PALETTE.WHITE,
+  fontSize: 12,
+  fontWeight: 600,
+  padding: '6px 14px',
+  borderRadius: 24,
+  textTransform: 'uppercase'
+})
 
 const ILLUSTRATIONS = {
   retrospective,
@@ -134,6 +148,7 @@ const NewMeetingCarousel = (props: Props) => {
                 <MeetingImage src={src} key={meetingType} />
                 <Title isActive={isActive}>{title}</Title>
                 <Description isActive={isActive}>{description}</Description>
+                {meetingType === 'teamPrompt' && <Badge>Beta</Badge>}
               </Card>
             </SwiperSlide>
           )


### PR DESCRIPTION
# Description

Fixes #6937. 

Important: the dimensions of carousel elements are different in the application than in the designs so I couldn't make it pixel perfect as I had to scale the badge down a bit to make it look nice.

## Demo
<img width="1324" alt="CleanShot 2022-07-28 at 19 54 30@2x" src="https://user-images.githubusercontent.com/1017620/181605069-e79d2ccd-c6d6-4567-8331-f4ec030ffeed.png">
<img width="1324" alt="CleanShot 2022-07-28 at 19 54 38@2x" src="https://user-images.githubusercontent.com/1017620/181605094-3c3b0b5c-78b9-44c4-8287-b1fbe7e9c2e4.png">


## Testing scenarios

- [ ] Open a new meeting modal, the UI of unselected async standup should match the designs
- [ ] Open a new meeting modal, select async standup, and the UI should match the designs

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
