### PR TITLE
fix: EstimateStage was broken for Jira if the issue could not be fetched

### DIFF
--- a/packages/server/graphql/types/EstimateStage.ts
+++ b/packages/server/graphql/types/EstimateStage.ts
@@ -61,7 +61,7 @@ const EstimateStage = new GraphQLObjectType<Source, GQLContext>({
       ) => {
         const {dataLoader, authToken} = context
         const viewerId = getUserId(authToken)
-        const NULL_FIELD = {name: '', type: 'string'}
+        const NULL_FIELD = {name: SprintPokerDefaults.SERVICE_FIELD_NULL, type: 'string'}
         const task = await dataLoader.get('tasks').load(taskId)
         if (!task) return NULL_FIELD
         const {integration} = task
@@ -86,7 +86,7 @@ const EstimateStage = new GraphQLObjectType<Source, GQLContext>({
               .get('jiraIssue')
               .load({teamId, userId: accessUserId, cloudId, issueKey, taskId, viewerId})
           ])
-          if (!jiraIssue) return null
+          if (!jiraIssue) return NULL_FIELD
           const {issueType, possibleEstimationFieldNames} = jiraIssue
 
           const dimensionFields = await dataLoader
@@ -122,7 +122,7 @@ const EstimateStage = new GraphQLObjectType<Source, GQLContext>({
           const jiraServerIssue = await dataLoader
             .get('jiraServerIssue')
             .load({providerId, teamId, userId: accessUserId, issueId})
-          if (!jiraServerIssue) return null
+          if (!jiraServerIssue) return NULL_FIELD
           const {issueType} = jiraServerIssue
 
           const existingDimensionField = await dataLoader


### PR DESCRIPTION
# Description

Hotfix

The `serviceField` field is non-null and will break the meeting when `null` is returned. Instead default to "Do not update". This breaks existing Sprint Poker meetings for some users.

## Demo

No demo, Sprint Poker with Jira issue can be opened normally.

## Testing scenarios

This bug occured when trying to open a Sprint Poker meeting with a Jira issue which cannot be fetched anymore. Not sure how to reproduce this exactly.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
