### PR TITLE
fix: Retrospective demo canonical link

### DIFF
--- a/packages/server/createSSR.ts
+++ b/packages/server/createSSR.ts
@@ -69,6 +69,13 @@ const createSSR = (res: HttpResponse, req: HttpRequest) => {
     res.end()
     return
   }
+  const url = req.getUrl()
+
+  const demoMatch = url.match(/\/retrospective-demo\/(reflect|vote|group)/)
+
+  if (demoMatch) {
+    res.writeHeader('Link', '<https://action.parabol.co/retrospective-demo>; rel="canonical"')
+  }
   res.writeHeader('content-type', 'text/html; charset=utf-8')
   // no need for eTag since file is < 1 MTU
   if (acceptsBrotli(req)) {


### PR DESCRIPTION
# Description
Ahrefs continuously flags a minor error where our product signup and demo pages are confused as the same link. There is currently no canonical link set. 

Fixes #7125
However, the following URLs are flagged as duplicate content and we should set https://action.parabol.co/retrospective-demo as the canonical link for them.

1. https://action.parabol.co/retrospective-demo/reflect 

2. https://action.parabol.co/retrospective-demo/vote 

3. https://action.parabol.co/retrospective-demo/group 

## Demo

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
