### PR TITLE
feat(metrics): Send isPatient0 property to Google Analytics

### DIFF
--- a/packages/server/graphql/mutations/helpers/isPatientZero.ts
+++ b/packages/server/graphql/mutations/helpers/isPatientZero.ts
@@ -1,6 +1,16 @@
 import getPatientZeroByDomain from '../../../postgres/queries/getPatientZeroByDomain'
 
-const isPatientZero = async (userId: string, domain?: string | null) =>
-  domain ? userId === (await getPatientZeroByDomain(domain)).id : false
+const isPatientZero = async (userId: string, domain?: string | null) => {
+  if (domain) {
+    const patient0 = await getPatientZeroByDomain(domain)
+    if (!patient0) {
+      return true
+    } else {
+      return userId === patient0.id
+    }
+  } else {
+    return false
+  }
+}
 
 export default isPatientZero

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -73,6 +73,7 @@ export type AnalyticsEvent =
   | 'Task Published'
   | 'Task Estimate Set'
   // user
+  | 'Account Created'
   | 'Summary Email Setting Changed'
 
 /**
@@ -318,6 +319,16 @@ class Analytics {
 
   toggleSubToSummaryEmail = (userId: string, subscribeToSummaryEmail: boolean) => {
     this.track(userId, 'Summary Email Setting Changed', subscribeToSummaryEmail)
+  }
+
+  accountCreated = (userId: string, isInvited: boolean, isPatient0: boolean) => {
+    this.track(userId, 'Account Created', {
+      isInvited,
+      // properties below needed for Google Analytics goal setting
+      category: 'All',
+      label: 'isPatient0',
+      value: isPatient0 ? 1 : 0
+    })
   }
 
   private track = (userId: string, event: AnalyticsEvent, properties?: any) =>

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -326,8 +326,7 @@ class Analytics {
       isInvited,
       // properties below needed for Google Analytics goal setting
       category: 'All',
-      label: 'isPatient0',
-      value: isPatient0 ? 1 : 0
+      label: isPatient0 ? 'isPatient0' : 'isNotPatient0'
     })
   }
 


### PR DESCRIPTION
# Description

Fixes #7182 

## Demo
<img width="288" alt="Screen Shot 2022-10-10 at 11 28 29 AM" src="https://user-images.githubusercontent.com/1879975/194931214-71d343f9-24ed-44b5-b363-7e9d57b61008.png">


## Testing scenarios

- [ ] Patient 0
  - Create an account with a new domain
  - In Segment verify the value for label `isPatient0` is 1

- [ ] Non-patient 0
  - Create an account with an existing domain
  - In Segment verify the value for label `isPatient0` is 0

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
