### PR TITLE
fix: Fix The animated 'Next' button background is beyond the bottom c…

### DIFF
--- a/packages/client/components/BottomControlBarReadyButton.tsx
+++ b/packages/client/components/BottomControlBarReadyButton.tsx
@@ -9,7 +9,7 @@ import isDemoRoute from '../utils/isDemoRoute'
 
 const shakeAnimation = keyframes`
   20%, 40%, 60% {
-    padding: 4px 4px 8px;
+    padding: 0px;
     overflow: hidden;
     background: #a06bd6;
     color: white;


### PR DESCRIPTION
# Description

Original Issue on clients side [#7133]
 ## Issue - Bug
 Related to #6815

 ![Google Chrome-Retro Meeting Demo Team-000052-20220830](https://user-images.githubusercontent.com/4997466/187441421-70c3be52-de25-49e1-9fca-75f057dac968.gif) [ ![Google Chrome-Retro Meeting Demo Team-000052-20220830](https://user-images.githubusercontent.com/4997466/187441421-70c3be52-de25-49e1-9fca-75f057dac968.gif) ](https://user-images.githubusercontent.com/4997466/187441421-70c3be52-de25-49e1-9fca-75f057dac968.gif) [ ](https://user-images.githubusercontent.com/4997466/187441421-70c3be52-de25-49e1-9fca-75f057dac968.gif)
 
 ### Acceptance Criteria
 Users can:
 
 * mouse hover on the 'Next' button
 * when the button is animated
 * the background not beyond the border
 
 **Estimated effort:** 2 hour.



## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]
https://www.loom.com/share/8295aa39a80745f0a77bbdb860f1024d

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
