### PR TITLE
fix: hyperlink default focus

### DIFF
--- a/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
+++ b/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
@@ -125,8 +125,8 @@ const EditorLinkChangerModal = (props: Props) => {
           <InputBlock>
             <BasicInput
               {...fields.link}
+              autoFocus={!link && !!text}
               value={fields.link.value === null ? '' : fields.link.value}
-              autoFocus={link === null && text !== ''}
               onChange={onChange}
               name='link'
               spellCheck={false}

--- a/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
+++ b/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
@@ -57,13 +57,14 @@ interface Props {
 
 const EditorLinkChangerModal = (props: Props) => {
   const {originCoords, removeModal, link, text, handleSubmit, handleEscape} = props
+  const trimmedText = !!text ? text.trim() : ''
   const {menuPortal, openPortal} = useMenu(MenuPosition.UPPER_LEFT, {
     isDropdown: true,
     originCoords
   })
   const {setDirtyField, onChange, validateField, fields} = useForm({
     text: {
-      getDefault: () => text,
+      getDefault: () => trimmedText,
       validate: (value) =>
         new Legitity(value)
           .trim()
@@ -108,11 +109,11 @@ const EditorLinkChangerModal = (props: Props) => {
   }
 
   const hasError = !!(fields.text.error || fields.link.error)
-  const label = text ? 'Update' : 'Add'
+  const label = !!trimmedText ? 'Update' : 'Add'
   return menuPortal(
     <ModalBoundary onBlur={handleBlur} onKeyDown={handleKeyDown} tabIndex={-1}>
       <form onSubmit={onSubmit}>
-        {text !== null && (
+        {trimmedText !== null && (
           <TextBlock>
             <InputLabel>{'Text'}</InputLabel>
             <InputBlock>
@@ -125,8 +126,8 @@ const EditorLinkChangerModal = (props: Props) => {
           <InputBlock>
             <BasicInput
               {...fields.link}
-              autoFocus={!link && !!text}
               value={fields.link.value === null ? '' : fields.link.value}
+              autoFocus={!link && !!trimmedText}
               onChange={onChange}
               name='link'
               spellCheck={false}

--- a/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
+++ b/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
@@ -57,7 +57,7 @@ interface Props {
 
 const EditorLinkChangerModal = (props: Props) => {
   const {originCoords, removeModal, link, text, handleSubmit, handleEscape} = props
-  const trimmedText = !!text ? text.trim() : ''
+  const trimmedText = text ? text.trim() : ''
   const {menuPortal, openPortal} = useMenu(MenuPosition.UPPER_LEFT, {
     isDropdown: true,
     originCoords


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/6975

https://www.loom.com/share/3cb5f3c909474f95be24fa92ab299281


### To test

- [ ] In standups, if the user selects some text and presses cmd + k, the hyperlink modal focuses on the link input rather than the text input
- [ ] When using the hyperlink modal in any meeting type, if the text the user highlights is trimmed
- [ ] If the user highlights empty text, the focus remains on the text input