### PR TITLE
fix: Jira issues sometimes are not loading in poker meeting sidebar

### DIFF
--- a/packages/server/dataloader/atlassianLoaders.ts
+++ b/packages/server/dataloader/atlassianLoaders.ts
@@ -230,8 +230,9 @@ export const jiraIssue = (
             const possibleEstimationFieldNames = [] as string[]
             Object.entries<{schema: {type: string}}>(issueRes.editmeta?.fields)?.forEach(
               ([fieldId, {schema}]) => {
-                if (isValidEstimationField(schema.type, issueRes.names[fieldId], fieldId)) {
-                  possibleEstimationFieldNames.push(issueRes.names[fieldId])
+                const fieldName = issueRes.names[fieldId] ?? fieldId
+                if (isValidEstimationField(schema.type, fieldName, fieldId)) {
+                  possibleEstimationFieldNames.push(fieldName)
                 }
                 if (schema.type === 'timetracking') {
                   possibleEstimationFieldNames.push(issueRes.names['timeestimate'])


### PR DESCRIPTION
Fixes #7353

The issue happens because there is sometimes no field name exists `issueRes.names[fieldId]`

How to test:
- Simulate undefined field name `issueRes.names[fieldId]`
- Make sure poker meeting with jira work as expected
