### PR TITLE
feat: end buggy meetings for user

### DIFF
--- a/packages/server/database/migrations/20221108160418-end-buggy-meeting.ts
+++ b/packages/server/database/migrations/20221108160418-end-buggy-meeting.ts
@@ -1,0 +1,20 @@
+import {R} from 'rethinkdb-ts'
+
+const buggyMeetingIds = ['hmcyIBcqI0', 'dqoFvbCljO']
+
+export const up = async function (r: R) {
+  const now = new Date()
+  await r
+    .table('NewMeeting')
+    .getAll(r.args(buggyMeetingIds))
+    .update({endedAt: now, commentCount: 0, storyCount: 0})
+    .run()
+}
+
+export const down = async function (r: R) {
+  await r
+    .table('NewMeeting')
+    .getAll(r.args(buggyMeetingIds))
+    .replace((row) => row.without('endedAt', 'commentCount', 'storyCount'))
+    .run()
+}

--- a/packages/server/database/migrations/20221108160418-end-buggy-meeting.ts
+++ b/packages/server/database/migrations/20221108160418-end-buggy-meeting.ts
@@ -1,7 +1,6 @@
 import {R} from 'rethinkdb-ts'
 
 const buggyMeetingIds = ['hmcyIBcqI0', 'dqoFvbCljO']
-
 export const up = async function (r: R) {
   const now = new Date()
   await r


### PR DESCRIPTION
A customer has two buggy meetings that live on their meetings view but they can't access them.

- I’ve impersonated the user and can see the broken meetings in their meetings view
- In graphiql, `promoteNewMeetingFacilitator` returns the error message “Team not found”. Querying the meeting from the user query returns null
- In rethinkdb, I can see that the user is a member of team `9WBjkXfUty` that created dodgy meeting `dqoFvbCljO` and the meeting doesn’t have an endedAt field
- I updated the meeting’s facilitatorId in rethinkdb, impersonated the user, clicked “End Meeting”, but still couldn’t end the meeting. After clicking "End Meeting", nothing would happen. I can see in the db that there still isn’t an endedAt field
- I ran the `endSprintPoker` mutation in graphql and got the error message: `Cannot find facilitator stage`

See [Slack thread](https://parabol.slack.com/archives/C836NA350/p1667908215574529?thread_ts=1667808030.637389&cid=C836NA350) for further context

I'm not yet sure how the two meetings ended up like this, but I suggest that we run this migration to remove the meetings from their meetings view.

We could update the `TimelineEvent` table, but we don't want anyone to try to re-enter the broken meetings, so I think it's best that the don't appear on the timeline. Therefore, it's safe for the comment & story count to be 0.

### To test

- [ ] Create a Sprint Poker meeting locally, leave it, and view it on the meetings view
- [ ] Run the up migration replacing the `buggyMeetingIds` with your meeting id
- [ ] See that the Sprint Poker meeting no longer exists on the meetings view
- [ ] Run the down migration and see that it has returned