### PR TITLE
fix: task integration demo bug

### DIFF
--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -275,6 +275,18 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         }
       }
     },
+    TaskFooterIntegrateMenuListLocalQuery: (
+      _teamId: unknown
+      // _networkOnly: boolean,
+      // _first: number
+    ) => {
+      const user = this.db.users[0]
+      return {
+        viewer: {
+          ...user
+        }
+      }
+    },
     NewMeetingSummaryQuery: () => {
       return {
         viewer: {

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -275,11 +275,7 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         }
       }
     },
-    TaskFooterIntegrateMenuListLocalQuery: (
-      _teamId: unknown
-      // _networkOnly: boolean,
-      // _first: number
-    ) => {
+    TaskFooterIntegrateMenuListLocalQuery: () => {
       const user = this.db.users[0]
       return {
         viewer: {

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -92,6 +92,7 @@ class DemoJiraRemoteProject {
   key: string
   name: string
   avatar: string
+  service: 'jira'
   avatarUrls = {
     x16: '',
     x24: '',
@@ -110,6 +111,7 @@ class DemoJiraRemoteProject {
     this.key = projectKey
     this.name = name
     this.avatar = avatar
+    this.service = 'jira'
   }
 }
 export const GitHubDemoKey = 'ParabolInc/ParabolDemo'
@@ -257,16 +259,16 @@ const initDemoTeamMember = (
       slack: initSlackAuth(userId)
     },
     repoIntegrations: {
-      hasMore: true,
+      hasMore: false,
       items: [
         new DemoJiraRemoteProject(JiraDemoProjectId),
         makeRepoIntegrationGitHub(GitHubDemoKey)
       ]
     },
-    allAvailableRepoIntegrations: [
-      new DemoJiraRemoteProject(JiraDemoProjectId),
-      new DemoJiraRemoteProject(JiraSecretProjectId)
-    ],
+    prevUsedRepoIntegrations: {
+      hasMore: false,
+      items: []
+    },
     teamId: demoTeamId,
     userId
   }


### PR DESCRIPTION
@MindEvo discovered a bug in the demo where you couldn't push tasks to integrations (see Rafa's message in Slack [here](https://parabol.slack.com/archives/C836NA350/p1666857871119549?thread_ts=1666780209.440339&cid=C836NA350)). 

This was because https://github.com/ParabolInc/parabol/pull/7234 added `TaskFooterIntegrateMenuListLocalQuery` which wasn't added to the demo. 

The same PR also requested the `service` field from the repoIntegration, which wasn't being returned in the `DemoJiraRemoteProject` demo class. 

### To test

- [ ] Can open the task integration menu in the demo
- [ ] Can push a task to GitHub & Jira