### PR TITLE
feat: let super users invite to team

### DIFF
--- a/packages/server/graphql/mutations/inviteToTeam.ts
+++ b/packages/server/graphql/mutations/inviteToTeam.ts
@@ -13,7 +13,7 @@ import teamInviteEmailCreator from '../../email/teamInviteEmailCreator'
 import {getUsersByEmails} from '../../postgres/queries/getUsersByEmails'
 import removeSuggestedAction from '../../safeMutations/removeSuggestedAction'
 import {analytics} from '../../utils/analytics/analytics'
-import {getUserId, isTeamMember} from '../../utils/authorization'
+import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import getBestInvitationMeeting from '../../utils/getBestInvitationMeeting'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -57,8 +57,8 @@ export default {
 
       // AUTH
       const viewerId = getUserId(authToken)
-      if (!isTeamMember(authToken, teamId)) {
-        return standardError(new Error('Team not found'), {userId: viewerId})
+      if (!isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
+        return standardError(new Error('Viewer does not belong to that team'), {userId: viewerId})
       }
 
       // RESOLUTION

--- a/packages/server/graphql/mutations/inviteToTeam.ts
+++ b/packages/server/graphql/mutations/inviteToTeam.ts
@@ -58,7 +58,7 @@ export default {
       // AUTH
       const viewerId = getUserId(authToken)
       if (!isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
-        return standardError(new Error('Viewer does not belong to that team'), {userId: viewerId})
+        return standardError(new Error(`Viewer does not belong to that team`), {userId: viewerId})
       }
 
       // RESOLUTION

--- a/packages/server/graphql/mutations/inviteToTeam.ts
+++ b/packages/server/graphql/mutations/inviteToTeam.ts
@@ -58,7 +58,7 @@ export default {
       // AUTH
       const viewerId = getUserId(authToken)
       if (!isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
-        return standardError(new Error(`Viewer does not belong to that team`), {userId: viewerId})
+        return standardError(new Error('Team not found'), {userId: viewerId})
       }
 
       // RESOLUTION


### PR DESCRIPTION
See this Slack thread for further context: https://parabol.slack.com/archives/C4JAUUZ9P/p1663860269145519

A user would like to be added to a team that doesn't have any team members. We would like to be able to execute the `inviteToTeam` mutation, but can't do it because it requires the viewer to be on the team.

This PR enables super users to access the mutation.

### To test

- [ ] A super user can invite a user to a team even when the super user does not belong to that team
- [ ] After executing the mutation, the user receives an email invite and is able to join the team