### PR TITLE
fix: azure refresh auth

### DIFF
--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -153,7 +153,7 @@ export const freshAzureDevOpsAuth = (
             )
             const oauthRes = await manager.refresh(refreshToken)
             if (oauthRes instanceof Error) {
-              // Azure refresh token only lasts 24 hrs for SPAs. User needs to manually re-auth after that: https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4104
+              // Azure refresh token only lasts 24 hrs for SPAs. User must manually re-auth after that: https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4104
               if (oauthRes.message === 'invalid_grant') {
                 await removeTeamMemberIntegrationAuthQuery('azureDevOps', teamId, userId)
               }

--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -4,6 +4,7 @@ import {IGetTeamMemberIntegrationAuthQueryResult} from '../postgres/queries/gene
 import getAzureDevOpsDimensionFieldMaps from '../postgres/queries/getAzureDevOpsDimensionFieldMaps'
 import {IntegrationProviderAzureDevOps} from '../postgres/queries/getIntegrationProvidersByIds'
 import insertTaskEstimate from '../postgres/queries/insertTaskEstimate'
+import removeTeamMemberIntegrationAuthQuery from '../postgres/queries/removeTeamMemberIntegrationAuth'
 import upsertTeamMemberIntegrationAuth from '../postgres/queries/upsertTeamMemberIntegrationAuth'
 import {getInstanceId} from '../utils/azureDevOps/azureDevOpsFieldTypeToId'
 import AzureDevOpsServerManager, {
@@ -152,6 +153,10 @@ export const freshAzureDevOpsAuth = (
             )
             const oauthRes = await manager.refresh(refreshToken)
             if (oauthRes instanceof Error) {
+              // Azure refresh token only lasts 24 hrs for SPAs. User needs to manually re-auth after that: https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4104
+              if (oauthRes.message === 'invalid_grant') {
+                await removeTeamMemberIntegrationAuthQuery('azureDevOps', teamId, userId)
+              }
               return null
             }
             const {accessToken, refreshToken: newRefreshToken} = oauthRes


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7006

When refreshing the token, Azure returned the error `invalid_grant`. The error description said: 
`The refresh token was issued to a single page app (SPA), and therefore has a fixed, limited lifetime of 1.00:00:00, which cannot be extended. It is now expired and a new sign in request must be sent by the SPA to the sign in page`

This issue https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/4104 and this [Azure doc](https://docs.microsoft.com/en-us/azure/active-directory/develop/refresh-tokens#refresh-token-lifetime) confirm that the user needs to re-auth after 24 hours. 

In this PR, I'm removing the user's stale auth if the refresh token error message is `invalid_grant`. In Sprint Poker, the user will now see Parabol's auth button instead of an empty list of issues. 

### To test

- It's a difficult one to test, but you could integrate with Azure, wait 24 hours, go to a Poker meeting and see that you need to re-auth
- After re-authenticating, you can see the issues