### PR TITLE
chore: add Standup smoke test into the testing basics

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_test.md
+++ b/.github/ISSUE_TEMPLATE/release_test.md
@@ -4,14 +4,15 @@ about: Issue created when releasing a new version
 title: Release test v
 labels: ''
 assignees: ''
-
 ---
 
 - The basic checklist is required
 - Adding tests from merged PRs is optional
 
 ## The basics
+
 Run through this list at least once at [staging](https://action-staging.parabol.co):
+
 - [ ] Smoke tested the [Demo](https://action-staging.parabol.co/retrospective-demo), unauthenticated
 - [ ] Created an account
 - [ ] Verified invite via mass link works (Team > Invite Button > Invite Link, visit URL in an incognito window)
@@ -34,7 +35,9 @@ Run through this list at least once at [staging](https://action-staging.parabol.
 - [ ] Test previously existed meetings to make sure that existing data is not corrupted
 
 ## What’s changed
+
 At your discretion, complete the tests for any merged PRs:
+
 - List each PR with a header and link to ([title], #[issue id])
 - Copy and paste tests, or note what was tested, in this issue
 - Run the equivalent test on staging that you would run in a local environment as closely as possible (e.g. updating the database to simulate cases, etc.)

--- a/.github/ISSUE_TEMPLATE/release_test.md
+++ b/.github/ISSUE_TEMPLATE/release_test.md
@@ -24,7 +24,8 @@ Run through this list at least once at [staging](https://action-staging.parabol.
 - [ ] Added JiraServer, verified issue created
 - [ ] Smoke tested the Retro meeting with 2 players
 - [ ] Smoke tested the Sprint Poker meeting with 2 players
-- [ ] Smoke tested the Action meeting with 2 players
+- [ ] Smoke tested the Team Check-in meeting with 2 players
+- [ ] Smoke tested the Standup meeting with 2 players
 - [ ] Smoke tested cards on the dashboard
 - [ ] Created a 2nd team
 - [ ] Created a 2nd organization


### PR DESCRIPTION
# Description

While doing Release Testing, I realized that we're now missing a release check for the new Standup meeting type. btw I renamed the `Action` to `Team Check-in` meeting to keep consistent with the new-meeting dialog.

## Demo

![Google Chrome-Team Dashboard  Jimmy Test Team-000340-20220916](https://user-images.githubusercontent.com/4997466/190641479-35493449-2ec5-499c-a55d-00e1e6e34ddf.png)

## Testing scenarios

https://github.com/ParabolInc/parabol/issues/new?assignees=&labels=&template=release_test.md&title=Release+test+v

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
