### PR TITLE
fix: Text without spaces breaks the UI in discussion

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -40,7 +40,8 @@ const Wrapper = styled('div')<{isReply: boolean; isDisabled: boolean}>(({isDisab
   marginTop: isReply ? 8 : undefined,
   pointerEvents: isDisabled ? 'none' : undefined,
   // required for the shadow to overlay draft-js in the task cards
-  zIndex: 0
+  zIndex: 0,
+  overflowX: 'hidden',
 }))
 
 const CommentContainer = styled('div')({
@@ -56,7 +57,27 @@ const CommentAvatar = styled(Avatar)({
 
 const EditorWrap = styled('div')({
   flex: 1,
-  margin: '14px 0'
+  margin: '14px 0',
+  maxWidth: '100%',
+  maxHeight: '40px',
+  overflowX: 'hidden',
+  overflowY: 'auto',
+  '&::-webkit-scrollbar': {
+    width: '0.4em'
+  },
+  '&::-webkit-scrollbar-track': {
+    boxShadow: 'inset 0 0 6px rgba(0,0,0,0)',
+    webkitBoxShadow: 'inset 0 0 6px rgba(0,0,0,0)',
+    backgroundColor: 'rgba(0,0,0,.1)',
+    borderRadius: '10px'
+  },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: 'rgba(0,0,0,.1)',
+    borderRadius: '10px'
+  },
+  '&::-webkit-scrollbar-corner, & *::-webkit-scrollbar-corner': {
+    backgroundColor: '#2b2b2b'
+  }
 })
 
 const ActionsContainer = styled('div')({


### PR DESCRIPTION
# Description
Original issue linked [here](https://github.com/ParabolInc/parabol/issues/7090)

## Demo
[Loom Video](https://www.loom.com/share/672bae5c749b404bb850bc291885bcb5)

## Issue - Bug
If there are no spaces in the text then it breaks the UI ![Screenshot 2022-08-18 174854](https://user-images.githubusercontent.com/106697681/185434977-3cc0b72e-fdd7-41ed-859f-c02404060ed7.png)
 
### Acceptance Criteria (optional)
UI should not break in above situation



## Test cases

 - [x] verify that texts without spacing do not go off the specified width 
 - [x] ascertain that text without spacing wraps when it gets to the required width assigned and goes to the text line
 - [x] ascertain that for long texts without spacing, the text do not go off the required width and overflows out of its container


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog