### PR TITLE
fix: 'Estimate phase is already complete' error message

### DIFF
--- a/packages/server/graphql/mutations/voteForPokerStory.ts
+++ b/packages/server/graphql/mutations/voteForPokerStory.ts
@@ -1,6 +1,5 @@
 import {GraphQLID, GraphQLNonNull, GraphQLString} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
 import getRethink from '../../database/rethinkDriver'
 import {RValue} from '../../database/stricterR'
 import EstimateUserScore from '../../database/types/EstimateUserScore'
@@ -86,9 +85,10 @@ const voteForPokerStory = {
     if (meetingType !== 'poker') {
       return {error: {message: 'Not a poker meeting'}}
     }
-    if (isPhaseComplete('ESTIMATE', phases)) {
-      return {error: {message: 'Estimate phase is already complete'}}
-    }
+    // No need to check for now (https://github.com/ParabolInc/parabol/issues/7191)
+    // if (isPhaseComplete('ESTIMATE', phases)) {
+    //   return {error: {message: 'Estimate phase is already complete'}}
+    // }
 
     // VALIDATION
     const estimatePhase = getPhase(phases, 'ESTIMATE')


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #7191 #6755 #6890

## Testing scenarios
Check if the voting is enabled in the below scenarios:
- [ ] By deleting the end stage
- [ ] By moving the end stage up and clicking next 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
