### PR TITLE
fix: only check clientGraphQLServer for isDemoRoute

### DIFF
--- a/packages/client/components/BottomControlBarTips.tsx
+++ b/packages/client/components/BottomControlBarTips.tsx
@@ -134,10 +134,10 @@ const BottomControlBarTips = (props: Props) => {
   const atmosphere = useAtmosphere()
   const demoPauseOpen = useTimeout(1000)
   const menus = isDemoRoute() ? demoHelps : helps
-  const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
   const MenuContent = menus[phaseType]
   useEffect(() => {
     if (demoPauseOpen && isDemoRoute()) {
+      const {clientGraphQLServer} = atmosphere as unknown as LocalAtmosphere
       if (clientGraphQLServer.db._started) {
         openPortal()
       } else {
@@ -147,7 +147,7 @@ const BottomControlBarTips = (props: Props) => {
         })
       }
     }
-  }, [demoPauseOpen, openPortal, clientGraphQLServer.db._started])
+  }, [demoPauseOpen, openPortal])
   return (
     <BottomNavControl
       dataCy={`tip-menu-toggle`}


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #6946 
in https://github.com/ParabolInc/parabol/pull/7131, moved `clientGraphQLServer.db._started` out of the useEffect, which broke all retro meetings (not demo meeting).

## Testing scenarios

- [ ] open normal retro meeting successful

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
