### PR TITLE
feat: rename christmas template

### DIFF
--- a/packages/server/database/migrations/20221021163318-rename-christmas-template.ts
+++ b/packages/server/database/migrations/20221021163318-rename-christmas-template.ts
@@ -1,0 +1,18 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function (r: R) {
+  await r
+    .table('MeetingTemplate')
+    .get('aChristmasCarolRetrospectiveTemplate')
+    .update({name: 'Christmas Retrospective'})
+    .run()
+}
+
+export const down = async function (r: R) {
+  //
+  await r
+    .table('MeetingTemplate')
+    .get('aChristmasCarolRetrospectiveTemplate')
+    .update({name: 'A Christmas Carol Retrospective'})
+    .run()
+}

--- a/packages/server/database/migrations/20221021163318-rename-christmas-template.ts
+++ b/packages/server/database/migrations/20221021163318-rename-christmas-template.ts
@@ -9,7 +9,6 @@ export const up = async function (r: R) {
 }
 
 export const down = async function (r: R) {
-  //
   await r
     .table('MeetingTemplate')
     .get('aChristmasCarolRetrospectiveTemplate')

--- a/packages/server/database/migrations/20221021163318-rename-christmas-template.ts
+++ b/packages/server/database/migrations/20221021163318-rename-christmas-template.ts
@@ -4,7 +4,7 @@ export const up = async function (r: R) {
   await r
     .table('MeetingTemplate')
     .get('aChristmasCarolRetrospectiveTemplate')
-    .update({name: 'Christmas Retrospective'})
+    .update({name: 'Christmas Retrospective 🎅🏼'})
     .run()
 }
 
@@ -12,6 +12,6 @@ export const down = async function (r: R) {
   await r
     .table('MeetingTemplate')
     .get('aChristmasCarolRetrospectiveTemplate')
-    .update({name: 'A Christmas Carol Retrospective'})
+    .update({name: 'A Christmas Carol Retrospective 🎅🏼'})
     .run()
 }


### PR DESCRIPTION
This PR renames the Christmas template following this request: https://parabol.slack.com/archives/C836NA350/p1666361083087839

The id of meeting templates is based on the template name, which isn't ideal. I've updated the template name which means its id is out of sync with the name. I think that's OK, but an alternative solution could be removing the template from the db and inserting a new template with the updated name & id. 

### To test

- [ ] Run the migration and see that the `A Christmas Carol Retrospective` name is now `Christmas Retrospective`