### PR TITLE
chore: Fix whitespace in links

### DIFF
--- a/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
+++ b/packages/client/components/EditorLinkChanger/EditorLinkChangerModal.tsx
@@ -57,14 +57,13 @@ interface Props {
 
 const EditorLinkChangerModal = (props: Props) => {
   const {originCoords, removeModal, link, text, handleSubmit, handleEscape} = props
-  const trimmedText = text ? text.trim() : ''
   const {menuPortal, openPortal} = useMenu(MenuPosition.UPPER_LEFT, {
     isDropdown: true,
     originCoords
   })
   const {setDirtyField, onChange, validateField, fields} = useForm({
     text: {
-      getDefault: () => trimmedText,
+      getDefault: () => text,
       validate: (value) =>
         new Legitity(value)
           .required()
@@ -108,11 +107,11 @@ const EditorLinkChangerModal = (props: Props) => {
   }
 
   const hasError = !!(fields.text.error || fields.link.error)
-  const label = !!trimmedText ? 'Update' : 'Add'
+  const label = !!text ? 'Update' : 'Add'
   return menuPortal(
     <ModalBoundary onBlur={handleBlur} onKeyDown={handleKeyDown} tabIndex={-1}>
       <form onSubmit={onSubmit}>
-        {trimmedText !== null && (
+        {text !== null && (
           <TextBlock>
             <InputLabel>{'Text'}</InputLabel>
             <InputBlock>
@@ -126,7 +125,7 @@ const EditorLinkChangerModal = (props: Props) => {
             <BasicInput
               {...fields.link}
               value={fields.link.value === null ? '' : fields.link.value}
-              autoFocus={!link && !!trimmedText}
+              autoFocus={!link && !!text}
               onChange={onChange}
               name='link'
               spellCheck={false}


### PR DESCRIPTION
# Description

Fixes #7088

The changes in #7078 were conflicting with the initial fix in #7089. We cannot trim the link title for the dialog so it doesn't match the selection anymore.

## Demo

https://www.loom.com/share/9fc2d4a4576445739e65e5fbb4ec02b0

## Testing scenarios

- [ ] In discussion select a word + whitespace
  - press <Ctrl> + K to open link dialog and enter link
  - [ ] see word is linked, but whitepsace is not but preserved

- [ ] in discussion link whitespace only
  - [ ] whitespace is converted to a link

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
