### PR TITLE
chore: Use separate PAT for auto assigning reviewers

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -8,12 +8,10 @@ jobs:
   auto-request-review:
     name: Auto Request Review
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.7.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ASSIGN_REVIEWER_PAT }}
           config: .github/reviewers.yml # Config file location override
 


### PR DESCRIPTION
# Description

External contributors don't have the correct permissions to assign reviewers, thus use a separate token for this