### PR TITLE
feat(tiptap): Emoji Support

### DIFF
--- a/packages/client/components/EmojiMenu.tsx
+++ b/packages/client/components/EmojiMenu.tsx
@@ -13,7 +13,7 @@ interface EmojiSuggestion {
 interface Props {
   menuProps: MenuProps
   onSelectEmoji: (emoji: string) => void
-  menuRef: Ref<any>
+  menuRef?: Ref<any>
   query: string
 }
 

--- a/packages/client/components/EmojiMenu.tsx
+++ b/packages/client/components/EmojiMenu.tsx
@@ -1,4 +1,3 @@
-import {EditorState} from 'draft-js'
 import React, {Component, Ref} from 'react'
 import stringScore from 'string-score'
 import {MenuProps} from '../hooks/useMenu'
@@ -13,14 +12,12 @@ interface EmojiSuggestion {
 
 interface Props {
   menuProps: MenuProps
-  editorState: EditorState
-  onSelectEmoji: (emoji: string, editorState: EditorState) => void
+  onSelectEmoji: (emoji: string) => void
   menuRef: Ref<any>
   query: string
 }
 
 interface State {
-  focusedEditorState: EditorState | null
   suggestedEmojis: EmojiSuggestion[]
   query: string
 }
@@ -47,7 +44,7 @@ class EmojiMenu extends Component<Props, State> {
     nextProps: Readonly<Props>,
     prevState: State
   ): Partial<State> | null {
-    const {editorState, query} = nextProps
+    const {query} = nextProps
     if (query && query === prevState.query) return null
     const suggestedEmojis = EmojiMenu.filterByQuery(query)
     if (suggestedEmojis.length === 0) {
@@ -55,24 +52,18 @@ class EmojiMenu extends Component<Props, State> {
       return null
     }
     return {
-      // clicking on a menu will cause the editorStateSelection to lose focus, so we persist the last state before that point
-      focusedEditorState: editorState.getSelection().getHasFocus()
-        ? editorState
-        : prevState.focusedEditorState,
       query,
       suggestedEmojis
     }
   }
 
   state: State = {
-    focusedEditorState: null,
     suggestedEmojis: [],
     query: ''
   }
 
   render() {
     const {menuProps, menuRef, onSelectEmoji} = this.props
-    const {focusedEditorState} = this.state
     const {suggestedEmojis} = this.state
     return (
       <Menu ariaLabel={'Select the emoji'} {...menuProps} keepParentFocus ref={menuRef} tabReturns>
@@ -82,7 +73,7 @@ class EmojiMenu extends Component<Props, State> {
             label={`${emoji} ${value}`}
             onClick={(e) => {
               e.preventDefault()
-              onSelectEmoji(emoji, focusedEditorState!)
+              onSelectEmoji(emoji)
             }}
           />
         ))}

--- a/packages/client/components/EmojiMenu.tsx
+++ b/packages/client/components/EmojiMenu.tsx
@@ -1,10 +1,10 @@
 import {EditorState} from 'draft-js'
 import React, {Component, Ref} from 'react'
 import stringScore from 'string-score'
-import Menu from './Menu'
-import MenuItem from './MenuItem'
 import {MenuProps} from '../hooks/useMenu'
 import emojiArray from '../utils/emojiArray'
+import Menu from './Menu'
+import MenuItem from './MenuItem'
 
 interface EmojiSuggestion {
   value: string
@@ -14,7 +14,7 @@ interface EmojiSuggestion {
 interface Props {
   menuProps: MenuProps
   editorState: EditorState
-  menuItemClickFactory: (emoji: string, editorState: EditorState) => (e: React.MouseEvent) => void
+  onSelectEmoji: (emoji: string, editorState: EditorState) => void
   menuRef: Ref<any>
   query: string
 }
@@ -71,7 +71,7 @@ class EmojiMenu extends Component<Props, State> {
   }
 
   render() {
-    const {menuProps, menuRef, menuItemClickFactory} = this.props
+    const {menuProps, menuRef, onSelectEmoji} = this.props
     const {focusedEditorState} = this.state
     const {suggestedEmojis} = this.state
     return (
@@ -80,7 +80,10 @@ class EmojiMenu extends Component<Props, State> {
           <MenuItem
             key={value}
             label={`${emoji} ${value}`}
-            onClick={menuItemClickFactory(emoji, focusedEditorState!)}
+            onClick={(e) => {
+              e.preventDefault()
+              onSelectEmoji(emoji, focusedEditorState!)
+            }}
           />
         ))}
       </Menu>

--- a/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
+++ b/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
@@ -7,7 +7,7 @@ interface Props {
   originCoords: ClientRect
   onSelectEmoji: (emoji: string) => void
   query: string
-  menuRef: Ref<any>
+  menuRef?: Ref<any>
   removeModal: () => void
 }
 

--- a/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
+++ b/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
@@ -6,7 +6,7 @@ import lazyPreload from '../../utils/lazyPreload'
 
 interface Props {
   originCoords: ClientRect
-  menuItemClickFactory: (emoji: string, editorState: EditorState) => (e: React.MouseEvent) => void
+  onSelectEmoji: (emoji: string, editorState: EditorState) => void
   query: string
   menuRef: Ref<any>
   editorState: EditorState
@@ -16,16 +16,17 @@ interface Props {
 const EmojiMenu = lazyPreload(() => import(/* webpackChunkName: 'EmojiMenu' */ '../EmojiMenu'))
 
 const EmojiMenuContainer = (props: Props) => {
-  const {originCoords, removeModal, menuItemClickFactory, query, menuRef, editorState} = props
+  const {originCoords, removeModal, onSelectEmoji, query, menuRef, editorState} = props
   const {menuProps, menuPortal, togglePortal} = useMenu(MenuPosition.UPPER_LEFT, {
     originCoords,
     onClose: removeModal
   })
+
   useEffect(togglePortal, [])
   return menuPortal(
     <EmojiMenu
       menuProps={menuProps}
-      menuItemClickFactory={menuItemClickFactory}
+      onSelectEmoji={onSelectEmoji}
       query={query}
       menuRef={menuRef}
       editorState={editorState}

--- a/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
+++ b/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
@@ -8,7 +8,7 @@ interface Props {
   onSelectEmoji: (emoji: string) => void
   query: string
   menuRef?: Ref<any>
-  removeModal: () => void
+  removeModal?: () => void
 }
 
 const EmojiMenu = lazyPreload(() => import(/* webpackChunkName: 'EmojiMenu' */ '../EmojiMenu'))

--- a/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
+++ b/packages/client/components/TaskEditor/EmojiMenuContainer.tsx
@@ -1,4 +1,3 @@
-import {EditorState} from 'draft-js'
 import React, {Ref, useEffect} from 'react'
 import {MenuPosition} from '../../hooks/useCoords'
 import useMenu from '../../hooks/useMenu'
@@ -6,17 +5,16 @@ import lazyPreload from '../../utils/lazyPreload'
 
 interface Props {
   originCoords: ClientRect
-  onSelectEmoji: (emoji: string, editorState: EditorState) => void
+  onSelectEmoji: (emoji: string) => void
   query: string
   menuRef: Ref<any>
-  editorState: EditorState
   removeModal: () => void
 }
 
 const EmojiMenu = lazyPreload(() => import(/* webpackChunkName: 'EmojiMenu' */ '../EmojiMenu'))
 
 const EmojiMenuContainer = (props: Props) => {
-  const {originCoords, removeModal, onSelectEmoji, query, menuRef, editorState} = props
+  const {originCoords, removeModal, onSelectEmoji, query, menuRef} = props
   const {menuProps, menuPortal, togglePortal} = useMenu(MenuPosition.UPPER_LEFT, {
     originCoords,
     onClose: removeModal
@@ -29,7 +27,6 @@ const EmojiMenuContainer = (props: Props) => {
       onSelectEmoji={onSelectEmoji}
       query={query}
       menuRef={menuRef}
-      editorState={editorState}
     />
   )
 }

--- a/packages/client/components/TaskEditor/useEmojis.tsx
+++ b/packages/client/components/TaskEditor/useEmojis.tsx
@@ -26,6 +26,11 @@ const useEmojis = (
   const cachedCoordsRef = useRef<ClientRect | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState('')
+  const [focusedEditorState, setFocusedEditorState] = useState<EditorState>(editorState)
+  if (focusedEditorState !== editorState && editorState.getSelection().getHasFocus()) {
+    setFocusedEditorState(editorState)
+  }
+
   const handleKeyBindingFn: Handlers['keyBindingFn'] = (e) => {
     if (keyBindingFn) {
       const result = keyBindingFn(e)
@@ -37,8 +42,8 @@ const useEmojis = (
     }
     return null
   }
-  const onSelectEmoji = (emoji: string, editorState: EditorState) => {
-    const nextEditorState = autoCompleteEmoji(editorState, emoji)
+  const onSelectEmoji = (emoji: string) => {
+    const nextEditorState = autoCompleteEmoji(focusedEditorState, emoji)
     setEditorState(nextEditorState)
   }
 
@@ -73,7 +78,6 @@ const useEmojis = (
         onSelectEmoji={onSelectEmoji}
         query={query}
         menuRef={menuRef}
-        editorState={editorState}
         originCoords={cachedCoordsRef.current!}
       />
     )

--- a/packages/client/components/TaskEditor/useEmojis.tsx
+++ b/packages/client/components/TaskEditor/useEmojis.tsx
@@ -1,11 +1,11 @@
-import React, {ReactNode, useRef, useState} from 'react'
-import getWordAt from './getWordAt'
-import getDraftCoords from '../../utils/getDraftCoords'
-import getAnchorLocation from './getAnchorLocation'
-import {autoCompleteEmoji} from '../../utils/draftjs/completeEntity'
-import EmojiMenuContainer from './EmojiMenuContainer'
 import {EditorProps, EditorState} from 'draft-js'
+import React, {ReactNode, useRef, useState} from 'react'
 import {SetEditorState} from '../../types/draft'
+import {autoCompleteEmoji} from '../../utils/draftjs/completeEntity'
+import getDraftCoords from '../../utils/getDraftCoords'
+import EmojiMenuContainer from './EmojiMenuContainer'
+import getAnchorLocation from './getAnchorLocation'
+import getWordAt from './getWordAt'
 
 type Handlers = Pick<EditorProps, 'keyBindingFn' | 'onChange'> & {
   renderModal?: () => ReactNode | null
@@ -37,10 +37,7 @@ const useEmojis = (
     }
     return null
   }
-  const menuItemClickFactory = (emoji: string, editorState: EditorState) => (
-    e: React.MouseEvent
-  ) => {
-    e.preventDefault()
+  const onSelectEmoji = (emoji: string, editorState: EditorState) => {
     const nextEditorState = autoCompleteEmoji(editorState, emoji)
     setEditorState(nextEditorState)
   }
@@ -73,7 +70,7 @@ const useEmojis = (
     return (
       <EmojiMenuContainer
         removeModal={onRemoveModal}
-        menuItemClickFactory={menuItemClickFactory}
+        onSelectEmoji={onSelectEmoji}
         query={query}
         menuRef={menuRef}
         editorState={editorState}

--- a/packages/client/components/TaskEditor/withEmojis.tsx
+++ b/packages/client/components/TaskEditor/withEmojis.tsx
@@ -29,8 +29,7 @@ const withEmojis = (ComposedComponent) => {
 
     menuRef = React.createRef<any>()
 
-    menuItemClickFactory = (emoji, editorState) => (e) => {
-      e.preventDefault()
+    onSelectEmoji = (emoji, editorState) => {
       const {setEditorState} = this.props
       const nextEditorState = autoCompleteEmoji(editorState, emoji)
       setEditorState(nextEditorState)
@@ -80,7 +79,7 @@ const withEmojis = (ComposedComponent) => {
       return (
         <EmojiMenuContainer
           removeModal={this.removeModal}
-          menuItemClickFactory={this.menuItemClickFactory}
+          onSelectEmoji={this.onSelectEmoji}
           query={query}
           menuRef={this.menuRef}
           editorState={editorState}

--- a/packages/client/components/promptResponse/EmojiMenuTipTap.tsx
+++ b/packages/client/components/promptResponse/EmojiMenuTipTap.tsx
@@ -23,6 +23,9 @@ const EmojiMenuTipTap = (props: Props) => {
     }
 
     const plugin = Suggestion({
+      // The 'pluginKey' type definition seems to be a mismatch between prosemirror and this
+      // extension, so cast to 'any' to get around it.
+      // :TODO: (jmtaber129): get these type definitions to play nice.
       pluginKey: pluginKey as any,
       editor: tiptapEditor,
       char: ':',

--- a/packages/client/components/promptResponse/EmojiMenuTipTap.tsx
+++ b/packages/client/components/promptResponse/EmojiMenuTipTap.tsx
@@ -1,0 +1,73 @@
+import {Editor, Range} from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+import {PluginKey} from 'prosemirror-state'
+import React, {useEffect, useState} from 'react'
+import EmojiMenuContainer from '../TaskEditor/EmojiMenuContainer'
+import {getSelectionBoundingBox} from './tiptapConfig'
+
+interface Props {
+  tiptapEditor: Editor
+}
+
+const pluginKey = new PluginKey('emojiMenu')
+
+const EmojiMenuTipTap = (props: Props) => {
+  const {tiptapEditor} = props
+  const [openEmojiMenu, setOpenEmojiMenu] = useState(false)
+  const [emojiQuery, setEmojiQuery] = useState('')
+  const [range, setRange] = useState<Range | null>(null)
+
+  useEffect(() => {
+    if (tiptapEditor.isDestroyed) {
+      return
+    }
+
+    const plugin = Suggestion({
+      pluginKey: pluginKey as any,
+      editor: tiptapEditor,
+      char: ':',
+      render: () => ({
+        onStart: ({range}) => {
+          setRange(range)
+          setOpenEmojiMenu(true)
+        },
+        onExit: () => {
+          setRange(null)
+          setOpenEmojiMenu(false)
+        },
+        onUpdate: ({query, range}) => {
+          setRange(range)
+          setEmojiQuery(query)
+        }
+      })
+    }) as any
+
+    tiptapEditor.registerPlugin(plugin)
+    return () => tiptapEditor.unregisterPlugin(pluginKey)
+  }, [tiptapEditor, setOpenEmojiMenu, setEmojiQuery])
+
+  const onSelectEmoji = (emoji: string) => {
+    if (!range) return
+    tiptapEditor
+      .chain()
+      .focus()
+      .setTextSelection(range)
+      .command(({tr}) => {
+        tr.insertText(emoji)
+
+        return true
+      })
+      .run()
+  }
+
+  return openEmojiMenu ? (
+    <EmojiMenuContainer
+      originCoords={getSelectionBoundingBox(tiptapEditor)}
+      onSelectEmoji={onSelectEmoji}
+      query={emojiQuery}
+      removeModal={() => setOpenEmojiMenu(false)}
+    />
+  ) : null
+}
+
+export default EmojiMenuTipTap

--- a/packages/client/components/promptResponse/EmojiMenuTipTap.tsx
+++ b/packages/client/components/promptResponse/EmojiMenuTipTap.tsx
@@ -36,6 +36,7 @@ const EmojiMenuTipTap = (props: Props) => {
           setOpenEmojiMenu(false)
         },
         onUpdate: ({query, range}) => {
+          setOpenEmojiMenu(true)
           setRange(range)
           setEmojiQuery(query)
         }
@@ -60,12 +61,11 @@ const EmojiMenuTipTap = (props: Props) => {
       .run()
   }
 
-  return openEmojiMenu ? (
+  return openEmojiMenu && tiptapEditor.isFocused ? (
     <EmojiMenuContainer
       originCoords={getSelectionBoundingBox(tiptapEditor)}
       onSelectEmoji={onSelectEmoji}
       query={emojiQuery}
-      removeModal={() => setOpenEmojiMenu(false)}
     />
   ) : null
 }

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -10,6 +10,7 @@ import BaseButton from '../BaseButton'
 import EditorLinkChangerTipTap from '../EditorLinkChanger/EditorLinkChangerTipTap'
 import EditorLinkViewerTipTap from '../EditorLinkViewer/EditorLinkViewerTipTap'
 import Icon from '../Icon'
+import EmojiMenuTipTap from './EmojiMenuTipTap'
 import {createEditorExtensions, getLinkProps, LinkMenuProps, LinkPreviewProps} from './tiptapConfig'
 
 const LinkIcon = styled(Icon)({
@@ -234,6 +235,7 @@ const PromptResponseEditor = (props: Props) => {
             </BubbleMenuWrapper>
           </BubbleMenu>
         )}
+        {editor && <EmojiMenuTipTap tiptapEditor={editor} />}
         {editor && linkOverlayProps?.linkMenuProps && (
           <EditorLinkChangerTipTap
             text={linkOverlayProps.linkMenuProps.text}

--- a/packages/client/components/promptResponse/tiptapConfig.ts
+++ b/packages/client/components/promptResponse/tiptapConfig.ts
@@ -24,7 +24,7 @@ export type LinkOverlayProps =
     }
   | undefined
 
-const getSelectionBoundingBox = (editor: Editor) => {
+export const getSelectionBoundingBox = (editor: Editor) => {
   const selection = editor.view.state.selection
   const {from, to} = selection
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -68,6 +68,7 @@
     "@tiptap/extension-placeholder": "^2.0.0-beta.48",
     "@tiptap/react": "^2.0.0-beta.109",
     "@tiptap/starter-kit": "^2.0.0-beta.185",
+    "@tiptap/suggestion": "^2.0.0-beta.97",
     "chart.js": "^3.8.0",
     "chartjs-adapter-dayjs-3": "^1.2.3",
     "core-js": "3.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4636,6 +4636,15 @@
     "@tiptap/extension-strike" "^2.0.0-beta.27"
     "@tiptap/extension-text" "^2.0.0-beta.15"
 
+"@tiptap/suggestion@^2.0.0-beta.97":
+  version "2.0.0-beta.97"
+  resolved "https://registry.yarnpkg.com/@tiptap/suggestion/-/suggestion-2.0.0-beta.97.tgz#2e3dc20deebc2c37c5d39c848e61e9c837e7188a"
+  integrity sha512-3NWG+HE7v2w97Ek6z1tUosoZKpCDH+oAtIG9XoNkK1PmlaVV/H4d6HT9uPX+Y6SeN7fSAqlcXFUGLXcDi9d+Zw==
+  dependencies:
+    prosemirror-model "1.18.1"
+    prosemirror-state "1.4.1"
+    prosemirror-view "1.26.2"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -5905,9 +5914,9 @@ are-we-there-yet@^2.0.0:
     readable-stream "^3.6.0"
 
 are-we-there-yet@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.0.tgz#ba20bd6b553e31d62fc8c31bd23d22b95734390d"
-  integrity sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz#679df222b278c64f2cdba1175cdc00b0d96164bd"
+  integrity sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
@@ -6737,9 +6746,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001359, caniuse-lite@~1.0.0:
-  version "1.0.30001370"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz#0a30d4f20d38b9e108cc5ae7cc62df9fe66cd5ba"
-  integrity sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==
+  version "1.0.30001381"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz#e62955310e6e69cdf4b40bc5bc0895aa24bc4b8b"
+  integrity sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -13455,6 +13464,11 @@ orderedmap@^1.1.0:
   resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-1.1.5.tgz#4174c90b61bd7c25294932edf789f3b5677744d0"
   integrity sha512-/fzlCGKRmfayGoI9UUXvJfc2nMZlJHW30QqEvwPvlg8tsX7jyiUSomYie6mYqx7Z9bOMGoag0H/q1PS/0PjYkg==
 
+orderedmap@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/orderedmap/-/orderedmap-2.0.0.tgz#12ff5ef6ea9d12d6430b80c701b35475e1c9ff34"
+  integrity sha512-buf4PoAMlh45b8a8gsGy/X6w279TSqkyAS0C0wdTSJwFSU+ljQFJON5I8NfjLHoCXwpSROIo2wr0g33T+kQshQ==
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -14353,6 +14367,13 @@ prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.1.5:
     prosemirror-state "^1.0.0"
     w3c-keyname "^2.2.0"
 
+prosemirror-model@1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.18.1.tgz#1d5d6b6de7b983ee67a479dc607165fdef3935bd"
+  integrity sha512-IxSVBKAEMjD7s3n8cgtwMlxAXZrC7Mlag7zYsAKDndAqnDScvSmp/UdnRTV/B33lTCVU3CCm7dyAn/rVVD0mcw==
+  dependencies:
+    orderedmap "^2.0.0"
+
 prosemirror-model@^1.0.0, prosemirror-model@^1.16.0, prosemirror-model@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.16.1.tgz#fb388270bc9609b66298d6a7e15d0cc1d6c61253"
@@ -14364,6 +14385,14 @@ prosemirror-schema-list@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.1.6.tgz#c3e13fe2f74750e4a53ff88d798dc0c4ccca6707"
   integrity sha512-aFGEdaCWmJzouZ8DwedmvSsL50JpRkqhQ6tcpThwJONVVmCgI36LJHtoQ4VGZbusMavaBhXXr33zyD2IVsTlkw==
+  dependencies:
+    prosemirror-model "^1.0.0"
+    prosemirror-transform "^1.0.0"
+
+prosemirror-state@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.4.1.tgz#f6e26c7b6a7e11206176689eb6ebbf91870953e1"
+  integrity sha512-U/LBDW2gNmVa07sz/D229XigSdDQ5CLFwVB1Vb32MJbAHHhWe/6pOc721faI17tqw4pZ49i1xfY/jEZ9tbIhPg==
   dependencies:
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
@@ -14382,6 +14411,15 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transfor
   integrity sha512-H/yrA934hJeHjANq6QArqjzg+kdyIq7gf4qEY/EX3WEaVnc+mX+yvyIwE7W4iqQ8Bmps4kZxECHaWMnolPRsGA==
   dependencies:
     prosemirror-model "^1.0.0"
+
+prosemirror-view@1.26.2:
+  version "1.26.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.26.2.tgz#e673894ecf26aea330b727622d561c51b41d31eb"
+  integrity sha512-CGKw+GadkfSBEwRAJTHCEKJ4DlV6/3IhAdjpwGyZHUHtbP7jX4Ol4zmi7xa2c6GOabDlIJLYXJydoNYLX7lNeQ==
+  dependencies:
+    prosemirror-model "^1.16.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
 
 prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.23.6:
   version "1.23.11"


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6883

Add emoji support by typing `:`.  Reuse the emoji menu used in our Draft.js editor to show emojis in TipTap.

Changes:
* Refactor existing emoji menu to decouple the menu from the draft.js editor
* Add a new tiptap emoji component that uses the [Suggestion](https://github.com/ueberdosis/tiptap/tree/main/packages/suggestion) tiptap utility to render the emoji menu.

This uses a pattern used by many TipTap React components in which the component is rendered by simply passing in the editor - no added configuration in the config (see the [React Bubble Menu](https://github.com/ueberdosis/tiptap/blob/9a254bf9daf6d839bd02c968e14837098b903b38/packages/react/src/BubbleMenu.tsx)).

**note**: one test case this fails is when the cursor is part-way through the emoji query - the emoji suggestions are only based on the query from `:` to the cursor, and selecting an emoji will only replace the text from `:` to the cursor.  E.g. if I type out `:joy`, and place my cursor between `o` and `y` and click the `:joy:` emoji, the resultant text will look like `😂y`.  **This is an issue with the tiptap `Suggestion` utility** (see the example on their [Emojis package docs](https://tiptap.dev/api/nodes/emoji)), so we'll need to either PR a fix into that package, or do some custom range selection to fix this. This likely isn't enough of a degradation to prioritize fixing in the near-term, but we should stay attentive to feedback about this.

## Demo
https://www.loom.com/share/fa5cb5c6b84445e9bbbdf877df8c926b

## Testing scenarios
Do the following on both standups and Draft.js:
* Type out part of an emoji by typing `:<emoji`, then click an emoji
* Type out part of an emoji, select elsewhere in the textbox, then select the end of the emoji query, and click an emoji
* Type out part of an emoji, click out of the textbox to lose focus, then select the end of the emoji query, and click an emoji
* Type out part of an emoji, then type a space and see that the menu disappears.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
