### PR TITLE
feat: show you in emoji list instead of viewer name

### DIFF
--- a/packages/client/components/ReflectionCard/EmojiUsersReaction.tsx
+++ b/packages/client/components/ReflectionCard/EmojiUsersReaction.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {EmojiUsersReaction_reactji$key} from '~/__generated__/EmojiUsersReaction_reactji.graphql'
+import useAtmosphere from '../../hooks/useAtmosphere'
 import {PALETTE} from '../../styles/paletteV3'
 
 const EmojiUsersReactionRoot = styled('div')({
@@ -33,7 +34,9 @@ interface Props {
 }
 
 const EmojiUsersReaction = ({reactjiRef, reactjiShortName}: Props) => {
-  const reactji = useFragment(
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
+  const {users} = useFragment(
     graphql`
       fragment EmojiUsersReaction_reactji on Reactji {
         id
@@ -45,10 +48,15 @@ const EmojiUsersReaction = ({reactjiRef, reactjiShortName}: Props) => {
     `,
     reactjiRef
   )
+  const userNames: string[] = []
+
+  users.forEach(({id, preferredName}) =>
+    id === viewerId ? userNames.unshift('You') : userNames.push(preferredName)
+  )
 
   return (
     <EmojiUsersReactionRoot>
-      {LIST_FORMATTER.format(reactji.users.map(({preferredName}) => preferredName))}
+      {LIST_FORMATTER.format(userNames)}
       {reactjiShortName && <DarkerGrayPart>reacted with :{reactjiShortName}:</DarkerGrayPart>}
     </EmojiUsersReactionRoot>
   )

--- a/packages/client/components/ReflectionCard/EmojiUsersReaction.tsx
+++ b/packages/client/components/ReflectionCard/EmojiUsersReaction.tsx
@@ -49,7 +49,6 @@ const EmojiUsersReaction = ({reactjiRef, reactjiShortName}: Props) => {
     reactjiRef
   )
   const userNames: string[] = []
-
   users.forEach(({id, preferredName}) =>
     id === viewerId ? userNames.unshift('You') : userNames.push(preferredName)
   )


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7249

### To test

- [ ] If the viewer clicks on an emoji, the list says `You` instead of their name
- [ ] If multiple people including the viewer click on the emoji, the `You` appears first in the list, just like in Slack, i.e. `You and Susan reacted with :fire:` instead of `Susan and you reacted with :fire:`