### PR TITLE
chore: Automatically add reviewers

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -15,12 +15,17 @@ reviewers:
     designers:
       - ackernaut
       - enriquesanchez
+    none:
 
   per_author:
     developers:
+      - none
     maintainers:
+      - none
     data:
+      - none
     designers:
+      - none
 
   defaults:
     - developers

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,36 @@
+reviewers:
+  groups:
+    developers:
+      - JimmyLv
+      - jmtaber129
+      - igorlesnenko
+      - nickoferral
+      - BartoszJarocki
+    maintainers:
+      - mattkrick
+      - Dschoordsch
+    data:
+      - tianrunhe
+      - tghanken
+    designers:
+      - ackernaut
+      - enriquesanchez
+
+  per_author:
+    developers:
+    maintainers:
+    data:
+    designers:
+
+  defaults:
+    - developers
+
+files:
+  '**/migrations/**':
+    - data
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - WIP
+  number_of_reviewers: 1
+

--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -1,0 +1,17 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location override
+


### PR DESCRIPTION
Try to automatically add reviewers for external contributers and migration changes for now.

# Description

Fixes #6969
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
