### PR TITLE
chore: Limit meeting history on timeline

### DIFF
--- a/packages/client/components/TimelineEventCard.tsx
+++ b/packages/client/components/TimelineEventCard.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import {AccountCircle, ChangeHistory, GroupAdd, GroupWork, History} from '@mui/icons-material'
+import {AccountCircle, ChangeHistory, GroupAdd, GroupWork, History, Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactNode} from 'react'
 import {createFragmentContainer} from 'react-relay'
@@ -76,7 +76,8 @@ const TimelineEventCard = (props: Props) => {
                   history: <History />,
                   account_circle: <AccountCircle />,
                   group_add: <GroupAdd />,
-                  group_work: <GroupWork />
+                  group_work: <GroupWork />,
+                  lock: <Lock />
                 }[iconName]
               }
             </EventIcon>

--- a/packages/client/components/TimelineEventCard.tsx
+++ b/packages/client/components/TimelineEventCard.tsx
@@ -61,6 +61,10 @@ const HeaderText = styled('div')({
   paddingTop: 2
 })
 
+const GrapeLock = styled(Lock)({
+  color: PALETTE.GRAPE_500
+})
+
 const TimelineEventCard = (props: Props) => {
   const {children, iconName, IconSVG, title, timelineEvent} = props
   const {id: timelineEventId, createdAt, type} = timelineEvent
@@ -77,7 +81,7 @@ const TimelineEventCard = (props: Props) => {
                   account_circle: <AccountCircle />,
                   group_add: <GroupAdd />,
                   group_work: <GroupWork />,
-                  lock: <Lock />
+                  lock: <GrapeLock />
                 }[iconName]
               }
             </EventIcon>

--- a/packages/client/components/TimelineEventCompletedActionMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedActionMeeting.tsx
@@ -32,7 +32,8 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
     endedAt,
     agendaItemCount,
     commentCount,
-    taskCount
+    taskCount,
+    locked
   } = meeting
   const {name: teamName} = team
   const meetingDuration = relativeDate(createdAt, {
@@ -43,7 +44,7 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
   })
   return (
     <TimelineEventCard
-      iconName='change_history'
+      iconName={locked ? 'lock' : 'change_history'}
       timelineEvent={timelineEvent}
       title={<TimelineEventTitle>{`${meetingName} with ${teamName} Complete`}</TimelineEventTitle>}
     >
@@ -55,9 +56,18 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
         {' and '}
         <CountItem>{`${commentCount} ${plural(commentCount, 'comment')}.`}</CountItem>
         <br />
-        <Link to={`/meet/${meetingId}/agendaitems/1`}>See the discussion</Link>
-        {' in your meeting or '}
-        <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+        {locked ? (
+          <>
+            <Link to={`/meet/${meetingId}/agendaitems/1`}>Upgrade now</Link> to see the discussion
+            in your meeting or review a summary
+          </>
+        ) : (
+          <>
+            <Link to={`/meet/${meetingId}/agendaitems/1`}>See the discussion</Link>
+            {' in your meeting or '}
+            <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+          </>
+        )}
       </TimelineEventBody>
     </TimelineEventCard>
   )
