### PR TITLE
fix(demo): prevent demo meeting auto-start after page refresh

### DIFF
--- a/packages/client/components/BeginDemoModal.tsx
+++ b/packages/client/components/BeginDemoModal.tsx
@@ -1,12 +1,10 @@
-import React from 'react'
 import styled from '@emotion/styled'
-import Icon from './Icon'
+import React from 'react'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
 import DialogContainer from './DialogContainer'
+import Icon from './Icon'
 import PrimaryButton from './PrimaryButton'
-import useAtmosphere from '../hooks/useAtmosphere'
-import LocalAtmosphere from '../modules/demo/LocalAtmosphere'
 
 const StyledDialogContainer = styled(DialogContainer)({
   alignItems: 'center',
@@ -30,21 +28,12 @@ const StyledIcon = styled(Icon)({
 })
 
 interface Props {
-  closePortal: () => void
+  startDemo: () => void
 }
 
 const BeginDemoModal = (props: Props) => {
-  const {closePortal} = props
-  const atmosphere = (useAtmosphere() as unknown) as LocalAtmosphere
-  const {clientGraphQLServer} = atmosphere
-  const {startBot} = clientGraphQLServer
-  const onClick = () => {
-    startBot()
-    closePortal()
-    setTimeout(() => {
-      clientGraphQLServer.emit('startDemo')
-    }, 1000)
-  }
+  const {startDemo} = props
+
   return (
     <StyledDialogContainer>
       <StyledIcon>chat</StyledIcon>
@@ -52,7 +41,7 @@ const BeginDemoModal = (props: Props) => {
         Try Parabol for yourself by holding a 2-minute retrospective meeting with our simulated
         colleagues
       </StyledCopy>
-      <PrimaryButton dataCy='start-demo-button' onClick={onClick} size='medium'>
+      <PrimaryButton dataCy='start-demo-button' onClick={startDemo} size='medium'>
         Start Demo
       </PrimaryButton>
     </StyledDialogContainer>

--- a/packages/client/components/BottomControlBarTips.tsx
+++ b/packages/client/components/BottomControlBarTips.tsx
@@ -134,10 +134,10 @@ const BottomControlBarTips = (props: Props) => {
   const atmosphere = useAtmosphere()
   const demoPauseOpen = useTimeout(1000)
   const menus = isDemoRoute() ? demoHelps : helps
+  const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
   const MenuContent = menus[phaseType]
   useEffect(() => {
     if (demoPauseOpen && isDemoRoute()) {
-      const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
       if (clientGraphQLServer.db._started) {
         openPortal()
       } else {
@@ -147,7 +147,7 @@ const BottomControlBarTips = (props: Props) => {
         })
       }
     }
-  }, [demoPauseOpen, openPortal])
+  }, [demoPauseOpen, openPortal, clientGraphQLServer.db._started])
   return (
     <BottomNavControl
       dataCy={`tip-menu-toggle`}

--- a/packages/client/components/BottomControlBarTips.tsx
+++ b/packages/client/components/BottomControlBarTips.tsx
@@ -138,13 +138,11 @@ const BottomControlBarTips = (props: Props) => {
   useEffect(() => {
     if (demoPauseOpen && isDemoRoute()) {
       const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
-      const {isNew} = clientGraphQLServer
-      if (!isNew) {
+      if (clientGraphQLServer.db._started) {
         openPortal()
       } else {
         // wait for the startBot event to occur
         clientGraphQLServer.once('startDemo', () => {
-          clientGraphQLServer.isNew = false
           openPortal()
         })
       }

--- a/packages/client/hooks/useDemoMeeting.tsx
+++ b/packages/client/hooks/useDemoMeeting.tsx
@@ -1,27 +1,27 @@
-import useAtmosphere from './useAtmosphere'
-import useForceUpdate from './useForceUpdate'
-import useModal from './useModal'
 import React, {useEffect} from 'react'
 import LocalAtmosphere from '../modules/demo/LocalAtmosphere'
 import lazyPreload from '../utils/lazyPreload'
+import useAtmosphere from './useAtmosphere'
+import useForceUpdate from './useForceUpdate'
+import useModal from './useModal'
 
-const BeginDemoModal = lazyPreload(() =>
-  import(/* webpackChunkName: 'BeginDemoModal' */ '../components/BeginDemoModal')
+const BeginDemoModal = lazyPreload(
+  () => import(/* webpackChunkName: 'BeginDemoModal' */ '../components/BeginDemoModal')
 )
 
 const useDemoMeeting = () => {
   const atmosphere = useAtmosphere()
   const forceUpdate = useForceUpdate()
-  const {modalPortal, closePortal, togglePortal} = useModal({noClose: true})
+  const {modalPortal, closePortal, openPortal} = useModal({noClose: true})
   useEffect(() => {
-    const {clientGraphQLServer} = (atmosphere as unknown) as LocalAtmosphere
+    const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
     if (clientGraphQLServer) {
       clientGraphQLServer.on('botsFinished', () => {
         // for the demo, we're essentially using the isBotFinished() prop as state
         forceUpdate()
       })
       if (clientGraphQLServer.isNew) {
-        togglePortal()
+        openPortal()
       }
     }
   }, [atmosphere, forceUpdate])

--- a/packages/client/hooks/useDemoMeeting.tsx
+++ b/packages/client/hooks/useDemoMeeting.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react'
+import React, {useCallback, useEffect} from 'react'
 import LocalAtmosphere from '../modules/demo/LocalAtmosphere'
 import lazyPreload from '../utils/lazyPreload'
 import useAtmosphere from './useAtmosphere'
@@ -12,20 +12,32 @@ const BeginDemoModal = lazyPreload(
 const useDemoMeeting = () => {
   const atmosphere = useAtmosphere()
   const forceUpdate = useForceUpdate()
-  const {modalPortal, closePortal, openPortal} = useModal({noClose: true})
+  const {modalPortal, openPortal, closePortal} = useModal({noClose: true})
+  const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
+
   useEffect(() => {
-    const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
     if (clientGraphQLServer) {
       clientGraphQLServer.on('botsFinished', () => {
         // for the demo, we're essentially using the isBotFinished() prop as state
         forceUpdate()
       })
-      if (clientGraphQLServer.isNew) {
+      if (!clientGraphQLServer.db._started) {
         openPortal()
       }
     }
   }, [atmosphere, forceUpdate])
-  return () => modalPortal(<BeginDemoModal closePortal={closePortal} />)
+
+  const startDemo = useCallback(() => {
+    clientGraphQLServer.startDemo()
+
+    closePortal()
+
+    setTimeout(() => {
+      clientGraphQLServer.emit('startDemo')
+    }, 1000)
+  }, [])
+
+  return () => modalPortal(<BeginDemoModal startDemo={startDemo} />)
 }
 
 export default useDemoMeeting

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -1,6 +1,6 @@
 import {stateToHTML} from 'draft-js-export-html'
 import EventEmitter from 'eventemitter3'
-import {parse} from 'flatted'
+import {parse, stringify} from 'flatted'
 import ms from 'ms'
 import {Variables} from 'relay-runtime'
 import StrictEventEmitter from 'strict-event-emitter-types'
@@ -158,14 +158,13 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
   getTempId = (prefix: string) => `${prefix}${this.db._tempID++}`
   pendingBotTimeout: number | undefined
   pendingBotAction?: (() => any[]) | undefined
-  isNew = true
   constructor(atmosphere: LocalAtmosphere) {
     super()
     this.atmosphere = atmosphere
     const validDB = this.getValidDB()
     if (validDB) {
       this.db = validDB
-      this.startDemo()
+      this.db._started && this.startBot()
     } else {
       this.db = initDB(initBotScript())
     }
@@ -188,8 +187,9 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
   }
 
   startDemo() {
-    this.isNew = false
     this.startBot()
+    this.db._started = true
+    window.localStorage.setItem('retroDemo', stringify(this.db))
   }
 
   getUnlockedStages(stageIds: string[]) {

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -178,10 +178,8 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
     } catch (e) {
       // noop
     }
-    // const isStale = false
-    const isUpdatedIn5Minutes =
-      validDB && new Date(validDB._updatedAt).getTime() >= Date.now() - ms('5m')
-    if (!isUpdatedIn5Minutes) return
+    const isFresh = validDB && new Date(validDB._updatedAt).getTime() >= Date.now() - ms('5m')
+    if (!isFresh) return
 
     return validDB
   }

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -573,6 +573,7 @@ const initDB = (botScript: ReturnType<typeof initBotScript>) => {
     team,
     teamMembers,
     users,
+    _started: false,
     _updatedAt: new Date(),
     _tempID: 1,
     _botScript: botScript


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #6946 
prevent demo meeting auto start after page refresh

## Demo

https://www.loom.com/share/c032b342f9ed4762b76642d8b135a279

## Testing scenarios

- [ ] open http://localhost:3000/retrospective-demo
  - Refresh Page
  - Click "Start Demo" button
  - Bots start adding reflections

- [ ] open http://localhost:3000/retrospective-demo
  - Click "Start Demo" button
  - Refresh Page
  - Everything continues

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
