### PR TITLE
fix: Changed copy on /create-account page

### DIFF
--- a/packages/client/components/AuthenticationPage.tsx
+++ b/packages/client/components/AuthenticationPage.tsx
@@ -43,7 +43,7 @@ const AuthenticationPage = (props: Props) => {
           Better Meetings, <br />
           Less Effort
         </h1>
-        <p>Help your team connect &amp; improve with an agile meeting co-pilot</p>
+        <p>92&#37; of users agreed that Parabol improves the efficiency of their meetings.</p>
       </CopyBlock>
       <GenericAuthentication page={page} goToPage={goToPage} />
     </TeamInvitationWrapper>


### PR DESCRIPTION
# Description

Fixes #7126 
Changed the copy on the /create-account page to:
_92% of users agreed that Parabol improves the efficiency of their meetings._

## Demo
<img width="925" alt="CleanShot 2022-08-30 at 14 22 53@2x" src="https://user-images.githubusercontent.com/1415538/187435556-4457704a-1b5d-42ae-87d0-15e1fc1efcf5.png">

## Testing scenarios

- [x] checked this locally - see Demo Screenshot

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
