### PR TITLE
fix: prompt highlight color does not cover the full-height of the column

### DIFF
--- a/packages/client/components/RetroReflectPhase/PhaseItemColumn.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemColumn.tsx
@@ -84,8 +84,8 @@ const ColorSpacer = styled('div')({
   width: 8,
   marginRight: 8
 })
-const ColumnColorDrop = styled('div')<{groupColor: string; isFocused: boolean}>(
-  ({groupColor, isFocused}) => ({
+const ColumnColorDrop = styled('div')<{groupColor: string; isDesktop: boolean; isFocused: boolean}>(
+  ({groupColor, isDesktop, isFocused}) => ({
     backgroundColor: groupColor,
     boxShadow: `0 0 0 1px ${PALETTE.SLATE_200}`,
     borderRadius: '50%',
@@ -96,7 +96,7 @@ const ColumnColorDrop = styled('div')<{groupColor: string; isFocused: boolean}>(
     height: 8,
     width: 8,
     top: 20, // must be out of layout  so it doesn't color the text
-    transform: `scale(${isFocused ? 163 : 1})`,
+    transform: `scale(${isFocused ? (isDesktop ? 200 : 350) : 1})`,
     transition: `all 300ms ${BezierCurve.DECELERATE}`,
     opacity: isFocused ? 0.35 : 1
   })
@@ -204,7 +204,7 @@ const PhaseItemColumn = (props: Props) => {
   return (
     <ColumnWrapper data-cy={`reflection-column-${question}`} isDesktop={isDesktop}>
       <ColumnHighlight isDesktop={isDesktop}>
-        <ColumnColorDrop isFocused={isFocused} groupColor={groupColor} />
+        <ColumnColorDrop isDesktop={isDesktop} isFocused={isFocused} groupColor={groupColor} />
         <ColumnContent isDesktop={isDesktop}>
           <HeaderAndEditor isDesktop={isDesktop}>
             <PromptHeader isClickable={isFacilitator && !isComplete} onClick={setColumnFocus}>


### PR DESCRIPTION
# Description

[From our UI refinement backlog 🔒](https://www.notion.so/parabol/UI-System-7860fc91e5024379a2d49e000458a914?p=dec72adfa88c45e290d2a577bb32f2ad&pm=s)

<img width="639" alt="Captura de Pantalla 2022-10-10 a la(s) 5 14 37 p m" src="https://user-images.githubusercontent.com/3276087/201186405-5c667b2c-951e-4711-bb09-36257734da71.png">

This PR increases the scale value used on the colored dot so it cover more area both in desktop and mobile sizes.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
