### PR TITLE
fix(usageStats): active teams definition

### DIFF
--- a/packages/server/graphql/mutations/navigateMeeting.ts
+++ b/packages/server/graphql/mutations/navigateMeeting.ts
@@ -110,11 +110,11 @@ export default {
       .table('NewMeeting')
       .get(meetingId)
       .update(
-        {
+        (meeting) => ({
           facilitatorStageId: facilitatorStageId ?? undefined,
           phases,
-          updatedAt: now
-        },
+          updatedAt: r.branch(meeting('endedAt'), meeting('updatedAt'), now)
+        }),
         {returnChanges: true}
       )('changes')(0)('old_val')('facilitatorStageId')
       .default(null)


### PR DESCRIPTION
# Description

Fixes #7054

An active team was defined by the team having a meeting.updatedAt being less than 30 days old. updatedAt is now replaced with endedAt/createdAt.
Also, updated applied fixes to stop meeting.updatedAt from updating after the meeting has ended.
 
Test:
- [ ] goto /usage on staging, see parabol.co has 66 active teams (or just review the code, I know that's probably a heavy lift)
- [ ] end a meeting, then go back to it as facilitator & move around. the facilitator stage stays the same
- [ ] end a meeting, promote someone else to facilitator, you can't.
