### PR TITLE
feat(metrics): Add `isActive` and `featureFlags` as new User Properties for Segment identify calls

### DIFF
--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -167,6 +167,19 @@ export default async function adjustUserCount(
     }
   }
 
+  if (
+    type === InvoiceItemType.PAUSE_USER ||
+    type === InvoiceItemType.AUTO_PAUSE_USER ||
+    type === InvoiceItemType.REMOVE_USER
+  ) {
+    segmentIo.identify({
+      userId,
+      traits: {
+        isActive: false
+      }
+    })
+  }
+
   const prorationDate = options.prorationDate ? toEpochSeconds(options.prorationDate) : undefined
   const hooks = proOrgs.map((org) => {
     return new InvoiceItemHook({

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -84,7 +84,8 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
   segmentIo.identify({
     userId,
     traits: {
-      isActive: true
+      isActive: true,
+      featureFlags: user.featureFlags
     }
   })
   return user

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -81,6 +81,12 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
       tms
     }
   })
+  segmentIo.identify({
+    userId,
+    traits: {
+      isActive: true
+    }
+  })
   return user
 }
 


### PR DESCRIPTION
# Description

Partially Fixes #6952. As a first step, I added `isActive` and `featureFlags` because the infomation is available upon socket connection. Any other properties suggested in the issue are expensive to calculate. For example, `isTeamLead`, we could call `identify` on `promoteToTeamLead` but that would only work for **new** team lead. To "backfill" existing team leads, we have to `identify` them on login, but it seems expensive to calculate if the user is a team lead on all the logins for every user? I need to think about the performance impact more hence not including them in this PR.

## Demo

<img width="474" alt="Screen Shot 2022-08-03 at 4 55 37 PM" src="https://user-images.githubusercontent.com/1879975/182733373-a9bcd565-daad-4c8f-8db7-009397fed0e8.png">


## Testing scenarios
 - [ ] Login and check Segment to verify an `identify` call was issued, with appropriate `traits` included.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
