### PR TITLE
fix: support documentation easier to find in-app

### DIFF
--- a/packages/client/components/TopBarHelpMenu.tsx
+++ b/packages/client/components/TopBarHelpMenu.tsx
@@ -15,19 +15,19 @@ interface Props {
 const TopBarHelpMenu = (props: Props) => {
   const {menuProps, toggleShortcuts, dataCy} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
-  const gotoTeamworkResources = () => {
-    window.open(ExternalLinks.RESOURCES, '_blank', 'noreferrer')
-  }
   const gotoSupport = () => {
     window.open(ExternalLinks.SUPPORT, '_blank', 'noreferrer')
+  }
+  const gotoContact = () => {
+    window.open(ExternalLinks.CONTACT, '_blank', 'noreferrer')
   }
   return (
     <Menu ariaLabel={'How may we help?'} {...menuProps}>
       <MenuItem
         label={
-          <MenuItemWithIcon dataCy={`${dataCy}`} label={'Teamwork Resources'} icon={'bookmark'} />
+          <MenuItemWithIcon dataCy={`${dataCy}`} label={'Documentation'} icon={'bookmark'} />
         }
-        onClick={gotoTeamworkResources}
+        onClick={gotoSupport}
       />
       {isDesktop && (
         <MenuItem
@@ -38,8 +38,8 @@ const TopBarHelpMenu = (props: Props) => {
         />
       )}
       <MenuItem
-        label={<MenuItemWithIcon dataCy={`${dataCy}`} label={'Give Feedback'} icon={'comment '} />}
-        onClick={gotoSupport}
+        label={<MenuItemWithIcon dataCy={`${dataCy}`} label={'Get help'} icon={'comment '} />}
+        onClick={gotoContact}
       />
     </Menu>
   )


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #[7055](https://github.com/ParabolInc/parabol/issues/7055)

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

### Screen Shot
![chrome_iXoc4vw2ZV](https://user-images.githubusercontent.com/31279142/185924936-649e5043-1a31-4f6e-8670-24fddc383174.png)


## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [x] Scenario
- Step 1
   Ensure "Teamwork Resource" was changed to Documentation and points to Support page

-  Step 2
   Ensure "Give Feedback" is changed to "Get Help" and links to Contact Form

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
