### PR TITLE
feat: Add confirmation tooltip on the retro meeting sidebar

### DIFF
--- a/packages/client/components/NewMeetingSidebarPhaseListItem.tsx
+++ b/packages/client/components/NewMeetingSidebarPhaseListItem.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import {NewMeetingPhaseTypeEnum} from '~/__generated__/NewMeetingSettingsToggleCheckIn_settings.graphql'
+import {MenuPosition} from '../hooks/useCoords'
+import useTooltip from '../hooks/useTooltip'
 import {PALETTE} from '../styles/paletteV3'
-import {NavSidebar} from '../types/constEnums'
+import {NavSidebar, Times} from '../types/constEnums'
 import {phaseIconLookup, phaseImageLookup, phaseLabelLookup} from '../utils/meetings/lookups'
 import Badge from './Badge/Badge'
 import Icon from './Icon'
@@ -125,6 +127,7 @@ interface Props {
   isUnsyncedFacilitatorStage?: boolean
   phaseCount?: number | null
   phaseType: NewMeetingPhaseTypeEnum
+  isConfirming?: boolean
 }
 
 const NewMeetingSidebarPhaseListItem = (props: Props) => {
@@ -136,12 +139,28 @@ const NewMeetingSidebarPhaseListItem = (props: Props) => {
     isUnsyncedFacilitatorPhase,
     isUnsyncedFacilitatorStage,
     phaseCount,
-    phaseType
+    phaseType,
+    isConfirming
   } = props
   const label = phaseLabelLookup[phaseType]
   const icon = phaseIconLookup[phaseType]
   const Image = phaseImageLookup[phaseType]
   const showPhaseCount = Boolean(phaseCount || phaseCount === 0)
+
+  const {openTooltip, tooltipPortal, originRef} = useTooltip<HTMLDivElement>(
+    MenuPosition.UPPER_CENTER,
+    {
+      disabled: !isConfirming,
+      delay: Times.MEETING_CONFIRM_TOOLTIP_DELAY
+    }
+  )
+
+  React.useEffect(() => {
+    if (isConfirming) {
+      openTooltip()
+    }
+  }, [isConfirming])
+
   return (
     <NavListItemLink
       isActive={isActive}
@@ -151,6 +170,7 @@ const NewMeetingSidebarPhaseListItem = (props: Props) => {
       isUnsyncedFacilitatorStage={isUnsyncedFacilitatorStage}
       onClick={handleClick}
       title={label}
+      ref={originRef}
     >
       {icon && (
         <NavItemIcon isUnsyncedFacilitatorPhase={isUnsyncedFacilitatorPhase}>{icon}</NavItemIcon>
@@ -166,6 +186,7 @@ const NewMeetingSidebarPhaseListItem = (props: Props) => {
           <StyledBadge>{phaseCount}</StyledBadge>
         </PhaseCountBlock>
       )}
+      {tooltipPortal(`Tap '${label}' again if everyone is ready`)}
     </NavListItemLink>
   )
 }

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {Fragment} from 'react'
+import React, {Fragment, useState} from 'react'
 import {createFragmentContainer} from 'react-relay'
 import useRouter from '~/hooks/useRouter'
 import isDemoRoute from '~/utils/isDemoRoute'
@@ -39,7 +39,8 @@ const RetroMeetingSidebar = (props: Props) => {
     localPhase,
     localStage,
     phases,
-    settings
+    settings,
+    meetingMembers
   } = meeting
   const {phaseTypes} = settings
   const localPhaseType = localPhase ? localPhase.phaseType : ''
@@ -48,6 +49,7 @@ const RetroMeetingSidebar = (props: Props) => {
   const isViewerFacilitator = facilitatorUserId === viewerId
   const isUnsyncedFacilitatorPhase = facilitatorPhaseType !== localPhaseType
   const isUnsyncedFacilitatorStage = localStage ? localStage.id !== facilitatorStageId : undefined
+  const [confirmingPhase, setConfirmingPhase] = useState<NewMeetingPhaseTypeEnum | null>(null)
   return (
     <NewMeetingSidebar
       handleMenuClick={handleMenuClick}
@@ -55,17 +57,39 @@ const RetroMeetingSidebar = (props: Props) => {
       meeting={meeting}
     >
       <MeetingNavList>
-        {phaseTypes.map((phaseType) => {
+        {phaseTypes.map((phaseType, index) => {
           const itemStage = getSidebarItemStage(phaseType, phases, facilitatorStageId)
           const {
             id: itemStageId = '',
             isNavigable = false,
-            isNavigableByFacilitator = false
-          } = itemStage || {}
+            isNavigableByFacilitator = false,
+            isComplete = false
+          } = itemStage ?? {}
           const canNavigate = isViewerFacilitator ? isNavigableByFacilitator : isNavigable
           const handleClick = () => {
-            gotoStageId(itemStageId).catch()
-            handleMenuClick()
+            const prevPhaseType = phaseTypes[index - 1]
+            const prevItemStage = prevPhaseType
+              ? getSidebarItemStage(prevPhaseType, phases, facilitatorStageId)
+              : null
+
+            const {isComplete: isPrevItemStageComplete = false, readyCount = 0} =
+              prevItemStage ?? {}
+
+            const activeCount = meetingMembers.length
+            const isConfirmRequired = readyCount < activeCount - 1 && activeCount > 1
+
+            if (
+              isComplete ||
+              isPrevItemStageComplete ||
+              !isConfirmRequired ||
+              confirmingPhase === phaseType
+            ) {
+              setConfirmingPhase(null)
+              gotoStageId(itemStageId).catch()
+              handleMenuClick()
+            } else {
+              setConfirmingPhase(phaseType)
+            }
           }
           const discussPhase = phases.find((phase) => {
             return phase.phaseType === 'discuss'
@@ -87,6 +111,7 @@ const RetroMeetingSidebar = (props: Props) => {
                 key={phaseType}
                 phaseCount={phaseCount}
                 phaseType={phaseType}
+                isConfirming={confirmingPhase === phaseType}
               />
               <RetroSidebarPhaseListItemChildren
                 gotoStageId={gotoStageId}
@@ -137,6 +162,9 @@ export default createFragmentContainer(RetroMeetingSidebar, {
       localStage {
         id
       }
+      meetingMembers {
+        id
+      }
       phases {
         phaseType
         stages {
@@ -144,6 +172,7 @@ export default createFragmentContainer(RetroMeetingSidebar, {
           isComplete
           isNavigable
           isNavigableByFacilitator
+          readyCount
         }
       }
     }

--- a/packages/client/utils/getSidebarItemStage.ts
+++ b/packages/client/utils/getSidebarItemStage.ts
@@ -6,6 +6,8 @@ interface Phase {
     id: string
     isNavigable: boolean
     isNavigableByFacilitator: boolean
+    isComplete: boolean
+    readyCount?: number
   }[]
 }
 


### PR DESCRIPTION
# Description

#4881

- Added a confirmation tooltip on the sidebar
- Changed 'Tap next' message everywhere.

## Demo

https://user-images.githubusercontent.com/466991/193296964-9ad2733e-b17f-41ed-b52a-d42f5003dfaa.mov

## Testing scenarios
