### PR TITLE
fix: AdjustMeetingMemberCountPosition

### DIFF
--- a/packages/client/components/AvatarList.tsx
+++ b/packages/client/components/AvatarList.tsx
@@ -83,7 +83,7 @@ const AvatarList = (props: Props) => {
               isAnimated={showAnimated}
               onTransitionEnd={onTransitionEnd}
               status={status}
-              offset={offsetSize * displayIdx}
+              offset={offsetSize * (displayIdx - overflowCount)}
               overflowCount={overflowCount}
               onClick={onOverflowClick}
               width={size}

--- a/packages/client/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup.tsx
+++ b/packages/client/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup.tsx
@@ -96,9 +96,7 @@ const NewMeetingAvatarGroup = (props: Props) => {
             meetingMember.user.isConnected)
         )
       })
-      .sort((a, b) =>
-        a.userId === viewerId ? -1 : a.user.lastSeenAt < b.user.lastSeenAt ? -1 : 1
-      )
+      .sort((a, b) => (a.userId === viewerId ? -1 : a.user.lastSeenAt < b.user.lastSeenAt ? -1 : 1))
       .map((tm) => ({
         ...tm,
         key: tm.userId


### PR DESCRIPTION
# Description
Fixes/Partially Fixes [issue](https://github.com/ParabolInc/parabol/issues/6060)
[Please include a summary of the changes and the related issue]

If there are too many meeting member avatars to fit in the meeting card, the meeting member count avatar can float away from the card.
![image](https://user-images.githubusercontent.com/68685849/189341531-773bb778-1828-42ae-98d9-1e72eec54b1f.png)

[loom video](https://www.loom.com/share/852d745e358b4501adceed7b1d43beae)

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
