### PR TITLE
feat(metrics): identify if user is patient 0 upon login

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -6,13 +6,13 @@ import SuggestedActionTryTheDemo from '../../../database/types/SuggestedActionTr
 import TimelineEventJoinedParabol from '../../../database/types/TimelineEventJoinedParabol'
 import User from '../../../database/types/User'
 import generateUID from '../../../generateUID'
-import getPatientZeroByDomain from '../../../postgres/queries/getPatientZeroByDomain'
 import insertUser from '../../../postgres/queries/insertUser'
 import IUser from '../../../postgres/types/IUser'
 import segmentIo from '../../../utils/segmentIo'
 import addSeedTasks from './addSeedTasks'
 import createNewOrg from './createNewOrg'
 import createTeamAndLeader from './createTeamAndLeader'
+import isPatientZero from './isPatientZero'
 
 // no waiting necessary, it's just analytics
 const handleSegment = async (user: User, isInvited: boolean) => {
@@ -27,7 +27,7 @@ const handleSegment = async (user: User, isInvited: boolean) => {
       isActive: true,
       featureFlags,
       highestTier: tier,
-      isPatient0: domain ? userId === (await getPatientZeroByDomain(domain)).id : undefined
+      isPatient0: await isPatientZero(userId, domain)
     },
     anonymousId: segmentId
   })

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -16,11 +16,14 @@ import createTeamAndLeader from './createTeamAndLeader'
 
 // no waiting necessary, it's just analytics
 const handleSegment = async (user: User, isInvited: boolean) => {
-  const {id: userId, email, featureFlags, tier, segmentId} = user
+  const {id: userId, createdAt, email, featureFlags, tier, segmentId, preferredName} = user
   const domain = email.split('@')[1]
   segmentIo.identify({
     userId,
     traits: {
+      createdAt,
+      email,
+      name: preferredName,
       isActive: true,
       featureFlags,
       highestTier: tier,

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -6,6 +6,7 @@ import SuggestedActionTryTheDemo from '../../../database/types/SuggestedActionTr
 import TimelineEventJoinedParabol from '../../../database/types/TimelineEventJoinedParabol'
 import User from '../../../database/types/User'
 import generateUID from '../../../generateUID'
+import getPatientZeroByDomain from '../../../postgres/queries/getPatientZeroByDomain'
 import insertUser from '../../../postgres/queries/insertUser'
 import IUser from '../../../postgres/types/IUser'
 import segmentIo from '../../../utils/segmentIo'
@@ -15,14 +16,15 @@ import createTeamAndLeader from './createTeamAndLeader'
 
 // no waiting necessary, it's just analytics
 const handleSegment = async (user: User, isInvited: boolean) => {
-  const {id: userId, createdAt, email, segmentId, picture, preferredName} = user
+  const {id: userId, email, featureFlags, tier, segmentId} = user
+  const domain = email.split('@')[1]
   segmentIo.identify({
     userId,
     traits: {
-      avatar: picture,
-      createdAt,
-      email,
-      name: preferredName
+      isActive: true,
+      featureFlags,
+      highestTier: tier,
+      isPatient0: domain ? userId === (await getPatientZeroByDomain(domain)).id : undefined
     },
     anonymousId: segmentId
   })

--- a/packages/server/graphql/mutations/helpers/isPatientZero.ts
+++ b/packages/server/graphql/mutations/helpers/isPatientZero.ts
@@ -1,0 +1,6 @@
+import getPatientZeroByDomain from '../../../postgres/queries/getPatientZeroByDomain'
+
+const isPatientZero = async (userId: string, domain?: string | null) =>
+  domain ? userId === (await getPatientZeroByDomain(domain)).id : false
+
+export default isPatientZero

--- a/packages/server/graphql/mutations/helpers/updateUserProfile.ts
+++ b/packages/server/graphql/mutations/helpers/updateUserProfile.ts
@@ -87,6 +87,12 @@ const updateUserProfile = async (
         name: validUpdatedUser.preferredName
       }
     })
+    segmentIo.identify({
+      userId,
+      traits: {
+        name: validUpdatedUser.preferredName
+      }
+    })
   }
 
   const teamIds = teamMembers.map(({teamId}) => teamId)

--- a/packages/server/graphql/mutations/helpers/updateUserProfile.ts
+++ b/packages/server/graphql/mutations/helpers/updateUserProfile.ts
@@ -1,4 +1,3 @@
-import {GQLContext} from './../../graphql'
 import sanitizeSVG from '@mattkrick/sanitize-svg'
 import {JSDOM} from 'jsdom'
 import fetch from 'node-fetch'
@@ -13,6 +12,7 @@ import publish from '../../../utils/publish'
 import segmentIo from '../../../utils/segmentIo'
 import standardError from '../../../utils/standardError'
 import {UpdateUserProfileInputType} from '../../types/UpdateUserProfileInput'
+import {GQLContext} from './../../graphql'
 
 const updateUserProfile = async (
   _source: unknown,
@@ -84,12 +84,6 @@ const updateUserProfile = async (
       userId,
       event: 'Changed name',
       properties: {
-        name: validUpdatedUser.preferredName
-      }
-    })
-    segmentIo.identify({
-      userId,
-      traits: {
         name: validUpdatedUser.preferredName
       }
     })

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -1,13 +1,13 @@
 import {InvoiceItemType, SubscriptionChannel} from 'parabol-client/types/constEnums'
 import adjustUserCount from '../../../billing/helpers/adjustUserCount'
 import getRethink from '../../../database/rethinkDriver'
-import getPatientZeroByDomain from '../../../postgres/queries/getPatientZeroByDomain'
 import updateUser from '../../../postgres/queries/updateUser'
 import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
 import publish from '../../../utils/publish'
 import segmentIo from '../../../utils/segmentIo'
+import isPatientZero from '../../mutations/helpers/isPatientZero'
 import {MutationResolvers} from '../resolverTypes'
 
 export interface UserPresence {
@@ -88,9 +88,7 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
       isActive: true,
       featureFlags: user.featureFlags,
       highestTier: user.tier,
-      isPatient0: user.domain
-        ? userId === (await getPatientZeroByDomain(user.domain)).id
-        : undefined
+      isPatient0: await isPatientZero(userId, user.domain)
     }
   })
   return user

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -1,6 +1,7 @@
 import {InvoiceItemType, SubscriptionChannel} from 'parabol-client/types/constEnums'
 import adjustUserCount from '../../../billing/helpers/adjustUserCount'
 import getRethink from '../../../database/rethinkDriver'
