### PR TITLE
feat(metrics): Add metrics about `disableAnonymity` in retro meetings

### DIFF
--- a/packages/server/graphql/mutations/setMeetingSettings.ts
+++ b/packages/server/graphql/mutations/setMeetingSettings.ts
@@ -3,6 +3,7 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {isNotNull} from 'parabol-client/utils/predicates'
 import getRethink from '../../database/rethinkDriver'
 import {RValue} from '../../database/stricterR'
+import {analytics} from '../../utils/analytics/analytics'
 import {getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -44,7 +45,7 @@ const setMeetingSettings = {
     if (!settings) {
       return standardError(new Error('Settings not found'), {userId: viewerId})
     }
-    const {teamId} = settings
+    const {teamId, meetingType} = settings
 
     // RESOLUTION
     await r
@@ -69,6 +70,10 @@ const setMeetingSettings = {
       .run()
 
     const data = {settingsId}
+    analytics.meetingSettingsChanged(viewerId, teamId, meetingType, {
+      hasIcebreaker: !!checkinEnabled,
+      disableAnonymity: !!disableAnonymity
+    })
     publish(SubscriptionChannel.TEAM, teamId, 'SetMeetingSettingsPayload', data, subOptions)
     return data
   }

--- a/packages/server/graphql/mutations/setMeetingSettings.ts
+++ b/packages/server/graphql/mutations/setMeetingSettings.ts
@@ -47,6 +47,7 @@ const setMeetingSettings = {
     }
     const {teamId, meetingType} = settings
 
+    const meetingSettings = {}
     // RESOLUTION
     await r
       .table('MeetingSettings')
@@ -59,10 +60,12 @@ const setMeetingSettings = {
             checkinEnabled ? row('phaseTypes') : row('phaseTypes').difference(['checkin']),
             checkinEnabled ? row('phaseTypes').prepend('checkin') : row('phaseTypes')
           )
+          Object.assign(meetingSettings, {hasIcebreaker: checkinEnabled})
         }
 
         if (isNotNull(disableAnonymity)) {
           updatedSettings.disableAnonymity = disableAnonymity
+          Object.assign(meetingSettings, {disableAnonymity})
         }
 
         return updatedSettings
@@ -70,10 +73,7 @@ const setMeetingSettings = {
       .run()
 
     const data = {settingsId}
-    analytics.meetingSettingsChanged(viewerId, teamId, meetingType, {
-      hasIcebreaker: !!checkinEnabled,
-      disableAnonymity: !!disableAnonymity
-    })
+    analytics.meetingSettingsChanged(viewerId, teamId, meetingType, meetingSettings)
     publish(SubscriptionChannel.TEAM, teamId, 'SetMeetingSettingsPayload', data, subOptions)
     return data
   }

--- a/packages/server/graphql/mutations/setMeetingSettings.ts
+++ b/packages/server/graphql/mutations/setMeetingSettings.ts
@@ -3,7 +3,7 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {isNotNull} from 'parabol-client/utils/predicates'
 import getRethink from '../../database/rethinkDriver'
 import {RValue} from '../../database/stricterR'
-import {analytics} from '../../utils/analytics/analytics'
+import {analytics, MeetingSettings} from '../../utils/analytics/analytics'
 import {getUserId} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -47,7 +47,7 @@ const setMeetingSettings = {
     }
     const {teamId, meetingType} = settings
 
-    const meetingSettings = {}
+    const meetingSettings = {} as MeetingSettings
     // RESOLUTION
     await r
       .table('MeetingSettings')
@@ -60,12 +60,12 @@ const setMeetingSettings = {
             checkinEnabled ? row('phaseTypes') : row('phaseTypes').difference(['checkin']),
             checkinEnabled ? row('phaseTypes').prepend('checkin') : row('phaseTypes')
           )
-          Object.assign(meetingSettings, {hasIcebreaker: checkinEnabled})
+          meetingSettings.hasIcebreaker = checkinEnabled
         }
 
         if (isNotNull(disableAnonymity)) {
           updatedSettings.disableAnonymity = disableAnonymity
-          Object.assign(meetingSettings, {disableAnonymity})
+          meetingSettings.disableAnonymity = disableAnonymity
         }
 
         return updatedSettings

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -1,5 +1,6 @@
 import Meeting from '../../database/types/Meeting'
 import MeetingMember from '../../database/types/MeetingMember'
