### PR TITLE
fix: demo comments are always anonymous

### DIFF
--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -71,6 +71,9 @@ export default createFragmentContainer(ThreadedCommentHeader, {
   comment: graphql`
     fragment ThreadedCommentHeader_comment on Comment {
       id
+      createdByUser {
+        preferredName
+      }
       createdByUserNullable: createdByUser {
         preferredName
       }

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -32,9 +32,9 @@ interface Props {
 }
 
 const getName = (comment: ThreadedCommentHeader_comment) => {
-  const {isActive, createdByUser, isViewerComment} = comment
+  const {isActive, createdByUserNullable, isViewerComment} = comment
   if (!isActive) return 'Message Deleted'
-  if (createdByUser?.preferredName) return createdByUser.preferredName
+  if (createdByUserNullable?.preferredName) return createdByUserNullable.preferredName
   return isViewerComment ? 'Anonymous (You)' : 'Anonymous'
 }
 
@@ -71,7 +71,7 @@ export default createFragmentContainer(ThreadedCommentHeader, {
   comment: graphql`
     fragment ThreadedCommentHeader_comment on Comment {
       id
-      createdByUser {
+      createdByUserNullable: createdByUser {
         preferredName
       }
       isActive

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -32,9 +32,9 @@ interface Props {
 }
 
 const getName = (comment) => {
-  const {isActive, createdByUserNullable, isViewerComment} = comment
+  const {isActive, createdByUser, isViewerComment} = comment
   if (!isActive) return 'Message Deleted'
-  if (createdByUserNullable?.preferredName) return createdByUserNullable.preferredName
+  if (createdByUser?.preferredName) return createdByUser.preferredName
   return isViewerComment ? 'Anonymous (You)' : 'Anonymous'
 }
 
@@ -72,9 +72,6 @@ export default createFragmentContainer(ThreadedCommentHeader, {
     fragment ThreadedCommentHeader_comment on Comment {
       id
       createdByUser {
-        preferredName
-      }
-      createdByUserNullable: createdByUser {
         preferredName
       }
       isActive

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -31,7 +31,7 @@ interface Props {
   meetingId: string
 }
 
-const getName = (comment) => {
+const getName = (comment: ThreadedCommentHeader_comment) => {
   const {isActive, createdByUser, isViewerComment} = comment
   if (!isActive) return 'Message Deleted'
   if (createdByUser?.preferredName) return createdByUser.preferredName

--- a/packages/client/modules/demo/commentLookup.ts
+++ b/packages/client/modules/demo/commentLookup.ts
@@ -1,6 +1,6 @@
 const commentLookup = {
   botRef6: [
-    `{"blocks":[{"key":"2c991","text":"While our meetings could be more efficient, we agree that some of them are necessary","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}`
+    `{"blocks":[{"key":"2c991","text":"We could make our standups async?","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}`
   ]
 } as const
 

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -401,7 +401,7 @@ export class DemoComment {
   createdAt: string
   updatedAt: string
   createdBy: string | null
-  createdByUser: DemoUser | null
+  createdByUserNullable: DemoUser | null
   id: string
   isActive = true
   isViewerComment: boolean
@@ -435,7 +435,7 @@ export class DemoComment {
     this.createdAt = new Date().toJSON()
     this.updatedAt = new Date().toJSON()
     this.createdBy = isAnonymous ? null : userId
-    this.createdByUser = isAnonymous ? null : db.users.find(({id}) => id === userId)!
+    this.createdByUserNullable = isAnonymous ? null : db.users.find(({id}) => id === userId)!
     this.id = id
     this.discussionId = discussionId
     this.isViewerComment = userId === demoViewerId

--- a/packages/integration-tests/tests/retrospective-demo/step4-discuss.test.ts
+++ b/packages/integration-tests/tests/retrospective-demo/step4-discuss.test.ts
@@ -1,10 +1,10 @@
-import {test, expect} from '@playwright/test'
+import {expect, test} from '@playwright/test'
 import config from '../config'
 import {
-  startDemo,
-  goToNextPhase,
   dragReflectionCard,
-  skipToDiscussPhase
+  goToNextPhase,
+  skipToDiscussPhase,
+  startDemo
 } from './retrospective-demo-helpers'
 
 test.describe('retrospective-demo / discuss page', () => {
@@ -82,9 +82,7 @@ test.describe('retrospective-demo / discuss page', () => {
         'Try no-meeting Thursdays',
         'Use our planning meetings to discover which meetings and attendees to schedule'
       ],
-      comments: [
-        'While our meetings could be more efficient, we agree that some of them are necessary'
-      ]
+      comments: ['We could make our standups async?']
     }
     // To optimize for speed, we don't check every discuss group.
     // {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6905

I've also updated the comment text to mention standups. 

Currently, in prod:
![prod-demo](https://user-images.githubusercontent.com/39854876/184684831-71472d28-36c5-49d7-b224-32387f55882b.png)

This PR:
![new-demo](https://user-images.githubusercontent.com/39854876/184684854-85a65ac1-6268-47a3-a8ff-b02a17be1ea0.png)

### To test

- Can add comments to a thread in the demo and see the author (yourself)
- When the bot adds a comment, it says the author's name
- Can add anonymous comments
- Can add comments & anonymous comments in the Retro & Poker discussion thread