### PR TITLE
fix(metrics): update activeUserCount & activeTeamCount for companies in HubSpot more often

### DIFF
--- a/packages/server/utils/updateHubspot.ts
+++ b/packages/server/utils/updateHubspot.ts
@@ -66,6 +66,8 @@ query MeetingCompleted($userIds: [ID!]!, $userId: ID!) {
     tier
     lastMetAt
     meetingCount
+    activeUserCount
+    activeTeamCount
     monthlyTeamStreakMax
   }
   users(userIds: $userIds) {
@@ -120,6 +122,7 @@ query AccountCreated($userId: ID!) {
     company {
       userCount
       activeUserCount
+      activeTeamCount
     }
   }
 }`,
@@ -131,6 +134,7 @@ query AccountRemoved($userId: ID!) {
     company {
       userCount
       activeUserCount
+      activeTeamCount
     }
   }
 }`,
@@ -140,6 +144,7 @@ query AccountPaused($userId: ID!) {
     email
     company {
       activeUserCount
+      activeTeamCount
     }
   }
 }`,
@@ -149,6 +154,7 @@ query AccountUnpaused($userId: ID!) {
     email
     company {
       activeUserCount
+      activeTeamCount
     }
   }
 }`,


### PR DESCRIPTION
# Description

Partially Fixes #6982 

1. This solution is not perfect but workable for now.
2. Adding more fields will NOT increase API call volume to HubSpot as we update all properties for a company in one call.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
