### PR TITLE
fix: There should be no scroll bar on task header

### DIFF
--- a/packages/client/modules/userDashboard/components/UserTasksHeader/UserTasksHeader.tsx
+++ b/packages/client/modules/userDashboard/components/UserTasksHeader/UserTasksHeader.tsx
@@ -72,7 +72,8 @@ const StyledCheckbox = styled(Checkbox)({
 const UserTasksHeaderDashSectionControls = styled(DashSectionControls)({
   justifyContent: 'flex-start',
   flexWrap: 'wrap',
-  width: '100%'
+  width: '100%',
+  overflow: 'initial'
 })
 
 interface Props {


### PR DESCRIPTION
## Description
Removing the scrollbar that exist on the task page header

## Step to reproduce Bug

- Open app on a Mobile devices or web
- Navigate to task page
- scroll the navbar on the page

## Demo
[loom](https://www.loom.com/share/136b5e73f30747288a170dedb1e8ad11)

## Testing scenarios

- [x] Test if the scrollbar still exist on the navbar section of the task page.


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog



### Ref
[Ticket Link](https://developers.gitstart.com/ticket/PARA-7456)
Gitstart issues link https://github.com/GitStartHQ/client-parabolinc-parabol/issues/31
Pull from https://github.com/ParabolInc/parabol/issues/7456
