### PR TITLE
fix: Text without spaces breaks the UI in discussion

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -25,10 +25,10 @@ import AddPollButton from './AddPollButton'
 import AddTaskButton from './AddTaskButton'
 import Avatar from './Avatar/Avatar'
 import {DiscussionThreadables} from './DiscussionThreadList'
+import {createLocalPoll} from './Poll/local/newPoll'
 import SendCommentButton from './SendCommentButton'
 import CommentEditor from './TaskEditor/CommentEditor'
 import {ReplyMention, SetReplyMention} from './ThreadedItem'
-import {createLocalPoll} from './Poll/local/newPoll'
 
 const Wrapper = styled('div')<{isReply: boolean; isDisabled: boolean}>(({isDisabled, isReply}) => ({
   display: 'flex',
@@ -56,7 +56,10 @@ const CommentAvatar = styled(Avatar)({
 
 const EditorWrap = styled('div')({
   flex: 1,
-  margin: '14px 0'
+  margin: '14px 0',
+  overflowWrap: 'break-word',
+  // width below the required size does not have effect
+  width: 0
 })
 
 const ActionsContainer = styled('div')({


### PR DESCRIPTION
# Description
Fixes: #7090

## Demo
![Screenshot 2022-08-31 231255](https://user-images.githubusercontent.com/106697681/187746093-f12ccda6-677b-4568-8ee3-51d1975da228.png)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
