### PR TITLE
feat(dx): createFragmentContainer -> useFragment codeshift automation

### DIFF
--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -12,11 +12,6 @@ const transform: Transform = (fileInfo, api, options) => {
 
   const root = j(source)
 
-  if (root.find(j.Identifier, {name: 'createFragmentContainer'}).size() > 2) {
-    // We only expect two refs - the import and the call to wrap the component.
-    throw new Error('more than two refs to createFragmentContainer')
-  }
-
   // Find where we're wrapping our component with 'createFragmentContainer':
   //   createFragmentContainer(MyComponent, {myProp: graphql`<fragment>`})
   const functionExpressions = root.find(j.CallExpression, {

--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -52,6 +52,9 @@ const transform: Transform = (fileInfo, api, options) => {
   const fragmentProps = functionExpression.arguments[1]
   const propMap = {}
   fragmentProps.properties.forEach((prop) => {
+    if (root.find(j.Identifier, {name: `${prop.key.name}Ref`}).length > 0) {
+      throw new Error(`Naming conflict with ${prop.key.name}Ref`)
+    }
     propMap[prop.key.name] = prop.value
   })
 

--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -1,0 +1,132 @@
+/*
+ Usage: jscodeshift --extensions=tsx --parser=tsx -t ./scripts/codeshift/convertToUseFragment.ts ./packages/client/components/TeamArchived.tsx
+ This codemod converts a component using 'createFragmentContainer' to use 'useFragment'.
+*/
+
+import {Transform} from 'jscodeshift/src/core'
+
+const transform: Transform = (fileInfo, api, options) => {
+  const j = api.jscodeshift
+  const {statement} = j.template
+  const {source} = fileInfo
+
+  const root = j(source)
+
+  const functionExpressions = root.find(j.CallExpression, {
+    callee: {
+      type: 'Identifier',
+      name: 'createFragmentContainer'
+    }
+  })
+
+  if (functionExpressions.size() !== 1) {
+    throw new Error('trying to convert file with multiple fragment containers')
+  }
+
+  const functionExpression = functionExpressions.get().value
+
+  const replacementExport = functionExpression.arguments[0]
+  const fragmentProps = functionExpression.arguments[1]
+
+  functionExpressions.replaceWith(replacementExport)
+
+  const componentName = replacementExport.name
+
+  console.log(fragmentProps)
+  const propMap = {}
+  fragmentProps.properties.forEach((prop) => {
+    propMap[prop.key.name] = prop.value
+  })
+
+  // Find the component we're changing
+  const component = root.find(j.VariableDeclarator, {id: {name: componentName}})
+  if (component.size() !== 1) {
+    throw new Error("can't find component!")
+  }
+
+  // Find its destructuring of props
+  const propDeclaration = component.find(j.VariableDeclaration, {
+    declarations: [
+      {
+        id: {type: 'ObjectPattern'},
+        init: {type: 'Identifier', name: 'props'}
+      }
+    ]
+  })
+
+  if (propDeclaration.size() !== 1) {
+    throw new Error('props destructured never or more than once')
+  }
+
+  const hasRenamedProps =
+    propDeclaration
+      .find(j.ObjectProperty)
+      .filter(
+        (p) =>
+          p.value.key.type === 'Identifier' &&
+          Object.keys(propMap).includes(p.value.key.name) &&
+          p.value.value.type === 'Identifier' &&
+          p.value.value.name !== p.value.key.name
+      )
+      .size() > 0
+
+  if (hasRenamedProps) {
+    throw new Error('props already renaming destructured prop')
+  }
+
+  propDeclaration
+    .find(j.ObjectProperty)
+    .filter(
+      (p) =>
+        p.value.key.type === 'Identifier' &&
+        Object.keys(propMap).includes(p.value.key.name) &&
+        p.value.value.type === 'Identifier' &&
+        p.value.value.name === p.value.key.name
+    )
+    .replaceWith((p) => {
+      // Make the destructured name appended with Ref.
+      if (p.value.key.type === 'Identifier' && p.value.value.type === 'Identifier') {
+        return j.objectProperty.from({
+          key: p.value.key,
+          value: j.identifier(`${p.value.key.name}Ref`)
+        })
+      }
+    })
+
+  propDeclaration.insertAfter((p) => {
+    return Object.keys(propMap).map((prop) => {
+      console.log(prop)
+      return statement`const ${prop} = useFragment(${propMap[prop]}, ${j.identifier(
+        prop + 'Ref'
+      )})\n`
+    })
+  })
+
+  root
+    .find(j.TSInterfaceDeclaration, {id: {name: 'Props'}})
+    .find(j.TSPropertySignature, {key: {type: 'Identifier'}})
+    .filter((p) => Object.keys(propMap).includes((p.value.key as any).name))
+    .forEach((p) => {
+      if (
+        p.value.typeAnnotation?.type !== 'TSTypeAnnotation' ||
+        p.value.typeAnnotation.typeAnnotation.type !== 'TSTypeReference' ||
+        p.value.typeAnnotation.typeAnnotation.typeName.type !== 'Identifier'
+      ) {
+        throw new Error(
+          `invalid type for prop: ${(p.value.key as any).name}, ${p.value.initializer?.type}`
+        )
+      }
+
+      const name = p.value.typeAnnotation.typeAnnotation.typeName.name
+
+      root.find(j.Identifier, {name}).replaceWith(j.identifier(name + '$key'))
+    })
+
+  root
+    .find(j.Identifier, {name: 'createFragmentContainer'})
+    .replaceWith(j.identifier('useFragment'))
+
+  return root.toSource()
+}
+
+module.exports = transform

--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -12,6 +12,13 @@ const transform: Transform = (fileInfo, api, options) => {
 
   const root = j(source)
 
+  if (root.find(j.Identifier, {name: 'createFragmentContainer'}).size() > 2) {
+    // We only expect two refs - the import and the call to wrap the component.
+    throw new Error('more than two refs to createFragmentContainer')
+  }
+
+  // Find where we're wrapping our component with 'createFragmentContainer':
+  //   createFragmentContainer(MyComponent, {myProp: graphql`<fragment>`})
   const functionExpressions = root.find(j.CallExpression, {
     callee: {
       type: 'Identifier',
@@ -26,26 +33,40 @@ const transform: Transform = (fileInfo, api, options) => {
   const functionExpression = functionExpressions.get().value
 
   const replacementExport = functionExpression.arguments[0]
-  const fragmentProps = functionExpression.arguments[1]
 
+  // Replace the call to 'createFragmentContainer' with just a reference to the component we're
+  // wrapping:
+  //   createFragmentContainer(MyComponent, {myProp: graphql``})
   functionExpressions.replaceWith(replacementExport)
+
+  if (replacementExport.type !== 'Identifier') {
+    // We need to get the component idetifier from the HOC call site, so if the export looks like:
+    //   createFragmentContainer(withOtherHoc(Component), {myProp: <fragment>})
+    // It's less trivial to get the identifier.
+    // :TODO: (jmtaber129): Support files that look like this, either by traversing down the tree of
+    // call expressions until we hit the identifier, or by taking in the component name from the
+    // command line or file name.
+    throw new Error('trying to convert component with non-trivial HOC wrapping')
+  }
 
   const componentName = replacementExport.name
 
-  console.log(fragmentProps)
+  // Build a map of propName -> graphql fragment.
+  const fragmentProps = functionExpression.arguments[1]
   const propMap = {}
   fragmentProps.properties.forEach((prop) => {
     propMap[prop.key.name] = prop.value
   })
 
-  // Find the component we're changing
-  const component = root.find(j.VariableDeclarator, {id: {name: componentName}})
-  if (component.size() !== 1) {
+  // Find the declaration of the component we're changing
+  const componentDeclaration = root.find(j.VariableDeclarator, {id: {name: componentName}})
+  if (componentDeclaration.size() !== 1) {
     throw new Error("can't find component!")
   }
 
-  // Find its destructuring of props
-  const propDeclaration = component.find(j.VariableDeclaration, {
+  // Find where the component destructures its props:
+  //  const {myProp} = props
+  const propDestructuring = componentDeclaration.find(j.VariableDeclaration, {
     declarations: [
       {
         id: {type: 'ObjectPattern'},
@@ -54,12 +75,14 @@ const transform: Transform = (fileInfo, api, options) => {
     ]
   })
 
-  if (propDeclaration.size() !== 1) {
+  if (propDestructuring.size() !== 1) {
     throw new Error('props destructured never or more than once')
   }
 
+  // Check whether this is renaming any props when destructuring:
+  //  const {myProp: otherNameForProp} = props
   const hasRenamedProps =
-    propDeclaration
+    propDestructuring
       .find(j.ObjectProperty)
       .filter(
         (p) =>
@@ -71,10 +94,15 @@ const transform: Transform = (fileInfo, api, options) => {
       .size() > 0
 
   if (hasRenamedProps) {
-    throw new Error('props already renaming destructured prop')
+    // :TODO: (jmtaber129): Support this.
+    throw new Error('prop names renamed during prop destructuring')
   }
 
-  propDeclaration
+  // Rename the destructured props to '<propName>Ref'. From
+  //   const {myProp} = props
+  // to
+  //   const {myProp: myPropRef} = props
+  propDestructuring
     .find(j.ObjectProperty)
     .filter(
       (p) =>
@@ -93,7 +121,10 @@ const transform: Transform = (fileInfo, api, options) => {
       }
     })
 
-  propDeclaration.insertAfter((p) => {
+  // Insert the 'useFragment' call right after the prop destructuring:
+  //   const {myProp: myPropRef} = props
+  //   const myProp = useFragment(graphql`<fragment>`, myPropRef)
+  propDestructuring.insertAfter(() => {
     return Object.keys(propMap).map((prop) => {
       console.log(prop)
       return statement`const ${prop} = useFragment(${propMap[prop]}, ${j.identifier(
@@ -102,26 +133,46 @@ const transform: Transform = (fileInfo, api, options) => {
     })
   })
 
-  root
-    .find(j.TSInterfaceDeclaration, {id: {name: 'Props'}})
-    .find(j.TSPropertySignature, {key: {type: 'Identifier'}})
-    .filter((p) => Object.keys(propMap).includes((p.value.key as any).name))
-    .forEach((p) => {
-      if (
-        p.value.typeAnnotation?.type !== 'TSTypeAnnotation' ||
-        p.value.typeAnnotation.typeAnnotation.type !== 'TSTypeReference' ||
-        p.value.typeAnnotation.typeAnnotation.typeName.type !== 'Identifier'
-      ) {
-        throw new Error(
-          `invalid type for prop: ${(p.value.key as any).name}, ${p.value.initializer?.type}`
-        )
-      }
+  // Find the interface declaration for the Props type:
+  //   interface Props {
+  //     nonFragmentProp: string
+  //     myProp: MyFragmentName_type
+  //   }
+  // and update the types to be a graphql key:
+  //   interface Props {
+  //     nonFragmentProp: string
+  //     myProp: MyFragmentName_type$key
+  //   }
+  const didUpdateTypes =
+    root
+      .find(j.TSInterfaceDeclaration, {id: {name: 'Props'}})
+      .find(j.TSPropertySignature, {key: {type: 'Identifier'}})
+      .filter((p) => Object.keys(propMap).includes((p.value.key as any).name))
+      .forEach((p) => {
+        if (
+          p.value.typeAnnotation?.type !== 'TSTypeAnnotation' ||
+          p.value.typeAnnotation.typeAnnotation.type !== 'TSTypeReference' ||
+          p.value.typeAnnotation.typeAnnotation.typeName.type !== 'Identifier'
+        ) {
+          throw new Error(
+            `invalid type for prop: ${(p.value.key as any).name}, ${p.value.initializer?.type}`
+          )
+        }
 
-      const name = p.value.typeAnnotation.typeAnnotation.typeName.name
+        const name = p.value.typeAnnotation.typeAnnotation.typeName.name
 
-      root.find(j.Identifier, {name}).replaceWith(j.identifier(name + '$key'))
-    })
+        root.find(j.Identifier, {name}).replaceWith(j.identifier(name + '$key'))
+      })
+      .size() === Object.keys(propMap).length
 
+  if (!didUpdateTypes) {
+    throw new Error('Could not update types in interface')
+  }
+
+  // Update the import:
+  //   import {createFragmentContainer} from 'react-relay'
+  // to
+  //   import {useFragment} from 'react-relay'
   root
     .find(j.Identifier, {name: 'createFragmentContainer'})
     .replaceWith(j.identifier('useFragment'))

--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -22,7 +22,7 @@ const transform: Transform = (fileInfo, api, options) => {
   })
 
   if (functionExpressions.size() !== 1) {
-    throw new Error('trying to convert file with multiple fragment containers')
+    throw new Error('trying to convert file with zero or multiple fragment containers')
   }
 
   const functionExpression = functionExpressions.get().value
@@ -32,6 +32,8 @@ const transform: Transform = (fileInfo, api, options) => {
   // Replace the call to 'createFragmentContainer' with just a reference to the component we're
   // wrapping:
   //   createFragmentContainer(MyComponent, {myProp: graphql``})
+  // to
+  //   MyComponent
   functionExpressions.replaceWith(replacementExport)
 
   if (replacementExport.type !== 'Identifier') {
@@ -156,6 +158,7 @@ const transform: Transform = (fileInfo, api, options) => {
 
         const name = p.value.typeAnnotation.typeAnnotation.typeName.name
 
+        // Rename all identifiers with this name to also update the import.
         root.find(j.Identifier, {name}).replaceWith(j.identifier(name + '$key'))
       })
       .size() === Object.keys(propMap).length


### PR DESCRIPTION
# Description

Automate the migration from `createFragmentContainer` to `useFragment` for a particular file.

Please also review the [guide](https://www.notion.so/parabol/How-to-Migrate-createFragmentContainer-useFragment-with-codeshift-d534e7d0b8674089a2075f2835544558).

Usage:
```
jscodeshift --extensions=tsx --parser=tsx -t ./scripts/codeshift/convertToUseFragment.ts ./packages/client/components/TeamArchived.tsx
```

Doesn't work in all cases, but should work in most.

Partially Fixes https://github.com/ParabolInc/parabol/issues/6283

## Demo
See https://github.com/ParabolInc/parabol/pull/7136

## Testing scenarios
Run on a few different files and confirm that this does the right thing. This is expected to fail in a lot of ways, so in this case, the "right thing" is:
* Works most of the time
* When it doesn't work, spits out an error instead of doing the wrong thing to the file

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
