### PR TITLE
chore: update vscode import settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,7 @@
   "javascript.preferences.quoteStyle": "single",
   "javascript.preferences.useAliasesForRenames": false,
   "typescript.format.semicolons": "remove",
+  "typescript.preferences.importModuleSpecifier": "relative",
   "typescript.preferences.quoteStyle": "single",
   "typescript.preferences.useAliasesForRenames": false,
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,

--- a/.vscode/tips.md
+++ b/.vscode/tips.md
@@ -27,4 +27,4 @@ code --list-extensions | xargs -L 1 code-insiders --install-extension
 
 ## Other tips and tricks
 
-- On a Mac, TypeScript imports can be incorrect, e.g. it tries to import from 'server/...'. To fix, go to VSCode Settings (UI), type "import module" into the search, and change TypeScript > Preferences: Import Module Specifier from "auto" to "relative".
+- On a Mac, TypeScript imports can be incorrect, e.g. it imports from 'server/...'. To fix, go to VSCode Settings (UI), type "import module" into the search, and change TypeScript > Preferences: Import Module Specifier from "auto" to "relative".

--- a/.vscode/tips.md
+++ b/.vscode/tips.md
@@ -24,3 +24,7 @@ code --list-extensions | xargs -L 1 code-insiders --install-extension
 
 - Flow Language Support: causes goto definition (ctrl + click) to go to the import statement.
 - Apollo GraphQL (apollographql.vscode-apollo): makes autosuggest popups painfully slow!
+
+## Other tips and tricks
+
+- On a Mac, TypeScript imports can be incorrect, e.g. it tries to import from 'server/...'. To fix, go to VSCode Settings (UI), type "import module" into the search, and change TypeScript > Preferences: Import Module Specifier from "auto" to "relative".

--- a/.vscode/tips.md
+++ b/.vscode/tips.md
@@ -24,7 +24,3 @@ code --list-extensions | xargs -L 1 code-insiders --install-extension
 
 - Flow Language Support: causes goto definition (ctrl + click) to go to the import statement.
 - Apollo GraphQL (apollographql.vscode-apollo): makes autosuggest popups painfully slow!
-
-## Other tips and tricks
-
-- On a Mac, TypeScript imports can be incorrect, e.g. it imports from 'server/...'. To fix, go to VSCode Settings (UI), type "import module" into the search, and change TypeScript > Preferences: Import Module Specifier from "auto" to "relative".


### PR DESCRIPTION
Add relative import preference. Currently, importing server files often incorrectly begins with `server/`. Now they'll import using the relative path, e.g. `'../../database/types/User'`