### PR TITLE
chore: Remove @types/ioredis package

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,7 +33,6 @@
     "@types/dotenv": "^6.1.1",
     "@types/fbjs": "^3.0.2",
     "@types/graphql": "^14.5.0",
-    "@types/ioredis": "^4.28.10",
     "@types/jest": "^27.0.1",
     "@types/json2csv": "^5.0.3",
     "@types/jsonwebtoken": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5017,13 +5017,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ioredis@^4.28.10":
-  version "4.28.10"
-  resolved "https://registry.yarnpkg.com/@types/ioredis/-/ioredis-4.28.10.tgz#40ceb157a4141088d1394bb87c98ed09a75a06ff"
-  integrity sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"


### PR DESCRIPTION
# Description

Fixes: #7280 

The package is obsolete with the current ioredis version.

## Demo

No demo, nothing changed.

## Testing scenarios

- typecheck passes

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
