### PR TITLE
fix: add delete confirmation button and waiting effect

### DIFF
--- a/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeam.tsx
+++ b/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeam.tsx
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {ArchiveTeam_team} from '~/__generated__/ArchiveTeam_team.graphql'
+import {useFragment} from 'react-relay'
+import {ArchiveTeam_team$key} from '~/__generated__/ArchiveTeam_team.graphql'
 import IconLabel from '../../../../components/IconLabel'
 import LinkButton from '../../../../components/LinkButton'
 import {PALETTE} from '../../../../styles/paletteV3'
 import ArchiveTeamForm from './ArchiveTeamForm'
 
 interface Props {
-  team: ArchiveTeam_team
+  team: ArchiveTeam_team$key
 }
 
 const Hint = styled('div')({
@@ -19,7 +19,15 @@ const Hint = styled('div')({
 })
 
 const ArchiveTeam = (props: Props) => {
-  const {team} = props
+  const {team: teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment ArchiveTeam_team on Team {
+        ...ArchiveTeamForm_team
+      }
+    `,
+    teamRef
+  )
   const [showConfirmationField, setShowConfirmationField] = useState(false)
   const handleClick = () => {
     setShowConfirmationField(true)
@@ -49,10 +57,4 @@ const ArchiveTeam = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ArchiveTeam, {
-  team: graphql`
-    fragment ArchiveTeam_team on Team {
-      ...ArchiveTeamForm_team
-    }
-  `
-})
+export default ArchiveTeam

--- a/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeam.tsx
+++ b/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeam.tsx
@@ -32,7 +32,7 @@ const ArchiveTeam = (props: Props) => {
   const handleClick = () => {
     setShowConfirmationField(true)
   }
-  const handleFormBlur = () => {
+  const handleCancel = () => {
     setShowConfirmationField(false)
   }
   return (
@@ -51,7 +51,7 @@ const ArchiveTeam = (props: Props) => {
           </Hint>
         </div>
       ) : (
-        <ArchiveTeamForm handleFormBlur={handleFormBlur} team={team} />
+        <ArchiveTeamForm handleCancel={handleCancel} team={team} />
       )}
     </div>
   )

--- a/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeamForm.tsx
+++ b/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeamForm.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useForm from '~/hooks/useForm'
 import useMutationProps from '~/hooks/useMutationProps'
 import useRouter from '~/hooks/useRouter'
-import {ArchiveTeamForm_team} from '~/__generated__/ArchiveTeamForm_team.graphql'
+import {ArchiveTeamForm_team$key} from '~/__generated__/ArchiveTeamForm_team.graphql'
 import FieldLabel from '../../../../components/FieldLabel/FieldLabel'
 import BasicInput from '../../../../components/InputField/BasicInput'
 import ArchiveTeamMutation from '../../../../mutations/ArchiveTeamMutation'
@@ -13,7 +13,7 @@ import Legitity from '../../../../validation/Legitity'
 
 interface Props {
   handleFormBlur: () => any
-  team: ArchiveTeamForm_team
+  team: ArchiveTeamForm_team$key
 }
 
 const normalize = (str: string | undefined | null) => str && str.toLowerCase().replace('’', "'")
@@ -22,7 +22,16 @@ const ArchiveTeamForm = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
   const {history} = useRouter()
-  const {handleFormBlur, team} = props
+  const {handleFormBlur, team: teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment ArchiveTeamForm_team on Team {
+        id
+        name
+      }
+    `,
+    teamRef
+  )
   const {id: teamId, name: teamName} = team
   const {validateField, setDirtyField, onChange, fields} = useForm({
     archivedTeamName: {
@@ -70,11 +79,4 @@ const ArchiveTeamForm = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ArchiveTeamForm, {
-  team: graphql`
-    fragment ArchiveTeamForm_team on Team {
-      id
-      name
-    }
-  `
-})
+export default ArchiveTeamForm

--- a/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeamForm.tsx
+++ b/packages/client/modules/teamDashboard/components/ArchiveTeam/ArchiveTeamForm.tsx
@@ -1,6 +1,8 @@
+import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import SecondaryButton from '~/components/SecondaryButton'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useForm from '~/hooks/useForm'
 import useMutationProps from '~/hooks/useMutationProps'
@@ -8,11 +10,21 @@ import useRouter from '~/hooks/useRouter'
 import {ArchiveTeamForm_team$key} from '~/__generated__/ArchiveTeamForm_team.graphql'
 import FieldLabel from '../../../../components/FieldLabel/FieldLabel'
 import BasicInput from '../../../../components/InputField/BasicInput'
+import PrimaryButton from '../../../../components/PrimaryButton'
 import ArchiveTeamMutation from '../../../../mutations/ArchiveTeamMutation'
 import Legitity from '../../../../validation/Legitity'
 
+const ButtonGroup = styled('div')({
+  marginTop: 16,
+  display: 'flex'
+})
+
+const SubmitButton = styled(PrimaryButton)`
+  margin-right: 12px;
+`
+
 interface Props {
-  handleFormBlur: () => any
+  handleCancel: () => any
   team: ArchiveTeamForm_team$key
 }
 
@@ -22,7 +34,7 @@ const ArchiveTeamForm = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
   const {history} = useRouter()
-  const {handleFormBlur, team: teamRef} = props
+  const {handleCancel, team: teamRef} = props
   const team = useFragment(
     graphql`
       fragment ArchiveTeamForm_team on Team {
@@ -60,21 +72,30 @@ const ArchiveTeamForm = (props: Props) => {
   return (
     <form onSubmit={onSubmit}>
       <FieldLabel
+        customStyles={{
+          paddingTop: 0,
+          paddingLeft: 0
+        }}
         fieldSize='medium'
         htmlFor='archivedTeamName'
         indent
         inline
-        label='Enter your team name and hit Enter to delete it.'
+        label='Please type your team name to confirm and hit Enter to delete it.'
       />
       <BasicInput
         value={value}
         error={dirty ? error : undefined}
         onChange={onChange}
         autoFocus
-        onBlur={handleFormBlur}
         name='archivedTeamName'
-        placeholder='E.g. "My Team"'
+        placeholder={teamName}
       />
+      <ButtonGroup>
+        <SubmitButton type='submit' waiting={submitting}>
+          I understand the consequences, delete this team
+        </SubmitButton>
+        <SecondaryButton onClick={handleCancel}>Cancel</SecondaryButton>
+      </ButtonGroup>
     </form>
   )
 }


### PR DESCRIPTION
# Description

Fixes #6424

> I noticed that when I try to delete a team, it looks like nothing happens. But once I refresh the page the team is gone.

The 'delete team' feature should work, but the user interaction just makes it confusing, because: 
1. **The delete operation takes time**, but there is no indicator, like a loading effect when deleting. Only after deleted, there's a snackbar message "team has been archived"
2. **The confirmation button is not clear**, we use the text hint to confirm using the `Enter`, but using a red delete confirmation button like GitHub does might be clearer.

This PR added improvements for adding a **confirmation red button with the updated copy text and the waiting effect when deleting in progress**.

![Google Chrome-Team Settings  Yet Another Roam Team-000800-20221107](https://user-images.githubusercontent.com/4997466/200275747-42e092c2-2f6a-4e0d-a312-10a9d1345e52.png)

## Demo

Before|After
----|----
<video src="https://user-images.githubusercontent.com/4997466/200275426-a261f1ee-e144-4e93-9b30-7c4e215bfd20.mp4" />|<video src="https://user-images.githubusercontent.com/4997466/200275400-29b9fb12-20c2-491c-99a6-57d9e4f7b84e.mp4" />

## Testing scenarios

- [ ] Delete Team
  - create new test team
  - click 'delete team'
  - type the test team name
  - click the red button or hit "Enter"
  - waiting for deleted
  - see the snackbar message

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
