### PR TITLE
fix: other tabs break when accepting a team invitation via a link

### DIFF
--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -126,6 +126,9 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   // Tell the rest of the team about the new team member
   publish(SubscriptionChannel.TEAM, teamId, 'AcceptTeamInvitationPayload', data, subOptions)
 
+  // Send individualized message to the user
+  publish(SubscriptionChannel.TEAM, viewerId, 'AcceptTeamInvitationPayload', data, subOptions)
+
   // Give the team lead new suggested actions
   if (teamLeadUserIdWithNewActions) {
     // the team lead just needs data about themselves. alternatively we could make an eg AcceptTeamInvitationTeamLeadPayload, but nulls are just as good


### PR DESCRIPTION
Fixes #4922

## Testing scenarios

- [ ] Scenario A
  - Open dashboard in one tab as User_1
  - As User_2 copy Team_2 invite link
  - As User_1 paste team invite link in **a new tab**
  - As User_1, on previously opened dashboard tab go to `Tasks`, see the app does not crash

- [ ] Scenario B
  - Invite User_1 to the team via email
  - As User_1 click `Accept` on the appeared **push notification**
  - See all works fine

- [ ] Scenario C
  -  Invite User_1 to the team via email
  - Click on invite link in email
  - See all works fine