+import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import MeetingTemplate from '../../database/types/MeetingTemplate'
 import {ReactableEnum} from '../../database/types/Reactable'
 import {TaskServiceEnum} from '../../database/types/Task'
@@ -106,12 +107,15 @@ class Analytics {
   }
 
   retrospectiveEnd = (
-    completedMeeting: Meeting,
+    completedMeeting: MeetingRetrospective,
     meetingMembers: MeetingMember[],
     template: MeetingTemplate
   ) => {
+    const {disableAnonymity} = completedMeeting
     meetingMembers.forEach((meetingMember) =>
-      this.meetingEnd(meetingMember.userId, completedMeeting, meetingMembers, template)
+      this.meetingEnd(meetingMember.userId, completedMeeting, meetingMembers, template, {
+        disableAnonymity
+      })
     )
   }
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -42,6 +42,11 @@ export type TaskEstimateProperties = {
   errorMessage?: string
 }
 
+export type MeetingSettings = {
+  hasIcebreaker?: boolean
+  disableAnonymity?: boolean
+}
+
 export type AnalyticsEvent =
   // meeting
   | 'Meeting Started'
@@ -52,6 +57,7 @@ export type AnalyticsEvent =
   | 'Reactji Interacted'
   | 'Meeting Recurrence Started'
   | 'Meeting Recurrence Stopped'
+  | 'Meeting Settings Changed'
   // team
   | 'Integration Added'
   | 'Integration Removed'
@@ -147,6 +153,19 @@ class Analytics {
 
   meetingJoined = (userId: string, meeting: Meeting) => {
     this.track(userId, 'Meeting Joined', createMeetingProperties(meeting))
+  }
+
+  meetingSettingsChanged = (
+    userId: string,
+    teamId: string,
+    meetingType: MeetingTypeEnum,
+    meetingSettings: MeetingSettings
+  ) => {
+    this.track(userId, 'Meeting Settings Changed', {
+      teamId,
+      meetingType,
+      ...meetingSettings
+    })
   }
 
   commentAdded = (

--- a/packages/server/utils/analytics/helpers.ts
+++ b/packages/server/utils/analytics/helpers.ts
@@ -1,6 +1,7 @@
 import {CHECKIN} from '../../../client/utils/constants'
 import Meeting from '../../database/types/Meeting'
 import MeetingMember from '../../database/types/MeetingMember'
+import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import MeetingTeamPrompt from '../../database/types/MeetingTeamPrompt'
 import MeetingTemplate from '../../database/types/MeetingTemplate'
 
@@ -23,6 +24,10 @@ export const createMeetingProperties = (
     meetingTemplateScope: template?.scope,
     meetingTemplateIsFromParabol: template?.isStarter,
     meetingSeriesId:
-      meetingType === 'teamPrompt' ? (meeting as MeetingTeamPrompt).meetingSeriesId : null
+      meetingType === 'teamPrompt' ? (meeting as MeetingTeamPrompt).meetingSeriesId : undefined,
+    disableAnonymity:
+      meetingType === 'retrospective'
+        ? (meeting as MeetingRetrospective).disableAnonymity
+        : undefined
   }
 }


### PR DESCRIPTION
# Description

Fixes #7163 

## Demo
New property `disableAnonymity` included in Meeting related events:
<img width="479" alt="Screen Shot 2022-09-12 at 3 43 30 PM" src="https://user-images.githubusercontent.com/1879975/189771142-5d25608c-adb1-4872-919c-fbdd806e78f6.png">

New event `Meeting Settings Changed` published to Segment:
<img width="464" alt="Screen Shot 2022-09-12 at 3 42 39 PM" src="https://user-images.githubusercontent.com/1879975/189771042-38b78dfe-96dd-40ee-91c6-dcd4545523aa.png">



## Testing scenarios

- [ ] New property `disableAnonymity` included in Meeting related events
  - Start/Join/Complete a meeting
  - Verify `disableAnonymity` is included in the relevant events in Segment

- [ ] New event `Meeting Settings Changed` published to Segment:
  - Go to meeting selector modal
  - Toggle the `Anonymous reflections` setting
  - Verify a new `Meeting Settings Changed` event was published and the `disableAnonymity` property is expected

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
