### PR TITLE
fix(poker): fix an bug where task estimate is not written to DB when it's a Parabol task

### DIFF
--- a/packages/server/graphql/mutations/setTaskEstimate.ts
+++ b/packages/server/graphql/mutations/setTaskEstimate.ts
@@ -306,9 +306,10 @@ const setTaskEstimate = {
         success = true
         break
       }
-      default:
+      case undefined: {
         success = true
         break
+      }
     }
 
     analytics.taskEstimateSet(viewerId, {

--- a/packages/server/graphql/mutations/setTaskEstimate.ts
+++ b/packages/server/graphql/mutations/setTaskEstimate.ts
@@ -307,6 +307,7 @@ const setTaskEstimate = {
         break
       }
       default:
+        success = true
         break
     }
 


### PR DESCRIPTION
# Description

I noticed after https://github.com/ParabolInc/parabol/pull/7117 is merged, task estimates for Parabol task (i.e., tasks that were not integrated with any services) were not written in the `TaskEstimate` table. This PR fixes it.

## Demo

After the fix, in Segment we see that an event with `success = true` is published:
<img width="921" alt="Screen Shot 2022-09-12 at 9 31 20 AM" src="https://user-images.githubusercontent.com/1879975/189708289-75df20f0-dd95-45ef-b6d4-b76d75a377f2.png">

Also in DB we can see the corresponding row:
<img width="1397" alt="Screen Shot 2022-09-12 at 9 30 50 AM" src="https://user-images.githubusercontent.com/1879975/189708349-b2ede47b-031f-41cf-8078-6ab71a4c0ad7.png">


## Testing scenarios

- [ ] Set an estimate for a Parabol task in Poker meeting
  - Start a poker meeting
  - Scope or create a Parabol task
  - Vote and set an estimate for the task
  - In Segment, verify an event with `success = true` is published
  - In `TaskEstimate` table in Postgres, verify a new row is added

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
