### PR TITLE
POC: Generic notification publishing

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -33,6 +33,7 @@
         "contextType": "../graphql#GQLContext",
         "mappers": {
           "AddApprovedOrganizationDomainsSuccess": "./types/AddApprovedOrganizationDomainsSuccess#AddApprovedOrganizationDomainsSuccessSource",
+          "AddedNotification": "./types/AddedNotification#AddedNotificationSource",
           "AddFeatureFlagPayload": "./types/AddFeatureFlagPayload#AddFeatureFlagPayloadSource",
           "Company": "./types/Company#CompanySource",
           "CreateImposterTokenPayload": "./types/CreateImposterTokenPayload#CreateImposterTokenPayloadSource",

--- a/packages/client/components/NotificationPicker.tsx
+++ b/packages/client/components/NotificationPicker.tsx
@@ -48,6 +48,7 @@ export default createFragmentContainer(NotificationPicker, {
   notification: graphql`
     fragment NotificationPicker_notification on Notification {
       type
+      id
       ...KickedOut_notification
       ...PaymentRejected_notification
       ...TaskInvolves_notification

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -83,6 +83,12 @@ const subscription = graphql`
       ...PersistJiraServerSearchQueryMutation_notification @relay(mask: false)
       ...UpsertTeamPromptResponseMutation_notification @relay(mask: false)
 
+      ... on AddedNotification {
+        addedNotification {
+          ...NotificationPicker_notification @relay(mask: false)
+        }
+      }
+
       ... on AuthTokenPayload {
         id
       }
@@ -289,6 +295,11 @@ const NotificationSubscription = (
           break
         case 'UpsertTeamPromptResponseSuccess':
           upsertTeamPromptResponseNotificationUpdater(payload, context)
+          break
+        case 'AddedNotification':
+          const notification = payload.getLinkedRecord('addedNotification' as any)
+          if (!notification) break
+          handleAddNotifications(notification, context.store)
           break
         default:
           console.error('NotificationSubscription case fail', type)

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -94,8 +94,10 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
     publish(
       SubscriptionChannel.NOTIFICATION,
       notification.userId,
-      'UpsertTeamPromptResponseSuccess',
-      data,
+      'AddedNotification',
+      {
+        addedNotificationId: notification.id
+      },
       subOptions
     )
   })

--- a/packages/server/graphql/public/typeDefs/AddedNotification.graphql
+++ b/packages/server/graphql/public/typeDefs/AddedNotification.graphql
@@ -1,0 +1,8 @@
+type AddedNotification {
+  """
+  A notification
+  """
+  addedNotification: Notification
+}
+
+extend union NotificationSubscriptionPayload = AddedNotification

--- a/packages/server/graphql/public/types/AddedNotification.ts
+++ b/packages/server/graphql/public/types/AddedNotification.ts
@@ -1,0 +1,18 @@
+import {getUserId} from '../../../utils/authorization'
+import {AddedNotificationResolvers} from '../resolverTypes'
+
+export type AddedNotificationSource = {addedNotificationId: string}
+
+const AddedNotification: AddedNotificationResolvers = {
+  addedNotification: async ({addedNotificationId}, _args: unknown, {dataLoader, authToken}) => {
+    const viewerId = getUserId(authToken)
+    const notification = (await dataLoader.get('notifications').load(addedNotificationId)) as any
+    if (notification.userId === viewerId) {
+      return notification
+    } else {
+      return null
+    }
+  }
+}
+
+export default AddedNotification


### PR DESCRIPTION
POC for making the "publish notification" flow more generic. Instead of associating new notifications specifically with the mutation that triggered them (e.g. "someone posted a standup response with your name in it, so here's a notification triggered by that mutation"), new notifications can just be published via a generic `AddedNotification` type (e.g. "here's a notification telling you about how you were mentioned in someone's standup response").

Benefits of this approach:
* Most boilerplate associated with adding a new notification is abstracted away
  * New notifications don't need changes to the `NotificationSubscription` or the triggering mutation
  * New notifications don't need to implement an updater to handle adding the notification in relay
  * See these changes needed for standup mention notifications:
    * https://github.com/ParabolInc/parabol/pull/7118/files#diff-21aeeb7bbbb0e6f8da9f5d79ce1a47e92a1b7f72f01782977288af585cda119e
    * https://github.com/ParabolInc/parabol/pull/7118/files#diff-4ae049d67f824570f8c2a3f8d68fd1ceb8a332209961392f00cd2e7a8f94955b
    * https://github.com/ParabolInc/parabol/pull/7118/files#diff-a23acb52670a08c06e8f8e7bdf09bd98d7983a0ae5566d8b463720f762682e6f
    * https://github.com/ParabolInc/parabol/pull/7118/files#diff-a6d5286e029f906a1d5fb60f8847bb2d6730cc8617c3be60a95d239e68ff946b
* Creating a new notification only requires:
  * Adding the notification component + fragment to the notification picker
  * Adding the notification's GQL + Database models
  * Calling `publish` _somewhere_ on the server.

Another way you might think about this at a high level is going from "this mutation just triggered a specific type of notification, so here's that notification, make sure you handle it when you handle the mutation" to "here's the ID for a new notification, we don't care where it came from, just resolve it and load it".

Other raw notes: https://www.notion.so/parabol/James-Notes-Notifications-publish-refactor-fc28fe02d76d4b3da1b21ebe0a0f278c