### PR TITLE
fix(pipeline): fix CircleCI error during Commit Deployment stage (missing dependency for sharp module)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
       - deploy:
           name: Commit Deployment
           command: |
+            sudo apt-get update && sudo apt-get install -y libvips-dev --no-install-recommends
             if [ "${CIRCLE_BRANCH}" == "production" ]; then
               export GITHUB_REMOTE="${GITHUB_REMOTE_PRODUCTION}"
               export DEPLOY_ENV="production"


### PR DESCRIPTION
# Description

Fixes error during pipeline execution deploying to Staging.

```
remote:        2022-09-06T10:57:57: PM2 log: App name:GQL Executor id:2 disconnected        
remote:        2022-09-06T10:57:57: PM2 log: App [GQL Executor:2] exited with code [0] via signal [SIGINT]        
remote:        2022-09-06T10:57:57: PM2 log: App [GQL Executor:2] starting in -cluster mode-        
remote:        2022-09-06T10:57:57: PM2 log: App [GQL Executor:2] online        
remote:        Error:         
remote:        Something went wrong installing the "sharp" module        
remote:        node-loader:        
remote:        Error: libvips-cpp.so.42: cannot open shared object file: No such file or directory        
remote:        Possible solutions:        
remote:        - Install with verbose logging and look for errors: "npm install --ignore-scripts=false --foreground-scripts --verbose sharp"        
remote:        - Install for the current linux-x64 runtime: "npm install --platform=linux --arch=x64 sharp"        
remote:        - Consult the installation documentation: https://sharp.pixelplumbing.com/install        
remote:            at Object.65939 (/app/dist/gqlExecutor.js:609852:9)        
remote:            at __webpack_require__ (/app/dist/gqlExecutor.js:875729:42)        
remote:            at Object.26955 (/app/dist/gqlExecutor.js:606042:1)        
remote:            at __webpack_require__ (/app/dist/gqlExecutor.js:875729:42)        
remote:            at Object.66456 (/app/dist/gqlExecutor.js:606431:15)        
remote:            at __webpack_require__ (/app/dist/gqlExecutor.js:875729:42)        
remote:            at Object.97198 (/app/dist/gqlExecutor.js:70699:17)        
remote:            at __webpack_require__ (/app/dist/gqlExecutor.js:875729:42)        
remote:            at Object.34960 (/app/dist/gqlExecutor.js:28795:18)        
remote:            at __webpack_require__ (/app/dist/gqlExecutor.js:875729:42)
```

Changes are only to add a line to install libvips-dev in the Commit Deployment stage of CircleCI
