### PR TITLE
feat: end meeting from meetings view

### DIFF
--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -61,8 +61,8 @@ const query = graphql`
       }
       meeting(meetingId: $meetingId) {
         id
-        facilitatorUserId
         meetingType
+        facilitatorUserId
       }
     }
   }

--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -77,8 +77,8 @@ const MeetingCardOptionsMenu = (props: Props) => {
   const {id: viewerId, team, meeting} = viewer
   const {massInvitation} = team!
   const {id: token} = massInvitation
-  const {id: meetingId, meetingType} = meeting!
-  const isViewerFacilitator = meeting!.facilitatorUserId === viewerId
+  const {id: meetingId, meetingType, facilitatorUserId} = meeting!
+  const isViewerFacilitator = facilitatorUserId === viewerId
   const canEndMeeting = meetingType === 'teamPrompt' || isViewerFacilitator
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7301

https://www.loom.com/share/f2c8aaab283c4d2d9d9a90d05b1bc132

### To test

- [ ] Open dropdown menu of a meeting card where the viewer is the facilitator. Click the "End the meeting" button and end the meeting
- [ ] If the viewer isn't the facilitator, the "End the meeting" option doesn't show up in the menu
- [ ] If it's a standup meeting, the "End the meeting" option always shows up