### PR TITLE
fix(standups): Update 'lastMeetingType' after a team prompt meeting starts

### DIFF
--- a/packages/server/graphql/mutations/startCheckIn.ts
+++ b/packages/server/graphql/mutations/startCheckIn.ts
@@ -86,8 +86,7 @@ export default {
     const agendaItemIds = agendaItems.map(({id}) => id)
 
     const updates = {
-      lastMeetingType: meetingType,
-      updatedAt: new Date()
+      lastMeetingType: meetingType
     }
     await Promise.all([
       r

--- a/packages/server/graphql/mutations/startRetrospective.ts
+++ b/packages/server/graphql/mutations/startRetrospective.ts
@@ -103,8 +103,7 @@ export default {
     }
 
     const updates = {
-      lastMeetingType: meetingType,
-      updatedAt: new Date()
+      lastMeetingType: meetingType
     }
     await Promise.all([
       r

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -148,8 +148,7 @@ export default {
     const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
     const {isSpectatingPoker} = teamMember
     const updates = {
-      lastMeetingType: meetingType,
-      updatedAt: new Date()
+      lastMeetingType: meetingType
     }
     await Promise.all([
       r


### PR DESCRIPTION
# Description

Fixes #7028 

## Testing scenarios

- [ ] Scenario A
  - Starts a team prompt meeting
  - Verify the `lastMeetingType` for the team is updated to `teamPrompt`

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
