### PR TITLE
fix: disable the Nx parallel run precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typecheck": "nx run-many --target=typecheck",
     "update-schema": "node scripts/runSchemaUpdater.js",
     "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
-    "precommit": "nx run-many --target=precommit",
+    "precommit": "nx run-many --target=precommit --parallel=1",
     "postcheckout": "node scripts/generateGraphQLArtifacts.js &>/dev/null &",
     "prepare": "husky install",
     "test:server": "yarn workspace parabol-server test"


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #6212 

Nx, unlike Lerna, will run NPM scripts (here is `precommit`) in parallel by default
and lint-staged actually cannot be executed in parallel, so it throws this error, https://github.com/okonet/lint-staged/issues/896

![image](https://user-images.githubusercontent.com/4997466/191533422-92cd1cf9-ceed-405b-aff8-9d76c9e38880.png)

## Demo

## Testing scenarios

The precommit script under each package should be run serially

```shell
yarn precommit
```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
