### PR TITLE
chore: Run auto assign reviewer workflow on pull request target

### DIFF
--- a/.github/workflows/assign_reviewers.yml
+++ b/.github/workflows/assign_reviewers.yml
@@ -1,7 +1,7 @@
 name: Auto Request Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
@@ -12,6 +12,5 @@ jobs:
       - name: Request review based on files changes and/or groups the author belongs to
         uses: necojackarc/auto-request-review@v0.7.0
         with:
-          token: ${{ secrets.ASSIGN_REVIEWER_PAT }}
           config: .github/reviewers.yml # Config file location override
 


### PR DESCRIPTION
# Description

Triggering on pull_request_target rather than pull_request will run the workflow from the base branch (i.e. master) rather than from the fork. This allows to use secrets as the running code is managed by us.

This will hopefully allow to auto-assign reviewers for external PRs.

## Demo

No demo. Because of the nature of this change, it can only run after being merged.

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
