### PR TITLE
fix: show the team lead first in the preview of team selector

### DIFF
--- a/packages/client/components/NewMeetingTeamPickerAvatars.tsx
+++ b/packages/client/components/NewMeetingTeamPickerAvatars.tsx
@@ -40,6 +40,8 @@ const NewMeetingTeamPickerAvatars = (props: Props) => {
         teamMembers {
           id
           picture
+          isLead
+          isSelf
         }
       }
     `,
@@ -50,7 +52,18 @@ const NewMeetingTeamPickerAvatars = (props: Props) => {
 
   const randomAvatars = useMemo(() => {
     const randomTeamMembers = getShuffledArr(teamMembers)
-    return randomTeamMembers.slice(0, 4)
+
+    const filteredMembers = [] as typeof randomTeamMembers
+    randomTeamMembers.forEach((member) => {
+      // Always show the lead first
+      if (member.isLead) {
+        filteredMembers.unshift(member)
+      } else if (teamMembers.length <= 4 || !member.isSelf) {
+        filteredMembers.push(member)
+      }
+    })
+
+    return filteredMembers.slice(0, 4)
   }, [teamMembers])
 
   return (


### PR DESCRIPTION
Fixes: #7072

<img width="888" alt="image" src="https://user-images.githubusercontent.com/466991/185445559-194c0ecf-a066-48f8-a7dd-7c6492922746.png">

How to test:

- Create a team with 4 members, see that team lead is always shown first, other members are shuffled
- Create a team with more than 4 members, see that you are excluded from the preview if you are not the team lead