### PR TITLE
fix: Aria-label “edit this reflection” should not exist when the reflection is no longer editable

### DIFF
--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -272,7 +272,7 @@ const ReflectionCard = (props: Props) => {
       <ReflectionEditorWrapper
         dataCy={`editor-wrapper`}
         isClipped={isClipped}
-        ariaLabel='Edit this reflection'
+        ariaLabel={readOnly ? '' : 'Edit this reflection'}
         editorRef={editorRef}
         editorState={editorState}
         onBlur={handleEditorBlur}

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -238,7 +238,7 @@ const PhaseItemEditor = (props: Props) => {
         <ReflectionEditorWrapper
           dataCy={`${dataCy}-wrapper`}
           isPhaseItemEditor
-          ariaLabel='Edit this reflection'
+          ariaLabel={readOnly ? '' : 'Edit this reflection'}
           editorState={editorState}
           editorRef={editorRef}
           onBlur={onBlur}


### PR DESCRIPTION
# Description

Fixes #7107

## Testing scenarios
Check if the screen readers read `edit this reflection` for non-editable reflections in different phases and different scenarios (for ex: when a phase is completed)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
