### PR TITLE
feat(notifications): Remaining email notifications

### DIFF
--- a/packages/client/modules/email/components/EmailNotifications/EmailNotificationPicker.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailNotificationPicker.tsx
@@ -5,19 +5,18 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import EmailKickedOut from './EmailKickedOut'
 import EmailMeetingStageTimeLimitEnd from './EmailMeetingStageTimeLimitEnd'
+import EmailPaymentRejected from './EmailPaymentRejected'
+import EmailPromoteToBillingLeader from './EmailPromoteToBillingLeader'
 import EmailResponseMentioned from './EmailResponseMentioned'
+import EmailTaskInvolves from './EmailTaskInvolves'
 import EmailTeamArchived from './EmailTeamArchived'
 import EmailTeamInvitation from './EmailTeamInvitation'
 
 export const NOTIFICATION_TEMPLATE_TYPE = {
   KICKED_OUT: EmailKickedOut,
-  // :TODO: (jmtaber129): Implement these.
-  // PAYMENT_REJECTED: EmailPaymentRejected,
-  // TASK_INVOLVES: EmailTaskInvolves,
-  // PROMOTE_TO_BILLING_LEADER: EmailPromoteToBillingLeader,
-  PAYMENT_REJECTED: null,
-  TASK_INVOLVES: null,
-  PROMOTE_TO_BILLING_LEADER: null,
+  PAYMENT_REJECTED: EmailPaymentRejected,
+  TASK_INVOLVES: EmailTaskInvolves,
+  PROMOTE_TO_BILLING_LEADER: EmailPromoteToBillingLeader,
   TEAM_ARCHIVED: EmailTeamArchived,
   TEAM_INVITATION: EmailTeamInvitation,
   MEETING_STAGE_TIME_LIMIT_END: EmailMeetingStageTimeLimitEnd,
@@ -37,9 +36,9 @@ const EmailNotificationPicker = (props: Props) => {
         type
         id
         ...EmailKickedOut_notification
-        # ...EmailPaymentRejected_notification
-        # ...EmailTaskInvolves_notification
-        # ...EmailPromoteToBillingLeader_notification
+        ...EmailPaymentRejected_notification
+        ...EmailTaskInvolves_notification
+        ...EmailPromoteToBillingLeader_notification
         ...EmailTeamArchived_notification
         ...EmailTeamInvitation_notification
         ...EmailMeetingStageTimeLimitEnd_notification

--- a/packages/client/modules/email/components/EmailNotifications/EmailPaymentRejected.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailPaymentRejected.tsx
@@ -1,0 +1,48 @@
+import graphql from 'babel-plugin-relay/macro'
+import {EmailPaymentRejected_notification$key} from 'parabol-client/__generated__/EmailPaymentRejected_notification.graphql'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import makeAppURL from '../../../../utils/makeAppURL'
+import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
+import EmailNotificationTemplate from './EmailNotificationTemplate'
+
+interface Props {
+  notificationRef: EmailPaymentRejected_notification$key
+  appOrigin: string
+}
+const EmailPaymentRejected = (props: Props) => {
+  const {notificationRef, appOrigin} = props
+  const notification = useFragment(
+    graphql`
+      fragment EmailPaymentRejected_notification on NotifyPaymentRejected {
+        ...EmailNotificationTemplate_notification
+        organization {
+          id
+          creditCard {
+            last4
+            brand
+          }
+        }
+      }
+    `,
+    notificationRef
+  )
+  const {organization} = notification
+  const {id: orgId, creditCard} = organization
+  const {last4, brand} = creditCard || {last4: '****', brand: 'Unknown'}
+
+  const linkUrl = makeAppURL(appOrigin, `/me/organizations/${orgId}`, {
+    searchParams: notificationSummaryUrlParams
+  })
+
+  return (
+    <EmailNotificationTemplate
+      message={`Your ${brand} card ending in ${last4} was rejected`}
+      notificationRef={notification}
+      linkLabel={'Updated billing information'}
+      linkUrl={linkUrl}
+    />
+  )
+}
+
+export default EmailPaymentRejected

--- a/packages/client/modules/email/components/EmailNotifications/EmailTaskInvolves.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailTaskInvolves.tsx
@@ -70,11 +70,9 @@ const EmailTaskInvolves = (props: Props) => {
       linkLabel='See the task'
       linkUrl={linkUrl}
     >
-      {task && (
-        <table style={{marginTop: '12px'}}>
-          <EmailTaskCard task={task} maxWidth={330} />
-        </table>
-      )}
+      <table style={{marginTop: '12px'}}>
+        <EmailTaskCard task={task} maxWidth={330} />
+      </table>
     </EmailNotificationTemplate>
   )
 }

--- a/packages/client/modules/email/components/EmailNotifications/EmailTaskInvolves.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailTaskInvolves.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import makeAppURL from '../../../../utils/makeAppURL'
 import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
+import EmailTaskCard from '../SummaryEmail/MeetingSummaryEmail/EmailTaskCard'
 import EmailNotificationTemplate from './EmailNotificationTemplate'
 
 const involvementWord = {
@@ -41,6 +42,7 @@ const EmailTaskInvolves = (props: Props) => {
         }
         task {
           tags
+          ...EmailTaskCard_task
         }
       }
     `,
@@ -67,7 +69,13 @@ const EmailTaskInvolves = (props: Props) => {
       notificationRef={notification}
       linkLabel='See the task'
       linkUrl={linkUrl}
-    />
+    >
+      {task && (
+        <table style={{marginTop: '12px'}}>
+          <EmailTaskCard task={task} maxWidth={330} />
+        </table>
+      )}
+    </EmailNotificationTemplate>
   )
 }
 

--- a/packages/client/modules/email/components/EmailNotifications/EmailTaskInvolves.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailTaskInvolves.tsx
@@ -1,0 +1,74 @@
+import graphql from 'babel-plugin-relay/macro'
+import {ASSIGNEE, MENTIONEE} from 'parabol-client/utils/constants'
+import {EmailTaskInvolves_notification$key} from 'parabol-client/__generated__/EmailTaskInvolves_notification.graphql'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import makeAppURL from '../../../../utils/makeAppURL'
+import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
+import EmailNotificationTemplate from './EmailNotificationTemplate'
+
+const involvementWord = {
+  [ASSIGNEE]: 'assigned',
+  [MENTIONEE]: 'mentioned'
+}
+
+interface Props {
+  notificationRef: EmailTaskInvolves_notification$key
+  appOrigin: string
+}
+
+const deletedTask = {
+  tags: [] as string[]
+} as const
+
+const EmailTaskInvolves = (props: Props) => {
+  const {notificationRef, appOrigin} = props
+  const notification = useFragment(
+    graphql`
+      fragment EmailTaskInvolves_notification on NotifyTaskInvolves {
+        ...EmailNotificationTemplate_notification
+        changeAuthor {
+          user {
+            rasterPicture
+          }
+          preferredName
+        }
+        involvement
+        status
+        team {
+          id
+          name
+        }
+        task {
+          tags
+        }
+      }
+    `,
+    notificationRef
+  )
+  const {task, team, involvement, changeAuthor} = notification
+  const {tags} = task || deletedTask
+  const {user, preferredName: changeAuthorName} = changeAuthor
+  const {rasterPicture: changeAuthorPicture} = user
+  const {name: teamName, id: teamId} = team
+  const action = involvementWord[involvement]
+
+  const archiveSuffix = tags.includes('archived') ? '/archive' : ''
+  const preposition = involvement === MENTIONEE ? ' in' : ''
+
+  const linkUrl = makeAppURL(appOrigin, `/team/${teamId}${archiveSuffix}`, {
+    searchParams: notificationSummaryUrlParams
+  })
+
+  return (
+    <EmailNotificationTemplate
+      avatar={changeAuthorPicture}
+      message={`${changeAuthorName} ${action} you ${preposition} a task on the ${teamName} team.`}
+      notificationRef={notification}
+      linkLabel='See the task'
+      linkUrl={linkUrl}
+    />
+  )
+}
+
+export default EmailTaskInvolves

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailTaskCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailTaskCard.tsx
@@ -11,27 +11,30 @@ import {TaskStatusEnum} from '../../../../../__generated__/EmailTaskCard_task.gr
 
 interface Props {
   task: EmailTaskCard_task
+  maxWidth?: number
 }
 
-const contentStyle = {
-  backgroundColor: '#FFFFFF',
-  borderColor: PALETTE.SLATE_400,
-  borderRadius: '4px',
-  borderStyle: 'solid',
-  borderWidth: '1px',
-  boxSizing: 'content-box',
-  color: PALETTE.SLATE_700,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontSize: '14px',
-  minHeight: '88px',
-  lineHeight: '20px',
-  padding: '4px 12px 12px',
-  textAlign: 'left',
-  verticalAlign: 'top',
-  width: 188,
-  minWidth: 188,
-  maxWidth: 188
-} as React.CSSProperties
+const contentStyle = (maxWidth?: number): React.CSSProperties => {
+  return {
+    backgroundColor: '#FFFFFF',
+    borderColor: PALETTE.SLATE_400,
+    borderRadius: '4px',
+    borderStyle: 'solid',
+    borderWidth: '1px',
+    boxSizing: 'content-box',
+    color: PALETTE.SLATE_700,
+    fontFamily: FONT_FAMILY.SANS_SERIF,
+    fontSize: '14px',
+    minHeight: '88px',
+    lineHeight: '20px',
+    padding: '4px 12px 12px',
+    textAlign: 'left',
+    verticalAlign: 'top',
+    width: maxWidth ? undefined : 188,
+    minWidth: 188,
+    maxWidth: maxWidth ? maxWidth : 188
+  }
+}
 
 const statusStyle = (status: TaskStatusEnum) => ({
   backgroundColor: taskStatusColors[status],
@@ -40,7 +43,7 @@ const statusStyle = (status: TaskStatusEnum) => ({
 })
 
 const EmailTaskCard = (props: Props) => {
-  const {task} = props
+  const {task, maxWidth} = props
   const {content, status} = task
   const contentState = useMemo(() => convertFromRaw(JSON.parse(content)), [content])
   const editorStateRef = useRef<EditorState>()
@@ -54,7 +57,7 @@ const EmailTaskCard = (props: Props) => {
   return (
     <tr>
       <td>
-        <table align='center' width='188' style={contentStyle}>
+        <table align='center' width={maxWidth ? undefined : '188'} style={contentStyle(maxWidth)}>
           <tbody>
             <tr>
               <td>

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailTaskCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailTaskCard.tsx
@@ -7,10 +7,11 @@ import {taskStatusColors} from 'parabol-client/utils/taskStatus'
 import {EmailTaskCard_task} from 'parabol-client/__generated__/EmailTaskCard_task.graphql'
 import React, {useMemo, useRef} from 'react'
 import {createFragmentContainer} from 'react-relay'
+import convertToTaskContent from '../../../../../utils/draftjs/convertToTaskContent'
 import {TaskStatusEnum} from '../../../../../__generated__/EmailTaskCard_task.graphql'
 
 interface Props {
-  task: EmailTaskCard_task
+  task: EmailTaskCard_task | null
   maxWidth?: number
 }
 
@@ -42,9 +43,19 @@ const statusStyle = (status: TaskStatusEnum) => ({
   width: 30
 })
 
+const deletedTask = {
+  content: convertToTaskContent('<<TASK DELETED>>'),
+  status: 'done',
+  tags: [] as string[],
+  user: {
+    picture: null,
+    preferredName: null
+  }
+} as const
+
 const EmailTaskCard = (props: Props) => {
   const {task, maxWidth} = props
-  const {content, status} = task
+  const {content, status} = task || deletedTask
   const contentState = useMemo(() => convertFromRaw(JSON.parse(content)), [content])
   const editorStateRef = useRef<EditorState>()
   const getEditorState = () => {


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7284

Implements the remaining email notifications:
* Task involves (user is mentioned in a task)
* Promoted to billing leader (included in original PR, but not linked to the picker 🙃 )
* Payment rejected

## Demo
<img width="603" alt="Screen Shot 2022-12-05 at 8 12 54 PM" src="https://user-images.githubusercontent.com/9013217/205791792-dd3fa875-f258-405c-9995-a1a53fe1c5a8.png">

## Testing scenarios
Trigger each of the notification types, trigger a notification email, and examine email.

"Payment rejected" can be manually created in the rethink data explorer with:
```
r.db('actionDevelopment')
        .table('Notification')
      // Only include notifications which occurred within the last day
  .insert({
    id: 'iQwJn2dxmg',
    status: 'UNREAD',
    createdAt: new Date(),
    type: 'PAYMENT_REJECTED',
    userId: 'local|eXBU1biSzK',
    orgId: 'ePchTFCMDe',
    last4: '1234',
    brand: 'Amex'
  })
```
(note that `last4` and `brand` come from the org, and will not appear in the email message).

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
