### PR TITLE
fix: increased the line-height of text in Standup responses

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -66,6 +66,7 @@ const CancelButton = styled(SubmitButton)({
 const StyledEditor = styled('div')`
   .ProseMirror {
     min-height: 40px;
+    line-height: 20px;
   }
 
   .ProseMirror :is(ul, ol) {


### PR DESCRIPTION
Fixes #7099 by increasing the line-height of text in responses to `20px`.

## Before

<img width="435" alt="Captura de Pantalla 2022-08-25 a la(s) 1 13 04 p m" src="https://user-images.githubusercontent.com/3276087/186738852-fc526502-3098-439f-8b99-9fa3a648e683.png">



## After

<img width="428" alt="Captura de Pantalla 2022-08-25 a la(s) 1 10 44 p m" src="https://user-images.githubusercontent.com/3276087/186738492-4938be36-ca19-4c0e-b43d-74d13d07eaa1.png">

With various formatting applied:

<img width="410" alt="Captura de Pantalla 2022-08-25 a la(s) 1 05 52 p m" src="https://user-images.githubusercontent.com/3276087/186738307-5eb7c77c-6c32-40c3-8f7a-3b4bdfaca842.png">

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
