### PR TITLE
chore(Review stats): Count IssueComment events towards comment count

### DIFF
--- a/scripts/reviewStats.ts
+++ b/scripts/reviewStats.ts
@@ -43,6 +43,10 @@ query($searchQuery: String!) {
               actor { ...UserFragment }
               createdAt
             }
+            ... on IssueComment {
+              author { ...UserFragment }
+              createdAt
+            }
           }
         }
       }
@@ -164,6 +168,25 @@ const parseStats = (rawData: any) => {
 
           reviewers.add(login)
           reviews++
+        }
+      }
+      if (item.__typename === 'IssueComment') {
+        const login = item.author.login
+        // no bots
+        if (login !== undefined) {
+          if (login !== pr.author.login) {
+            if (!reviewerStats[login]) {
+              reviewerStats[login] = {
+                ...item.author,
+                timesToReview: [],
+                reviewStates: [],
+                comments: 0,
+                reviewedPRs: 0,
+              }
+            }
+            reviewerStats[login].comments++
+          }
+          comments++
         }
       }
     })

--- a/scripts/reviewStats.ts
+++ b/scripts/reviewStats.ts
@@ -36,6 +36,7 @@ query($searchQuery: String!) {
               comments(first: 1) {
                 totalCount
               }
+              bodyText
               submittedAt
               state
             }
@@ -144,6 +145,9 @@ const parseStats = (rawData: any) => {
 
         reviewers.add(login)
         comments += item.comments.totalCount
+        if (item.bodyText) {
+          comments++
+        }
         reviews++
       }
       if (item.__typename === 'MergedEvent') {
@@ -185,8 +189,8 @@ const parseStats = (rawData: any) => {
               }
             }
             reviewerStats[login].comments++
+            comments++
           }
-          comments++
         }
       }
     })
@@ -196,6 +200,7 @@ const parseStats = (rawData: any) => {
 
     return {
       number: pr.number,
+      url: pr.url,
       author: pr.author,
       timeToMerge: timeToMerge,
       comments,
@@ -298,6 +303,19 @@ const main = async () => {
   console.log(`Total ${prs.length} PRs merged`)
   console.log(formatPrs(prs))
 
+  if (process.argv.includes('--debug')) {
+    console.log('\nDEBUG')
+    console.log('Read following PRs')
+    prs.forEach((pr) => {
+      console.log(`#${pr.number} ${pr.url}`)
+      console.log(`- author: ${pr.author.login}`)
+      console.log(`- comments: ${pr.comments}`)
+      console.log(`- reviews: ${pr.reviews}`)
+      console.log(`- time to merge: ${ms(pr.timeToMerge)}`)
+    })
+    console.log('DEBUG - Not sending to Slack')
+    return
+  }
 
   const slackMessage = {
     blocks: [{


### PR DESCRIPTION
## Description

Comment only events were not counted towards the total comment count.
Comments from the author are not counted.

## Testing

* Set following environment variables
  ```
  export GITHUB_TOKEN=<a PAT with publicRepo right>
  export TIME_DIFF=7d
  export REPO=ParabolInc/parabol
  ```
* run `yarn ts-node scripts/reviewStats.ts --debug`
* compare some of the comment counts with the ones from the PR