### PR TITLE
fix: task highlight sticks when adding a due date

### DIFF
--- a/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
+++ b/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {ContentState, convertToRaw} from 'draft-js'
 import React, {memo, useEffect, useRef, useState} from 'react'
 import {createFragmentContainer} from 'react-relay'
+import useClickAway from '~/hooks/useClickAway'
 import useScrollIntoView from '~/hooks/useScrollIntoVIew'
 import SetTaskHighlightMutation from '~/mutations/SetTaskHighlightMutation'
 import {OutcomeCardContainer_task} from '~/__generated__/OutcomeCardContainer_task.graphql'
@@ -100,14 +101,15 @@ const OutcomeCardContainer = memo((props: Props) => {
       UpdateTaskMutation(atmosphere, {updatedTask, area}, {})
     }
   }
-
   useScrollIntoView(ref, !contentState.hasText())
+  useClickAway(ref, () => setIsTaskHovered(false))
   return (
     <Wrapper
       tabIndex={-1}
       className={className}
       onMouseEnter={() => setIsTaskHovered(true)}
       onMouseLeave={() => setIsTaskHovered(false)}
+      onMouseOver={() => setIsTaskHovered(true)}
       ref={ref}
     >
       <OutcomeCard


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #7169

### Please include a summary 

- How to reproduce
- join a check-in with Hilde and Olga
- advance to solo update from Hilde with 2 tasks visible
- Hilde changes the due date of task 1 and moves the mouse to task 2

### Expected behaviour
Olga sees task 1 highlighted and then task 2

Actual behaviour
Olga sees task 1 still highlighted when Hilde moves to task 2, so both tasks are highlighted

### Demo 
[loom](https://www.loom.com/share/366055c8688b4ac69918ae6b0822abe9)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
