### PR TITLE
fix: allow to go to the discuss phase without voting

### DIFF
--- a/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
+++ b/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
@@ -33,6 +33,7 @@ graphql`
           viewerVoteCount
         }
       }
+      ...MeetingControlBar_meeting
     }
   }
 `

--- a/packages/server/database/types/DiscussStage.ts
+++ b/packages/server/database/types/DiscussStage.ts
@@ -17,5 +17,6 @@ export default class DiscussStage extends GenericMeetingStage {
     this.sortOrder = sortOrder
     this.discussionId = discussionId ?? generateUID()
     this.reflectionGroupId = reflectionGroupId
+    this.isNavigableByFacilitator = true
   }
 }


### PR DESCRIPTION
Fixes #6631

In this PR I make it possible to move to the discussion phase without voting.

Previous discussion here: #6886

How to test:
- Create a new retro meeting
- Advance to the voting phase but do not case any votes
- Click next, see the button works and advances to the discussion phase