### PR TITLE
fix(metrics): Always include email in traits for identify calls

### DIFF
--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -8,6 +8,8 @@ import insertOrgUserAudit from '../../postgres/helpers/insertOrgUserAudit'
 import {OrganizationUserAuditEventTypeEnum} from '../../postgres/queries/generated/insertOrgUserAuditQuery'
 import {getUserById} from '../../postgres/queries/getUsersByIds'
 import updateUser from '../../postgres/queries/updateUser'
+import IUser from '../../postgres/types/IUser'
+import {analytics} from '../../utils/analytics/analytics'
 import {toEpochSeconds} from '../../utils/epochTime'
 import getActiveDomainForOrgId from '../../utils/getActiveDomainForOrgId'
 import getDomainFromEmail from '../../utils/getDomainFromEmail'
@@ -40,15 +42,14 @@ const maybeUpdateOrganizationActiveDomain = async (orgId: string, newUserEmail: 
     .run()
 }
 
-const changePause = (inactive: boolean) => async (_orgIds: string[], userId: string) => {
+const changePause = (inactive: boolean) => async (_orgIds: string[], user: IUser) => {
   const r = await getRethink()
-  segmentIo.track({
-    userId,
-    event: inactive ? 'Account Paused' : 'Account Unpaused'
-  })
+  const {id: userId, email} = user
+  inactive ? analytics.accountPaused(userId) : analytics.accountUnpaused(userId)
   segmentIo.identify({
     userId,
     traits: {
+      email,
       isActive: !inactive
     }
   })
@@ -68,7 +69,8 @@ const changePause = (inactive: boolean) => async (_orgIds: string[], userId: str
   ])
 }
 
