### PR TITLE
fix(Azure DevOps): fix adding issues to Sprint Poker

### DIFF
--- a/packages/client/components/AzureDevOpsScopingSearchResults.tsx
+++ b/packages/client/components/AzureDevOpsScopingSearchResults.tsx
@@ -4,7 +4,6 @@ import React, {useState} from 'react'
 import {PreloadedQuery, useFragment, usePreloadedQuery} from 'react-relay'
 import useGetUsedServiceTaskIds from '~/hooks/useGetUsedServiceTaskIds'
 import MockScopingList from '~/modules/meeting/components/MockScopingList'
-import AzureDevOpsClientManager from '../utils/AzureDevOpsClientManager'
 import {AzureDevOpsScopingSearchResultsQuery} from '../__generated__/AzureDevOpsScopingSearchResultsQuery.graphql'
 import {AzureDevOpsScopingSearchResults_meeting$key} from '../__generated__/AzureDevOpsScopingSearchResults_meeting.graphql'
 import IntegrationScopingNoResults from './IntegrationScopingNoResults'
@@ -99,16 +98,6 @@ const AzureDevOpsScopingSearchResults = (props: Props) => {
   const usedServiceTaskIds = useGetUsedServiceTaskIds(estimatePhase)
   const handleAddIssueClick = () => setIsEditing(true)
 
-  const getProjectId = (url: URL) => {
-    const firstIndex = url.pathname.indexOf('/', 1)
-    const seconedIndex = url.pathname.indexOf('/', firstIndex + 1)
-    return url.pathname.substring(firstIndex + 1, seconedIndex)
-  }
-
-  const getServiceTaskId = (url: URL) => {
-    return AzureDevOpsClientManager.getInstanceId(url) + ':' + getProjectId(url)
-  }
-
   if (!edges) {
     return <MockScopingList />
   }
@@ -136,7 +125,7 @@ const AzureDevOpsScopingSearchResults = (props: Props) => {
             key={node.id}
             service={'azureDevOps'}
             usedServiceTaskIds={usedServiceTaskIds}
-            serviceTaskId={getServiceTaskId(new URL(node.url)) + ':' + node.id}
+            serviceTaskId={node.id}
             meetingId={meetingId}
             summary={node.title}
             url={node.url}


### PR DESCRIPTION
# Description

Adding ADO work items to Sprint Poker resulted in tasks which had an invalid issueKey and integrationHash because tenant and project were prepended twice.

## Demo

https://www.loom.com/share/a899f356ac8a45a7bdb8adcafc34d0de

## Testing scenarios

- [ ] Sprint Poker with ADO
  - [ ] add an issue to Sprint Poker and see it work
  - [ ] create a new issue in Sprint Poker and see it work

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
