### PR TITLE
chore: Fix isPatient0 migration runtime

### DIFF
--- a/packages/server/postgres/migrations/1666387804873_userPatient0.ts
+++ b/packages/server/postgres/migrations/1666387804873_userPatient0.ts
@@ -9,7 +9,7 @@ export async function up() {
     ADD COLUMN IF NOT EXISTS "isPatient0" BOOLEAN DEFAULT FALSE;
 
     DROP TABLE IF EXISTS "tmp_patient0";
-    SELECT DISTINCT ON ("domain") "domain", "id" INTO "tmp_patient0" FROM "User" ORDER BY "domain", "createdAt";
+    SELECT DISTINCT ON ("domain") "domain", "id" INTO TEMP "tmp_patient0" FROM "User" ORDER BY "domain", "createdAt";
     ALTER TABLE "tmp_patient0" ADD PRIMARY KEY ("id");
 
     UPDATE "User" u

--- a/packages/server/postgres/migrations/1666387804873_userPatient0.ts
+++ b/packages/server/postgres/migrations/1666387804873_userPatient0.ts
@@ -5,14 +5,18 @@ export async function up() {
   const client = new Client(getPgConfig())
   await client.connect()
   await client.query(`
-  ALTER TABLE "User"
-  ADD COLUMN IF NOT EXISTS "isPatient0" BOOLEAN DEFAULT FALSE;
-  `)
-  await client.query(`
-  UPDATE "User" u
-  SET "isPatient0" = COALESCE("createdAt" = (SELECT "createdAt" FROM "User" WHERE "domain" = u.domain ORDER BY "createdAt" LIMIT 1), false);
-  `)
-  await client.query(`
+    ALTER TABLE "User"
+    ADD COLUMN IF NOT EXISTS "isPatient0" BOOLEAN DEFAULT FALSE;
+
+    DROP TABLE IF EXISTS "tmp_patient0";
+    SELECT DISTINCT ON ("domain") "domain", "id" INTO "tmp_patient0" FROM "User" ORDER BY "domain", "createdAt";
+    ALTER TABLE "tmp_patient0" ADD PRIMARY KEY ("id");
+
+    UPDATE "User" u
+    SET "isPatient0" = COALESCE((SELECT true FROM "tmp_patient0" p0 WHERE u."id" = p0."id"), false) ;
+
+    DROP TABLE "tmp_patient0";
+
     ALTER TABLE "User"
     ALTER COLUMN "isPatient0" SET NOT NULL
   `)


### PR DESCRIPTION
# Description

The previous migration was too slow to run on production data and timed out. Solving this by creating a temporary table to read the patient 0 values from.

Previous version timed out after > 30 min while current version runs in < 2min on staging.

## Demo

![Screenshot from 2022-11-03 10-32-06](https://user-images.githubusercontent.com/7331043/199687687-5b235a1c-ad46-4d15-a24a-d2de8287a861.png)

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- Run migration on staging data
  - [ ] smoke test "isPatient0" values look correct

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
