### PR TITLE
feat: usage stats clarity improvements

### DIFF
--- a/packages/client/components/Insights.tsx
+++ b/packages/client/components/Insights.tsx
@@ -5,7 +5,6 @@ import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 import {Elevation} from '../styles/elevation'
-import {PALETTE} from '../styles/paletteV3'
 import {InsightsQuery} from '../__generated__/InsightsQuery.graphql'
 import InsightsCharts from './InsightsCharts'
 import InsightsDomainPanel from './InsightsDomainPanel'
@@ -14,13 +13,6 @@ import Panel from './Panel/Panel'
 interface Props {
   queryRef: PreloadedQuery<InsightsQuery>
 }
-
-const DashSectionHeader = styled('h1')({
-  color: PALETTE.SLATE_700,
-  fontSize: 20,
-  lineHeight: '28px',
-  paddingLeft: 32
-})
 
 const StatsPanel = styled(Panel)({
   boxShadow: Elevation.Z3,
@@ -57,7 +49,6 @@ const Insights = (props: Props) => {
 
   return (
     <div>
-      <DashSectionHeader>Usage</DashSectionHeader>
       {domains.length === 0 && (
         <StatsPanel>Usage stats are only available for qualified customers</StatsPanel>
       )}

--- a/packages/client/components/InsightsCharts.tsx
+++ b/packages/client/components/InsightsCharts.tsx
@@ -137,7 +137,7 @@ const meetingOptions: ChartOptions<'bar'> = {
     },
     title: {
       display: true,
-      text: 'Meetings',
+      text: 'Total Meetings',
       font: {
         size: 20,
         weight: '400'

--- a/packages/client/components/InsightsCharts.tsx
+++ b/packages/client/components/InsightsCharts.tsx
@@ -227,7 +227,7 @@ const makeOptions = (title: string, subtitle: string) => {
           style: 'italic'
         },
         padding: {
-          bottom: 8,
+          bottom: 16,
           top: 0
         }
       }

--- a/packages/client/components/InsightsCharts.tsx
+++ b/packages/client/components/InsightsCharts.tsx
@@ -141,11 +141,26 @@ const meetingOptions: ChartOptions<'bar'> = {
       font: {
         size: 20,
         weight: '400'
+      },
+      padding: 0
+    },
+    subtitle: {
+      display: true,
+      text: 'Total number of meetings by teams in associated organizations',
+      font: {
+        size: 12,
+        weight: '300',
+        style: 'italic'
+      },
+      padding: {
+        bottom: 8,
+        top: 0
       }
     }
   }
 }
-const makeOptions = (title: string) => {
+
+const makeOptions = (title: string, subtitle: string) => {
   const options: ChartOptions<'line'> = {
     responsive: true,
     maintainAspectRatio: false,
@@ -200,6 +215,20 @@ const makeOptions = (title: string) => {
         font: {
           size: 20,
           weight: '400'
+        },
+        padding: 0
+      },
+      subtitle: {
+        display: true,
+        text: subtitle,
+        font: {
+          size: 12,
+          weight: '300',
+          style: 'italic'
+        },
+        padding: {
+          bottom: 8,
+          top: 0
         }
       }
     }
@@ -297,8 +326,8 @@ const makeMeetingData = (flatMeetingStats: {createdAt: string; meetingType: Meet
   return {datasets} as ChartData<'bar'>
 }
 
-const membersOptions = makeOptions('Total Members')
-const teamsOptions = makeOptions('Total Teams')
+const membersOptions = makeOptions('Total Members', 'Total users in associated organizations')
+const teamsOptions = makeOptions('Total Teams', 'Total teams in associated organizations')
 
 const InsightsCharts = (props: Props) => {
   const {domainRef} = props

--- a/packages/client/components/InsightsDomainPanel.tsx
+++ b/packages/client/components/InsightsDomainPanel.tsx
@@ -2,10 +2,14 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {MenuPosition} from '../hooks/useCoords'
+import useTooltip from '../hooks/useTooltip'
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
+import {ICON_SIZE} from '../styles/typographyV2'
 import plural from '../utils/plural'
 import {InsightsDomainPanel_domain$key} from '../__generated__/InsightsDomainPanel_domain.graphql'
+import Icon from './Icon'
 import InsightsDomainNudge from './InsightsDomainNudge'
 import Panel from './Panel/Panel'
 
@@ -58,11 +62,31 @@ const StatBlockLabel = styled('div')({
   fontWeight: 600,
   lineHeight: '16px',
   textTransform: 'uppercase',
-  textAlign: 'center'
+  textAlign: 'center',
+  display: 'flex',
+  alignItems: 'center'
+})
+
+const StyledIcon = styled(Icon)({
+  color: PALETTE.SLATE_600,
+  fontSize: ICON_SIZE.MD18,
+  paddingLeft: '4px',
+  ':hover': {
+    cursor: 'pointer'
+  }
 })
 
 interface Props {
   domainRef: InsightsDomainPanel_domain$key
+}
+
+const tooltipTextLookup = {
+  org: 'Organizations with at least 1 unarchived team on it, which has at least 2 team members who have logged in within the last 30 days',
+  team: 'Teams with at least 2 team members who have logged in within the last 30 days & within an active organization that has had a meeting that has an updatedAt newer than 30 days ago',
+  member:
+    'The number of users on an active organization that has logged in within the last 30 days',
+  meeting:
+    'The number of meetings created by unarchived teams on organizations assigned to the domain'
 }
 
 const InsightsDomainPanel = (props: Props) => {
@@ -83,12 +107,37 @@ const InsightsDomainPanel = (props: Props) => {
     domainRef
   )
   const {
+    tooltipPortal: orgPortal,
+    openTooltip: orgOpenTooltip,
+    closeTooltip: orgCloseTooltip,
+    originRef: orgRef
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
+  const {
+    tooltipPortal: teamPortal,
+    openTooltip: teamOpenTooltip,
+    closeTooltip: teamCloseTooltip,
+    originRef: teamRef
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
+  const {
+    tooltipPortal: memberPortal,
+    openTooltip: memberOpenTooltip,
+    closeTooltip: memberCloseTooltip,
+    originRef: memberRef
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
+  const {
+    tooltipPortal: meetingPortal,
+    openTooltip: meetingOpenTooltip,
+    closeTooltip: meetingCloseTooltip,
+    originRef: meetingRef
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
+  const {
     id: domainId,
     activeOrganizationCount,
     activeTeamCount,
     activeUserCount,
     meetingCount
   } = domain
+
   return (
     <Wrapper>
       <StatsPanel>
@@ -96,19 +145,43 @@ const InsightsDomainPanel = (props: Props) => {
         <StatBlocks>
           <StatBlock>
             <StatBlockNumber>{activeOrganizationCount}</StatBlockNumber>
-            <StatBlockLabel>{plural(activeOrganizationCount, 'Organization')}</StatBlockLabel>
+            <StatBlockLabel ref={orgRef}>
+              {plural(activeOrganizationCount, 'Organization')}
+              <StyledIcon onMouseOver={orgOpenTooltip} onMouseOut={orgCloseTooltip}>
+                {'info'}
+              </StyledIcon>
+            </StatBlockLabel>
+            {orgPortal(tooltipTextLookup.org)}
           </StatBlock>
           <StatBlock>
             <StatBlockNumber>{activeTeamCount}</StatBlockNumber>
-            <StatBlockLabel>{plural(activeTeamCount, 'Active Team')}</StatBlockLabel>
+            <StatBlockLabel ref={teamRef}>
+              {plural(activeOrganizationCount, 'Active Team')}
+              <StyledIcon onMouseOver={teamOpenTooltip} onMouseOut={teamCloseTooltip}>
+                {'info'}
+              </StyledIcon>
+            </StatBlockLabel>
+            {teamPortal(tooltipTextLookup.team)}
           </StatBlock>
           <StatBlock>
             <StatBlockNumber>{activeUserCount}</StatBlockNumber>
-            <StatBlockLabel>{plural(activeUserCount, 'Active Member')}</StatBlockLabel>
+            <StatBlockLabel ref={memberRef}>
+              {plural(activeOrganizationCount, 'Active Member')}
+              <StyledIcon onMouseOver={memberOpenTooltip} onMouseOut={memberCloseTooltip}>
+                {'info'}
+              </StyledIcon>
+            </StatBlockLabel>
+            {memberPortal(tooltipTextLookup.member)}
           </StatBlock>
           <StatBlock>
             <StatBlockNumber>{meetingCount}</StatBlockNumber>
-            <StatBlockLabel>{plural(meetingCount, 'Meeting')}</StatBlockLabel>
+            <StatBlockLabel ref={meetingRef}>
+              {plural(activeOrganizationCount, 'Total Meeting')}
+              <StyledIcon onMouseOver={meetingOpenTooltip} onMouseOut={meetingCloseTooltip}>
+                {'info'}
+              </StyledIcon>
+            </StatBlockLabel>
+            {meetingPortal(tooltipTextLookup.meeting)}
           </StatBlock>
         </StatBlocks>
         <InsightsDomainNudge domainRef={domain} />

--- a/packages/client/components/InsightsDomainPanel.tsx
+++ b/packages/client/components/InsightsDomainPanel.tsx
@@ -81,12 +81,10 @@ interface Props {
 }
 
 const tooltipTextLookup = {
-  org: 'Organizations with at least 1 unarchived team on it, which has at least 2 team members who have logged in within the last 30 days',
-  team: 'Teams with at least 2 team members who have logged in within the last 30 days & within an active organization that has had a meeting that has an updatedAt newer than 30 days ago',
-  member:
-    'The number of users on an active organization that has logged in within the last 30 days',
-  meeting:
-    'The number of meetings created by unarchived teams on organizations assigned to the domain'
+  org: 'Organizations associated with this domain that have at least 2 active members',
+  team: 'Teams that met within the last 30 days and have at least 2 active members',
+  member: 'Users who have logged in within the last 30 days',
+  meeting: 'Total number of meetings by teams in associated organizations'
 }
 
 const InsightsDomainPanel = (props: Props) => {

--- a/packages/client/components/InsightsDomainPanel.tsx
+++ b/packages/client/components/InsightsDomainPanel.tsx
@@ -15,7 +15,7 @@ import Panel from './Panel/Panel'
 
 const StatsPanel = styled(Panel)({
   boxShadow: Elevation.Z3,
-  maxWidth: 520
+  maxWidth: 600
 })
 
 const Wrapper = styled('div')({
@@ -109,7 +109,7 @@ const InsightsDomainPanel = (props: Props) => {
     openTooltip: orgOpenTooltip,
     closeTooltip: orgCloseTooltip,
     originRef: orgRef
-  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_RIGHT)
   const {
     tooltipPortal: teamPortal,
     openTooltip: teamOpenTooltip,
@@ -139,7 +139,7 @@ const InsightsDomainPanel = (props: Props) => {
   return (
     <Wrapper>
       <StatsPanel>
-        <DomainName>{domainId}</DomainName>
+        <DomainName>{`${domainId} Usage`}</DomainName>
         <StatBlocks>
           <StatBlock>
             <StatBlockNumber>{activeOrganizationCount}</StatBlockNumber>

--- a/packages/client/components/InsightsDomainPanel.tsx
+++ b/packages/client/components/InsightsDomainPanel.tsx
@@ -2,11 +2,13 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import useBreakpoint from '../hooks/useBreakpoint'
 import {MenuPosition} from '../hooks/useCoords'
 import useTooltip from '../hooks/useTooltip'
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
+import {Breakpoint} from '../types/constEnums'
 import plural from '../utils/plural'
 import {InsightsDomainPanel_domain$key} from '../__generated__/InsightsDomainPanel_domain.graphql'
 import Icon from './Icon'
@@ -33,22 +35,30 @@ const DomainName = styled('div')({
 const StatBlocks = styled('div')({
   display: 'flex',
   borderTop: `1px solid ${PALETTE.SLATE_400}`,
-  width: '100%'
+  width: '100%',
+  flexWrap: 'wrap'
 })
 
-const StatBlock = styled('div')({
+const StatBlock = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
   borderLeft: `1px solid ${PALETTE.SLATE_400}`,
   ':first-of-type': {
-    border: 'none'
+    border: 'none',
+    borderBottom: isDesktop ? 'none' : `1px solid ${PALETTE.SLATE_400}`
+  },
+  ':nth-of-type(2)': {
+    borderBottom: isDesktop ? 'none' : `1px solid ${PALETTE.SLATE_400}`
+  },
+  ':nth-of-type(3)': {
+    borderLeft: isDesktop ? `1px solid ${PALETTE.SLATE_400}` : 'none'
   },
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'flex-start',
-  width: '25%',
+  width: isDesktop ? '25%' : '50%',
   paddingTop: 14,
   paddingBottom: 14
-})
+}))
 
 const StatBlockNumber = styled('div')({
   color: PALETTE.SLATE_600,
@@ -74,6 +84,10 @@ const StyledIcon = styled(Icon)({
   ':hover': {
     cursor: 'pointer'
   }
+})
+
+const IconBlock = styled('div')({
+  display: 'flex'
 })
 
 interface Props {
@@ -109,7 +123,7 @@ const InsightsDomainPanel = (props: Props) => {
     openTooltip: orgOpenTooltip,
     closeTooltip: orgCloseTooltip,
     originRef: orgRef
-  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_RIGHT)
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
   const {
     tooltipPortal: teamPortal,
     openTooltip: teamOpenTooltip,
@@ -136,48 +150,57 @@ const InsightsDomainPanel = (props: Props) => {
     meetingCount
   } = domain
 
+  const isDesktop = useBreakpoint(Breakpoint.NEW_MEETING_SELECTOR)
   return (
     <Wrapper>
       <StatsPanel>
         <DomainName>{`${domainId} Usage`}</DomainName>
         <StatBlocks>
-          <StatBlock>
+          <StatBlock isDesktop={isDesktop}>
             <StatBlockNumber>{activeOrganizationCount}</StatBlockNumber>
-            <StatBlockLabel ref={orgRef}>
+            <StatBlockLabel>
               {plural(activeOrganizationCount, 'Organization')}
-              <StyledIcon onMouseOver={orgOpenTooltip} onMouseOut={orgCloseTooltip}>
-                {'info'}
-              </StyledIcon>
+              <IconBlock ref={orgRef}>
+                <StyledIcon onMouseOver={orgOpenTooltip} onMouseOut={orgCloseTooltip}>
+                  {'info'}
+                </StyledIcon>
+              </IconBlock>
             </StatBlockLabel>
             {orgPortal(tooltipTextLookup.org)}
           </StatBlock>
-          <StatBlock>
+          <StatBlock isDesktop={isDesktop}>
             <StatBlockNumber>{activeTeamCount}</StatBlockNumber>
-            <StatBlockLabel ref={teamRef}>
+            <StatBlockLabel>
               {plural(activeOrganizationCount, 'Active Team')}
-              <StyledIcon onMouseOver={teamOpenTooltip} onMouseOut={teamCloseTooltip}>
-                {'info'}
-              </StyledIcon>
+              <IconBlock ref={teamRef}>
+                <StyledIcon onMouseOver={teamOpenTooltip} onMouseOut={teamCloseTooltip}>
+                  {'info'}
+                </StyledIcon>
+              </IconBlock>
             </StatBlockLabel>
             {teamPortal(tooltipTextLookup.team)}
           </StatBlock>
-          <StatBlock>
+          <StatBlock isDesktop={isDesktop}>
             <StatBlockNumber>{activeUserCount}</StatBlockNumber>
-            <StatBlockLabel ref={memberRef}>
+            <StatBlockLabel>
               {plural(activeOrganizationCount, 'Active Member')}
-              <StyledIcon onMouseOver={memberOpenTooltip} onMouseOut={memberCloseTooltip}>
-                {'info'}
-              </StyledIcon>
+              <IconBlock ref={memberRef}>
+                <StyledIcon onMouseOver={memberOpenTooltip} onMouseOut={memberCloseTooltip}>
+                  {'info'}
+                </StyledIcon>
+              </IconBlock>
             </StatBlockLabel>
             {memberPortal(tooltipTextLookup.member)}
           </StatBlock>
-          <StatBlock>
+          <StatBlock isDesktop={isDesktop}>
             <StatBlockNumber>{meetingCount}</StatBlockNumber>
-            <StatBlockLabel ref={meetingRef}>
+            <StatBlockLabel>
               {plural(activeOrganizationCount, 'Total Meeting')}
-              <StyledIcon onMouseOver={meetingOpenTooltip} onMouseOut={meetingCloseTooltip}>
-                {'info'}
-              </StyledIcon>
+              <IconBlock ref={meetingRef}>
+                <StyledIcon onMouseOver={meetingOpenTooltip} onMouseOut={meetingCloseTooltip}>
+                  {'info'}
+                </StyledIcon>
+              </IconBlock>
             </StatBlockLabel>
             {meetingPortal(tooltipTextLookup.meeting)}
           </StatBlock>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7037

This PR:
- Changes "Meetings" to "Total Meetings"
- Adds tooltips to all domain panel terms
- Adds a subtitle to the charts to explain the terms. Chart js requires a string as a title rather than a React element and it has support for subtitles so I felt that worked well
- Increased the width of the domain panels to accounts for tooltips
- Updated domain panel on mobile
- Removes "Usage" title and adds it to the domain panel

![desktop](https://user-images.githubusercontent.com/39854876/186650447-742f0478-2aeb-44af-aeaa-f41bc2e3373a.png)
![mobile](https://user-images.githubusercontent.com/39854876/186650451-4a4db7a7-3445-4eaf-a88a-7008bd400a5f.png)

