### PR TITLE
fix(Retro): a card dragged from an expanded group disappeared

### DIFF
--- a/packages/client/hooks/useDraggableReflectionCard.tsx
+++ b/packages/client/hooks/useDraggableReflectionCard.tsx
@@ -330,9 +330,12 @@ const useDragAndDrop = (
       drag.cardOffsetX = Math.min(clientX - bbox.left, bbox.width)
       drag.cardOffsetY = Math.min(clientY - bbox.top, bbox.height)
       drag.id = clientTempId()
+      // There are some constraints here.
+      // We want to clone the reflection card after the properties were set correctly, especially isDragging, thus the mutation needs to run first.
+      // in some cases, e.g. moving a card out of a reflection group, the component tree is shuffled which will set the drag.ref to null.
+      const dragRef = drag.ref
       StartDraggingReflectionMutation(atmosphere, {reflectionId, dragId: drag.id})
-      // clone is done after mutation as earlier it was creating issue (https://github.com/ParabolInc/parabol/pull/6910#issuecomment-1193069249)
-      drag.clone = cloneReflection(drag.ref, reflectionId)
+      drag.clone = cloneReflection(dragRef, reflectionId)
     }
     if (!drag.clone) return
     drag.clientY = clientY


### PR DESCRIPTION
# Description

Fixes: #7297

Dragged reflection cards are cloned elements outside of the usual component tree. In #6910 we changed the timing slightly when the clone was created, which caused this issue: The clone was created after the component tree was modified and the original disappeared already.

## Demo
![Peek 2022-10-20 12-11](https://user-images.githubusercontent.com/7331043/196921535-0f1430b1-1190-423f-89c1-11b40f56e19e.gif)

## Testing scenarios

- [ ] Create a retro with >= 2 reflections
  - create a reflection group
  - drag one card out of the expanded reflection group
  - [ ] check the card does not disappear while dragging

- [ ] Smoke test retro grouping

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
