### PR TITLE
feat(analytics): 'Copied Invite Link' event

### DIFF
--- a/packages/client/components/CopyLink.tsx
+++ b/packages/client/components/CopyLink.tsx
@@ -8,25 +8,28 @@ interface Props {
   title: string | undefined
   tooltip: string | undefined
   url: string
+  onCopy?: () => void
 }
 
 const CopyLink = (props: Props) => {
-  const {title, children, tooltip, url} = props
+  const {title, children, tooltip, url, onCopy} = props
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip(
     MenuPosition.LOWER_CENTER
   )
 
-  const onCopy = () => {
+  const handleCopy = () => {
     if (tooltip) {
       openTooltip()
       setTimeout(() => {
         closeTooltip()
       }, 2000)
     }
+
+    onCopy && onCopy()
   }
   return (
     <>
-      <CopyToClipboard text={url} onCopy={onCopy} title={title}>
+      <CopyToClipboard text={url} onCopy={handleCopy} title={title}>
         <span ref={originRef}>{children}</span>
       </CopyToClipboard>
       {tooltipPortal(tooltip)}

--- a/packages/client/components/MassInvitationTokenLink.tsx
+++ b/packages/client/components/MassInvitationTokenLink.tsx
@@ -8,6 +8,7 @@ import CreateMassInvitationMutation from '~/mutations/CreateMassInvitationMutati
 import makeMinWidthQuery from '~/utils/makeMinWidthMediaQuery'
 import useAtmosphere from '../hooks/useAtmosphere'
 import CopyShortLink from '../modules/meeting/components/CopyShortLink/CopyShortLink'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {Threshold} from '../types/constEnums'
 import getMassInvitationUrl from '../utils/getMassInvitationUrl'
@@ -74,6 +75,12 @@ const MassInvitationTokenLink = (props: Props) => {
     }
     doFetch().catch()
   }, [])
+  const onCopy = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Copied Invite Link', {
+      teamId: teamId,
+      meetingId: meetingId
+    })
+  }
   const displayToken = isTokenValid ? token : '············'
   const linkLabel = `${window.__ACTION__.prblIn}/${displayToken}`
   const url = getMassInvitationUrl(displayToken)
@@ -84,6 +91,7 @@ const MassInvitationTokenLink = (props: Props) => {
       label={linkLabel}
       title={'Copy invite link'}
       tooltip={'Copied! Valid for 30 days'}
+      onCopy={onCopy}
     />
   )
 }

--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -7,6 +7,7 @@ import useMutationProps from '~/hooks/useMutationProps'
 import useRouter from '~/hooks/useRouter'
 import EndTeamPromptMutation from '~/mutations/EndTeamPromptMutation'
 import {MenuProps} from '../hooks/useMenu'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {ICON_SIZE} from '../styles/typographyV2'
 import getMassInvitationUrl from '../utils/getMassInvitationUrl'
@@ -41,6 +42,7 @@ const query = graphql`
   query MeetingCardOptionsMenuQuery($teamId: ID!, $meetingId: ID!) {
     viewer {
       team(teamId: $teamId) {
+        id
         massInvitation(meetingId: $meetingId) {
           id
         }
@@ -84,6 +86,11 @@ const MeetingCardOptionsMenu = (props: Props) => {
           closePortal()
           const copyUrl = getMassInvitationUrl(token)
           await navigator.clipboard.writeText(copyUrl)
+
+          SendClientSegmentEventMutation(atmosphere, 'Copied Invite Link', {
+            teamId: team?.id,
+            meetingId: meetingId
+          })
         }}
       />
       {canEndMeeting && (

--- a/packages/client/modules/meeting/components/CopyShortLink/CopyShortLink.tsx
+++ b/packages/client/modules/meeting/components/CopyShortLink/CopyShortLink.tsx
@@ -38,12 +38,13 @@ interface Props {
   title?: string | undefined
   tooltip?: string | undefined
   url: string
+  onCopy?: () => void
 }
 const CopyShortLink = (props: Props) => {
-  const {className, icon, label, url, title, tooltip} = props
+  const {className, icon, label, url, title, tooltip, onCopy} = props
   const theLabel = label || url
   return (
-    <CopyLink url={url} title={title} tooltip={tooltip}>
+    <CopyLink url={url} title={title} tooltip={tooltip} onCopy={onCopy}>
       <CopyBlock className={className}>
         {icon && <CopyIcon>{icon}</CopyIcon>}
         <CopyLabel>{theLabel}</CopyLabel>


### PR DESCRIPTION
# Description
Send a "Copied Invite Link" event to segment when a user clicks the invite link in the "Invite to team" modal.

## Demo
<img width="254" alt="Screen Shot 2022-09-26 at 5 16 30 PM" src="https://user-images.githubusercontent.com/9013217/192390993-51f6c8b7-41f8-4db2-baec-f6364b497207.png">


## Testing scenarios
- [ ] Event is triggered with correct properties when the invite link is click-to-copied.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
