### PR TITLE
ci: setting write permissions to the PR for external contributor

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -8,6 +8,8 @@ jobs:
   auto-request-review:
     name: Auto Request Review
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.7.0


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #6969
the `Auto Request Review` GitHub workflow looks like it's still [a failure for external contributors](https://github.com/ParabolInc/parabol/actions/runs/3077044304/jobs/4971620538):

```shell
Matched no reviewers
Falling back to the default reviewers
Randomly picking reviewers if the number of reviewers is set
Requesting review to jmtaber[12](https://github.com/ParabolInc/parabol/actions/runs/3077044304/jobs/4971620538#step:2:13)9
Error: HttpError: Resource not accessible by integration
```

This `HttpError: Resource not accessible by integration`  error happens as soon as the person creating the PR does not have permission to the repository. [looking into this issue](https://github.com/actions/first-interaction/issues/10), there's a potential solution mentioned and let's have a try:

As mentioned in the [GitHub documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview), all permissions that you don't explicitly set on a job will be set to `none`:

> If you specify the access for any of these scopes, all of those that are not specified are set to none.

Setting `write` permissions to the pull request as follows fixed the problem for us completely:

```yml
jobs:
  job_name:
    name: Job Name
    runs-on: ubuntu-latest

    permissions:
      pull-requests: write
```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
