### PR TITLE
feat(standups): Rename Async standup -> standup

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -150,7 +150,7 @@ const MEETING_TYPE_LABEL = {
   retrospective: 'Retro',
   action: 'Check-In',
   poker: 'Sprint Poker',
-  teamPrompt: 'Async Standup'
+  teamPrompt: 'Standup'
 }
 
 const MeetingCard = (props: Props) => {

--- a/packages/client/components/NewMeetingCarousel.tsx
+++ b/packages/client/components/NewMeetingCarousel.tsx
@@ -86,7 +86,7 @@ const TITLES = {
   retrospective: 'Retrospective',
   action: 'Team Check-in',
   poker: 'Sprint Poker',
-  teamPrompt: 'Async Standup'
+  teamPrompt: 'Standup'
 } as Record<MeetingTypeEnum, string>
 
 const DESCRIPTIONS = {

--- a/packages/client/modules/email/components/TeamInvite.tsx
+++ b/packages/client/modules/email/components/TeamInvite.tsx
@@ -34,7 +34,7 @@ const meetingCopyLabelLookup = {
   action: 'a Check-in Meeting',
   retrospective: 'a Retrospective Meeting',
   poker: 'a Sprint Poker Meeting',
-  teamPrompt: 'an Async Standup Meeting'
+  teamPrompt: 'a Standup Meeting'
 } as const
 
 const utmParams = {

--- a/packages/server/database/types/MeetingTeamPrompt.ts
+++ b/packages/server/database/types/MeetingTeamPrompt.ts
@@ -24,7 +24,7 @@ function createTeamPromptDefaultTitle() {
     day: 'numeric'
   })
 
-  return `Async Standup - ${formattedDate}`
+  return `Standup - ${formattedDate}`
 }
 
 export default class MeetingTeamPrompt extends Meeting {

--- a/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
@@ -108,7 +108,7 @@ const makeTeamPromptStartMeetingNotification = (
         }
       ],
       {
-        fallback: `Async Standup started, submit response: ${meetingUrl}`,
+        fallback: `Standup started, submit response: ${meetingUrl}`,
         title: `${meeting.name} is open 💬 `,
         title_link: meetingUrl
       }


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6987

## Testing scenarios
- [ ] All places where we called standups "async standup" are changed to just "standup"

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
