### PR TITLE
feat(notifications): Batch notification emails - improve who gets emails

### DIFF
--- a/packages/client/modules/email/components/NotificationSummaryEmail.tsx
+++ b/packages/client/modules/email/components/NotificationSummaryEmail.tsx
@@ -44,7 +44,7 @@ export default function NotificationSummaryEmail(props: NotificationSummaryProps
         <p style={copyStyle}>
           {'You have '}
           <span style={{fontWeight: 600}}>
-            {`${notificationCount} new ${plural(notificationCount, 'notification')}`}
+            {`${notificationCount} new unread ${plural(notificationCount, 'notification')}`}
           </span>
           {' — see what’s changed with your teams.'}
         </p>


### PR DESCRIPTION
# Description
Fixes #7270 

Update which users receive notification batch emails according to the [spec](https://www.notion.so/parabol/Spec-Batch-Notification-Email-Enhancements-f5a99dd9509a4aff93b6ec6568a969ae#94a8626afe26472c8247f84ec018c2bb).

I decided not to make the optional changes listed in the AC, since those will be easier to implement when we update this query to support the new emails.

## Testing scenarios
- [ ] Trigger a notification for a user, but do not read the notification
- [ ] Execute `mutation{sendBatchNotificationEmails}` in the private GQL schema
- [ ] Confirm that the user with the notification appears as a user who received an email
- [ ] Confirm that the user receives an email.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
