### PR TITLE
feat(timer picker): add 10 minutes option

### DIFF
--- a/packages/client/components/StageTimerMinutePicker.tsx
+++ b/packages/client/components/StageTimerMinutePicker.tsx
@@ -10,7 +10,7 @@ interface Props {
   setMinuteTimeLimit: (n: number) => void
 }
 
-const options = [...Array(9).keys()].map((n) => n + 1)
+const options = [...Array(10).keys()].map((n) => n + 1)
 
 const StageTimerMinutePicker = (props: Props) => {
   const {menuProps, minuteTimeLimit, setMinuteTimeLimit} = props


### PR DESCRIPTION
# Description

It allows to have 10 minutes in the timer, instead of having to select 9mins then 1min to add up to 10 minutes

<!--
## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]-->

## Testing scenarios

- [X] Scenario A
  - Open a timer
  - Select 10 Minutes


## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
