### PR TITLE
fix:  header name should be more general

### DIFF
--- a/packages/client/components/EditorHelpModal/EditorHelpModal.tsx
+++ b/packages/client/components/EditorHelpModal/EditorHelpModal.tsx
@@ -198,7 +198,7 @@ const EditorHelpModal = (props: Props) => {
         <ModalHeaderIcon>
           <IconLabel icon='keyboard' iconLarge />
         </ModalHeaderIcon>
-        <ModalHeaderTitle>{'Task Card Formatting'}</ModalHeaderTitle>
+        <ModalHeaderTitle>{'Formatting Text'}</ModalHeaderTitle>
         <CloseButton icon='close' iconLarge onClick={handleCloseModal} palette='midGray' />
       </ModalHeader>
       <HeaderLabelBlock>


### PR DESCRIPTION
# Header name should be more General

Changed Header name from `Task Card Formatting` to ` Formatting Text `

Fixes/Partially Fixes #7245
Link to issue - https://github.com/ParabolInc/parabol/issues/7245

## After Bug is fixed

![Screenshot from 2022-10-14 10-56-55](https://user-images.githubusercontent.com/63657008/195793887-ebcd7009-48dd-44b1-a1ca-70b08de13397.png)




## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
