### PR TITLE
chore: Tweak review stats schedule to match other reminders

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,7 +2,7 @@ name: Pull Request Stats
 
 on:
   schedule:
-    - cron: '0 9 * * 5'
+    - cron: '54 14 * * 5'
 
 jobs:
   stats:


### PR DESCRIPTION
Try to match other reminders, taking into account the runtime of the job. This hopefully reduces distraction for everyone.