### PR TITLE
feat(dd sourcemaps): add source maps to deploy. fix(deploy): using staging .env, reverted code to

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,14 @@ jobs:
           name: Build Assets
           # Use the staging env to run webpack (NODE_ENV=production)
           command: |
-            cp $DEVOPS_WORKDIR/environments/staging .env
-            yarn build --deploy
+            if [ "${CIRCLE_BRANCH}" == "production" ] || [ "${CIRCLE_BRANCH}" == "staging" ] || [ "${CIRCLE_BRANCH}" == "development" ]; then
+              cp $DEVOPS_WORKDIR/environments/$CIRCLE_BRANCH .env
+              yarn build --deploy
+            fi
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              cp $DEVOPS_WORKDIR/environments/development .env
+              yarn build --deploy
+            fi
       - run:
           name: Push Assets to Databases
           # Use the test env so the ports match up (NODE_ENV=testing)
@@ -175,6 +181,26 @@ jobs:
               sentry-cli releases files "$ACTION_VERSION" upload-sourcemaps ~/action/build
               sentry-cli releases files "$ACTION_VERSION" upload-sourcemaps ~/action/dist
               sentry-cli releases finalize "$ACTION_VERSION"
+            fi
+      - run:
+          name: Upload source maps to datadog
+          # adding the node dep for datadog-ci here as it's not needed in the core app, only used for sourcemap upload
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "production" ]; then
+              export ACTION_VERSION=$(grep '"version":' package.json | cut -d\" -f4)
+              yarn add @datadog/datadog-ci -W
+              yarn datadog-ci sourcemaps upload ./build \
+                --service=parabol-saas-production \
+                --release-version=$ACTION_VERSION \
+                --minified-path-prefix=https://action-files.parabol.co/production/build/v$ACTION_VERSION
+            fi
+            if [ "${CIRCLE_BRANCH}" == "staging" ]; then
+              export ACTION_VERSION=$(grep '"version":' package.json | cut -d\" -f4)
+              yarn add @datadog/datadog-ci -W
+              yarn datadog-ci sourcemaps upload ./build \
+                --service=parabol-saas-staging \
+                --release-version=$ACTION_VERSION \
+                --minified-path-prefix=https://action-files.parabol.co/staging/build/v$ACTION_VERSION
             fi
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "production" ] || [ "${CIRCLE_BRANCH}" == "staging" ] || [ "${CIRCLE_BRANCH}" == "development" ]; then
               cp $DEVOPS_WORKDIR/environments/$CIRCLE_BRANCH .env
               yarn build --deploy
-            fi
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            else
               cp $DEVOPS_WORKDIR/environments/development .env
               yarn build --deploy
             fi

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -48,8 +48,8 @@ module.exports = ({isDeploy, isStats}) => ({
   output: {
     path: buildPath,
     publicPath,
-    filename: '[name]_[contenthash].js',
-    chunkFilename: '[name]_[contenthash].js',
+    filename: '[name]_[hash].js',
+    chunkFilename: '[name]_[hash].js',
     crossOriginLoading: 'anonymous'
   },
   resolve: {
@@ -124,7 +124,7 @@ module.exports = ({isDeploy, isStats}) => ({
       // This build may be deployed to many different environments
     }),
     new webpack.SourceMapDevToolPlugin({
-      filename: '[name]_[contenthash].js.map',
+      filename: '[name]_[hash].js.map',
       append: `\n//# sourceMappingURL=${publicPath}[url]`
     }),
     new InjectManifest({

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -48,8 +48,8 @@ module.exports = ({isDeploy, isStats}) => ({
   output: {
     path: buildPath,
     publicPath,
-    filename: '[name]_[hash].js',
-    chunkFilename: '[name]_[hash].js',
+    filename: '[name]_[fullhash].js',
+    chunkFilename: '[name]_[fullhash].js',
     crossOriginLoading: 'anonymous'
   },
   resolve: {
@@ -124,7 +124,7 @@ module.exports = ({isDeploy, isStats}) => ({
       // This build may be deployed to many different environments
     }),
     new webpack.SourceMapDevToolPlugin({
-      filename: '[name]_[hash].js.map',
+      filename: '[name]_[fullhash].js.map',
       append: `\n//# sourceMappingURL=${publicPath}[url]`
     }),
     new InjectManifest({

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -64,7 +64,7 @@ module.exports = ({isDeploy}) => ({
       __PROJECT_ROOT__: JSON.stringify(PROJECT_ROOT),
     }),
     new webpack.SourceMapDevToolPlugin({
-      filename: '[name]_[hash].js.map',
+      filename: '[name]_[fullhash].js.map',
       append: `\n//# sourceMappingURL=${getNormalizedWebpackPublicPath()}[url]`
     }),
     isDeploy &&

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -64,7 +64,7 @@ module.exports = ({isDeploy}) => ({
       __PROJECT_ROOT__: JSON.stringify(PROJECT_ROOT),
     }),
     new webpack.SourceMapDevToolPlugin({
-      filename: '[name]_[contenthash].js.map',
+      filename: '[name]_[hash].js.map',
       append: `\n//# sourceMappingURL=${getNormalizedWebpackPublicPath()}[url]`
     }),
     isDeploy &&


### PR DESCRIPTION
# Description

- datadog-ci sourcemap upload at build time, however, the cli requires the .js file and .js.map file to have the same root name. As currently built, the name is different between .js and .js.map file. e.g.name]_[contenthash].js.map and [name]_[contenthash].js' This PR changes contenthash to hash to resolve the datadog-ci issue.
- reverts changes that only used staging .env for deployment, thus all deployments were going to staging with build assets since v6.56.0

Note, I chose to add datadog-ci node module at the time it was needed vs having it placed into the build as it's not a runtime dep, only used for uploading sourcemaps.

resolves #6731 