### PR TITLE
feat(teams-limit): add limit exceeded and locking flags

### DIFF
--- a/packages/server/database/types/Organization.ts
+++ b/packages/server/database/types/Organization.ts
@@ -14,6 +14,9 @@ interface Input {
   updatedAt?: Date
   showConversionModal?: boolean
   payLaterClickCount?: number
+  tierLimitExceededAt?: Date
+  scheduledLockAt?: Date
+  lockedAt?: Date
 }
 
 export default class Organization {
@@ -32,6 +35,9 @@ export default class Organization {
   stripeSubscriptionId?: string | null
   upcomingInvoiceEmailSentAt?: Date
   tier: TierEnum
+  tierLimitExceededAt?: Date
+  scheduledLockAt?: Date
+  lockedAt?: Date
   updatedAt: Date
   constructor(input: Input) {
     const {
@@ -45,7 +51,10 @@ export default class Organization {
       showConversionModal,
       payLaterClickCount,
       picture,
-      tier
+      tier,
+      tierLimitExceededAt,
+      scheduledLockAt,
+      lockedAt
     } = input
     this.id = id || generateUID()
     this.activeDomain = activeDomain
@@ -58,5 +67,8 @@ export default class Organization {
     this.picture = picture
     this.showConversionModal = showConversionModal === null ? undefined : showConversionModal
     this.payLaterClickCount = payLaterClickCount || 0
+    this.tierLimitExceededAt = tierLimitExceededAt
+    this.scheduledLockAt = scheduledLockAt
+    this.lockedAt = lockedAt
   }
 }

--- a/packages/server/database/types/Organization.ts
+++ b/packages/server/database/types/Organization.ts
@@ -14,9 +14,6 @@ interface Input {
   updatedAt?: Date
   showConversionModal?: boolean
   payLaterClickCount?: number
-  tierLimitExceededAt?: Date
-  scheduledLockAt?: Date
-  lockedAt?: Date
 }
 
 export default class Organization {

--- a/packages/server/database/types/Organization.ts
+++ b/packages/server/database/types/Organization.ts
@@ -51,10 +51,7 @@ export default class Organization {
       showConversionModal,
       payLaterClickCount,
       picture,
-      tier,
-      tierLimitExceededAt,
-      scheduledLockAt,
-      lockedAt
+      tier
     } = input
     this.id = id || generateUID()
     this.activeDomain = activeDomain
@@ -67,8 +64,5 @@ export default class Organization {
     this.picture = picture
     this.showConversionModal = showConversionModal === null ? undefined : showConversionModal
     this.payLaterClickCount = payLaterClickCount || 0
-    this.tierLimitExceededAt = tierLimitExceededAt
-    this.scheduledLockAt = scheduledLockAt
-    this.lockedAt = lockedAt
   }
 }

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -73,6 +73,21 @@ type Organization {
   periodStart: DateTime
 
   """
+  Flag the organization as exceeding the tariff limits by setting a datetime
+  """
+  tierLimitExceededAt: DateTime
+
+  """
+  Schedule the organization to be locked at
+  """
+  scheduledLockAt: DateTime
+
+  """
+  Organization locked at
+  """
+  lockedAt: DateTime
+
+  """
   The total number of retroMeetings given to the team
   """
   retroMeetingsOffered: Int! @deprecated(reason: "Unlimited retros for all!")

--- a/packages/server/graphql/types/Organization.ts
+++ b/packages/server/graphql/types/Organization.ts
@@ -85,6 +85,18 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
       description: 'The datetime the current billing cycle starts',
       resolve: resolveForBillingLeaders('periodStart')
     },
+    tierLimitExceededAt: {
+      type: GraphQLISO8601Type,
+      description: 'Flag the organization as exceeding the tariff limits by setting a datetime'
+    },
+    scheduledLockAt: {
+      type: GraphQLISO8601Type,
+      description: 'Schedule the organization to be locked at'
+    },
+    lockedAt: {
+      type: GraphQLISO8601Type,
+      description: 'Organization locked at'
+    },
     retroMeetingsOffered: {
       deprecationReason: 'Unlimited retros for all!',
       type: new GraphQLNonNull(GraphQLInt),


### PR DESCRIPTION
Closes #7385

How to test:

Set flags on any org

http://localhost:8080/#dataexplorer
```
r.db('actionDevelopment').table('Organization').filter({
  id: 'ijVADO81eo'
}).update({
  tierLimitExceededAt: new Date('2021-01-01'),
  scheduledLockAt: new Date('2021-02-02') ,
  lockedAt: new Date('2021-03-03') 
})
```

Run query http://localhost:3000/admin/graphql

```
{
  viewer {
    organization(orgId: "ijVADO81eo") {
      tierLimitExceededAt
      scheduledLockAt
      lockedAt
    }
  }
}
```
