### PR TITLE
fix: fix truncated sprint poker description in new meeting dialog

### DIFF
--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -47,12 +47,12 @@ const TeamAndSettingsInner = styled('div')({
   boxShadow: Elevation.Z1
 })
 
-const NewMeetingDialog = styled(DialogContainer)<{isDesktop}>(({isDesktop}) =>({
-  width: '800px',
+const NewMeetingDialog = styled(DialogContainer)<{isDesktop}>(({isDesktop}) => ({
+  width: '860px',
   borderRadius: isDesktop ? Radius.FIELD : 0,
   minWidth: isDesktop ? 'unset' : '100vw',
   maxHeight: isDesktop ? 'unset' : '100vh',
-  minHeight: isDesktop ? 'unset' : '100vh',
+  minHeight: isDesktop ? 'unset' : '100vh'
 }))
 
 const Title = styled(DialogTitle)({


### PR DESCRIPTION
fixes #7025

Just restored previous dialog width that was changed for some reason

<img width="888" alt="image" src="https://user-images.githubusercontent.com/466991/183403894-1f297370-d5eb-4b81-8e58-e3c4f9ec15bc.png">
