### PR TITLE
feat(metrics): Use HubSpot Private apps access token for HubSpot calls

### DIFF
--- a/packages/server/utils/updateHubspot.ts
+++ b/packages/server/utils/updateHubspot.ts
@@ -262,10 +262,11 @@ const upsertHubspotContact = async (
     }))
   })
   const res = await fetch(
-    `https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/${email}/?hapikey=${hapiKey}`,
+    `https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/${email}/`,
     {
       method: 'POST',
       headers: {
+        Authorization: `Bearer ${hapiKey}`,
         'Content-Type': 'application/json'
       },
       body
@@ -291,9 +292,10 @@ const updateHubspotBulkContact = async (records: BulkRecord[], retryCount = 0) =
       }
     })
   )
-  const res = await fetch(`https://api.hubapi.com/contacts/v1/contact/batch/?hapikey=${hapiKey}`, {
+  const res = await fetch(`https://api.hubapi.com/contacts/v1/contact/batch/`, {
     method: 'POST',
     headers: {
+      Authorization: `Bearer ${hapiKey}`,
       'Content-Type': 'application/json'
     },
     body
@@ -312,8 +314,14 @@ const updateHubspotCompany = async (
   retryCount = 0
 ) => {
   if (!propertiesObj || Object.keys(propertiesObj).length === 0) return
-  const url = `https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?hapikey=${hapiKey}&property=associatedcompanyid&property_mode=value_only&formSubmissionMode=none&showListMemberships=false`
-  const contactRes = await fetch(url)
+  const url = `https://api.hubapi.com/contacts/v1/contact/email/${email}/profile?property=associatedcompanyid&property_mode=value_only&formSubmissionMode=none&showListMemberships=false`
+  const contactRes = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${hapiKey}`,
+      'Content-Type': 'application/json'
+    }
+  })
   const contactStatus = String(contactRes.status)
   if (!contactStatus.startsWith('2')) {
     await sleep(2000)
@@ -342,16 +350,14 @@ const updateHubspotCompany = async (
       value: normalize(propertiesObj[key])
     }))
   })
-  const companyRes = await fetch(
-    `https://api.hubapi.com/companies/v2/companies/${companyId}?hapikey=${hapiKey}`,
-    {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body
-    }
-  )
+  const companyRes = await fetch(`https://api.hubapi.com/companies/v2/companies/${companyId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${hapiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body
+  })
   if (!String(companyRes.status).startsWith('2')) {
     let errBody
     try {


### PR DESCRIPTION
# Description

Fixes #6958 

**Note**: 

1. Our access token is [here](https://app.hubspot.com/private-apps/3888472/). I'll update the [`HUBSPOT_API_KEY`](https://github.com/ParabolInc/action-devops/blob/4aa09acb2ddc8376aaabd11bfc5bcfd7380b9bf8/environments/production#L69) after this PR is merged.
2. Example on how to call HubSpot with Private Apps access token is [here](https://developers.hubspot.com/docs/api/private-apps#make-api-calls-with-your-app-s-access-token)

## Testing scenarios
Unfortunately there's no good way to test it locally, as we only have 1 production access token. For each of the API calls though, I've tested with CURL command and verified the responses:

```shell
## get contact by email
curl "https://api.hubapi.com/contacts/v1/contact/email/tianrunhe@gmail.com/profile" \
     -H 'Authorization: Bearer ${hapiKey}' \
     -H 'Content-Type: application/json'

## createOrUpdate a contact by email
curl -X "POST" "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/testingapis@hubspot.com/" \
     -H 'Authorization: Bearer ${hapiKey}' \
     -H 'Content-Type: application/json' \
     -d $'{
  "properties": [
    {
      "value": "HubSpot",
      "property": "firstname"
    },
    {
      "value": "Test",
      "property": "lastname"
    }
  ]
}'

## Get company by contact email
curl "https://api.hubapi.com/contacts/v1/contact/email/bruce@parabol.co/profile?property=associatedcompanyid&property_mode=value_only&formSubmissionMode=none&showListMemberships=false" \
     -H 'Authorization: Bearer ${hapiKey}' \
     -H 'Content-Type: application/json'

## Get company by id
curl "https://api.hubapi.com/companies/v2/companies/630504379" \
     -H 'Authorization: Bearer ${hapiKey}' \
     -H 'Content-Type: application/json'
```

See Audit logs from HubSpot:
<img width="1280" alt="Screen Shot 2022-08-05 at 2 26 59 PM" src="https://user-images.githubusercontent.com/1879975/183206570-645a75b3-d9dc-4bae-b091-16cf59166908.png">


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
