### PR TITLE
feat(analytics): 'Sent invite accepted' event

### DIFF
--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -64,6 +64,7 @@ export type AnalyticsEvent =
   | 'Integration Removed'
   | 'Invite Email Sent'
   | 'Invite Accepted'
+  | 'Sent Invite Accepted'
   // org
   | 'Organization Upgraded'
   | 'Organization Downgraded'
@@ -269,6 +270,13 @@ class Analytics {
     this.track(userId, 'Invite Accepted', {
       teamId,
       inviterId,
+      isNewUser,
+      acceptAt
+    })
+
+    this.track(inviterId, 'Sent Invite Accepted', {
+      teamId,
+      userId,
       isNewUser,
       acceptAt
     })

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -276,7 +276,7 @@ class Analytics {
 
     this.track(inviterId, 'Sent Invite Accepted', {
       teamId,
-      userId,
+      inviteeId: userId,
       isNewUser,
       acceptAt
     })


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7059

Event for when a user's invite was accepted by a different user. Can be used to answer questions like "What's the conversion rate from 'User creates account' to 'Another user accepts the user's invite'?" within Amplitude.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
