### PR TITLE
feat: prevent creating new templates from server

### DIFF
--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -4,6 +4,7 @@ import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import PokerTemplate from '../../database/types/PokerTemplate'
 import TemplateDimension from '../../database/types/TemplateDimension'
+import {getUserById} from '../../postgres/queries/getUsersByIds'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -53,7 +54,9 @@ const addPokerTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    if (viewerTeam.tier === 'personal') {
+    const viewer = await getUserById(viewerId)
+    const hasTemplateLimitFlag = viewer?.featureFlags?.includes('templateLimit')
+    if (viewerTeam.tier === 'personal' && hasTemplateLimitFlag) {
       return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
     }
     let data

--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -4,7 +4,6 @@ import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import PokerTemplate from '../../database/types/PokerTemplate'
 import TemplateDimension from '../../database/types/TemplateDimension'
-import {getUserById} from '../../postgres/queries/getUsersByIds'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -54,8 +53,8 @@ const addPokerTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    const viewer = await getUserById(viewerId)
-    const hasTemplateLimitFlag = viewer?.featureFlags?.includes('templateLimit')
+    const viewer = await dataLoader.get('users').loadNonNull(viewerId)
+    const hasTemplateLimitFlag = viewer.featureFlags.includes('templateLimit')
     if (viewerTeam.tier === 'personal' && hasTemplateLimitFlag) {
       return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
     }

--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -53,6 +53,9 @@ const addPokerTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
+    if (viewerTeam.tier === 'personal') {
+      return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
+    }
     let data
     if (parentTemplateId) {
       const parentTemplate = await dataLoader.get('meetingTemplates').load(parentTemplateId)

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -54,6 +54,9 @@ const addReflectTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
+    if (viewerTeam.tier === 'personal') {
+      return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
+    }
     let data
     if (parentTemplateId) {
       const parentTemplate = await dataLoader.get('meetingTemplates').load(parentTemplateId)

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -5,6 +5,7 @@ import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import ReflectTemplate from '../../database/types/ReflectTemplate'
 import RetrospectivePrompt from '../../database/types/RetrospectivePrompt'
+import {getUserById} from '../../postgres/queries/getUsersByIds'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -54,7 +55,9 @@ const addReflectTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    if (viewerTeam.tier === 'personal') {
+    const viewer = await getUserById(viewerId)
+    const hasTemplateLimitFlag = viewer?.featureFlags?.includes('templateLimit')
+    if (viewerTeam.tier === 'personal' && hasTemplateLimitFlag) {
       return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
     }
     let data

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -5,7 +5,6 @@ import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import ReflectTemplate from '../../database/types/ReflectTemplate'
 import RetrospectivePrompt from '../../database/types/RetrospectivePrompt'
-import {getUserById} from '../../postgres/queries/getUsersByIds'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
@@ -55,8 +54,8 @@ const addReflectTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    const viewer = await getUserById(viewerId)
-    const hasTemplateLimitFlag = viewer?.featureFlags?.includes('templateLimit')
+    const viewer = await dataLoader.get('users').loadNonNull(viewerId)
+    const hasTemplateLimitFlag = viewer.featureFlags.includes('templateLimit')
     if (viewerTeam.tier === 'personal' && hasTemplateLimitFlag) {
       return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
     }


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7487

### To test

- [ ] Update the client so a user on the free team can create a new retro template or clone an existing one, i.e. remove https://github.com/ParabolInc/parabol/blob/a7f18329d9a5047831b28a06feb572918f08e478/packages/client/modules/meeting/components/AddNewReflectTemplate.tsx#L81 and set `showClone` to `true` in https://github.com/ParabolInc/parabol/blob/8043bce3f29688e84d51fc7f57d35bec79142560/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx#L160
- [ ] Try to create a new template and see that it's not possible as `addReflectTemplate` returns an error
- [ ] Do the same for Poker and see that `addPokerTemplate` returns an error
