### PR TITLE
fix: add noindex for ppmis

### DIFF
--- a/packages/server/createSSR.ts
+++ b/packages/server/createSSR.ts
@@ -34,7 +34,10 @@ const getRaw = () => {
     const PROJECT_ROOT = path.join(__dirname, '../')
     const htmlPath = PROD ? './build/index.html' : './template.html'
     const html = fs.readFileSync(path.join(PROJECT_ROOT, htmlPath), 'utf8')
-    const extraHead = `<script>${dehydrate('__ACTION__', clientIds)}</script>`
+    // Hide staging & PPMIs from search engines
+    const noindex =
+      process.env.HOST === 'action.parabol.co' ? '' : `<meta name="robots" content="noindex"/>`
+    const extraHead = `${noindex}<script>${dehydrate('__ACTION__', clientIds)}</script>`
     const devBody = PROD
       ? ''
       : '<script src="/static/vendors.dll.js"></script><script src="/static/app.js"></script>'


### PR DESCRIPTION
# Description

Our PPMIs are showing up in google search results. See https://parabol.slack.com/archives/C4JAUUZ9P/p1666368289967199.

There are 2 ways to noindex them:
- Send a noindex header
- Add a noindex meta tag

Creating different rules for different hosts isn't great. it means staging !== production, but for a case like this, it's the only way.
I opted for using a meta tag for 2 reasons:
- our app is pretty stable (our infrastructure is about to change big time)
- we already do some noindexing for certain pages like invitation links. Nice to keep it all together

## Demo

- At time of release, when the new version is up on the staging server, change the env var HOST from action-staging.parabol.co to action.parabol.co this will trigger a server restart.
- goto the app & see that the meta tag exists. 

I'm sorry I can't test this before that point! Spinning up new servers for new PRs is coming soon :sweat_smile: 
