### PR TITLE
fix: use fallback values for PokerCardDeck

### DIFF
--- a/packages/client/components/PokerCardDeck.tsx
+++ b/packages/client/components/PokerCardDeck.tsx
@@ -50,12 +50,11 @@ const PokerCardDeck = (props: Props) => {
   const {meeting, estimateAreaRef} = props
   const {id: meetingId, isRightDrawerOpen, localStage, showSidebar, viewerMeetingMember} = meeting
   const isSpectating = !!viewerMeetingMember?.isSpectating
-  const stageId = localStage.id!
-  const {dimensionRef} = localStage
-  const scores = localStage.scores!
-  const isVoting = localStage.isVoting!
-  const {scale} = dimensionRef!
-  const {values: cards} = scale
+  // fallbacks used here to test https://github.com/ParabolInc/parabol/issues/6247
+  const stageId = localStage.id ?? ''
+  const cards = localStage.dimensionRef?.scale.values ?? []
+  const scores = localStage.scores ?? []
+  const isVoting = localStage.isVoting ?? false
   const totalCards = cards.length
   const [isCollapsed, setIsCollapsed] = useState(!isVoting)
   const [estimateAreaWidth, showTransition] = usePokerDeckLeftEdge(estimateAreaRef, isVoting)


### PR DESCRIPTION
# Description

Hopefully Fixes #6247

I assume the bug is caused by an untimely suspense on the part of relay (technically react, but :shrug:).

## Demo

I can't reproduce the bug, this is just a shot in the dark. :space_invader: :gun: 
We'll keep tracking this bug & if the frequency drops we'll know it worked!
