### PR TITLE
fix(metrics): remove duplicate viewerId in various Segment events

### DIFF
--- a/packages/client/components/DemoMeetingCard.tsx
+++ b/packages/client/components/DemoMeetingCard.tsx
@@ -105,12 +105,9 @@ const TopLine = styled('div')({
 const DemoMeetingCard = () => {
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
   const atmospehere = useAtmosphere()
-  const {viewerId} = atmospehere
 
   const onOpen = useCallback(() => {
-    SendClientSegmentEventMutation(atmospehere, 'Demo Meeting Card Clicked', {
-      viewerId
-    })
+    SendClientSegmentEventMutation(atmospehere, 'Demo Meeting Card Clicked')
   }, [])
 
   return (

--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -30,8 +30,7 @@ class ErrorBoundary extends Component<Props & {atmosphere: Atmosphere}, State> {
     const {error, isOldBrowserErr} = this.state
     if (!error || isOldBrowserErr) return
     const {atmosphere} = this.props
-    const {viewerId} = atmosphere
-    SendClientSegmentEventMutation(atmosphere, 'Fatal Error', {viewerId})
+    SendClientSegmentEventMutation(atmosphere, 'Fatal Error')
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {

--- a/packages/client/components/GitLabScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitLabScopingSearchFilterMenu.tsx
@@ -103,7 +103,6 @@ const GitLabScopingSearchFilterMenu = (props: Props) => {
   const gitlabSearchQuery = meeting?.gitlabSearchQuery
   const {selectedProjectsIds} = gitlabSearchQuery!
   const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
 
   const {
     query: searchQuery,
@@ -145,7 +144,6 @@ const GitLabScopingSearchFilterMenu = (props: Props) => {
             gitlabSearchQuery.setValue(newSelectedProjectsIds, 'selectedProjectsIds')
           })
           SendClientSegmentEventMutation(atmosphere, 'Selected Poker Scope Project Filter', {
-            viewerId,
             meetingId,
             projectId,
             service: 'gitlab'

--- a/packages/client/components/ScopingSearchInput.tsx
+++ b/packages/client/components/ScopingSearchInput.tsx
@@ -45,7 +45,6 @@ interface Props {
 const ScopingSearchInput = (props: Props) => {
   const {placeholder, queryString, meetingId, linkedRecordName, defaultInput, service} = props
   const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
   const inputRef = useRef<HTMLInputElement>(null)
   const isEmpty = !queryString
 
@@ -66,7 +65,6 @@ const ScopingSearchInput = (props: Props) => {
 
   const trackEvent = (eventTitle: string) => {
     SendClientSegmentEventMutation(atmosphere, eventTitle, {
-      viewerId,
       meetingId,
       service
     })

--- a/packages/client/components/SpotlightSearchBar.tsx
+++ b/packages/client/components/SpotlightSearchBar.tsx
@@ -1,17 +1,17 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
+import React, {useRef} from 'react'
+import {commitLocalUpdate, useFragment} from 'react-relay'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
+import Atmosphere from '../Atmosphere'
+import useAtmosphere from '../hooks/useAtmosphere'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
+import {ElementHeight, ElementWidth} from '../types/constEnums'
+import {SpotlightSearchBar_meeting$key} from '../__generated__/SpotlightSearchBar_meeting.graphql'
+import Icon from './Icon'
 import MenuItemComponentAvatar from './MenuItemComponentAvatar'
 import MenuItemLabel from './MenuItemLabel'
-import Icon from './Icon'
-import {ElementHeight, ElementWidth} from '../types/constEnums'
-import Atmosphere from '../Atmosphere'
-import {commitLocalUpdate, useFragment} from 'react-relay'
-import {SpotlightSearchBar_meeting$key} from '../__generated__/SpotlightSearchBar_meeting.graphql'
-import useAtmosphere from '../hooks/useAtmosphere'
-import React, {useRef} from 'react'
-import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 
 const SearchWrapper = styled('div')({
   width: ElementWidth.REFLECTION_CARD
@@ -84,9 +84,7 @@ const SpotlightSearchBar = (props: Props) => {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSpotlightSearch(atmosphere, meetingId, e.currentTarget.value)
     if (!hasSearchedRef.current) {
-      const {viewerId} = atmosphere
       SendClientSegmentEventMutation(atmosphere, 'Searched in Spotlight', {
-        viewerId,
         reflectionId: spotlightReflectionId,
         meetingId
       })

--- a/packages/client/components/TutorialMeetingCard.tsx
+++ b/packages/client/components/TutorialMeetingCard.tsx
@@ -102,17 +102,12 @@ const THUMBNAIL = 'http://i.ytimg.com/vi/X_i60AMxPBU/maxresdefault.jpg'
 const TutorialMeetingCard = () => {
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
   const atmospehere = useAtmosphere()
-  const {viewerId} = atmospehere
 
   const onOpen = useCallback(() => {
-    SendClientSegmentEventMutation(atmospehere, 'Tutorial Meeting Card Opened', {
-      viewerId
-    })
+    SendClientSegmentEventMutation(atmospehere, 'Tutorial Meeting Card Opened')
   }, [])
   const onClose = useCallback(() => {
-    SendClientSegmentEventMutation(atmospehere, 'Tutorial Meeting Card Closed', {
-      viewerId
-    })
+    SendClientSegmentEventMutation(atmospehere, 'Tutorial Meeting Card Closed')
   }, [])
 
   const {togglePortal: toggleModal, modalPortal} = useModal({onOpen, onClose})

--- a/packages/client/hooks/useAnimatedSpotlightSource.ts
+++ b/packages/client/hooks/useAnimatedSpotlightSource.ts
@@ -1,13 +1,13 @@
-import useAtmosphere from '~/hooks/useAtmosphere'
-import clientTempId from '~/utils/relay/clientTempId'
-import {BezierCurve, ElementWidth} from '~/types/constEnums'
 import {Times} from 'parabol-client/types/constEnums'
-import {Elevation} from '~/styles/elevation'
-import cloneReflection from '~/utils/retroGroup/cloneReflection'
-import {PortalStatus} from '~/hooks/usePortal'
 import {MutableRefObject, useLayoutEffect, useRef} from 'react'
-import StartDraggingReflectionMutation from '~/mutations/StartDraggingReflectionMutation'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import {PortalStatus} from '~/hooks/usePortal'
 import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
+import StartDraggingReflectionMutation from '~/mutations/StartDraggingReflectionMutation'
+import {Elevation} from '~/styles/elevation'
+import {BezierCurve, ElementWidth} from '~/types/constEnums'
+import clientTempId from '~/utils/relay/clientTempId'
+import cloneReflection from '~/utils/retroGroup/cloneReflection'
 
 const useAnimatedSpotlightSource = (
   portalStatus: PortalStatus,
@@ -15,7 +15,6 @@ const useAnimatedSpotlightSource = (
   dragIdRef: MutableRefObject<string | undefined>
 ) => {
   const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
   const sourceRef = useRef<HTMLDivElement | null>(null)
   const sourceCloneRef = useRef<HTMLDivElement | null>(null)
 
@@ -55,7 +54,6 @@ const useAnimatedSpotlightSource = (
     // execute mutation after cloning as the mutation will cause reflection height to change
     startDrag(reflectionId, dragIdRef.current)
     SendClientSegmentEventMutation(atmosphere, 'Opened Spotlight', {
-      viewerId,
       reflectionId
     })
     const dragInterval = setInterval(() => {

--- a/packages/client/hooks/useDraggableReflectionCard.tsx
+++ b/packages/client/hooks/useDraggableReflectionCard.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useState, useRef} from 'react'
+import React, {useContext, useEffect, useRef, useState} from 'react'
 import {commitLocalUpdate} from 'relay-runtime'
 import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 import {DraggableReflectionCard_meeting} from '~/__generated__/DraggableReflectionCard_meeting.graphql'
@@ -238,7 +238,6 @@ const useDragAndDrop = (
   swipeColumn?: SwipeColumn
 ) => {
   const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
   const {id: meetingId, spotlightGroup, spotlightSearchQuery} = meeting
   const spotlightResultGroups = useSpotlightResults(meeting)
   const {id: reflectionId, reflectionGroupId, isDropping, isEditing} = reflection
@@ -270,7 +269,6 @@ const useDragAndDrop = (
         ? `Spotlight result to ${targetType === 'REFLECTION_GROUP' ? 'source' : 'result'}`
         : `Spotlight source to ${targetType === 'REFLECTION_GROUP' ? 'result' : 'grid'}`
       SendClientSegmentEventMutation(atmosphere, event, {
-        viewerId,
         reflectionId,
         meetingId,
         spotlightSearchQuery

--- a/packages/client/hooks/useSpotlightSimulatedDrag.tsx
+++ b/packages/client/hooks/useSpotlightSimulatedDrag.tsx
@@ -1,10 +1,10 @@
 import {MutableRefObject, useCallback, useEffect, useMemo, useRef} from 'react'
+import {commitLocalUpdate} from 'react-relay'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
+import {Times} from '~/types/constEnums'
+import {GroupingKanban_meeting} from '~/__generated__/GroupingKanban_meeting.graphql'
 import EndDraggingReflectionMutation from '../mutations/EndDraggingReflectionMutation'
 import useAtmosphere from './useAtmosphere'
-import {GroupingKanban_meeting} from '~/__generated__/GroupingKanban_meeting.graphql'
-import {commitLocalUpdate} from 'react-relay'
-import {Times} from '~/types/constEnums'
-import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 
 const useSpotlightSimulatedDrag = (
   meeting: GroupingKanban_meeting,
@@ -18,7 +18,6 @@ const useSpotlightSimulatedDrag = (
     () => reflectionGroups.map(({reflections}) => reflections).length,
     [reflectionGroups]
   )
-  const {viewerId} = atmosphere
 
   // handle the case when someone steals the reflection
   useEffect(() => {
@@ -55,7 +54,6 @@ const useSpotlightSimulatedDrag = (
       dragId: dragIdRef.current
     })
     SendClientSegmentEventMutation(atmosphere, 'Closed Spotlight', {
-      viewerId,
       reflectionsCount,
       meetingId,
       reflectionId,

--- a/packages/client/modules/teamDashboard/components/ProviderRow/JiraServerProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/JiraServerProviderRow.tsx
@@ -48,7 +48,6 @@ const JiraServerProviderRow = (props: Props) => {
     viewerRef
   )
   const atmosphere = useAtmosphere()
-  const {viewerId} = atmosphere
   const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
   const {teamMember} = viewer
@@ -77,9 +76,7 @@ const JiraServerProviderRow = (props: Props) => {
         providerLogo={<JiraServerProviderLogo />}
         contactUsUrl={ExternalLinks.INTEGRATIONS_JIRASERVER}
         onContactUsSubmit={() => {
-          SendClientSegmentEventMutation(atmosphere, 'Clicked Jira Server Request Button', {
-            viewerId
-          })
+          SendClientSegmentEventMutation(atmosphere, 'Clicked Jira Server Request Button')
         }}
         hasProvider={!!provider}
       />

--- a/packages/client/mutations/SendClientSegmentEventMutation.ts
+++ b/packages/client/mutations/SendClientSegmentEventMutation.ts
@@ -1,6 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {getRequest} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
+import {SegmentEventTrackOptions} from '../__generated__/SendClientSegmentEventMutation.graphql'
 
 const mutation = graphql`
   mutation SendClientSegmentEventMutation($event: String!, $options: SegmentEventTrackOptions) {
@@ -8,10 +9,9 @@ const mutation = graphql`
   }
 `
 
-interface Options {
+type Options = {
   eventId?: number
-  [key: string]: any
-}
+} & SegmentEventTrackOptions
 
 const SendClientSegmentEventMutation = (
   atmosphere: Atmosphere,

--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -290,15 +290,13 @@ const UpdatePokerScopeMutation: StandardMutation<TUpdatePokerScopeMutation, Hand
       const {updatePokerScope} = res
       const {meeting} = updatePokerScope
       if (!meeting) return
-      const {viewerId} = atmosphere
       const {meetingId, updates} = variables
       const update = updates[0]!
       const {service, action} = update
       const searchQuery = getSearchQueryFromMeeting(meeting, service)
       if (!searchQuery) return
-      const [searchQueryString, searchQueryFilters] = searchQuery
+      const {searchQueryString, searchQueryFilters} = searchQuery
       SendClientSegmentEventMutation(atmosphere, 'Updated Poker Scope', {
-        viewerId,
         meetingId,
         service,
         action,

--- a/packages/client/utils/getSearchQueryFromMeeting.ts
+++ b/packages/client/utils/getSearchQueryFromMeeting.ts
@@ -5,20 +5,30 @@ const getSearchQueryFromMeeting = (meeting: PokerScopeMeeting, service: TaskServ
   switch (service) {
     case 'PARABOL':
       const {parabolSearchQuery} = meeting
-      return [parabolSearchQuery.queryString]
+      return {
+        searchQueryString: parabolSearchQuery.queryString ?? undefined
+      }
     case 'github':
       const {githubSearchQuery} = meeting
-      return [githubSearchQuery.queryString]
+      return {
+        searchQueryString: githubSearchQuery.queryString ?? undefined
+      }
     case 'gitlab':
       const {gitlabSearchQuery} = meeting
       const {queryString, selectedProjectsIds} = gitlabSearchQuery
-      return [queryString, selectedProjectsIds]
+      return {
+        searchQueryString: queryString,
+        searchQueryFilters: selectedProjectsIds?.concat()
+      }
     case 'jira':
       const {jiraSearchQuery} = meeting
       const {queryString: jiraQueryString, projectKeyFilters} = jiraSearchQuery
-      return [jiraQueryString, projectKeyFilters]
+      return {
+        searchQueryString: jiraQueryString,
+        searchQueryFilters: projectKeyFilters.concat()
+      }
   }
-  return null
+  return undefined
 }
 
 export default getSearchQueryFromMeeting

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -21,7 +21,6 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     spotlightSearchQuery: {type: GraphQLString},
     meetingId: {type: GraphQLID},
     reflectionId: {type: GraphQLID},
-    viewerId: {type: GraphQLID},
     reflectionsCount: {type: GraphQLInt},
     action: {type: GraphQLString},
     searchQueryString: {type: GraphQLString},


### PR DESCRIPTION
# Description

Fixes #6996 

`viewerId` is an unnecessary property for Segment events we published because:
1. [Each event is already associated with the `userId`](https://github.com/ParabolInc/parabol/blob/master/packages/server/graphql/mutations/segmentEventTrack.ts#L81)
2. We grabbed the `viewerId` [from `authToken`](https://github.com/ParabolInc/parabol/blob/master/packages/server/graphql/mutations/segmentEventTrack.ts#L58)

This PR:
1. removed `viewerId` from `SegmentEventTrackOptions`
2. made `SendClientSegmentEventMutation`'s `options` arg strong typed with `SegmentEventTrackOptions`
3. removed all unnecessary `viewerId` arg in various places `SendClientSegmentEventMutation` is called

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
