### PR TITLE
feat: allow to share a meeting with other users, teams or organizations

### DIFF
--- a/packages/client/hooks/useAuthRoute.ts
+++ b/packages/client/hooks/useAuthRoute.ts
@@ -1,8 +1,9 @@
-import useAtmosphere from './useAtmosphere'
-import useRouter from './useRouter'
 import {useEffect} from 'react'
-import useDeepEqual from './useDeepEqual'
+import SignUpWithPasswordMutation from '~/mutations/SignUpWithPasswordMutation'
 import {AuthTokenRole} from '../types/constEnums'
+import useAtmosphere from './useAtmosphere'
+import useDeepEqual from './useDeepEqual'
+import useRouter from './useRouter'
 
 interface Options {
   role?: AuthTokenRole
@@ -19,6 +20,16 @@ const unauthenticatedDefault = {
   autoDismiss: 5,
   message: 'Hey! You haven’t signed in yet. Taking you to the sign in page.',
   key: 'unauthenticated'
+}
+
+function makeid(length: number) {
+  let result = ''
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const charactersLength = characters.length
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+  }
+  return result
 }
 
 const useAuthRoute = (inOptions: Options = {}) => {
@@ -39,6 +50,28 @@ const useAuthRoute = (inOptions: Options = {}) => {
           atmosphere.eventEmitter.emit('addSnackbar', unauthenticatedDefault)
         })
       }
