### PR TITLE
fix(Team): leave team does not work until refresh

### DIFF
--- a/packages/client/modules/teamDashboard/components/LeaveTeamModal/LeaveTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/LeaveTeamModal/LeaveTeamModal.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import DialogContainer from '../../../../components/DialogContainer'
 import DialogContent from '../../../../components/DialogContent'
 import DialogTitle from '../../../../components/DialogTitle'
@@ -10,7 +10,7 @@ import PrimaryButton from '../../../../components/PrimaryButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useRouter from '../../../../hooks/useRouter'
 import RemoveTeamMemberMutation from '../../../../mutations/RemoveTeamMemberMutation'
-import {LeaveTeamModal_teamMember} from '../../../../__generated__/LeaveTeamModal_teamMember.graphql'
+import {LeaveTeamModal_teamMember$key} from '../../../../__generated__/LeaveTeamModal_teamMember.graphql'
 
 const StyledDialogContainer = styled(DialogContainer)({
   width: 356
@@ -21,12 +21,20 @@ const StyledButton = styled(PrimaryButton)({
 })
 
 interface Props {
-  teamMember: LeaveTeamModal_teamMember
+  teamMember: LeaveTeamModal_teamMember$key
   closePortal: () => void
 }
 
 const LeaveTeamModal = (props: Props) => {
-  const {closePortal, teamMember} = props
+  const {closePortal, teamMember: teamMemberRef} = props
+  const teamMember = useFragment(
+    graphql`
+      fragment LeaveTeamModal_teamMember on TeamMember {
+        teamMemberId: id
+      }
+    `,
+    teamMemberRef
+  )
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   const {teamMemberId} = teamMember
@@ -50,10 +58,4 @@ const LeaveTeamModal = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(LeaveTeamModal, {
-  teamMember: graphql`
-    fragment LeaveTeamModal_teamMember on TeamMember {
-      teamMemberId: id
-    }
-  `
-})
+export default LeaveTeamModal

--- a/packages/client/modules/teamDashboard/components/ManageTeam/ManageTeamMember.tsx
+++ b/packages/client/modules/teamDashboard/components/ManageTeam/ManageTeamMember.tsx
@@ -36,7 +36,8 @@ const Name = styled('div')({
   fontWeight: 400,
   color: PALETTE.SLATE_700,
   lineHeight: '20px',
-  padding: '0px 16px'
+  padding: '0px 16px',
+  wordBreak: 'break-word'
 })
 
 const Content = styled('div')({

--- a/packages/client/mutations/RemoveTeamMemberMutation.ts
+++ b/packages/client/mutations/RemoveTeamMemberMutation.ts
@@ -155,6 +155,7 @@ export const removeTeamMemberTeamUpdater: SharedUpdater<RemoveTeamMemberMutation
   handleAddNotifications(notification, store)
 
   const removedTasks = payload.getLinkedRecords('updatedTasks')
+  if (!removedTasks) return
   const taskIds = removedTasks.map((task) => task.getValue('id'))
   handleRemoveTasks(taskIds, store)
 }


### PR DESCRIPTION
# Description

Fixes #6061 https://github.com/ParabolInc/parabol/issues/7291 https://github.com/ParabolInc/parabol/issues/7311
This issue occurs when leaving the team. When cleaning up the member's task list, an error occurs. So add compatible logic here, not let the error terminate subsequent mutation operations when tasks is `null`.

## Demo

Before: https://www.loom.com/share/a8d96b8141734f499dc74311a64aa5ac
After: https://www.loom.com/share/de2c205926d24440811486ae02203a5f

In the meantime, fixing a style issue with a name that was too long

Before|After
----|----
![Google Chrome-Team Dashboard  TOFU Squad-000759-20221102](https://user-images.githubusercontent.com/4997466/199480329-06d8aef2-5a6b-49e6-9eb8-0624ebb63ad6.png)|![Google Chrome-Team Dashboard  TOFU Squad-000757-20221102](https://user-images.githubusercontent.com/4997466/199480344-d7ac58b1-6c1f-4bfa-afec-208b0c33f5f6.png)

## Testing scenarios

- [ ] Invite to another team with another account, then
  - leave the team
  - check the nav team list

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
