### PR TITLE
feat(notifications): Auto-open notifications from email

### DIFF
--- a/packages/client/components/TopBarNotifications.tsx
+++ b/packages/client/components/TopBarNotifications.tsx
@@ -1,10 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {useRef} from 'react'
+import React, {useEffect, useRef} from 'react'
 import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import lazyPreload from '~/utils/lazyPreload'
 import {TopBarNotifications_query$key} from '~/__generated__/TopBarNotifications_query.graphql'
+import useRouter from '../hooks/useRouter'
 import TopBarIcon from './TopBarIcon'
 
 const NotificationDropdown = lazyPreload(
@@ -44,10 +45,21 @@ const TopBarNotifications = ({queryRef}: Props) => {
   const {edges} = notifications
   const hasNotifications = edges.some(({node}) => node.status === 'UNREAD')
   const menuContentRef = useRef<HTMLDivElement>(null)
-  const {togglePortal, originRef, menuPortal, menuProps} = useMenu<HTMLDivElement>(
+  const {togglePortal, openPortal, originRef, menuPortal, menuProps} = useMenu<HTMLDivElement>(
     MenuPosition.UPPER_RIGHT,
     {menuContentRef}
   )
+  const {location} = useRouter()
+  useEffect(() => {
+    const parsed = new URLSearchParams(location.search)
+    if (parsed.get('openNotifs')) {
+      // :HACK: Opening the portal immediately sometimes leads to rendering just off the left side
+      // of the window, so delay a bit before opening. This might be benefial regardless, as it
+      // catches the user's attention when it opens shortly after the rest of the page loads.
+      setTimeout(openPortal, 500)
+    }
+  }, [])
+
   return (
     <>
       <TopBarIcon

--- a/packages/client/modules/email/components/NotificationSummaryEmail.tsx
+++ b/packages/client/modules/email/components/NotificationSummaryEmail.tsx
@@ -24,7 +24,8 @@ const linkStyle = {
 export const notificationSummaryUrlParams = {
   utm_source: 'notification email',
   utm_medium: 'email',
-  utm_campaign: 'notifications'
+  utm_campaign: 'notifications',
+  openNotifs: '1'
 }
 
 export interface NotificationSummaryProps {

--- a/packages/client/utils/makeAppURL.ts
+++ b/packages/client/utils/makeAppURL.ts
@@ -3,6 +3,7 @@ interface Options {
     utm_source: string
     utm_medium: string
     utm_campaign: string
+    openNotifs?: string
   }
 }
 


### PR DESCRIPTION
# Description
Our current notifications simply go to the user's tasks page with no additional information.

Instead, include a query param on notification summary email links, and when this parameter is present, auto-open the notifications menu after some delay.

~I'd like to hold off on merging this until after the next release, so we can first get some baseline data from the [UTM parameters](https://github.com/ParabolInc/parabol/pull/7224)~ the release with updated UTM parameters has been deployed.

## Demo
https://www.loom.com/share/0b150be30ad04f9d89ea73e6a36d11dd

## Testing scenarios
- [ ] Trigger a notification email for a user
  - [ ] Trigger a notification for a user
  - [ ] Modify the `sendBatchNotificationEmails` mutation to send regardless of whether the user was active in the past day by deleting [this clause](https://github.com/ParabolInc/parabol/blob/6955c71afff4bf5b1322428c9cb21dcd4823143e/packages/server/graphql/private/mutations/sendBatchNotificationEmails.ts#L45) and removing `yesterday`.
  - [ ] Run `mutation{sendBatchNotificationEmails}` to trigger 
- [ ] Open the notification email and click the "See my dashboard" CTA
- [ ] See that the notification menu is open
- [ ] Close the menu and click around a bit, and confirm that the menu doesn't reopen automatically 

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
