### PR TITLE
fix: Don't import team prompt summary for SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.70.1 2022-August-11
+
+### Fixed
+
+- fix: Email summaries not sending for non-standup meetings.
+
 ## 6.70.0 2022-August-10
 
 ### Added

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
-  "version": "6.70.0",
+  "version": "6.70.1",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.70.0",
+  "version": "6.70.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -5,6 +5,7 @@ import {ACTION} from 'parabol-client/utils/constants'
 import {SummarySheet_meeting} from 'parabol-client/__generated__/SummarySheet_meeting.graphql'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import lazyPreload from '~/utils/lazyPreload'
 import ExportToCSV from '../ExportToCSV'
 import ContactUsFooter from './ContactUsFooter'
 import LogoFooter from './LogoFooter'
@@ -16,7 +17,6 @@ import RetroTopics from './RetroTopics'
 import SummaryHeader from './SummaryHeader'
 import SummaryPokerStories from './SummaryPokerStories'
 import SummarySheetCTA from './SummarySheetCTA'
-import TeamPromptResponseSummary from './TeamPromptResponseSummary'
 
 interface Props {
   emailCSVUrl: string
@@ -38,6 +38,12 @@ const SummarySheet = (props: Props) => {
   const {emailCSVUrl, urlAction, meeting, referrer, teamDashUrl, appOrigin} = props
   const {id: meetingId, meetingType} = meeting
   const isDemo = !!props.isDemo
+
+  // 'TeamPromptResponseSummary' includes client-side-only code that breaks SSR, so lazy-load it.
+  // :TODO: (jmtaber129): Change this to a normal import once 'TeamPromptResponseSummary' supports
+  // SSR.
+  const TeamPromptResponseSummary = lazyPreload(() => import('./TeamPromptResponseSummary'))
+
   return (
     <table width='100%' height='100%' align='center' bgcolor='#FFFFFF' style={sheetStyle}>
       <tbody>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.70.0",
+  "version": "6.70.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"

--- a/packages/gql-executor/package.json
+++ b/packages/gql-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gql-executor",
-  "version": "6.70.0",
+  "version": "6.70.1",
   "description": "A Stateless GraphQL Executor",
   "author": "Matt Krick <matt.krick@gmail.com>",
   "homepage": "https://github.com/ParabolInc/parabol/tree/master/packages/gqlExecutor#readme",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "dd-trace": "^2.10.0",
-    "parabol-client": "^6.70.0",
-    "parabol-server": "^6.70.0"
+    "parabol-client": "^6.70.1",
+    "parabol-server": "^6.70.1"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "description": "An open-source app for building smarter, more agile teams.",
   "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
-  "version": "6.70.0",
+  "version": "6.70.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/ParabolInc/parabol"
@@ -128,7 +128,7 @@
     "nodemailer": "^6.4.6",
     "oauth-1.0a": "^2.2.6",
     "oy-vey": "^0.11.0",
-    "parabol-client": "^6.70.0",
+    "parabol-client": "^6.70.1",
     "pg": "^8.5.1",
     "pm2": "^5.2.0",
     "react": "^17.0.2",


### PR DESCRIPTION
# Description

Fixes production issue - email summaries not being sent.  Caused by standup-specific client-side-only code being imported for server-side rending of non-standup meeting summaries.

## Testing scenarios
Go through a retro, end meeting, and confirm summary email is sent

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
