### PR TITLE
style: increase font size of standup meeting title

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -14,7 +14,7 @@ import {IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
 import TeamPromptOptions from './TeamPromptOptions'
 
 const TeamPromptHeaderTitle = styled('h1')({
-  fontSize: 16,
+  fontSize: 18,
   lineHeight: '24px',
   margin: 0,
   padding: 0,


### PR DESCRIPTION
# Description

Increases the font size of the standup meeting title from `16px` to `18px`. This improves hierarchy and visual balance.

## Demo

Before and after:

<img width="495" alt="Captura de Pantalla 2022-08-31 a la(s) 5 46 38 p m" src="https://user-images.githubusercontent.com/3276087/187798911-adee80b7-6085-4855-ad23-cfb55d9c6c56.png">

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