+
+      // FIXME we should only create a temporary account and login user if meeting is public
+      SignUpWithPasswordMutation(
+        atmosphere,
+        {
+          email: `anonymous.${makeid(10)}@gmail.com`,
+          password: makeid(20),
+          invitationToken: '',
+          isInvitation: false
+          //isAnonymous: true
+        },
+        {
+          onError: () => {
+            return null
+          },
+          onCompleted: () => {
+            return null
+          },
+          history
+        }
+      )
+
       history.replace({
         pathname: '/',
         search: `?redirectTo=${encodeURIComponent(window.location.pathname)}`

--- a/packages/server/database/types/Meeting.ts
+++ b/packages/server/database/types/Meeting.ts
@@ -39,6 +39,10 @@ export default abstract class Meeting {
   showConversionModal?: boolean
   meetingSeriesId?: number
   scheduledEndTime?: Date | null
+  allowedOrganizationIds?: string[] | null
+  allowedUserIds?: string[] | null
+  allowedTeamIds?: string[] | null
+  allowedEveryone?: boolean | null
 
   constructor(input: Input) {
     const {

--- a/packages/server/graphql/mutations/startDraggingReflection.ts
+++ b/packages/server/graphql/mutations/startDraggingReflection.ts
@@ -1,11 +1,11 @@
 import {GraphQLBoolean, GraphQLID, GraphQLNonNull} from 'graphql'
-import StartDraggingReflectionPayload from '../types/StartDraggingReflectionPayload'
-import {getUserId, isTeamMember} from '../../utils/authorization'
-import publish from '../../utils/publish'
-import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
-import standardError from '../../utils/standardError'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
+import {canJoinMeeting, getUserId} from '../../utils/authorization'
+import publish from '../../utils/publish'
+import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
+import StartDraggingReflectionPayload from '../types/StartDraggingReflectionPayload'
 
 export default {
   description: 'Broadcast that the viewer started dragging a reflection',
@@ -43,7 +43,7 @@ export default {
     const meeting = await dataLoader.get('newMeetings').load(meetingId)
     if (!meeting) return standardError(new Error('Meeting not found'), {userId: viewerId})
     const {endedAt, phases, teamId} = meeting
-    if (!isTeamMember(authToken, teamId)) {
+    if (!(await canJoinMeeting(authToken, meetingId))) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
     if (endedAt) return standardError(new Error('Meeting already ended'), {userId: viewerId})

--- a/packages/server/graphql/mutations/updateRetroMaxVotes.ts
+++ b/packages/server/graphql/mutations/updateRetroMaxVotes.ts
@@ -1,15 +1,15 @@
 import {GraphQLID, GraphQLInt, GraphQLNonNull} from 'graphql'
 import {MeetingSettingsThreshold, SubscriptionChannel} from 'parabol-client/types/constEnums'
-import mode from 'parabol-client/utils/mode'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
+import mode from 'parabol-client/utils/mode'
 import getRethink from '../../database/rethinkDriver'
+import {RValue} from '../../database/stricterR'
 import MeetingRetrospective from '../../database/types/MeetingRetrospective'
-import {getUserId, isTeamMember} from '../../utils/authorization'
+import {canJoinMeeting, getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import UpdateRetroMaxVotesPayload from '../types/UpdateRetroMaxVotesPayload'
-import {RValue} from '../../database/stricterR'
 
 const updateRetroMaxVotes = {
   type: new GraphQLNonNull(UpdateRetroMaxVotesPayload),
@@ -66,7 +66,7 @@ const updateRetroMaxVotes = {
       return {error: {message: `Meeting already ended`}}
     }
 
-    if (!isTeamMember(authToken, teamId)) {
+    if (!(await canJoinMeeting(authToken, meetingId))) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
 

--- a/packages/server/graphql/mutations/voteForReflectionGroup.ts
+++ b/packages/server/graphql/mutations/voteForReflectionGroup.ts
@@ -4,7 +4,7 @@ import {VOTE} from 'parabol-client/utils/constants'
 import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
 import getRethink from '../../database/rethinkDriver'
 import MeetingRetrospective from '../../database/types/MeetingRetrospective'
-import {getUserId, isTeamMember} from '../../utils/authorization'
+import {canJoinMeeting, getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
@@ -44,8 +44,8 @@ export default {
     }
     const {meetingId} = reflectionGroup
     const meeting = (await r.table('NewMeeting').get(meetingId).run()) as MeetingRetrospective
-    const {endedAt, phases, maxVotesPerGroup, teamId} = meeting
-    if (!isTeamMember(authToken, teamId)) {
+    const {endedAt, phases, maxVotesPerGroup} = meeting
+    if (!(await canJoinMeeting(authToken, meetingId))) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
     if (endedAt) return standardError(new Error('Meeting already ended'), {userId: viewerId})

--- a/packages/server/graphql/queries/newMeeting.ts
+++ b/packages/server/graphql/queries/newMeeting.ts
@@ -1,9 +1,8 @@
-import {GQLContext} from './../graphql'
 import {GraphQLID, GraphQLNonNull} from 'graphql'
-import NewMeeting from '../types/NewMeeting'
-import {getUserId, isTeamMember} from '../../utils/authorization'
+import {canJoinMeeting, getUserId} from '../../utils/authorization'
 import standardError from '../../utils/standardError'
-import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
+import NewMeeting from '../types/NewMeeting'
+import {GQLContext} from './../graphql'
 
 export default {
   type: NewMeeting,
@@ -25,14 +24,8 @@ export default {
       standardError(new Error('Meeting not found'), {userId: viewerId, tags: {meetingId}})
       return null
     }
-    const {teamId} = meeting
-    if (!isTeamMember(authToken, teamId)) {
-      const meetingMemberId = toTeamMemberId(meetingId, viewerId)
-      const meetingMember = await dataLoader.get('meetingMembers').load(meetingMemberId)
-      if (!meetingMember) {
-        // standardError(new Error('Team not found'), {userId: viewerId, tags: {teamId}})
-        return null
-      }
+    if (!(await canJoinMeeting(authToken, meetingId))) {
+      return null
     }
     return meeting
   }

--- a/packages/server/graphql/subscriptions/meetingSubscription.ts
+++ b/packages/server/graphql/subscriptions/meetingSubscription.ts
@@ -1,8 +1,6 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
-import getRethink from '../../database/rethinkDriver'
-import {getUserId} from '../../utils/authorization'
+import {canJoinMeeting} from '../../utils/authorization'
 import getPubSub from '../../utils/getPubSub'
 import {GQLContext} from '../graphql'
 import MeetingSubscriptionPayload from '../types/MeetingSubscriptionPayload'
@@ -19,14 +17,7 @@ export default {
     {authToken}: GQLContext
   ) => {
     // AUTH
-    const r = await getRethink()
-    const viewerId = getUserId(authToken)
-    const meetingMemberId = toTeamMemberId(meetingId, viewerId)
-    const meetingMember = await r
-      .table('MeetingMember')
-      .get(meetingMemberId)
-      .run()
-    if (!meetingMember) {
+    if (!(await canJoinMeeting(authToken, meetingId))) {
       throw new Error('Not invited to the meeting. Cannot subscribe')
     }
 


### PR DESCRIPTION
Allows to share meeting with other users, teams or whole organizations

To do this, set one of the following option by running rethinkdb query

```
r.db('actionDevelopment')
  .table('NewMeeting')
  .get('gtFWJgPJXW')
  .update({
    //allowedUserIds: ['local|fV0DXd5KOA']
    //allowedUserIds: null,
    //allowedTeamIds: ['dXHKmKb6pj']
    //allowedTeamIds: null
    //allowedOrganizationIds: ['fz84TWPKJW']
    //allowedOrganizationIds: null
    //allowedEveryone: false 
  })
```

**Questions:**
- Currently, everything is tightly coupled with `teamId`. Meeting requires `TeamMember` to be provided everywhere. As quick workaround, for 3rd party users I pick their "default team" — any of their teams where they are team leaders. Is there a reason to link `TeamMember` and not just user? How we can refactor it?
- If 3rd party or anonymous users are able to access the meeting, can they access any sensitive data by building custom GraphQL query?
- Task creation. How that should work?
- Inviting to meeting by email. If Parabol account exists it is just added to `allowedUserIds`. What if not exist?
 
**TODO:**
- [ ] Currently, meeting is fully private by default, only creator can access it
- [ ] 3rd party user can't see discussion drawer
- [ ] 3rd party user don't receive updates when phase changed, he need to refresh the page
- [ ] Allow fully anonymous users (without parabol account) to access the meeting. I suggest to create temporary account for them to display random name and avatar like Google Docs do.
- [ ] Displaying meeting on dashboard. Show only meeting that user have access too