+import getPatientZeroByDomain from '../../../postgres/queries/getPatientZeroByDomain'
 import updateUser from '../../../postgres/queries/updateUser'
 import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
@@ -86,7 +87,10 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
     traits: {
       isActive: true,
       featureFlags: user.featureFlags,
-      highestTier: user.tier
+      highestTier: user.tier,
+      isPatient0: user.domain
+        ? userId === (await getPatientZeroByDomain(user.domain)).id
+        : undefined
     }
   })
   return user

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -21,7 +21,7 @@ import OrganizationType from '../../database/types/Organization'
 import OrganizationUserType from '../../database/types/OrganizationUser'
 import Reflection from '../../database/types/Reflection'
 import SuggestedActionType from '../../database/types/SuggestedAction'
-import getPg from '../../postgres/getPg'
+import getPatientZeroByDomain from '../../postgres/queries/getPatientZeroByDomain'
 import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import getDomainFromEmail from '../../utils/getDomainFromEmail'
 import getMonthlyStreak from '../../utils/getMonthlyStreak'
@@ -105,12 +105,8 @@ const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLC
       description: 'true if the user is the first to sign up from their domain, else false',
       resolve: async ({id: userId, email}: {id: string; email: string}) => {
         const domain = getDomainFromEmail(email)
-        const pg = getPg()
-        const patientZeroId = await pg.query(
-          'SELECT "id" FROM "User" WHERE "domain" = $1 ORDER BY "createdAt" LIMIT 1',
-          [domain]
-        )
-        return patientZeroId.rows[0]?.id === userId
+        const patientZero = await getPatientZeroByDomain(domain)
+        return patientZero.id === userId
       }
     },
     reasonRemoved: {

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -21,7 +21,6 @@ import OrganizationType from '../../database/types/Organization'
 import OrganizationUserType from '../../database/types/OrganizationUser'
 import Reflection from '../../database/types/Reflection'
 import SuggestedActionType from '../../database/types/SuggestedAction'
-import getPatientZeroByDomain from '../../postgres/queries/getPatientZeroByDomain'
 import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import getDomainFromEmail from '../../utils/getDomainFromEmail'
 import getMonthlyStreak from '../../utils/getMonthlyStreak'
@@ -30,6 +29,7 @@ import standardError from '../../utils/standardError'
 import errorFilter from '../errorFilter'
 import {DataLoaderWorker, GQLContext} from '../graphql'
 import isValid from '../isValid'
+import isPatientZero from '../mutations/helpers/isPatientZero'
 import invoiceDetails from '../queries/invoiceDetails'
 import invoices from '../queries/invoices'
 import organization from '../queries/organization'
@@ -105,8 +105,7 @@ const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLC
       description: 'true if the user is the first to sign up from their domain, else false',
       resolve: async ({id: userId, email}: {id: string; email: string}) => {
         const domain = getDomainFromEmail(email)
-        const patientZero = await getPatientZeroByDomain(domain)
-        return patientZero.id === userId
+        return isPatientZero(userId, domain)
       }
     },
     reasonRemoved: {

--- a/packages/server/postgres/queries/getPatientZeroByDomain.ts
+++ b/packages/server/postgres/queries/getPatientZeroByDomain.ts
@@ -1,0 +1,10 @@
+import getPg from '../getPg'
+import IUser from '../types/IUser'
+import {getPatientZeroByDomainQuery} from './generated/getPatientZeroByDomainQuery'
+
+const getPatient0ByDomain = async (domain: string): Promise<IUser> => {
+  const usersInDomain = await getPatientZeroByDomainQuery.run({domain}, getPg())
+  return usersInDomain[0] as unknown as IUser
+}
+
+export default getPatient0ByDomain

--- a/packages/server/postgres/queries/src/getPatientZeroByDomainQuery.sql
+++ b/packages/server/postgres/queries/src/getPatientZeroByDomainQuery.sql
@@ -1,0 +1,5 @@
+/*
+  @name getPatientZeroByDomainQuery
+*/
+SELECT * FROM "User"
+WHERE "domain" = :domain ORDER BY "createdAt" LIMIT 1;


### PR DESCRIPTION
# Description

Fixes #7128 

## Demo

<img width="395" alt="Screen Shot 2022-08-29 at 4 49 18 PM" src="https://user-images.githubusercontent.com/1879975/187318207-b9522f21-9f38-41e8-bad9-5bf075a30723.png">


## Testing scenarios

1. Log in
2. Verify in Segment the `isPatient0` property is included in the `identify` call


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
