### PR TITLE
feat(standups): Added ended meeting view

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {PALETTE} from '~/styles/paletteV3'
+
+const TeamPromptEndedRoot = styled('div')({
+  borderRadius: 24,
+  height: 48,
+  backgroundColor: PALETTE.WHITE,
+  color: PALETTE.SLATE_700,
+  fontWeight: 500,
+  fontSize: 14,
+  padding: '8px 16px 8px 16px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: 'auto 0'
+})
+
+export const TeamPromptEndedBadge = () => {
+  return <TeamPromptEndedRoot>✅ This activity has ended.</TeamPromptEndedRoot>
+}

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -123,6 +123,7 @@ const TeamPromptResponseCard = (props: Props) => {
         meetingId
         meeting {
           ... on TeamPromptMeeting {
+            endedAt
             localStageId
             isRightDrawerOpen
           }
@@ -191,8 +192,11 @@ const TeamPromptResponseCard = (props: Props) => {
   const discussionEdges = discussion.thread.edges
   const replyCount = discussionEdges.length
 
-  const isCurrentViewer = userId === viewerId
-  const isEmptyResponse = !isCurrentViewer && !plaintextContent
+  const isMeetingEnded = !!meeting?.endedAt
+  const isViewerResponse = userId === viewerId
+  const isEmptyResponse = !isViewerResponse && !plaintextContent
+  const viewerEmptyResponsePlaceholder = isMeetingEnded ? 'No response' : 'Share your response...'
+  const nonViewerEmptyResponsePlaceholder = isMeetingEnded ? 'No response' : 'No response yet...'
 
   const {onError, onCompleted, submitMutation, submitting} = useMutationProps()
   const handleSubmit = useEventCallback((editorState: EditorState) => {
@@ -249,16 +253,16 @@ const TeamPromptResponseCard = (props: Props) => {
         isHighlighted={meeting?.isRightDrawerOpen && meeting?.localStageId === responseStage.id}
       >
         {isEmptyResponse ? (
-          'No response, yet...'
+          nonViewerEmptyResponsePlaceholder
         ) : (
           <>
             <PromptResponseEditor
               teamId={teamId}
-              autoFocus={isCurrentViewer}
+              autoFocus={isViewerResponse}
               handleSubmit={handleSubmit}
               content={contentJSON}
-              readOnly={!isCurrentViewer}
-              placeholder={'Share your response...'}
+              readOnly={!isViewerResponse || isMeetingEnded}
+              placeholder={viewerEmptyResponsePlaceholder}
             />
             {!!plaintextContent && (
               <ResponseCardFooter>

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -7,33 +7,60 @@ import {useRenameMeeting} from '~/hooks/useRenameMeeting'
 import NewMeetingAvatarGroup from '~/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
 import {PALETTE} from '~/styles/paletteV3'
 import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
-import {meetingAvatarMediaQueries} from '../../styles/meeting'
+import {meetingAvatarMediaQueries, meetingTopBarMediaQuery} from '../../styles/meeting'
 import EditableText from '../EditableText'
 import LogoBlock from '../LogoBlock/LogoBlock'
 import {IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
+import {TeamPromptEndedBadge} from './TeamPromptEndedBadge'
 import TeamPromptOptions from './TeamPromptOptions'
 
 const TeamPromptLogoBlock = styled(LogoBlock)({
   marginRight: '8px',
-  paddingLeft: '0'
+  paddingLeft: '0',
+  flexShrink: 0
 })
 
 const TeamPromptHeaderTitle = styled('h1')({
-  fontSize: 18,
+  fontSize: 16,
   lineHeight: '24px',
   margin: 0,
   padding: 0,
-  fontWeight: 600
+  fontWeight: 600,
+  [meetingTopBarMediaQuery]: {
+    fontSize: 18
+  }
 })
 
 const EditableTeamPromptHeaderTitle = TeamPromptHeaderTitle.withComponent(EditableText)
 
-const TeamPromptHeader = styled('div')({
+const MeetingTitleSection = styled('div')({
   margin: 'auto 0',
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  justifyContent: 'flex-start'
+  justifyContent: 'flex-start',
+  flex: 1
+})
+
+const MiddleSection = styled('div')({
+  margin: 'auto 0',
+  flex: 2,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center'
+})
+
+export const RightSection = styled(IconGroupBlock)({
+  margin: 'auto 0',
+  flex: 1,
+  display: 'flex',
+  justifyContent: 'flex-end'
+})
+
+export const RightSectionContainer = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
 })
 
 const ButtonContainer = styled('div')({
@@ -74,6 +101,7 @@ const TeamPromptTopBar = (props: Props) => {
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         id
         name
+        endedAt
         facilitatorUserId
         ...TeamPromptOptions_meeting
         ...NewMeetingAvatarGroup_meeting
@@ -83,13 +111,14 @@ const TeamPromptTopBar = (props: Props) => {
   )
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
-  const {id: meetingId, name: meetingName, facilitatorUserId} = meeting
+  const {id: meetingId, name: meetingName, facilitatorUserId, endedAt} = meeting
   const isFacilitator = viewerId === facilitatorUserId
   const {handleSubmit, validate, error} = useRenameMeeting(meetingId)
+  const isMeetingEnded = !!endedAt
 
   return (
     <MeetingTopBarStyles>
-      <TeamPromptHeader>
+      <MeetingTitleSection>
         <TeamPromptLogoBlock />
         {isFacilitator ? (
           <EditableTeamPromptHeaderTitle
@@ -104,14 +133,21 @@ const TeamPromptTopBar = (props: Props) => {
         ) : (
           <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
         )}
-      </TeamPromptHeader>
-      <IconGroupBlock>
-        {isDesktop && <BetaBadge>BETA</BetaBadge>}
-        <NewMeetingAvatarGroup meetingRef={meeting} />
-        <ButtonContainer>
-          <TeamPromptOptions meetingRef={meeting} />
-        </ButtonContainer>
-      </IconGroupBlock>
+      </MeetingTitleSection>
+      {isDesktop && isMeetingEnded && (
+        <MiddleSection>
+          <TeamPromptEndedBadge />
+        </MiddleSection>
+      )}
+      <RightSection>
+        <RightSectionContainer>
+          {isDesktop && <BetaBadge>BETA</BetaBadge>}
+          <NewMeetingAvatarGroup meetingRef={meeting} />
+          <ButtonContainer>
+            <TeamPromptOptions meetingRef={meeting} />
+          </ButtonContainer>
+        </RightSectionContainer>
+      </RightSection>
     </MeetingTopBarStyles>
   )
 }

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -69,6 +69,7 @@ const TeamPromptMeeting = (props: Props) => {
         ...TeamPromptTopBar_meeting
         ...TeamPromptDiscussionDrawer_meeting
         ...TeamPromptEditablePrompt_meeting
+        endedAt
         isRightDrawerOpen
         phases {
           ... on TeamPromptResponsesPhase {
@@ -124,8 +125,8 @@ const TeamPromptMeeting = (props: Props) => {
   }, [phase])
   const transitioningStages = useTransition(stages)
   const {safeRoute, isDesktop} = useMeeting(meeting)
-  const {isRightDrawerOpen} = meeting
-
+  const {isRightDrawerOpen, endedAt} = meeting
+  const isMeetingEnded = !!endedAt
   if (!safeRoute) return null
 
   return (
@@ -138,7 +139,7 @@ const TeamPromptMeeting = (props: Props) => {
               hideBottomBar={true}
             >
               <TeamPromptTopBar meetingRef={meeting} isDesktop={isDesktop} />
-              {!isDesktop && (
+              {!isDesktop && isMeetingEnded && (
                 <BadgeContainer>
                   <TeamPromptEndedBadge />
                 </BadgeContainer>

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -17,6 +17,7 @@ import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import MeetingStyles from './MeetingStyles'
 import TeamPromptDiscussionDrawer from './TeamPrompt/TeamPromptDiscussionDrawer'
 import TeamPromptEditablePrompt from './TeamPrompt/TeamPromptEditablePrompt'
+import {TeamPromptEndedBadge} from './TeamPrompt/TeamPromptEndedBadge'
 import {
   GRID_PADDING_LEFT_RIGHT_PERCENT,
   ResponsesGridBreakpoints
@@ -41,6 +42,12 @@ const ResponsesGrid = styled('div')({
   flexWrap: 'wrap',
   position: 'relative',
   gap: 32
+})
+
+const BadgeContainer = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center'
 })
 
 interface Props {
@@ -116,9 +123,7 @@ const TeamPromptMeeting = (props: Props) => {
     })
   }, [phase])
   const transitioningStages = useTransition(stages)
-
   const {safeRoute, isDesktop} = useMeeting(meeting)
-
   const {isRightDrawerOpen} = meeting
 
   if (!safeRoute) return null
@@ -133,6 +138,11 @@ const TeamPromptMeeting = (props: Props) => {
               hideBottomBar={true}
             >
               <TeamPromptTopBar meetingRef={meeting} isDesktop={isDesktop} />
+              {!isDesktop && (
+                <BadgeContainer>
+                  <TeamPromptEndedBadge />
+                </BadgeContainer>
+              )}
               <TeamPromptEditablePrompt meetingRef={meeting} />
               <ErrorBoundary>
                 <ResponsesGridContainer>

--- a/packages/client/components/promptResponse/tiptapConfig.ts
+++ b/packages/client/components/promptResponse/tiptapConfig.ts
@@ -98,6 +98,7 @@ export const createEditorExtensions = (
     openOnClick: isReadOnly
   }),
   Placeholder.configure({
+    showOnlyWhenEditable: false,
     placeholder
   }),
   Mention.extend({

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -18,7 +18,7 @@ graphql`
     meeting {
       id
       endedAt
-      teamId
+      ...TeamPromptMeeting_meeting
     }
     team {
       id

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -70,6 +70,7 @@ const safeEndTeamPrompt = async ({
   // TipTap-formatted responses on the server-side.
   // sendNewMeetingSummary(completedTeamPrompt, context).catch(console.log)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses)
+  dataLoader.get('newMeetings').clear(meetingId)
 
   const data = {
     meetingId,


### PR DESCRIPTION
# Description

Fixes #7298.

## Demo

![localhost_3000_meet_hMZzwiD1wk_responses(iPhone SE)](https://user-images.githubusercontent.com/1017620/198297527-e3cad0a5-5130-45ec-898e-b5679248af82.png)
![localhost_3000_meet_hMZzwiD1wk_responses](https://user-images.githubusercontent.com/1017620/198297249-63703514-bc34-4f04-bdca-b53482ad7b2e.png)

## Testing scenarios

- [ ] End the standup meeting, go back to the meeting and make sure the `✅ This activity has ended.` badge is visible
- [ ] Check the same on mobile
- [ ] It should not be possible to add a response after the meeting has ended
- [ ] Discussion thread should normally work when meeting has ended ie. user should be able to add a response

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
