### PR TITLE
fix(dx): Run all yarn clean commands, even if one fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "pm2-runtime start pm2.config.js",
     "heroku-postbuild": "echo 'Skipping build'",
     "build": "node scripts/prod.js",
-    "clean": "rm -rf ./packages/client/__generated__; rm ./queryMap.json; rm ./packages/server/graphql/public/schema.graphql; rm ./packages/server/graphql/private/schema.graphql; rm -rf ./dev; rm -rf ./dist; rm -rf ./build",
+    "clean": "rm -rf ./packages/client/__generated__ ./queryMap.json ./packages/server/graphql/public/schema.graphql ./packages/server/graphql/private/schema.graphql ./dev ./dist ./build",
     "codegen": "node scripts/codegenGraphQL.js",
     "pg:build": "pgtyped -c ./packages/server/postgres/pgtypedConfig.js",
     "pg:migrate": "node-pg-migrate -f ./packages/server/postgres/pgmConfig.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "pm2-runtime start pm2.config.js",
     "heroku-postbuild": "echo 'Skipping build'",
     "build": "node scripts/prod.js",
-    "clean": "rm -rf ./packages/client/__generated__ && rm ./queryMap.json && rm ./packages/server/graphql/public/schema.graphql && rm ./packages/server/graphql/private/schema.graphql && rm -rf ./dev && rm -rf ./dist && rm -rf ./build",
+    "clean": "rm -rf ./packages/client/__generated__; rm ./queryMap.json; rm ./packages/server/graphql/public/schema.graphql; rm ./packages/server/graphql/private/schema.graphql; rm -rf ./dev; rm -rf ./dist; rm -rf ./build",
     "codegen": "node scripts/codegenGraphQL.js",
     "pg:build": "pgtyped -c ./packages/server/postgres/pgtypedConfig.js",
     "pg:migrate": "node-pg-migrate -f ./packages/server/postgres/pgmConfig.js",


### PR DESCRIPTION
# Description
`yarn clean` will fail if certain expected files are missing due to the use of the `&&` operator. Instead, use `;`, which will run all commands regardless of the result of the preceding commands.

## Testing scenarios
Run `yarn clean`, then running `yarn clean` again and see that all commands are still executed.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