@@ -77,6 +87,7 @@ export default createFragmentContainer(TimelineEventCompletedActionMeeting, {
         endedAt
         name
         taskCount
+        locked
       }
       team {
         id

--- a/packages/client/components/TimelineEventCompletedActionMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedActionMeeting.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import useAtmosphere from '../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import relativeDate from '../utils/date/relativeDate'
 import plural from '../utils/plural'
 import {TimelineEventCompletedActionMeeting_timelineEvent} from '../__generated__/TimelineEventCompletedActionMeeting_timelineEvent.graphql'
@@ -35,7 +37,19 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
     taskCount,
     locked
   } = meeting
-  const {name: teamName} = team
+  const {name: teamName, orgId} = team
+
+  const atmosphere = useAtmosphere()
+  const onUpgrade = () => {
+    SendClientSegmentEventMutation(
+      atmosphere,
+      'Timeline History Locked Meeting Upgrade CTA Clicked',
+      {
+        meetingId
+      }
+    )
+  }
+
   const meetingDuration = relativeDate(createdAt, {
     now: endedAt,
     max: 2,
@@ -58,8 +72,10 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
         <br />
         {locked ? (
           <>
-            <Link to={`/meet/${meetingId}/agendaitems/1`}>Upgrade now</Link> to see the discussion
-            in your meeting or review a summary
+            <Link to={`/me/organizations/${orgId}`} onClick={onUpgrade}>
+              Upgrade now
+            </Link>{' '}
+            to see the discussion in your meeting or review a summary
           </>
         ) : (
           <>
@@ -92,6 +108,7 @@ export default createFragmentContainer(TimelineEventCompletedActionMeeting, {
       team {
         id
         name
+        orgId
       }
     }
   `

--- a/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import useAtmosphere from '../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import plural from '../utils/plural'
 import {TimelineEventCompletedRetroMeeting_timelineEvent} from '../__generated__/TimelineEventCompletedRetroMeeting_timelineEvent.graphql'
 import StyledLink from './StyledLink'
@@ -33,7 +35,19 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
     taskCount,
     locked
   } = meeting
-  const {name: teamName} = team
+  const {name: teamName, orgId} = team
+
+  const atmosphere = useAtmosphere()
+  const onUpgrade = () => {
+    SendClientSegmentEventMutation(
+      atmosphere,
+      'Timeline History Locked Meeting Upgrade CTA Clicked',
+      {
+        meetingId
+      }
+    )
+  }
+
   return (
     <TimelineEventCard
       iconName={locked ? 'lock' : 'history'}
@@ -63,8 +77,10 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
         <br />
         {locked ? (
           <>
-            <Link to={`/meet/${meetingId}/discuss/1`}>Upgrade now</Link> to get access to the
-            summary and discussion
+            <Link to={`/me/organizations/${orgId}`} onClick={onUpgrade}>
+              Upgrade now
+            </Link>{' '}
+            to get access to the summary and discussion
           </>
         ) : (
           <>
@@ -95,6 +111,7 @@ export default createFragmentContainer(TimelineEventCompletedRetroMeeting, {
       team {
         id
         name
+        orgId
       }
     }
   `

--- a/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
@@ -30,12 +30,13 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
     commentCount,
     reflectionCount,
     topicCount,
-    taskCount
+    taskCount,
+    locked
   } = meeting
   const {name: teamName} = team
   return (
     <TimelineEventCard
-      iconName='history'
+      iconName={locked ? 'lock' : 'history'}
       timelineEvent={timelineEvent}
       title={<TimelineEventTitle>{`${meetingName} with ${teamName} Complete`}</TimelineEventTitle>}
     >
@@ -60,9 +61,18 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
         </CountItem>
         {'.'}
         <br />
-        <Link to={`/meet/${meetingId}/discuss/1`}>See the discussion</Link>
-        {' in your meeting or '}
-        <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+        {locked ? (
+          <>
+            <Link to={`/meet/${meetingId}/discuss/1`}>Upgrade now</Link> to get access to the
+            summary and discussion
+          </>
+        ) : (
+          <>
+            <Link to={`/meet/${meetingId}/discuss/1`}>See the discussion</Link>
+            {' in your meeting or '}
+            <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+          </>
+        )}
       </TimelineEventBody>
     </TimelineEventCard>
   )
@@ -80,6 +90,7 @@ export default createFragmentContainer(TimelineEventCompletedRetroMeeting, {
         reflectionCount
         taskCount
         topicCount
+        locked
       }
       team {
         id

--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
+import useAtmosphere from '../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import plural from '../utils/plural'
 import {TimelineEventPokerComplete_timelineEvent} from '../__generated__/TimelineEventPokerComplete_timelineEvent.graphql'
 import CardsSVG from './CardsSVG'
@@ -26,7 +28,19 @@ const TimelineEventPokerComplete = (props: Props) => {
   const {timelineEvent} = props
   const {meeting, team} = timelineEvent
   const {id: meetingId, name: meetingName, commentCount, storyCount, locked} = meeting
-  const {name: teamName} = team
+  const {name: teamName, orgId} = team
+
+  const atmosphere = useAtmosphere()
+  const onUpgrade = () => {
+    SendClientSegmentEventMutation(
+      atmosphere,
+      'Timeline History Locked Meeting Upgrade CTA Clicked',
+      {
+        meetingId
+      }
+    )
+  }
+
   return (
     <TimelineEventCard
       IconSVG={locked ? undefined : <CardsSVG />}
@@ -47,8 +61,10 @@ const TimelineEventPokerComplete = (props: Props) => {
         <br />
         {locked ? (
           <>
-            <Link to={`/meet/${meetingId}/discuss/1`}>Upgrade now</Link> to get access to the
-            estimates and summary
+            <Link to={`/me/organizations/${orgId}`} onClick={onUpgrade}>
+              Upgrade now
+            </Link>{' '}
+            to get access to the estimates and summary
           </>
         ) : (
           <>
@@ -85,6 +101,7 @@ export default createFragmentContainer(TimelineEventPokerComplete, {
       team {
         id
         name
+        orgId
       }
     }
   `

--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -25,11 +25,12 @@ const Link = styled(StyledLink)({
 const TimelineEventPokerComplete = (props: Props) => {
   const {timelineEvent} = props
   const {meeting, team} = timelineEvent
-  const {id: meetingId, name: meetingName, commentCount, storyCount} = meeting
+  const {id: meetingId, name: meetingName, commentCount, storyCount, locked} = meeting
   const {name: teamName} = team
   return (
     <TimelineEventCard
-      IconSVG={<CardsSVG />}
+      IconSVG={locked ? undefined : <CardsSVG />}
+      iconName={locked ? 'lock' : undefined}
       timelineEvent={timelineEvent}
       title={<TimelineEventTitle>{`${meetingName} with ${teamName} Complete`}</TimelineEventTitle>}
     >
@@ -44,9 +45,18 @@ const TimelineEventPokerComplete = (props: Props) => {
         </CountItem>
         {'.'}
         <br />
-        <Link to={`/meet/${meetingId}/estimate/1`}>See the estimates</Link>
-        {' in your meeting or '}
-        <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+        {locked ? (
+          <>
+            <Link to={`/meet/${meetingId}/discuss/1`}>Upgrade now</Link> to get access to the
+            estimates and summary
+          </>
+        ) : (
+          <>
+            <Link to={`/meet/${meetingId}/estimate/1`}>See the estimates</Link>
+            {' in your meeting or '}
+            <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+          </>
+        )}
       </TimelineEventBody>
     </TimelineEventCard>
   )
@@ -70,6 +80,7 @@ export default createFragmentContainer(TimelineEventPokerComplete, {
             }
           }
         }
+        locked
       }
       team {
         id

--- a/packages/client/components/TimelineEventTeamPromptComplete.tsx
+++ b/packages/client/components/TimelineEventTeamPromptComplete.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import useAtmosphere from '../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import plural from '../utils/plural'
 import {TimelineEventTeamPromptComplete_timelineEvent$key} from '../__generated__/TimelineEventTeamPromptComplete_timelineEvent.graphql'
 import StyledLink from './StyledLink'
@@ -39,6 +41,7 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
         team {
           id
           name
+          orgId
         }
       }
     `,
@@ -51,7 +54,18 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
   }
 
   const {id: meetingId, name: meetingName, responseCount, commentCount, taskCount, locked} = meeting
-  const {name: teamName} = team
+  const {name: teamName, orgId} = team
+
+  const atmosphere = useAtmosphere()
+  const onUpgrade = () => {
+    SendClientSegmentEventMutation(
+      atmosphere,
+      'Timeline History Locked Meeting Upgrade CTA Clicked',
+      {
+        meetingId
+      }
+    )
+  }
 
   return (
     <TimelineEventCard
@@ -78,8 +92,10 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
         <br />
         {locked ? (
           <>
-            <Link to={`/meet/${meetingId}/responses`}>Upgrade now</Link> to see responses and
-            discussion or review a summary
+            <Link to={`/me/organizations/${orgId}`} onClick={onUpgrade}>
+              Upgrade now
+            </Link>{' '}
+            to see responses and discussion or review a summary
           </>
         ) : (
           <>

--- a/packages/client/components/TimelineEventTeamPromptComplete.tsx
+++ b/packages/client/components/TimelineEventTeamPromptComplete.tsx
@@ -34,6 +34,7 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
           responseCount
           taskCount
           commentCount
+          locked
         }
         team {
           id
@@ -49,12 +50,12 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
     return null
   }
 
-  const {id: meetingId, name: meetingName, responseCount, commentCount, taskCount} = meeting
+  const {id: meetingId, name: meetingName, responseCount, commentCount, taskCount, locked} = meeting
   const {name: teamName} = team
 
   return (
     <TimelineEventCard
-      iconName='group_work'
+      iconName={locked ? 'lock' : 'group_work'}
       timelineEvent={timelineEvent}
       title={<TimelineEventTitle>{`${meetingName} with ${teamName}`}</TimelineEventTitle>}
     >
@@ -75,9 +76,18 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
         </CountItem>
         {'.'}
         <br />
-        <Link to={`/meet/${meetingId}/responses`}>See responses and discussions</Link>
-        {' or '}
-        <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+        {locked ? (
+          <>
+            <Link to={`/meet/${meetingId}/responses`}>Upgrade now</Link> to see responses and
+            discussion or review a summary
+          </>
+        ) : (
+          <>
+            <Link to={`/meet/${meetingId}/responses`}>See responses and discussions</Link>
+            {' or '}
+            <Link to={`/new-summary/${meetingId}`}>review a summary</Link>
+          </>
+        )}
       </TimelineEventBody>
     </TimelineEventCard>
   )

--- a/packages/client/components/TimelineFeedList.tsx
+++ b/packages/client/components/TimelineFeedList.tsx
@@ -1,16 +1,12 @@
 import styled from '@emotion/styled'
-import {Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
 import {usePaginationFragment} from 'react-relay'
 import useLoadNextOnScrollBottom from '~/hooks/useLoadNextOnScrollBottom'
-import {cardShadow} from '../styles/elevation'
-import {PALETTE} from '../styles/paletteV3'
 import {TimelineFeedListPaginationQuery} from '../__generated__/TimelineFeedListPaginationQuery.graphql'
 import {TimelineFeedList_query$key} from '../__generated__/TimelineFeedList_query.graphql'
-import PrimaryButton from './PrimaryButton'
 import TimelineEvent from './TimelineEvent'
-import TimelineEventTitle from './TImelineEventTitle'
+import TimelineHistoryLockedCard from './TimelineHistoryLockedCard'
 
 const ResultScroller = styled('div')({
   overflow: 'auto'
@@ -19,50 +15,6 @@ const ResultScroller = styled('div')({
 interface Props {
   queryRef: TimelineFeedList_query$key
 }
-
-const Surface = styled('div')({
-  background: '#FFFFFF',
-  borderRadius: 4,
-  boxShadow: cardShadow,
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  marginBottom: 16,
-  overflow: 'hidden',
-  position: 'relative',
-  padding: 16,
-  width: '100%'
-})
-
-const TimelineEventBody = styled('div')({
-  padding: '0 16px 16px 16px',
-  fontSize: 14,
-  lineHeight: '20px',
-  textAlign: 'center'
-})
-
-const EventIcon = styled('div')({
-  borderRadius: '100%',
-  color: PALETTE.GRAPE_500,
-  display: 'block',
-  userSelect: 'none',
-  height: 40,
-  width: 40,
-  svg: {
-    height: 40,
-    width: 40
-  }
-})
-
-const HeaderText = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  fontSize: 14,
-  justifyContent: 'space-around',
-  lineHeight: '20px',
-  margin: '16px 16px 8px',
-  paddingTop: 2
-})
 
 const TimelineFeedList = (props: Props) => {
   const {queryRef} = props
@@ -85,7 +37,7 @@ const TimelineFeedList = (props: Props) => {
                 id
                 teamId
                 team {
-                  name
+                  ...TimelineHistoryLockedCard_team
                 }
                 ... on TimelineEventCompletedActionMeeting {
                   meeting {
@@ -147,19 +99,7 @@ const TimelineFeedList = (props: Props) => {
       ))}
       {lockedHistory && (
         <>
-          <Surface>
-            <EventIcon>
-              <Lock />
-            </EventIcon>
-            <HeaderText>
-              <TimelineEventTitle>Past Meetings Locked</TimelineEventTitle>
-            </HeaderText>
-            <TimelineEventBody>
-              Your plan includes 30 days of meeting history. Unlock{' '}
-              <i>{lockedHistory[0]!.node.team?.name}</i> by upgrading.
-            </TimelineEventBody>
-            <PrimaryButton>Unlock past meetings</PrimaryButton>
-          </Surface>
+          <TimelineHistoryLockedCard teamRef={lockedHistory[0]!.node.team} />
           {lockedHistory.map(({node: timelineEvent}) => (
             <TimelineEvent key={timelineEvent.id} timelineEvent={timelineEvent} />
           ))}

--- a/packages/client/components/TimelineFeedList.tsx
+++ b/packages/client/components/TimelineFeedList.tsx
@@ -84,6 +84,9 @@ const TimelineFeedList = (props: Props) => {
                 __typename
                 id
                 teamId
+                team {
+                  name
+                }
                 ... on TimelineEventCompletedActionMeeting {
                   meeting {
                     locked
@@ -152,7 +155,8 @@ const TimelineFeedList = (props: Props) => {
               <TimelineEventTitle>Past Meetings Locked</TimelineEventTitle>
             </HeaderText>
             <TimelineEventBody>
-              Your plan includes 30 days of meeting history. Unlock more by upgrading.
+              Your plan includes 30 days of meeting history. Unlock{' '}
+              <i>{lockedHistory[0]!.node.team?.name}</i> by upgrading.
             </TimelineEventBody>
             <PrimaryButton>Unlock past meetings</PrimaryButton>
           </Surface>

--- a/packages/client/components/TimelineFeedList.tsx
+++ b/packages/client/components/TimelineFeedList.tsx
@@ -1,11 +1,16 @@
 import styled from '@emotion/styled'
+import {Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useMemo} from 'react'
 import {usePaginationFragment} from 'react-relay'
 import useLoadNextOnScrollBottom from '~/hooks/useLoadNextOnScrollBottom'
+import {cardShadow} from '../styles/elevation'
+import {PALETTE} from '../styles/paletteV3'
 import {TimelineFeedListPaginationQuery} from '../__generated__/TimelineFeedListPaginationQuery.graphql'
 import {TimelineFeedList_query$key} from '../__generated__/TimelineFeedList_query.graphql'
+import PrimaryButton from './PrimaryButton'
 import TimelineEvent from './TimelineEvent'
+import TimelineEventTitle from './TImelineEventTitle'
 
 const ResultScroller = styled('div')({
   overflow: 'auto'
@@ -14,6 +19,50 @@ const ResultScroller = styled('div')({
 interface Props {
   queryRef: TimelineFeedList_query$key
 }
+
+const Surface = styled('div')({
+  background: '#FFFFFF',
+  borderRadius: 4,
+  boxShadow: cardShadow,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  marginBottom: 16,
+  overflow: 'hidden',
+  position: 'relative',
+  padding: 16,
+  width: '100%'
+})
+
+const TimelineEventBody = styled('div')({
+  padding: '0 16px 16px 16px',
+  fontSize: 14,
+  lineHeight: '20px',
+  textAlign: 'center'
+})
+
+const EventIcon = styled('div')({
+  borderRadius: '100%',
+  color: PALETTE.GRAPE_500,
+  display: 'block',
+  userSelect: 'none',
+  height: 40,
+  width: 40,
+  svg: {
+    height: 40,
+    width: 40
+  }
+})
+
+const HeaderText = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  fontSize: 14,
+  justifyContent: 'space-around',
+  lineHeight: '20px',
+  margin: '16px 16px 8px',
+  paddingTop: 2
+})
 
 const TimelineFeedList = (props: Props) => {
   const {queryRef} = props
@@ -34,6 +83,27 @@ const TimelineFeedList = (props: Props) => {
                 ...TimelineEvent_timelineEvent
                 __typename
                 id
+                teamId
+                ... on TimelineEventCompletedActionMeeting {
+                  meeting {
+                    locked
+                  }
+                }
+                ... on TimelineEventPokerComplete {
+                  meeting {
+                    locked
+                  }
+                }
+                ... on TimelineEventTeamPromptComplete {
+                  meeting {
+                    locked
+                  }
+                }
+                ... on TimelineEventCompletedRetroMeeting {
+                  meeting {
+                    locked
+                  }
+                }
               }
             }
             pageInfo {
@@ -51,11 +121,46 @@ const TimelineFeedList = (props: Props) => {
   const {viewer} = data
   const {timeline} = viewer
   const lastItem = useLoadNextOnScrollBottom(paginationRes, {}, 10)
+
+  const {freeHistory, lockedHistory} = useMemo(() => {
+    const firstLocked = timeline.edges.findIndex(
+      ({node: timelineEvent}) => !!timelineEvent.meeting?.locked
+    )
+    if (firstLocked === -1) {
+      return {
+        freeHistory: timeline.edges
+      }
+    }
+    return {
+      freeHistory: timeline.edges.slice(0, firstLocked),
+      lockedHistory: timeline.edges.slice(firstLocked)
+    }
+  }, [timeline.edges])
+
   return (
     <ResultScroller>
-      {timeline.edges.map(({node: timelineEvent}) => (
+      {freeHistory.map(({node: timelineEvent}) => (
         <TimelineEvent key={timelineEvent.id} timelineEvent={timelineEvent} />
       ))}
+      {lockedHistory && (
+        <>
+          <Surface>
+            <EventIcon>
+              <Lock />
+            </EventIcon>
+            <HeaderText>
+              <TimelineEventTitle>Past Meetings Locked</TimelineEventTitle>
+            </HeaderText>
+            <TimelineEventBody>
+              Your plan includes 30 days of meeting history. Unlock more by upgrading.
+            </TimelineEventBody>
+            <PrimaryButton>Unlock past meetings</PrimaryButton>
+          </Surface>
+          {lockedHistory.map(({node: timelineEvent}) => (
+            <TimelineEvent key={timelineEvent.id} timelineEvent={timelineEvent} />
+          ))}
+        </>
+      )}
       {lastItem}
     </ResultScroller>
   )

--- a/packages/client/components/TimelineHistoryLockedCard.tsx
+++ b/packages/client/components/TimelineHistoryLockedCard.tsx
@@ -1,0 +1,112 @@
+import styled from '@emotion/styled'
+import {Lock} from '@mui/icons-material'
+import graphql from 'babel-plugin-relay/macro'
+import React, {useEffect, useRef} from 'react'
+import {useFragment} from 'react-relay'
+import useAtmosphere from '../hooks/useAtmosphere'
+import useIsVisible from '../hooks/useIsVisible'
+import useRouter from '../hooks/useRouter'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
+import {cardShadow} from '../styles/elevation'
+import {PALETTE} from '../styles/paletteV3'
+import {TimelineHistoryLockedCard_team$key} from '../__generated__/TimelineHistoryLockedCard_team.graphql'
+import PrimaryButton from './PrimaryButton'
+
+interface Props {
+  teamRef: TimelineHistoryLockedCard_team$key | null
+}
+
+const Card = styled('div')({
+  background: '#FFFFFF',
+  borderRadius: 4,
+  boxShadow: cardShadow,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  marginBottom: 16,
+  overflow: 'hidden',
+  position: 'relative',
+  padding: 18,
+  width: '100%'
+})
+
+const CardBody = styled('div')({
+  fontSize: 14,
+  padding: '4px 32px 16px 32px',
+  lineHeight: '20px',
+  textAlign: 'center'
+})
+
+const Icon = styled(Lock)({
+  borderRadius: '100%',
+  color: PALETTE.GRAPE_500,
+  display: 'block',
+  userSelect: 'none',
+  height: 40,
+  width: 40,
+  svg: {
+    height: 40,
+    width: 40
+  }
+})
+
+const HeaderText = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  color: PALETTE.SLATE_700,
+  fontSize: 20,
+  fontWeight: 600,
+  lineHeight: '20px',
+  justifyContent: 'space-around',
+  margin: '16px 16px 8px',
+  paddingTop: 2
+})
+
+const TimelineHistoryLockedCard = (props: Props) => {
+  const {teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment TimelineHistoryLockedCard_team on Team {
+        id
+        name
+        orgId
+      }
+    `,
+    teamRef
+  )
+  const {id: teamId, name: teamName, orgId} = team ?? {}
+
+  const atmosphere = useAtmosphere()
+  const {history} = useRouter()
+
+  const cardRef = useRef<HTMLDivElement>(null)
+  const visible = useIsVisible(cardRef.current, 0.7)
+  useEffect(() => {
+    if (visible) {
+      SendClientSegmentEventMutation(atmosphere, 'Timeline History Locked Card Visible', {teamId})
+    }
+  }, [visible])
+
+  const onClick = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Timeline History Locked Card Upgrade CTA Clicked', {
+      teamId
+    })
+    history.push(`/me/organizations/${orgId}`)
+  }
+
+  return (
+    <Card ref={cardRef}>
+      <Icon />
+      <HeaderText>Past Meetings Locked</HeaderText>
+      <CardBody>
+        Your plan includes 30 days of meeting history. Unlock the meeting history of{' '}
+        <i>{teamName}</i> by upgrading.
+      </CardBody>
+      <PrimaryButton size='medium' onClick={onClick}>
+        Unlock past meetings
+      </PrimaryButton>
+    </Card>
+  )
+}
+
+export default TimelineHistoryLockedCard

--- a/packages/client/hooks/useIsVisible.tsx
+++ b/packages/client/hooks/useIsVisible.tsx
@@ -1,0 +1,32 @@
+import {useEffect, useState} from 'react'
+
+const useIsVisible = (element?: HTMLElement | null, threshold = 0.5) => {
+  const [visible, setVisible] = useState(false)
+  const [intersectionObserver] = useState(() => {
+    return new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries
+        setVisible(!!(entry && entry.intersectionRatio > threshold))
+      },
+      {
+        threshold
+      }
+    )
+  })
+  useEffect(() => {
+    return () => {
+      intersectionObserver.disconnect()
+    }
+  }, [])
+  useEffect(() => {
+    if (!element) return
+    intersectionObserver.observe(element)
+    return () => {
+      intersectionObserver.unobserve(element)
+    }
+  }, [element])
+
+  return visible
+}
+
+export default useIsVisible

--- a/packages/client/hooks/useSegmentTrack.ts
+++ b/packages/client/hooks/useSegmentTrack.ts
@@ -1,18 +1,13 @@
 import {useEffect, useRef} from 'react'
-import {NewMeetingPhaseTypeEnum} from '~/__generated__/ActionMeeting_meeting.graphql'
-import {CreditCardModalActionType} from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
-import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
+import SendClientSegmentEventMutation, {
+  SendClientSegmentEventOptions
+} from '../mutations/SendClientSegmentEventMutation'
 import useAtmosphere from './useAtmosphere'
-
-type Options = {
-  phase?: NewMeetingPhaseTypeEnum
-  actionType?: CreditCardModalActionType
-}
 
 // certain users keep sending this non-stop. not sure why.
 // include an eventId so we know if it's the component. if it's not here, then in must be in trebuchet
 let eventId = 0
-const useSegmentTrack = (event: string, options: Options) => {
+const useSegmentTrack = (event: string, options: SendClientSegmentEventOptions) => {
   const initialOptionsRef = useRef(options)
   const atmosphere = useAtmosphere()
   useEffect(() => {

--- a/packages/client/mutations/SendClientSegmentEventMutation.ts
+++ b/packages/client/mutations/SendClientSegmentEventMutation.ts
@@ -9,14 +9,12 @@ const mutation = graphql`
   }
 `
 
-type Options = {
-  eventId?: number
-} & SegmentEventTrackOptions
+export type SendClientSegmentEventOptions = SegmentEventTrackOptions
 
 const SendClientSegmentEventMutation = (
   atmosphere: Atmosphere,
   event: string,
-  options?: Options
+  options?: SendClientSegmentEventOptions
 ) => {
   atmosphere.handleFetchPromise(getRequest(mutation).params, {event, options})
 }

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -1042,6 +1042,11 @@ interface NewMeeting {
   The meeting member of the viewer
   """
   viewerMeetingMember: MeetingMember
+
+  """
+  Is this locked for personal plans?
+  """
+  locked: Boolean!
 }
 
 """

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -536,6 +536,11 @@ interface NewMeeting {
   The meeting member of the viewer
   """
   viewerMeetingMember: MeetingMember
+
+  """
+  Is this locked for personal plans?
+  """
+  locked: Boolean!
 }
 
 """

--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -149,6 +149,23 @@ export const newMeetingFields = () => ({
       const meetingMember = await dataLoader.get('meetingMembers').load(meetingMemberId)
       return meetingMember || null
     }
+  },
+  locked: {
+    type: new GraphQLNonNull(GraphQLBoolean),
+    description: 'Is this locked for personal plans?',
+    resolve: async (
+      {endedAt, teamId}: {endedAt: Date; teamId: string},
+      _args: any,
+      {dataLoader}: GQLContext
+    ) => {
+      const freeLimit = new Date()
+      freeLimit.setDate(freeLimit.getDate() - 30)
+      if (endedAt > freeLimit) {
+        return false
+      }
+      const team = await dataLoader.get('teams').loadNonNull(teamId)
+      return team.tier === 'personal'
+    }
   }
 })
 


### PR DESCRIPTION
# Description

Fixes #7374
Show a locked message on the timeline for meetings older than 30 days of free tiers. If there are locked meetings from multiple free teams, only for the first one the CTA is shown. All locked meetings have a different icon and link to the upgrade page.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

* check the timeline with meetings older than 30 days
* must include all 4 meeting types: check-in, retro, poker, stand-up
* [ ] meetings of free tier older than 30 days show a lock and Upgrade CTA
* [ ] clicking CTA links to upgrade page and sends segment event
* [ ] clicking CTA on the message does the same

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
