### PR TITLE
feat(metrics): identify user's tier upon login

### DIFF
--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -85,7 +85,8 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
     userId,
     traits: {
       isActive: true,
-      featureFlags: user.featureFlags
+      featureFlags: user.featureFlags,
+      highestTier: user.tier
     }
   })
   return user


### PR DESCRIPTION
# Description

Before we only identify user's `highestTier` [upon tier changes](https://github.com/ParabolInc/parabol/blob/master/packages/server/utils/setUserTierForUserIds.ts#L70). This causes [majority of our users in Segment/Amplitude has `none` highestTier](https://analytics.amplitude.com/parabol/chart/mknrler?source=redirect%3A%20chart%20saved). 

## Demo
<img width="422" alt="Screen Shot 2022-08-04 at 3 46 47 PM" src="https://user-images.githubusercontent.com/1879975/182966852-b10248fe-3daf-499d-bbcb-db943d02921a.png">

## Testing scenarios
- [ ] Login and verify an `identify` call was issued in Segment, with `highestTier` as a property in the User's traits

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
