### PR TITLE
fix: revert slack change until approval

### DIFF
--- a/packages/client/utils/GitHubClientManager.ts
+++ b/packages/client/utils/GitHubClientManager.ts
@@ -12,7 +12,7 @@ class GitHubClientManager {
     const {submitting, onError, onCompleted, submitMutation} = mutationProps
     const hash = Math.random().toString(36).substring(5)
     const providerState = btoa(
-      JSON.stringify({hash, origin: window.location.origin, service: 'slack'})
+      JSON.stringify({hash, origin: window.location.origin, service: 'github'})
     )
     const uri = `https://github.com/login/oauth/authorize?client_id=${window.__ACTION__.github}&scope=${GitHubClientManager.SCOPE}&state=${providerState}`
 

--- a/packages/client/utils/SlackClientManager.ts
+++ b/packages/client/utils/SlackClientManager.ts
@@ -2,6 +2,7 @@ import Atmosphere from '../Atmosphere'
 import {MenuMutationProps} from '../hooks/useMutationProps'
 import AddSlackAuthMutation from '../mutations/AddSlackAuthMutation'
 import getOAuthPopupFeatures from './getOAuthPopupFeatures'
+import makeHref from './makeHref'
 import SlackManager from './SlackManager'
 class SlackClientManager extends SlackManager {
   fetch = window.fetch.bind(window)
@@ -11,7 +12,9 @@ class SlackClientManager extends SlackManager {
     const providerState = btoa(
       JSON.stringify({hash, origin: window.location.origin, service: 'slack'})
     )
-    const redirect = window.__ACTION__.oauth2Redirect
+    const redirect = makeHref('/auth/slack')
+    // use this when slack approves our app
+    // const redirect = window.__ACTION__.oauth2Redirect
     const uri = `https://slack.com/oauth/v2/authorize?client_id=${window.__ACTION__.slack}&scope=${SlackClientManager.SCOPE}&state=${providerState}&redirect_uri=${redirect}`
     const popup = window.open(
       uri,

--- a/packages/server/utils/SlackServerManager.ts
+++ b/packages/server/utils/SlackServerManager.ts
@@ -1,6 +1,8 @@
 import fetch from 'node-fetch'
 import SlackManager from 'parabol-client/utils/SlackManager'
 import {stringify} from 'querystring'
+import makeAppURL from '../../client/utils/makeAppURL'
+import appOrigin from '../appOrigin'
 
 interface IncomingWebhook {
   url: string
@@ -37,7 +39,9 @@ class SlackServerManager extends SlackManager {
       client_id: process.env.SLACK_CLIENT_ID,
       client_secret: process.env.SLACK_CLIENT_SECRET,
       code,
-      redirect_uri: process.env.OAUTH2_REDIRECT!
+      redirect_uri: makeAppURL(appOrigin, 'auth/slack')
+      // use this after slack approves our app
+      // redirect_uri: process.env.OAUTH2_REDIRECT!
     }
 
     const uri = `https://slack.com/api/oauth.v2.access?${stringify(queryParams)}`


### PR DESCRIPTION
Signed-off-by: Matt Krick <matt.krick@gmail.com>

# Description

Reverts slack redirect strategy until slack approves our app.
also fixes the callback url for github oauth2.
