### PR TITLE
feat: focus on newly created template

### DIFF
--- a/packages/client/hooks/useActiveTopTemplate.ts
+++ b/packages/client/hooks/useActiveTopTemplate.ts
@@ -29,7 +29,7 @@ const useActiveTopTemplate = (
         })
       }
     }, 300)
-  }, [isActive, selectedTemplateId])
+  }, [isActive, selectedTemplateId, edges])
 }
 
 export default useActiveTopTemplate

--- a/packages/client/modules/meeting/components/EditableTemplateName.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplateName.tsx
@@ -30,6 +30,7 @@ const EditableTemplateName = (props: Props) => {
   const {name, templateId, teamTemplates, isOwner} = props
   const atmosphere = useAtmosphere()
   const {onError, error, onCompleted, submitMutation, submitting} = useMutationProps()
+  const autoFocus = name === '*New Template' || name.slice(-4) === 'Copy'
 
   const handleSubmit = (rawName: string) => {
     if (submitting) return
@@ -66,6 +67,7 @@ const EditableTemplateName = (props: Props) => {
   return (
     <InheritedStyles>
       <StyledEditableText
+        autoFocus={autoFocus}
         disabled={!isOwner}
         error={error ? error.message : undefined}
         handleSubmit={handleSubmit}

--- a/packages/client/utils/relay/setActiveTemplate.ts
+++ b/packages/client/utils/relay/setActiveTemplate.ts
@@ -6,14 +6,14 @@ import Atmosphere from '../../Atmosphere'
 const setActiveTemplateInRelayStore = (
   store: RecordSourceProxy,
   teamId: string,
-  templateId: string | null,
+  templateId: string,
   meetingType: MeetingTypeEnum
 ) => {
   const team = store.get(teamId)
   if (!team) return
   const meetingSettings = team.getLinkedRecord('meetingSettings', {meetingType: meetingType})
   if (!meetingSettings) return
-  const activeTemplate = templateId ? store.get(templateId)! : null
+  const activeTemplate = store.get(templateId)
   if (activeTemplate) {
     meetingSettings.setLinkedRecord(activeTemplate, 'activeTemplate')
   } else {
@@ -24,7 +24,7 @@ const setActiveTemplateInRelayStore = (
 const setActiveTemplate = (
   atmosphere: Atmosphere,
   teamId: string,
-  templateId: string | null,
+  templateId: string,
   meetingType: MeetingTypeEnum
 ) => {
   commitLocalUpdate(atmosphere, (store) => {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7240

Demo: https://www.loom.com/share/f72494cfa44b4b8185de636df04c3b45

### To test

- [ ] Create a new template and see that the newly created template item (the item in the list on the left) is highlighted
- [ ] See that the newly created template's title is autofocused
- [ ] Clone a template and see that the template item is highlighted and the title is autofocused
- [ ] Templates that are not newly created don't have their titles autofocused