### PR TITLE
fix(metrics): Move identify inactive up to within changePause()

### DIFF
--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -45,6 +45,12 @@ const changePause = (inactive: boolean) => async (_orgIds: string[], userId: str
     userId,
     event: inactive ? 'Account Paused' : 'Account Unpaused'
   })
+  segmentIo.identify({
+    userId,
+    traits: {
+      isActive: !inactive
+    }
+  })
   return Promise.all([
     updateUser(
       {
@@ -165,19 +171,6 @@ export default async function adjustUserCount(
     if (!user || user.inactive) {
       return
     }
-  }
-
-  if (
-    type === InvoiceItemType.PAUSE_USER ||
-    type === InvoiceItemType.AUTO_PAUSE_USER ||
-    type === InvoiceItemType.REMOVE_USER
-  ) {
-    segmentIo.identify({
-      userId,
-      traits: {
-        isActive: false
-      }
-    })
   }
 
   const prorationDate = options.prorationDate ? toEpochSeconds(options.prorationDate) : undefined


### PR DESCRIPTION
# Description

Following up with https://github.com/ParabolInc/parabol/pull/6997. I noticed the method might exit early on [this line](https://github.com/ParabolInc/parabol/blob/master/packages/server/billing/helpers/adjustUserCount.ts#L161) without calling `identify`. This change just move the call to near the `track` call so it's easier & cleaner.

## Demo
<img width="410" alt="Screen Shot 2022-08-17 at 4 24 16 PM" src="https://user-images.githubusercontent.com/1879975/185260564-ee7259bb-e044-4c09-be4b-c0dd1afa626d.png">

## Tests
1. Manually set a few user's `lastSeenAt` timestamp to 30 days ago
2. Run the `autopauseUsers` mutation
3. Check Segment and verify identify calls were emitted

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
