### PR TITLE
fix: missing daki prompt

### DIFF
--- a/packages/server/database/migrations/20221012142324-fixDakiMigration.ts
+++ b/packages/server/database/migrations/20221012142324-fixDakiMigration.ts
@@ -1,0 +1,24 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function (r: R) {
+  const now = new Date()
+  const missingKeepPrompt = {
+    createdAt: now,
+    description: 'What should we continue doing?',
+    groupColor: '#D9D916',
+    id: 'keepPrompt',
+    isActive: true,
+    question: 'Keep',
+    sortOrder: 2,
+    teamId: 'aGhostTeam',
+    templateId: 'dropAddKeepImproveDAKITemplate',
+    title: 'Keep',
+    updatedAt: now
+  }
+
+  await r.db('actionDevelopment').table('ReflectPrompt').insert(missingKeepPrompt).run()
+}
+
+export const down = async function (r: R) {
+  await r.db('actionDevelopment').table('ReflectPrompt').get('keepPrompt').delete().run()
+}

--- a/packages/server/database/migrations/20221012142324-fixDakiMigration.ts
+++ b/packages/server/database/migrations/20221012142324-fixDakiMigration.ts
@@ -15,9 +15,9 @@ export const up = async function (r: R) {
     title: 'Keep',
     updatedAt: now
   }
-  await r.db('actionDevelopment').table('ReflectPrompt').insert(missingKeepPrompt).run()
+  await r.table('ReflectPrompt').insert(missingKeepPrompt).run()
 }
 
 export const down = async function (r: R) {
-  await r.db('actionDevelopment').table('ReflectPrompt').get('keepPrompt').delete().run()
+  await r.table('ReflectPrompt').get('keepPrompt').delete().run()
 }

--- a/packages/server/database/migrations/20221012142324-fixDakiMigration.ts
+++ b/packages/server/database/migrations/20221012142324-fixDakiMigration.ts
@@ -15,7 +15,6 @@ export const up = async function (r: R) {
     title: 'Keep',
     updatedAt: now
   }
-
   await r.db('actionDevelopment').table('ReflectPrompt').insert(missingKeepPrompt).run()
 }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7221

To test:

- Run the up migration, open the retro template menu, see that the DAKI template includes the "Keep" prompt
- Running the down migration removes the prompt

I'm not really sure why/how the prompt doesn't exist in the db when it was included here https://github.com/ParabolInc/parabol/blob/ec1cc40f177b02a0a5f37b8e7cd7b422b3f7961e/packages/server/database/migrations/20210602120505-addAdditionalRetroTemplates.ts#L80 and the other three prompts are all there 🤔 