### PR TITLE
chore: Weekly review stats in Slack

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,10 +1,6 @@
 name: Pull Request Stats
 
-on:
-  schedule:
-    - cron: '*/5 * * * *'
-  pull_request:
-    types: [opened, ready_for_review, reopened]
+on: [pull_request]
 
 jobs:
   stats:
@@ -22,5 +18,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          REPO: ${{ github.action_repository }}
+          REPO: ${{ github.repository }}
           TIME_DIFF: 7d

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -3,6 +3,8 @@ name: Pull Request Stats
 on:
   schedule:
     - cron: '*/5 * * * *'
+  pull_request:
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   stats:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,16 +2,23 @@ name: Pull Request Stats
 
 on:
   schedule:
-    - cron: '0 * * * 5'
+    - cron: '*/5 * * * *'
 
 jobs:
   stats:
     runs-on: ubuntu-latest
     steps:
-      - name: Run pull request stats
-        uses: flowwer-dev/pull-request-stats@master
+      - uses: actions/checkout@v1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
         with:
-          slack-channel: '#t_product_github_notifications'
-          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-          charts: true
-          sort-by: 'TIME'
+          node-version: "16.14.0"
+      - name: Run pull request stats
+        run: |
+          yarn
+          yarn ts-node scripts/reviewStats.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          REPO: ${{ github.action_repository }}
+          TIME_DIFF: 7d

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,6 +1,8 @@
 name: Pull Request Stats
 
-on: [pull_request]
+on:
+  schedule:
+    - cron: '0 9 * * 5'
 
 jobs:
   stats:

