### PR TITLE
fix: fix stripe quantity mismatch error

### DIFF
--- a/packages/server/billing/helpers/processInvoiceItemHook.ts
+++ b/packages/server/billing/helpers/processInvoiceItemHook.ts
@@ -69,6 +69,16 @@ const processInvoiceItemHook = async (stripeSubscriptionId: string) => {
     return
   }
   const {id: hookId, type, prorationDate, isProrated, orgId, userId} = hook
+
+  const orgUsers = await r
+    .table('OrganizationUser')
+    .getAll(orgId, {index: 'orgId'})
+    .filter({
+      inactive: false,
+      removedAt: null
+    })
+    .run()
+
   const tentativeProrationDate = isProrated
     ? prorationDate ?? toEpochSeconds(new Date())
     : undefined
@@ -108,14 +118,6 @@ const processInvoiceItemHook = async (stripeSubscriptionId: string) => {
     .run()
 
   if (isFlushed) {
-    const orgUsers = await r
-      .table('OrganizationUser')
-      .getAll(orgId, {index: 'orgId'})
-      .filter({
-        inactive: false,
-        removedAt: null
-      })
-      .run()
     const orgUserCount = orgUsers.length
     if (orgUserCount !== nextQuantity) {
       insertStripeQuantityMismatchLogging(


### PR DESCRIPTION
Partially solves: #5325

See detailed explanation here: https://github.com/ParabolInc/parabol/issues/5325#issuecomment-1292336866

**How to test:**

- Create organization and upgrade to PRO
- Put some sleep `await new Promise(r => setTimeout(r, 10000));` in the code [here](https://github.com/ParabolInc/parabol/blob/master/packages/server/billing/helpers/processInvoiceItemHook.ts#L101)
- Create and login with 2 users in 2 different browsers
- Copy and paste the invite link for those users at the same time
- See no error quantity mismatch error
- Remove sleep, smoke test that stripe invoices are working fine when adding/removing users