### PR TITLE
fix: remove double scrollbar on discuss phase

### DIFF
--- a/packages/client/components/RetroDiscussPhase.tsx
+++ b/packages/client/components/RetroDiscussPhase.tsx
@@ -109,7 +109,7 @@ const ReflectionColumn = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
   flexDirection: 'column',
   height: isDesktop ? '100%' : undefined,
   flex: isDesktop ? 1 : undefined,
-  overflow: 'auto',
+  overflow: 'hidden',
   width: '100%'
 }))
 


### PR DESCRIPTION
# Description

We have 2 scrollbar containers.
Note, this isn't visible on macOS or windows, but it's there! it'll be noticeable as you use your scrollwheel on all platforms.
Specifically, when the outer container is scrolled, the cards will sit on top of the "12 Reflections" header.


## Demo

![Screenshot from 2022-08-15 11-54-26](https://user-images.githubusercontent.com/5514175/184697910-8f0c5455-5c44-4a98-8c4a-ab336c653db2.png)

## Testing scenarios

[ ] - create a retro with a bunch of reflections in a group. you can scroll them just fine