--- a/scripts/reviewStats.ts
+++ b/scripts/reviewStats.ts
@@ -1,0 +1,271 @@
+const ms = require('ms')
+
+const GITHUB_ENDPOINT = 'https://api.github.com/graphql'
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN
+const TIME_DIFF = process.env.TIME_DIFF || '7d'
+const SLACK_WEBHOOK = process.env.SLACK_WEBHOOK
+const REPO = process.env.REPO
+
+const query = `
+query($searchQuery: String!) { 
+  search(query: $searchQuery, type: ISSUE, first: 100) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+        ... on PullRequest {
+          number
+          url
+          publishedAt
+          mergedAt
+          author { ...UserFragment }
+          timelineItems(first: 100) {
+              nodes {
+                __typename
+                ... on ReviewRequestedEvent {
+                  createdAt
+                  requestedReviewer { ...UserFragment }
+                }
+                ... on PullRequestReview {
+                id
+                author { ...UserFragment }
+                comments(first: 1) {
+                  totalCount
+                }
+                submittedAt
+                state
+            }
+          }
+        }
+      }
+    }
+  }
+}
+fragment UserFragment on User {
+  url
+  login
+  avatarUrl
+}
+`
+
+const fetchData = async (mergedAfter: Date) => {
+  const fetch = require('node-fetch')
+  const searchQuery = `is:pr archived:false is:closed is:merged repo:${REPO} merged:>=${mergedAfter.toISOString()}`
+  const response = await fetch(GITHUB_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'Authorization': `bearer ${GITHUB_TOKEN}`
+    },
+    body: JSON.stringify({
+      query,
+      variables: {
+        searchQuery
+      }
+    })
+  })
+
+  console.log(GITHUB_TOKEN, response)
+
+  //TODO we're not checking pagination yet
+   
+  return response.json()
+}
+
+const pushToSlack = async (body: any) => {
+  const fetch = require('node-fetch')
+  const response = await fetch(SLACK_WEBHOOK, {
+    method: 'POST',
+    body: JSON.stringify(body)
+  })
+
+  console.log(response)
+}
+
+const median = (values: number[]) => {
+  if(values.length === 0) return '-'
+
+  values.sort()
+  var middle = Math.floor(values.length / 2)
+  if (values.length % 2) return values[middle]
+  return (values[middle- 1] + values[middle]) / 2.0;
+}
+
+const parseStats = (rawData: any) => {
+  const reviewerStats = {} as any
+
+  const prs = rawData.data.search.nodes.map((pr: any) => {
+    const publishedAt = new Date(pr.publishedAt)
+    const mergedAt = new Date(pr.mergedAt)
+    const timeToMerge = mergedAt.valueOf() - publishedAt.valueOf()
+
+    const requestedReviewers = {} as Record<string, Date | undefined>
+    const reviewers = new Set<string>() 
+    let comments = 0
+    let reviews = 0
+    pr.timelineItems.nodes.forEach((item: any) => {
+      if (item.__typename === 'ReviewRequestedEvent') {
+        requestedReviewers[item.requestedReviewer.login] = new Date(item.createdAt)
+      }
+      if (item.__typename === 'PullRequestReview') {
+        const login = item.author.login
+
+        if (!reviewerStats[login]) {
+          reviewerStats[login] = {
+            ...item.author,
+            timesToReview: [],
+            reviewStates: [],
+            comments: 0,
+            reviewedPRs: 0,
+          }
+        }
+        reviewerStats[login].reviewStates.push(item.state)
+        reviewerStats[login].comments += item.comments.totalCount
+
+        const request = requestedReviewers[login]
+        if (request) {
+          const timeToReview = (new Date(item.submittedAt)).valueOf() - request.valueOf()
+          reviewerStats[login].timesToReview.push(timeToReview)
+          requestedReviewers[login] = undefined
+        }
+
+        reviewers.add(login)
+        comments += item.comments.totalCount
+        reviews++
+      }
+    })
+    reviewers.forEach(reviewer => {
+      reviewerStats[reviewer].reviewedPRs++
+    })
+
+    return {
+      number: pr.number,
+      author: pr.author,
+      timeToMerge: timeToMerge,
+      comments,
+      reviews,
+    }
+  })
+
+  return {
+    reviewerStats,
+    prs
+  }
+}
+
+const padRight = (str: string, width: number) => {
+  const length = Math.min(str.length, width)
+  return str.slice(0, length) + ' '.repeat(width - length)
+}
+
+const formatRow = (values: (string|number)[], format: number[]) => {
+  const rows = [] as string[]
+
+  do {
+    const row = [] as string[]
+
+    const overflow = Array(values.length).fill('')
+    values.forEach((value, index) => {
+      const valueStr = value.toString()
+      const fieldLength = format[Math.min(index, format.length - 1)]
+      row.push(padRight(valueStr, fieldLength))
+      if (valueStr.length > fieldLength) {
+        overflow[index] = valueStr.slice(fieldLength)
+      }
+    })
+    values = overflow
+
+    rows.push(row.join(' | '))
+  } while(values.find(value => !!value))
+
+  return rows.join('\n')
+}
+
+const formatReviewers = (reviewerStats) => {
+  const format = [15, 8]
+  const rows = [] as string[]
+  rows.push(formatRow(['login', 'median time to review', 'reviewed PRs', 'comments', 'approvals', 'changes requested'], format))
+  Object.values(reviewerStats).forEach((reviewer: any) => {
+    const {login, timesToReview, reviewedPRs, reviewStates, comments} = reviewer
+    const medianTimeToReview = median(timesToReview)
+    const formattedMedianTimeToReview = medianTimeToReview !== undefined ? ms(medianTimeToReview) : '-'
+    const approvals = reviewStates.filter(state => state === 'APPROVED').length
+    const changesRequested = reviewStates.filter(state => state === 'CHANGES_REQUESTED').length
+    rows.push(formatRow([login, formattedMedianTimeToReview, reviewedPRs, comments, approvals, changesRequested], format))
+  })
+  return rows.join('\n')
+}
+
+const formatPrs = (prs) => {
+  const format = [20, 6]
+  const rows = [] as string[]
+  rows.push(formatRow(['', 'min', 'max', 'median'], format))
+
+  const timesToMerge = prs.map(({timeToMerge}: {timeToMerge: number}) => timeToMerge)
+  rows.push(formatRow(['time to merge', ms(Math.min(...timesToMerge)), ms(Math.max(...timesToMerge)), ms(median(timesToMerge))], format))
+
+  const comments = prs.map(({comments}) => comments)
+  rows.push(formatRow(['comments per PR', Math.min(...comments), Math.max(...comments), median(comments)], format))
+
+  const reviews = prs.map(({reviews}) => reviews)
+  rows.push(formatRow(['reviews per PR', Math.min(...reviews), Math.max(...reviews), median(reviews)], format))
+
+  return rows.join('\n')
+}
+
+const main = async () => {
+  const now = new Date()
+  const mergedSince = new Date(now.valueOf() - ms(TIME_DIFF))
+
+  const rawData = await fetchData(mergedSince)
+  const {reviewerStats, prs} = parseStats(rawData)
+
+  console.log(`Stats for last ${TIME_DIFF}`)
+  console.log('Reviewer stats')
+  console.log(formatReviewers(reviewerStats))
+  console.log('PR stats')
+  console.log(`Total ${prs.length} PRs merged`)
+  console.log(formatPrs(prs))
+
+
+  const slackMessage = {
+    blocks: [{
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*Review stats for last ${TIME_DIFF}*\nTotal ${prs.length} PRs merged`
+      },
+    }, {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'Reviewer stats'
+      },
+    }, {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '```\n' + formatReviewers(reviewerStats) + '\n```'
+      },
+    }, {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: 'PR stats'
+      },
+    }, {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '```\n' + formatPrs(prs) + '\n```'
+      },
+    }]
+  }
+
+  pushToSlack(slackMessage)
+}
+
+main()
+


### PR DESCRIPTION
# Description

Let's run review stats on a regular basis. The previously used review stats package had 2 major disadvantages:
1) it calculated time to review wrong
2) it requires monthly sponsorship to be able to post to Slack
Grep the PR timeline for PRs merged in the last 7 days and calculate the time to review etc. from those.

## Demo

![Screenshot from 2022-09-20 12-27-18](https://user-images.githubusercontent.com/7331043/191235597-addb1453-e138-41af-9e51-72a20e77abc8.png)


## Testing scenarios

* create GitHub personal access token with `public_repo` right
* if you want to check Slack, you need to create a bot with a webhook, otherwise stats will be printed on console but pushing to slack will fail
* export following environment variables
  ```
  GITHUB_TOKEN=<your personal access token>
  TIME_DIFF=<defaults to 7d if not set>
  SLACK_WEBHOOK=<your channel webhook>
  REPO=ParabolInc/parabol
  ```
* run `yarn ts-node scripts/reviewStats.ts`

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
