### PR TITLE
feat: allow meeting to be reset to the reflect phase

### DIFF
--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -46,7 +46,7 @@ const RetroReflectPhase = (props: Props) => {
           </PhaseHeaderDescription>
         </MeetingTopBar>
         <PhaseWrapper>
-          <StageTimerDisplay meeting={meeting} />
+          <StageTimerDisplay meeting={meeting} canUndo={true} />
           <ColumnWrapper
             setActiveIdx={setActiveIdx}
             activeIdx={activeIdx}

--- a/packages/client/components/StageTimerDisplay.tsx
+++ b/packages/client/components/StageTimerDisplay.tsx
@@ -2,13 +2,14 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
-import {Breakpoint} from '~/types/constEnums'
-import {StageTimerDisplay_meeting} from '~/__generated__/StageTimerDisplay_meeting.graphql'
-import StageTimerDisplayGauge from './StageTimerDisplayGauge'
 import PhaseCompleteTag from '~/components/Tag/PhaseCompleteTag'
 import UndoableGroupPhaseControl from '~/components/UndoableGroupPhaseControl'
+import UndoableReflectPhaseControl from '~/components/UndoableReflectPhaseControl'
 import useAtmosphere from '~/hooks/useAtmosphere'
+import {Breakpoint} from '~/types/constEnums'
 import isDemoRoute from '~/utils/isDemoRoute'
+import {StageTimerDisplay_meeting} from '~/__generated__/StageTimerDisplay_meeting.graphql'
+import StageTimerDisplayGauge from './StageTimerDisplayGauge'
 
 interface Props {
   meeting: StageTimerDisplay_meeting
@@ -18,12 +19,13 @@ interface Props {
 const DisplayRow = styled('div')({
   display: 'flex',
   justifyContent: 'center',
-  [`@media screen and (min-height: 800px) and (min-width: ${Breakpoint.SINGLE_REFLECTION_COLUMN}px)`]: {
-    // for larger viewports: dont' want stuff to move when it turns on
-    // adding a min-height, we lose too much vertical real estate when the timer is not used
-    // todo: float over top bar when there’s room @ laptop+ breakpoint
-    minHeight: 44
-  }
+  [`@media screen and (min-height: 800px) and (min-width: ${Breakpoint.SINGLE_REFLECTION_COLUMN}px)`]:
+    {
+      // for larger viewports: dont' want stuff to move when it turns on
+      // adding a min-height, we lose too much vertical real estate when the timer is not used
+      // todo: float over top bar when there’s room @ laptop+ breakpoint
+      minHeight: 44
+    }
 })
 
 const PhaseCompleteWrapper = styled('div')({
@@ -41,18 +43,22 @@ const StageTimerDisplay = (props: Props) => {
   const {viewerId} = atmosphere
   // scoping this to the group phase for a real retro
   const isDemo = isDemoRoute()
-  const canUndoGroupPhase = !isDemo && canUndo && viewerId === facilitatorUserId && phaseType === 'group'
+  const canUndoGroupPhase =
+    !isDemo && canUndo && viewerId === facilitatorUserId && phaseType === 'group'
+  const canUndoReflectPhase =
+    !isDemo && canUndo && viewerId === facilitatorUserId && phaseType === 'reflect'
   return (
     <DisplayRow>
       {localScheduledEndTime && !isComplete ? (
         <StageTimerDisplayGauge endTime={localScheduledEndTime} />
       ) : null}
-      {isPhaseComplete
-        ? <PhaseCompleteWrapper>
+      {isPhaseComplete ? (
+        <PhaseCompleteWrapper>
           <PhaseCompleteTag isComplete={isPhaseComplete} />
           {canUndoGroupPhase ? <UndoableGroupPhaseControl meetingId={meeting.id} /> : null}
+          {canUndoReflectPhase ? <UndoableReflectPhaseControl meetingId={meeting.id} /> : null}
         </PhaseCompleteWrapper>
-        : null}
+      ) : null}
     </DisplayRow>
   )
 }

--- a/packages/client/components/UndoableReflectPhaseControl.tsx
+++ b/packages/client/components/UndoableReflectPhaseControl.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import FlatButton from '~/components/FlatButton'
+import Icon from '~/components/Icon'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import useHotkey from '~/hooks/useHotkey'
+import useModal from '~/hooks/useModal'
+import ResetRetroMeetingToReflectStageMutation from '~/mutations/ResetRetroMeetingToReflectStageMutation'
+import lazyPreload from '~/utils/lazyPreload'
+
+interface Props {
+  meetingId: string
+}
+
+const StyledButton = styled(FlatButton)({
+  fontWeight: 600,
+  height: 28,
+  marginLeft: 16,
+  padding: 0
+})
+
+const StyledIcon = styled(Icon)({
+  marginRight: 4
+})
+
+const UndoableReflectPhaseDialog = lazyPreload(
+  () => import(/* webpackChunkName: 'UndoableReflectPhaseDialog' */ './UndoableReflectPhaseDialog')
+)
+
+const UndoableReflectPhaseControl = (props: Props) => {
+  const {meetingId} = props
+  const {togglePortal: toggleModal, closePortal: closeModal, modalPortal} = useModal()
+  const atmosphere = useAtmosphere()
+  useHotkey('i d i d n t m e a n t o', () => {
+    console.log('didntmean')
+    ResetRetroMeetingToReflectStageMutation(atmosphere, {meetingId})
+  })
+  return (
+    <>
+      <StyledButton onClick={toggleModal} palette={'blue'}>
+        <StyledIcon>restart_alt</StyledIcon>
+        {' Reset meeting'}
+      </StyledButton>
+      {modalPortal(<UndoableReflectPhaseDialog closePortal={closeModal} meetingId={meetingId} />)}
+    </>
+  )
+}
+
+export default UndoableReflectPhaseControl

--- a/packages/client/components/UndoableReflectPhaseDialog.tsx
+++ b/packages/client/components/UndoableReflectPhaseDialog.tsx
@@ -1,0 +1,54 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import DialogContainer from '~/components/DialogContainer'
+import DialogContent from '~/components/DialogContent'
+import DialogTitle from '~/components/DialogTitle'
+import FlatButton from '~/components/FlatButton'
+import PrimaryButton from '~/components/PrimaryButton'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import ResetRetroMeetingToReflectStageMutation from '~/mutations/ResetRetroMeetingToReflectStageMutation'
+import {PALETTE} from '~/styles/paletteV3'
+
+interface Props {
+  closePortal: () => void
+  meetingId: string
+}
+
+const ButtonGroup = styled('div')({
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: 16
+})
+
+const StyledButton = styled(FlatButton)({
+  color: PALETTE.SLATE_600,
+  fontWeight: 600,
+  marginRight: 16
+})
+
+const UndoableReflectPhaseDialog = (props: Props) => {
+  const {closePortal, meetingId} = props
+  const atmosphere = useAtmosphere()
+  const handleConfirm = () => {
+    ResetRetroMeetingToReflectStageMutation(atmosphere, {meetingId}) && closePortal()
+  }
+  return (
+    <DialogContainer>
+      <DialogTitle>Reset meeting?</DialogTitle>
+      <DialogContent>
+        <p>
+          <b>Danger zone</b>: The meeting will be reset to this point.
+        </p>
+        <p>All reflections will remain.</p>
+        <p>All groups, votes and discussion will be lost. </p>
+        <ButtonGroup>
+          <StyledButton onClick={closePortal}>Cancel</StyledButton>
+          <PrimaryButton onClick={handleConfirm}>Confirm Reset</PrimaryButton>
+        </ButtonGroup>
+      </DialogContent>
+    </DialogContainer>
+  )
+}
+
+export default UndoableReflectPhaseDialog

--- a/packages/client/mutations/ResetRetroMeetingToReflectStageMutation.ts
+++ b/packages/client/mutations/ResetRetroMeetingToReflectStageMutation.ts
@@ -1,0 +1,94 @@
+import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
+import Atmosphere from '~/Atmosphere'
+import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
+import {
+  ResetRetroMeetingToReflectStageMutation as TResetRetroMeetingToReflectStageMutation,
+  ResetRetroMeetingToReflectStageMutationVariables
+} from '../__generated__/ResetRetroMeetingToReflectStageMutation.graphql'
+import getDiscussionThreadConn from './connections/getDiscussionThreadConn'
+
+graphql`
+  fragment ResetRetroMeetingToReflectStageMutation_meeting on ResetRetroMeetingToReflectStagePayload {
+    meeting {
+      id
+      phases {
+        id
+        stages {
+          id
+          isComplete
+          isNavigable
+          isNavigableByFacilitator
+        }
+      }
+      ... on RetrospectiveMeeting {
+        viewerMeetingMember {
+          id
+          votesRemaining
+        }
+        votesRemaining
+        reflectionGroups {
+          id
+          viewerVoteCount
+          meetingId
+          sortOrder
+          promptId
+          ...ReflectionGroupHeader_reflectionGroup @relay(mask: false)
+          ...ReflectionGroupVoting_reflectionGroup @relay(mask: false)
+          ...ReflectionGroup_reflectionGroup @relay(mask: false)
+          ...ReflectionGroupTitleEditor_reflectionGroup @relay(mask: false)
+          ...GroupingKanbanColumn_reflectionGroups @relay(mask: false)
+          reflections {
+            ...DraggableReflectionCard_reflection @relay(mask: false)
+          }
+          voteCount
+        }
+      }
+      ...MeetingControlBar_meeting
+    }
+  }
+`
+
+const mutation = graphql`
+  mutation ResetRetroMeetingToReflectStageMutation($meetingId: ID!) {
+    resetRetroMeetingToReflectStage(meetingId: $meetingId) {
+      error {
+        message
+      }
+      ...ResetRetroMeetingToReflectStageMutation_meeting @relay(mask: false)
+    }
+  }
+`
+
+export const resetRetroMeetingToReflectStageUpdater: SharedUpdater<
+  TResetRetroMeetingToReflectStageMutation['response']['resetRetroMeetingToReflectStage']
+> = (payload, {store}) => {
+  const meeting = payload.getLinkedRecord('meeting')
+  if (!meeting) return
+  const phases = meeting.getLinkedRecords('phases')
+  if (!phases) return
+  const discussPhase = phases.find((phase) => phase?.getValue('phaseType') === 'discuss')
+  if (!discussPhase) return
+  const stages = discussPhase.getLinkedRecords('stages')
+  stages.forEach((stage) => {
+    const discussionId = stage?.getValue('discussionId') as string
+    const thread = getDiscussionThreadConn(store, discussionId)
+    thread?.setLinkedRecords([], 'edges')
+  })
+}
+
+const ResetRetroMeetingToReflectStageMutation: SimpleMutation<
+  TResetRetroMeetingToReflectStageMutation
+> = (atmosphere: Atmosphere, variables: ResetRetroMeetingToReflectStageMutationVariables) => {
+  return commitMutation<TResetRetroMeetingToReflectStageMutation>(atmosphere, {
+    mutation,
+    updater: (store) => {
+      const payload = store.getRootField('resetRetroMeetingToReflectStage')
+      if (!payload) return
+      resetRetroMeetingToReflectStageUpdater(payload, {store, atmosphere})
+    },
+    variables
+  })
+}
+
+export default ResetRetroMeetingToReflectStageMutation

--- a/packages/client/subscriptions/MeetingSubscription.ts
+++ b/packages/client/subscriptions/MeetingSubscription.ts
@@ -21,6 +21,7 @@ import {pokerAnnounceDeckHoverMeetingUpdater} from '../mutations/PokerAnnounceDe
 import {promoteNewMeetingFacilitatorMeetingOnNext} from '../mutations/PromoteNewMeetingFacilitatorMutation'
 import {removeReflectionMeetingUpdater} from '../mutations/RemoveReflectionMutation'
 import {resetRetroMeetingToGroupStageUpdater} from '../mutations/ResetRetroMeetingToGroupStageMutation'
+import {resetRetroMeetingToReflectStageUpdater} from '../mutations/ResetRetroMeetingToReflectStageMutation'
 import {setStageTimerMeetingUpdater} from '../mutations/SetStageTimerMutation'
 import {startDraggingReflectionMeetingUpdater} from '../mutations/StartDraggingReflectionMutation'
 
@@ -49,6 +50,7 @@ const subscription = graphql`
       ...PromoteNewMeetingFacilitatorMutation_meeting @relay(mask: false)
       ...RemoveReflectionMutation_meeting @relay(mask: false)
       ...ResetRetroMeetingToGroupStageMutation_meeting @relay(mask: false)
+      ...ResetRetroMeetingToReflectStageMutation_meeting @relay(mask: false)
       ...SetPhaseFocusMutation_meeting @relay(mask: false)
       ...SetStageTimerMutation_meeting @relay(mask: false)
       ...StartDraggingReflectionMutation_meeting @relay(mask: false)
@@ -81,7 +83,8 @@ const updateHandlers = {
   EndDraggingReflectionPayload: endDraggingReflectionMeetingUpdater,
   RemoveReflectionPayload: removeReflectionMeetingUpdater,
   SetStageTimerPayload: setStageTimerMeetingUpdater,
-  ResetRetroMeetingToGroupStagePayload: resetRetroMeetingToGroupStageUpdater,
+  ResetRetroMeetingToGroupStagePayload: resetRetroMeetingToReflectStageUpdater,
+  ResetRetroMeetingToReflectStagePayload: resetRetroMeetingToGroupStageUpdater,
   StartDraggingReflectionPayload: startDraggingReflectionMeetingUpdater,
   PokerAnnounceDeckHoverSuccess: pokerAnnounceDeckHoverMeetingUpdater,
   UpsertTeamPromptResponseSuccess: upsertTeamPromptResponseUpdater

--- a/packages/server/graphql/mutations/resetRetroMeetingToReflectStage.ts
+++ b/packages/server/graphql/mutations/resetRetroMeetingToReflectStage.ts
@@ -1,0 +1,167 @@
+import {GraphQLID, GraphQLNonNull} from 'graphql'
+import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import getGroupSmartTitle from '~/utils/smartGroup/getGroupSmartTitle'
+import {CHECKIN, DISCUSS, GROUP, REFLECT, VOTE} from '../../../client/utils/constants'
+import getRethink from '../../database/rethinkDriver'
+import DiscussPhase from '../../database/types/DiscussPhase'
+import GenericMeetingPhase from '../../database/types/GenericMeetingPhase'
+import MeetingRetrospective from '../../database/types/MeetingRetrospective'
+import Reflection from '../../database/types/Reflection'
+import ReflectionGroup from '../../database/types/ReflectionGroup'
+import generateUID from '../../generateUID'
+import {getUserId} from '../../utils/authorization'
+import getPhase from '../../utils/getPhase'
+import publish from '../../utils/publish'
+import standardError from '../../utils/standardError'
+import {GQLContext} from '../graphql'
+import ResetRetroMeetingToReflectStagePayload from '../types/ResetRetroMeetingToReflectStagePayload'
+import {primePhases} from './helpers/createNewMeetingPhases'
+
+const resetRetroMeetingToReflectStage = {
+  type: new GraphQLNonNull(ResetRetroMeetingToReflectStagePayload),
+  description: `Reset a retro meeting to reflect stage`,
+  args: {
+    meetingId: {
+      type: new GraphQLNonNull(GraphQLID)
+    }
+  },
+  resolve: async (
+    _source: unknown,
+    {meetingId}: {meetingId: string},
+    {authToken, socketId: mutatorId, dataLoader}: GQLContext
+  ) => {
+    const r = await getRethink()
+    const operationId = dataLoader.share()
+    const subOptions = {mutatorId, operationId}
+
+    // AUTH
+    const viewerId = getUserId(authToken)
+    const meeting = (await dataLoader.get('newMeetings').load(meetingId)) as MeetingRetrospective
+    if (!meeting) return standardError(new Error('Meeting not found'), {userId: viewerId})
+    const {createdBy, facilitatorUserId, phases, meetingType} = meeting
+    if (meetingType !== 'retrospective') {
+      return standardError(new Error('Meeting type is not retrospective'), {userId: viewerId})
+    }
+    if (viewerId !== facilitatorUserId) {
+      if (viewerId !== createdBy)
+        return standardError(new Error('Not meeting facilitator'), {userId: viewerId})
+      return standardError(new Error('Not meeting facilitator anymore'), {userId: viewerId})
+    }
+
+    // VALIDATION
+    const reflectPhase = phases.find((phase) => phase.phaseType === REFLECT)
+    if (!reflectPhase)
+      return standardError(new Error('Reflect phase not found'), {userId: viewerId})
+    const resetToStage = reflectPhase.stages.find((stage) => stage.phaseType === REFLECT)
+    if (!resetToStage)
+      return standardError(new Error('Reflect stage not found'), {userId: viewerId})
+    if (!resetToStage.isNavigableByFacilitator)
+      return standardError(new Error('Reflect stage has not started'), {userId: viewerId})
+    if (!resetToStage.isComplete)
+      return standardError(new Error('Reflect stage has not finished'), {userId: viewerId})
+    if (meeting.endedAt)
+      return standardError(new Error('The meeting has already ended'), {userId: viewerId})
+
+    // RESOLUTION
+    const discussionPhase = getPhase(phases, DISCUSS)
+    const discussionIdsToDelete =
+      discussionPhase?.stages?.map(({discussionId}) => discussionId) ?? []
+    let resetToPhaseIndex = -1
+
+    const newPhases = phases.map((phase, index) => {
+      switch (phase.phaseType) {
+        case CHECKIN: {
+          return phase
+        }
+        case REFLECT: {
+          resetToPhaseIndex = index
+          const newReflectPhase = new GenericMeetingPhase(phase.phaseType)
+          newReflectPhase.id = phase.id
+          // reflect phase always has a stage
+          newReflectPhase.stages[0]!.id = phase.stages[0]!.id
+          return newReflectPhase
+        }
+        case GROUP: {
+          const newGroupPhase = new GenericMeetingPhase(phase.phaseType)
+          newGroupPhase.id = phase.id
+          return newGroupPhase
+        }
+        case VOTE: {
+          const newVotePhase = new GenericMeetingPhase(phase.phaseType)
+          newVotePhase.id = phase.id
+          return newVotePhase
+        }
+        case DISCUSS: {
+          const newDiscussPhase = new DiscussPhase([])
+          newDiscussPhase.id = phase.id
+          return newDiscussPhase
+        }
+        default:
+          throw new Error(`Unhandled phaseType: ${phase.phaseType}`)
+      }
+    })
+
+    primePhases(newPhases, resetToPhaseIndex)
+    meeting.phases = newPhases
+
+    const reflections = await dataLoader.get('retroReflectionsByMeetingId').load(meetingId)
+
+    const newRefectionGroups = [] as ReflectionGroup[]
+    const reflectionUpdates = [] as Partial<Reflection>[]
+
+    reflections.forEach((reflection, index) => {
+      const reflectionGroupId = generateUID()
+      const smartTitle = getGroupSmartTitle([reflection])
+      const newReflectionGroup = new ReflectionGroup({
+        id: reflectionGroupId,
+        smartTitle,
+        title: smartTitle,
+        meetingId,
+        promptId: reflection.promptId,
+        sortOrder: index + 1
+      })
+
+      newRefectionGroups.push(newReflectionGroup)
+
+      // mutates the dataloader response
+      reflection.reflectionGroupId = reflectionGroupId
+      reflectionUpdates.push({id: reflection.id, reflectionGroupId})
+    })
+
+    await Promise.all([
+      r
+        .table('Comment')
+        .getAll(r.args(discussionIdsToDelete), {index: 'discussionId'})
+        .delete()
+        .run(),
+      r.table('Task').getAll(r.args(discussionIdsToDelete), {index: 'discussionId'}).delete().run(),
+      r
+        .table('RetroReflectionGroup')
+        // .getAll(r.args(reflectionGroupIds))
+        .getAll(meetingId, {index: 'meetingId'})
+        .delete()
+        .run(),
+      r.table('RetroReflection').insert(reflectionUpdates, {conflict: 'update'}).run(),
+      r.table('NewMeeting').get(meetingId).update({phases: newPhases}).run(),
+      (r.table('MeetingMember').getAll(meetingId, {index: 'meetingId'}) as any)
+        .update({votesRemaining: meeting.totalVotes})
+        .run()
+    ])
+
+    await r.table('RetroReflectionGroup').insert(newRefectionGroups).run()
+
+    const data = {
+      meetingId
+    }
+    publish(
+      SubscriptionChannel.MEETING,
+      meetingId,
+      'ResetRetroMeetingToReflectStagePayload',
+      data,
+      subOptions
+    )
+    return data
+  }
+}
+
+export default resetRetroMeetingToReflectStage

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -7665,6 +7665,11 @@ type Mutation {
   resetRetroMeetingToGroupStage(meetingId: ID!): ResetRetroMeetingToGroupStagePayload!
 
   """
+  Reset a retro meeting to group stage
+  """
+  resetRetroMeetingToReflectStage(meetingId: ID!): ResetRetroMeetingToReflectStagePayload!
+
+  """
   track an event in segment, like when errors are hit
   """
   segmentEventTrack(event: String!, options: SegmentEventTrackOptions): Boolean
@@ -9722,6 +9727,11 @@ type ResetRetroMeetingToGroupStagePayload {
   meeting: NewMeeting
 }
 
+type ResetRetroMeetingToReflectStagePayload {
+  error: StandardMutationError
+  meeting: NewMeeting
+}
+
 input SegmentEventTrackOptions {
   teamId: ID
   orgId: ID
@@ -10885,6 +10895,7 @@ union MeetingSubscriptionPayload =
   | PromoteNewMeetingFacilitatorPayload
   | RemoveReflectionPayload
   | ResetRetroMeetingToGroupStagePayload
+  | ResetRetroMeetingToReflectStagePayload
   | SetPhaseFocusPayload
   | SetStageTimerPayload
   | StartDraggingReflectionPayload

--- a/packages/server/graphql/rootMutation.ts
+++ b/packages/server/graphql/rootMutation.ts
@@ -91,6 +91,7 @@ import renamePokerTemplateScale from './mutations/renamePokerTemplateScale'
 import renameReflectTemplatePrompt from './mutations/renameReflectTemplatePrompt'
 import resetPassword from './mutations/resetPassword'
 import resetRetroMeetingToGroupStage from './mutations/resetRetroMeetingToGroupStage'
+import resetRetroMeetingToReflectStage from './mutations/resetRetroMeetingToReflectStage'
 import segmentEventTrack from './mutations/segmentEventTrack'
 import selectTemplate from './mutations/selectTemplate'
 import setAppLocation from './mutations/setAppLocation'
@@ -222,6 +223,7 @@ export default new GraphQLObjectType<any, GQLContext>({
       removeTeamMember,
       resetPassword,
       resetRetroMeetingToGroupStage,
+      resetRetroMeetingToReflectStage,
       segmentEventTrack,
       selectTemplate,
       setAppLocation,

--- a/packages/server/graphql/types/MeetingSubscriptionPayload.ts
+++ b/packages/server/graphql/types/MeetingSubscriptionPayload.ts
@@ -20,6 +20,7 @@ import {PokerRevealVotesSuccess} from './PokerRevealVotesPayload'
 import PromoteNewMeetingFacilitatorPayload from './PromoteNewMeetingFacilitatorPayload'
 import RemoveReflectionPayload from './RemoveReflectionPayload'
 import ResetRetroMeetingToGroupStagePayload from './ResetRetroMeetingToGroupStagePayload'
+import ResetRetroMeetingToReflectStagePayload from './ResetRetroMeetingToReflectStagePayload'
 import SetPhaseFocusPayload from './SetPhaseFocusPayload'
 import {SetPokerSpectateSuccess} from './SetPokerSpectatePayload'
 import SetStageTimerPayload from './SetStageTimerPayload'
@@ -54,6 +55,7 @@ const types = [
   PromoteNewMeetingFacilitatorPayload,
   RemoveReflectionPayload,
   ResetRetroMeetingToGroupStagePayload,
+  ResetRetroMeetingToReflectStagePayload,
   SetPhaseFocusPayload,
   SetStageTimerPayload,
   StartDraggingReflectionPayload,

--- a/packages/server/graphql/types/ResetRetroMeetingToReflectStagePayload.ts
+++ b/packages/server/graphql/types/ResetRetroMeetingToReflectStagePayload.ts
@@ -1,0 +1,20 @@
+import {GraphQLObjectType} from 'graphql'
+import {GQLContext} from '../graphql'
+import {resolveNewMeeting} from '../resolvers'
+import NewMeeting from './NewMeeting'
+import StandardMutationError from './StandardMutationError'
+
+const ResetRetroMeetingToReflectStagePayload = new GraphQLObjectType<any, GQLContext>({
+  name: 'ResetRetroMeetingToReflectStagePayload',
+  fields: () => ({
+    error: {
+      type: StandardMutationError
+    },
+    meeting: {
+      type: NewMeeting,
+      resolve: resolveNewMeeting
+    }
+  })
+})
+
+export default ResetRetroMeetingToReflectStagePayload


### PR DESCRIPTION
# Description

Fixes #4881

Allows retro meeting to be reset to the reflect phase

## Demo

Loom: https://www.loom.com/share/edf4861480be42d18c25a2d25411fb57

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/466991/190210230-33802704-e4f3-41b1-8293-352f77feec79.png">

<img width="840" alt="image" src="https://user-images.githubusercontent.com/466991/190210295-464dba36-7c53-441e-8438-90dd37cbf760.png">


## Testing scenarios

- Create a meeting with at least 2 participants
- Add reflections for both participants, go to group phase, create some groups
- Go back to reflect phase, reset meeting
- Check that meeting was correctly reset for the second participant in real time
- Check that all meeting functionality works correctly for both participants and you can go through all phases and finish the meeting.
- Try to reset meeting from discussion phase or vote phase too