### PR TITLE
fix: snack on jira auth error

### DIFF
--- a/packages/client/mutations/AddAtlassianAuthMutation.ts
+++ b/packages/client/mutations/AddAtlassianAuthMutation.ts
@@ -34,7 +34,17 @@ const AddAtlassianAuthMutation: StandardMutation<TAddAtlassianAuthMutation> = (
   return commitMutation<TAddAtlassianAuthMutation>(atmosphere, {
     mutation,
     variables,
-    onCompleted,
+    onCompleted: (res, errors) => {
+      const error = res?.addAtlassianAuth?.error?.message
+      if (error) {
+        atmosphere.eventEmitter.emit('addSnackbar', {
+          autoDismiss: 0,
+          key: 'atlassianAuthError',
+          message: error
+        })
+      }
+      onCompleted(res, errors)
+    },
     onError
   })
 }

--- a/packages/server/graphql/mutations/addAtlassianAuth.ts
+++ b/packages/server/graphql/mutations/addAtlassianAuth.ts
@@ -39,13 +39,13 @@ export default {
     // RESOLUTION
     const oauthResponse = await AtlassianServerManager.init(code)
     if (oauthResponse instanceof Error) {
-      return standardError(oauthResponse, {userId: viewerId})
+      return standardError(new Error(`Jira: ${oauthResponse}`), {userId: viewerId})
     }
     const {accessToken, refreshToken} = oauthResponse
     const manager = new AtlassianServerManager(accessToken)
     const sites = await manager.getAccessibleResources()
     if (!Array.isArray(sites)) {
-      return standardError(new Error(sites.message), {userId: viewerId})
+      return standardError(new Error(`Jira: ${sites.message}`), {userId: viewerId})
     }
     const cloudIds = sites.map((cloud) => cloud.id)
     const cloudId = cloudIds[0]
@@ -54,7 +54,7 @@ export default {
     }
     const self = await manager.getMyself(cloudId)
     if (!('accountId' in self)) {
-      return standardError(new Error(self.message), {userId: viewerId})
+      return standardError(new Error(`Jira: ${self.message}`), {userId: viewerId})
     }
 
     // if there are the same Jira integrations existing we need to update them with new credentials as well


### PR DESCRIPTION
Signed-off-by: Matt Krick <matt.krick@gmail.com>

# Description

Fix #7430 when a jira tenant is unpaid, don't fail silently

Typically, errors should be propagated to an error message line that usually lives in a span below the input. This is nice because it shows _where_ the error hapened.
In this case, there are 4 instances where a user can add atlassian auth. 2 of those are in menus. showing error messages in menus is a bit ugly, so i opted to use the snackbar pattern everywhere.

## Demo

![Screenshot from 2022-11-15 12-11-00](https://user-images.githubusercontent.com/5514175/202016587-906d0fb5-226e-494f-88ce-1936060fbd9f.png)

## Testing scenarios

- create a new team, start a poker meeting & integrate with jira using an unpaid tenant. see a snack pop up
