### PR TITLE
fix: Task assignee menu is missing entries

### DIFF
--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -60,6 +60,12 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
     () => teamMembers.filter((teamMember) => teamMember.userId !== userId),
     [userId, teamMembers]
   )
+
+  const selectedMember = teamMembers.filter((member) => {
+    return assignees.indexOf(member) < 0
+  })
+  const disableSelectedMember = selectedMember.find((member) => member.id)
+  
   const handleTaskUpdate = (newAssignee: {userId: string}) => () => {
     const newUserId = newAssignee.userId === userId ? null : newAssignee.userId
     UpdateTaskMutation(atmosphere, {updatedTask: {id: taskId, userId: newUserId}, area}, {})
@@ -69,7 +75,7 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
     query,
     filteredItems: matchedAssignees,
     onQueryChange
-  } = useSearchFilter(assignees, (assignee) => assignee.preferredName)
+  } = useSearchFilter(teamMembers, (assignee) => assignee.preferredName)
 
   if (!team) return null
   return (
@@ -80,7 +86,7 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
       {...menuProps}
     >
       <DropdownMenuLabel>Assign to:</DropdownMenuLabel>
-      {assignees.length > 5 && (
+      {teamMembers.length > 5 && (
         <SearchMenuItem placeholder='Search team members' onChange={onQueryChange} value={query} />
       )}
       {query && matchedAssignees.length === 0 && (
@@ -88,10 +94,12 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
           No team members found!
         </EmptyDropdownMenuItemLabel>
       )}
+
       {matchedAssignees.map((assignee) => {
         return (
           <MenuItem
             key={assignee.id}
+            isDisabled={assignee?.id === disableSelectedMember?.id}
             label={
               <MenuItemLabel>
                 <MenuAvatar alt={assignee.preferredName} src={assignee.picture || avatarUser} />


### PR DESCRIPTION
# Fixed TaskAssigneeMenu
Fixed Assignee menu to show all members . Initially Assignee menu was not showing members that had been assigned tasks. 
Fixes/Partially Fixes #6862
All team members are displayed on the TaskAssigneeMenu

## Before the Bug Fixed
![before](https://user-images.githubusercontent.com/63657008/187843849-a75ac7f0-84b9-4535-89b2-402dd8e336d9.png)

## After Bug Fixed
![after](https://user-images.githubusercontent.com/63657008/187843928-e8606387-fb5c-46a5-aa27-fa53f29627e5.png)

## Loom Video
https://www.loom.com/share/de0b763edc4f4eab983f5fcf1a574b68
## Testing scenarios
- [ ] Scenario A
  - Step 1
  - Start check-in meeting with 3 participants
  - Step 2...
  - Try reassigning a task in Solo updates
  - Step3
  - Try reassigning a task in Agenda item discussion

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