-const addUser = async (orgIds: string[], userId: string) => {
+const addUser = async (orgIds: string[], user: IUser) => {
+  const {id: userId} = user
   const r = await getRethink()
   const {organizations, organizationUsers} = await r({
     organizationUsers: r
@@ -95,13 +97,7 @@ const addUser = async (orgIds: string[], userId: string) => {
     return new OrganizationUser({orgId, userId, newUserUntil, tier: organization.tier})
   })
 
-  const [user] = await Promise.all([
-    getUserById(userId),
-    r.table('OrganizationUser').insert(docs).run()
-  ])
-  if (!user) {
-    throw new Error(`User does not exist: ${userId}`)
-  }
+  await r.table('OrganizationUser').insert(docs).run()
   await Promise.all(
     orgIds.map((orgId) => {
       return maybeUpdateOrganizationActiveDomain(orgId, user.email)
@@ -109,11 +105,11 @@ const addUser = async (orgIds: string[], userId: string) => {
   )
 }
 
-const deleteUser = async (orgIds: string[], userId: string) => {
+const deleteUser = async (orgIds: string[], user: IUser) => {
   const r = await getRethink()
   return r
     .table('OrganizationUser')
-    .getAll(userId, {index: 'userId'})
+    .getAll(user.id, {index: 'userId'})
     .filter((row: RDatum) => r.expr(orgIds).contains(row('orgId')))
     .update({
       removedAt: new Date()
@@ -150,8 +146,12 @@ export default async function adjustUserCount(
   const r = await getRethink()
   const orgIds = Array.isArray(orgInput) ? orgInput : [orgInput]
 
+  const user = await getUserById(userId)
+  if (!user) {
+    throw new Error(`User does not exist: ${userId}`)
+  }
   const dbAction = dbActionTypeLookup[type]
-  await dbAction(orgIds, userId)
+  await dbAction(orgIds, user)
 
   const auditEventType = auditEventTypeLookup[type]
   await insertOrgUserAudit(orgIds, userId, auditEventType)

--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -4,6 +4,7 @@ import {RDatum} from '../../database/stricterR'
 import InvoiceItemHook from '../../database/types/InvoiceItemHook'
 import Organization from '../../database/types/Organization'
 import OrganizationUser from '../../database/types/OrganizationUser'
+import {DataLoaderWorker} from '../../graphql/graphql'
 import insertOrgUserAudit from '../../postgres/helpers/insertOrgUserAudit'
 import {OrganizationUserAuditEventTypeEnum} from '../../postgres/queries/generated/insertOrgUserAuditQuery'
 import {getUserById} from '../../postgres/queries/getUsersByIds'
@@ -142,15 +143,13 @@ export default async function adjustUserCount(
   userId: string,
   orgInput: string | string[],
   type: InvoiceItemType,
+  dataLoader: DataLoaderWorker,
   options: Options = {}
 ) {
   const r = await getRethink()
   const orgIds = Array.isArray(orgInput) ? orgInput : [orgInput]
 
-  const user = await getUserById(userId)
-  if (!user) {
-    throw new Error(`User does not exist: ${userId}`)
-  }
+  const user = await dataLoader.get('users').loadNonNull(userId)
   const dbAction = dbActionTypeLookup[type]
   await dbAction(orgIds, user)
 

--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -107,6 +107,7 @@ const addUser = async (orgIds: string[], user: IUser) => {
 
 const deleteUser = async (orgIds: string[], user: IUser) => {
   const r = await getRethink()
+  orgIds.forEach((orgId) => analytics.userRemovedFromOrg(user.id, orgId))
   return r
     .table('OrganizationUser')
     .getAll(user.id, {index: 'userId'})

--- a/packages/server/graphql/mutations/helpers/removeFromOrg.ts
+++ b/packages/server/graphql/mutations/helpers/removeFromOrg.ts
@@ -90,7 +90,7 @@ const removeFromOrg = async (
     }
   }
   try {
-    await adjustUserCount(userId, orgId, InvoiceItemType.REMOVE_USER, {prorationDate})
+    await adjustUserCount(userId, orgId, InvoiceItemType.REMOVE_USER, dataLoader, {prorationDate})
   } catch (e) {
     console.log(e)
   }

--- a/packages/server/graphql/mutations/helpers/updateUserProfile.ts
+++ b/packages/server/graphql/mutations/helpers/updateUserProfile.ts
@@ -7,6 +7,7 @@ import makeUserServerSchema from 'parabol-client/validation/makeUserServerSchema
 import getRethink from '../../../database/rethinkDriver'
 import TeamMember from '../../../database/types/TeamMember'
 import updateUser from '../../../postgres/queries/updateUser'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId, isAuthenticated} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import segmentIo from '../../../utils/segmentIo'
@@ -79,17 +80,13 @@ const updateUserProfile = async (
   //   .catch(console.warn.bind(console));
   // }
   //
+  const user = await dataLoader.get('users').loadNonNull(userId)
   if (validUpdatedUser.preferredName) {
-    segmentIo.track({
-      userId,
-      event: 'Changed name',
-      properties: {
-        name: validUpdatedUser.preferredName
-      }
-    })
+    analytics.accountNameChanged(userId, validUpdatedUser.preferredName)
     segmentIo.identify({
       userId,
       traits: {
+        email: user.email,
         name: validUpdatedUser.preferredName
       }
     })

--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -106,7 +106,7 @@ const moveToOrg = async (
 
   await Promise.all(
     newToOrgUserIds.map((newUserId) => {
-      return adjustUserCount(newUserId, orgId, InvoiceItemType.ADD_USER)
+      return adjustUserCount(newUserId, orgId, InvoiceItemType.ADD_USER, dataLoader)
     })
   )
 
@@ -114,7 +114,7 @@ const moveToOrg = async (
 
   const inactiveUserIds = newUsers.filter((user) => user.inactive).map((user) => user!.id)
   inactiveUserIds.map((newInactiveUserId) => {
-    return adjustUserCount(newInactiveUserId, orgId, InvoiceItemType.AUTO_PAUSE_USER)
+    return adjustUserCount(newInactiveUserId, orgId, InvoiceItemType.AUTO_PAUSE_USER, dataLoader)
   })
 
   const inactiveAdded = inactiveUserIds.length

--- a/packages/server/graphql/private/mutations/autopauseUsers.ts
+++ b/packages/server/graphql/private/mutations/autopauseUsers.ts
@@ -4,7 +4,11 @@ import getRethink from '../../../database/rethinkDriver'
 import getUserIdsToPause from '../../../postgres/queries/getUserIdsToPause'
 import {MutationResolvers} from '../resolverTypes'
 
-const autopauseUsers: MutationResolvers['autopauseUsers'] = async () => {
+const autopauseUsers: MutationResolvers['autopauseUsers'] = async (
+  _source,
+  _args,
+  {dataLoader}
+) => {
   const r = await getRethink()
 
   // RESOLUTION
@@ -26,7 +30,7 @@ const autopauseUsers: MutationResolvers['autopauseUsers'] = async () => {
     await Promise.allSettled(
       results.map(async ({group: userId, reduction: orgIds}) => {
         try {
-          return await adjustUserCount(userId, orgIds, InvoiceItemType.AUTO_PAUSE_USER)
+          return await adjustUserCount(userId, orgIds, InvoiceItemType.AUTO_PAUSE_USER, dataLoader)
         } catch (e) {
           console.warn(`Error adjusting user count`)
         }

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -45,7 +45,7 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
       .getAll(userId, {index: 'userId'})
       .filter({removedAt: null, inactive: true})('orgId')
       .run()
-    adjustUserCount(userId, orgIds, InvoiceItemType.UNPAUSE_USER).catch(console.log)
+    adjustUserCount(userId, orgIds, InvoiceItemType.UNPAUSE_USER, dataLoader).catch(console.log)
     // TODO: re-identify
   }
   const datesAreOnSameDay = now.toDateString() === lastSeenAt.toDateString()

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -2,6 +2,7 @@ import {InvoiceItemType, SubscriptionChannel} from 'parabol-client/types/constEn
 import adjustUserCount from '../../../billing/helpers/adjustUserCount'
 import getRethink from '../../../database/rethinkDriver'
 import updateUser from '../../../postgres/queries/updateUser'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
@@ -72,18 +73,15 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
     })
   }
 
-  segmentIo.track({
-    userId,
-    event: 'Connect WebSocket',
-    properties: {
-      socketCount,
-      socketId,
-      tms
-    }
+  analytics.websocketConnected(userId, {
+    socketCount,
+    socketId,
+    tms
   })
   segmentIo.identify({
     userId,
     traits: {
+      email: user.email,
       isActive: true,
       featureFlags: user.featureFlags,
       highestTier: user.tier,

--- a/packages/server/graphql/private/mutations/disconnectSocket.ts
+++ b/packages/server/graphql/private/mutations/disconnectSocket.ts
@@ -5,7 +5,6 @@ import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
 import publish from '../../../utils/publish'
-import segmentIo from '../../../utils/segmentIo'
 import {UserPresence} from '../../private/mutations/connectSocket'
 import {MutationResolvers} from '../resolverTypes'
 
@@ -59,16 +58,6 @@ const disconnectSocket: MutationResolvers['disconnectSocket'] = async (
     socketCount: userPresence.length,
     socketId,
     tms
-  })
-  segmentIo.identify({
-    userId,
-    traits: {
-      email: user.email,
-      isActive: false,
-      featureFlags: user.featureFlags,
-      highestTier: user.tier,
-      isPatient0: user.isPatient0
-    }
   })
   return {user}
 }

--- a/packages/server/graphql/private/mutations/disconnectSocket.ts
+++ b/packages/server/graphql/private/mutations/disconnectSocket.ts
@@ -1,5 +1,6 @@
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import PROD from '../../../PROD'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
@@ -54,13 +55,19 @@ const disconnectSocket: MutationResolvers['disconnectSocket'] = async (
       )
     })
   }
-  segmentIo.track({
+  analytics.websocketDisconnected(userId, {
+    socketCount: userPresence.length,
+    socketId,
+    tms
+  })
+  segmentIo.identify({
     userId,
-    event: 'Disconnect WebSocket',
-    properties: {
-      socketCount: userPresence.length,
-      socketId,
-      tms
+    traits: {
+      email: user.email,
+      isActive: false,
+      featureFlags: user.featureFlags,
+      highestTier: user.tier,
+      isPatient0: user.isPatient0
     }
   })
   return {user}

--- a/packages/server/safeMutations/acceptTeamInvitation.ts
+++ b/packages/server/safeMutations/acceptTeamInvitation.ts
@@ -93,7 +93,7 @@ const acceptTeamInvitation = async (team: Team, userId: string, dataLoader: Data
     dataLoader.get('organizationUsersByUserIdOrgId').clear({userId, orgId})
     dataLoader.get('users').clear(userId)
     try {
-      await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER)
+      await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
     } catch (e) {
       console.log(e)
     }

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -49,6 +49,12 @@ export type MeetingSettings = {
   disableAnonymity?: boolean
 }
 
+export type WebSocketProperties = {
+  socketCount: number
+  socketId: string
+  tms: string[]
+}
+
 export type AnalyticsEvent =
   // meeting
   | 'Meeting Started'
@@ -76,6 +82,11 @@ export type AnalyticsEvent =
   | 'Task Estimate Set'
   // user
   | 'Account Created'
+  | 'Account Paused'
+  | 'Account Unpaused'
+  | 'Account Name Changed'
+  | 'Connect WebSocket'
+  | 'Disconnect WebSocket'
   | 'Summary Email Setting Changed'
 
 /**
@@ -323,10 +334,7 @@ class Analytics {
     this.track(userId, 'Task Estimate Set', taskEstimateProperties)
   }
 
-  toggleSubToSummaryEmail = (userId: string, subscribeToSummaryEmail: boolean) => {
-    this.track(userId, 'Summary Email Setting Changed', {subscribeToSummaryEmail})
-  }
-
+  // user
   accountCreated = (userId: string, isInvited: boolean, isPatient0: boolean) => {
     this.track(userId, 'Account Created', {
       isInvited,
@@ -334,6 +342,27 @@ class Analytics {
       category: 'All',
       label: isPatient0 ? 'isPatient0' : 'isNotPatient0'
     })
+  }
+
+  accountPaused = (userId: string) => this.track(userId, 'Account Paused')
+
+  accountUnpaused = (userId: string) => this.track(userId, 'Account Unpaused')
+
+  accountNameChanged = (userId: string, newName: string) =>
+    this.track(userId, 'Account Name Changed', {
+      newName
+    })
+
+  websocketConnected = (userId: string, websocketProperties: WebSocketProperties) => {
+    this.track(userId, 'Connect WebSocket', websocketProperties)
+  }
+
+  websocketDisconnected = (userId: string, websocketProperties: WebSocketProperties) => {
+    this.track(userId, 'Disconnect WebSocket', websocketProperties)
+  }
+
+  toggleSubToSummaryEmail = (userId: string, subscribeToSummaryEmail: boolean) => {
+    this.track(userId, 'Summary Email Setting Changed', {subscribeToSummaryEmail})
   }
 
   private track = (userId: string, event: AnalyticsEvent, properties?: Record<string, any>) =>

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -85,6 +85,7 @@ export type AnalyticsEvent =
   | 'Account Paused'
   | 'Account Unpaused'
   | 'Account Name Changed'
+  | 'User Removed From Org'
   | 'Connect WebSocket'
   | 'Disconnect WebSocket'
   | 'Summary Email Setting Changed'
@@ -352,6 +353,9 @@ class Analytics {
     this.track(userId, 'Account Name Changed', {
       newName
     })
+
+  userRemovedFromOrg = (userId: string, orgId: string) =>
+    this.track(userId, 'User Removed From Org', {userId, orgId})
 
   websocketConnected = (userId: string, websocketProperties: WebSocketProperties) => {
     this.track(userId, 'Connect WebSocket', websocketProperties)

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -67,6 +67,7 @@ const setUserTierForUserIds = async (userIds: string[]) => {
       segmentIo.identify({
         userId: user.id,
         traits: {
+          email: user.email,
           highestTier: user.tier
         }
       })


### PR DESCRIPTION
# Description

While investigating Segment <-> HubSpot integration, I saw this error pop out from Segment that complains `email` is missing from identify calls:

<img width="753" alt="Screenshot 2022-12-05 at 10 03 46 AM" src="https://user-images.githubusercontent.com/1879975/205527815-aee2579d-b653-4a82-a999-0b810886baa7.png">

## Demo

<img width="472" alt="Screenshot 2022-12-05 at 2 07 12 PM" src="https://user-images.githubusercontent.com/1879975/205528013-52dbe98b-8a51-4429-b7f5-217a1ec380f4.png">


## Testing scenarios
- [ ] Make sure `email` is included in `traits` for all `identify` calls

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
