### PR TITLE
feat(metrics): add 'inviterId' to Invite Accepted events

### DIFF
--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -49,7 +49,7 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   }
 
   const {invitation} = invitationRes
-  const {meetingId, teamId} = invitation
+  const {meetingId, teamId, invitedBy: inviterId} = invitation
   const acceptAt = invitation.meetingId ? 'meeting' : 'team'
   const meeting = meetingId ? await dataLoader.get('newMeetings').load(meetingId) : null
   const activeMeetingId = meeting && !meeting.endedAt ? meetingId : null
@@ -138,7 +138,7 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
     )
   }
   const isNewUser = viewer.createdAt.getDate() === viewer.lastSeenAt.getDate()
-  analytics.inviteAccepted(viewerId, teamId, isNewUser, acceptAt)
+  analytics.inviteAccepted(viewerId, teamId, inviterId, isNewUser, acceptAt)
   return {
     ...data,
     authToken: encodedAuthToken

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -199,11 +199,13 @@ class Analytics {
   inviteAccepted = (
     userId: string,
     teamId: string,
+    inviterId: string,
     isNewUser: boolean,
     acceptAt: 'meeting' | 'team'
   ) => {
     this.track(userId, 'Invite Accepted', {
       teamId,
+      inviterId,
       isNewUser,
       acceptAt
     })


### PR DESCRIPTION
# Description

Fixes #6973 

## Demo
<img width="415" alt="Screen Shot 2022-08-11 at 3 36 50 PM" src="https://user-images.githubusercontent.com/1879975/184254092-fed13820-f047-4cf0-8d25-b7297587de6b.png">

## Testing scenarios

- [ ] Scenario A
  - Inviter invites someone to the team
  - Invitee accepts the invitation
  - Verify the `inviterId` in the `Invite Accepted` event is the `userId` of the inviter

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
