### PR TITLE
fix: Sprint Poker-number of stories in summary stats is one less than…

### DIFF
--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -64,9 +64,7 @@ export default {
     if (!currentStageRes) {
       return standardError(new Error('Cannot find facilitator stage'), {userId: viewerId})
     }
-    const storyCount = new Set(
-      estimateStages.filter(({isComplete}) => isComplete).map(({taskId}) => taskId)
-    ).size
+    const storyCount = new Set(estimateStages.map(({taskId}) => taskId)).size
     const discussionIds = estimateStages.map((stage) => stage.discussionId)
     const {stage} = currentStageRes
     const phase = getMeetingPhase(phases)


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #7092

When a Sprint Poker meeting has ended, the number of stories in the summary stats is one less than the actual number of stories that were estimated. This pr fix the number of stories in the summary stats is equal to the number of stories estimated.

https://www.loom.com/share/8c0571915ad84669817de756233351df


