### PR TITLE
chore: add pull-request-stats github workflow

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -12,4 +12,4 @@ jobs:
         uses: flowwer-dev/pull-request-stats@master
         with:
           charts: true
-          sort-by: 'COMMENTS'
+          sort-by: 'REVIEWS'

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -13,4 +13,4 @@ jobs:
         uses: flowwer-dev/pull-request-stats@master
         with:
           charts: true
-          sort-by: 'REVIEWS'
+          sort-by: 'TIME'

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,16 +1,17 @@
 name: Pull Request Stats
 
 on:
-  pull_request:
-    types: [labeled]
+  schedule:
+    - cron: '0 * * * 5'
 
 jobs:
   stats:
-    if: ${{ github.event.label.name == 'pr_stats' }}
     runs-on: ubuntu-latest
     steps:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
         with:
+          slack-channel: '#t_product_github_notifications'
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
           charts: true
           sort-by: 'TIME'

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,10 +2,11 @@ name: Pull Request Stats
 
 on:
   pull_request:
-    types: [opened]
+    types: [labeled]
 
 jobs:
   stats:
+    if: ${{ github.event.label.name == 'pr_stats' }}
     runs-on: ubuntu-latest
     steps:
       - name: Run pull request stats

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,15 @@
+name: Pull Request Stats
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pull request stats
+        uses: flowwer-dev/pull-request-stats@master
+        with:
+          charts: true
+          sort-by: 'COMMENTS'


### PR DESCRIPTION
# Description

![Google Chrome-LinearB Engineering Operational Excellence-000005-20220825](https://user-images.githubusercontent.com/4997466/186625264-6e4a6378-166b-4c88-9e42-33d0272a0ae2.png)

According to the [Cycle Time](https://en.wikipedia.org/wiki/Cycle_time_(software)) statistics from [LinearB](https://linearb.io/), we're spending a longer time indeed in the Review phase, so let's figure out how to speed it up, and the first step might be to show more detailed Review data:
This PR adds usage of [pull-request-stats workflow](https://github.com/flowwer-dev/pull-request-stats), use this Github Action to print relevant stats about Pull Request reviewers. Let's continuously measure and do more improvements!

The objective of this action is to:

- Reduce the time taken to review the pull requests.
- Encourage quality on reviews.
- Help deciding which people to assign as reviewers.

Please feel free to comment, let's just see how it works in this PR, please let me know what you think!

## Demo

![image](https://user-images.githubusercontent.com/4997466/186625234-982203de-bc5e-43b8-bf00-eed9dc361d21.png)
