### PR TITLE
fix(notifications): UTM params on notification email link

### DIFF
--- a/packages/client/modules/email/components/NotificationSummaryEmail.tsx
+++ b/packages/client/modules/email/components/NotificationSummaryEmail.tsx
@@ -21,6 +21,12 @@ const linkStyle = {
   ...emailLinkStyle
 }
 
+export const notificationSummaryUrlParams = {
+  utm_source: 'notification email',
+  utm_medium: 'email',
+  utm_campaign: 'notifications'
+}
+
 export interface NotificationSummaryProps {
   appOrigin: string
   preferredName: string
@@ -28,7 +34,7 @@ export interface NotificationSummaryProps {
 }
 export default function NotificationSummaryEmail(props: NotificationSummaryProps) {
   const {appOrigin, notificationCount, preferredName} = props
-  const tasksURL = makeAppURL(appOrigin, 'me/tasks')
+  const tasksURL = makeAppURL(appOrigin, 'me/tasks', {searchParams: notificationSummaryUrlParams})
   return (
     <Layout maxWidth={544}>
       <EmailBlock innerMaxWidth={innerMaxWidth}>


### PR DESCRIPTION
# Description
We currently don't track UTM parameters for notification summary emails.

Add these UTM params

## Demo
<img width="659" alt="Screen Shot 2022-09-22 at 4 07 04 PM" src="https://user-images.githubusercontent.com/9013217/191851149-f44adf80-7b64-4eb6-adbd-e6f4b6015272.png">

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
