### PR TITLE
chore: limit direct access to locked meetings

### DIFF
--- a/packages/client/components/ActionMeeting.tsx
+++ b/packages/client/components/ActionMeeting.tsx
@@ -9,6 +9,7 @@ import {NewMeetingPhaseTypeEnum} from '../__generated__/ActionMeeting_meeting.gr
 import ActionMeetingSidebar from './ActionMeetingSidebar'
 import MeetingArea from './MeetingArea'
 import MeetingControlBar from './MeetingControlBar'
+import MeetingLockedOverlay from './MeetingLockedOverlay'
 import MeetingStyles from './MeetingStyles'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
 
@@ -74,6 +75,7 @@ const ActionMeeting = (props: Props) => {
         handleGotoNext={handleGotoNext}
         gotoStageId={gotoStageId}
       />
+      <MeetingLockedOverlay meetingRef={meeting} />
     </MeetingStyles>
   )
 }
@@ -90,6 +92,7 @@ export default createFragmentContainer(ActionMeeting, {
       ...ActionMeetingLastCall_meeting
       ...NewMeetingAvatarGroup_meeting
       ...MeetingControlBar_meeting
+      ...MeetingLockedOverlay_meeting
       localPhase {
         id
         phaseType

--- a/packages/client/components/ActionMeetingLastCall.tsx
+++ b/packages/client/components/ActionMeetingLastCall.tsx
@@ -41,8 +41,9 @@ const ActionMeetingLastCall = (props: Props) => {
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
   const {viewerId} = atmosphere
   const {endedAt, facilitator, facilitatorUserId, id: meetingId, phases, showSidebar} = meeting
-  const agendaItemPhase = phases.find((phase) => phase.phaseType === 'agendaitems')!
-  const {stages} = agendaItemPhase
+  const agendaItemPhase = phases.find((phase) => phase.phaseType === 'agendaitems')
+  const {stages} = agendaItemPhase ?? {}
+  if (!stages) return null
   const agendaItemsCompleted = stages.filter((stage) => stage.isComplete).length
   const {preferredName} = facilitator
   const isFacilitating = facilitatorUserId === viewerId && !endedAt

--- a/packages/client/components/MeetingLockedOverlay.tsx
+++ b/packages/client/components/MeetingLockedOverlay.tsx
@@ -113,6 +113,7 @@ const MeetingLockedOverlay = (props: Props) => {
 
   useEffect(() => {
     if (locked) {
+      // lock scrolling of the background, not super critical but looks nicer without scroll bar
       const prevOverflow = document.body.style.overflow
       document.body.style.overflow = 'hidden'
       return () => {

--- a/packages/client/components/MeetingLockedOverlay.tsx
+++ b/packages/client/components/MeetingLockedOverlay.tsx
@@ -1,0 +1,161 @@
+import styled from '@emotion/styled'
+import {Lock} from '@mui/icons-material'
+import graphql from 'babel-plugin-relay/macro'
+import React, {useEffect} from 'react'
+import {useFragment} from 'react-relay'
+import {MeetingLockedOverlay_meeting$key} from '~/__generated__/MeetingLockedOverlay_meeting.graphql'
+import useAtmosphere from '../hooks/useAtmosphere'
+import useRouter from '../hooks/useRouter'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
+import {modalShadow} from '../styles/elevation'
+import {PALETTE} from '../styles/paletteV3'
+import {Radius} from '../types/constEnums'
+import PrimaryButton from './PrimaryButton'
+
+interface Props {
+  meetingRef: MeetingLockedOverlay_meeting$key
+}
+
+const DialogOverlay = styled('div')({
+  position: 'fixed',
+  top: 0,
+  width: '100%',
+  height: '100%',
+  backdropFilter: 'blur(3px)',
+  zIndex: 100,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflowY: 'auto'
+})
+
+const DialogContainer = styled('div')({
+  display: 'flex',
+  backgroundColor: 'white',
+  borderRadius: Radius.DIALOG,
+  boxShadow: modalShadow,
+  flexDirection: 'column',
+  marginBottom: 100,
+  maxHeight: '90vh',
+  maxWidth: 'calc(100vw - 48px)',
+  minWidth: 280,
+  width: 512,
+  alignItems: 'center',
+  padding: 24
+})
+
+const DialogTitle = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  color: PALETTE.SLATE_700,
+  fontSize: 14,
+  justifyContent: 'space-around',
+  fontWeight: 600,
+  lineHeight: '20px',
+  margin: '16px 16px 8px',
+  paddingTop: 2
+})
+
+const DialogBody = styled('div')({
+  fontSize: 14,
+  lineHeight: '20px',
+  textAlign: 'center',
+  padding: '4px 48px 16px 48px'
+})
+
+const LockIcon = styled(Lock)({
+  borderRadius: '100%',
+  color: PALETTE.GRAPE_500,
+  display: 'block',
+  userSelect: 'none',
+  height: 40,
+  width: 40,
+  svg: {
+    height: 40,
+    width: 40
+  }
+})
+
+const MeetingLockedOverlay = (props: Props) => {
+  const {meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment MeetingLockedOverlay_meeting on NewMeeting {
+        id
+        locked
+        organization {
+          id
+          name
+          viewerOrganizationUser {
+            id
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
+  const {id: meetingId, locked, organization} = meeting
+  const {id: orgId, name: orgName, viewerOrganizationUser} = organization
+  const canUpgrade = !!viewerOrganizationUser
+
+  const atmosphere = useAtmosphere()
+  const {history} = useRouter()
+  useEffect(() => {
+    if (locked) {
+      SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Viewed', {
+        source: 'Direct Meeting Link',
+        upgradeTier: 'pro',
+        meetingId
+      })
+    }
+  }, [locked])
+
+  useEffect(() => {
+    if (locked) {
+      const prevOverflow = document.body.style.overflow
+      document.body.style.overflow = 'hidden'
+      return () => {
+        document.body.style.overflow = prevOverflow
+      }
+    }
+    return undefined
+  }, [locked])
+
+  const onClick = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
+      source: 'Direct Meeting Link Upgrade CTA',
+      upgradeTier: 'pro',
+      meetingId
+    })
+    history.push(`/me/organizations/${orgId}`)
+  }
+
+  if (!locked) return null
+
+  return (
+    <DialogOverlay>
+      <DialogContainer>
+        <LockIcon />
+        <DialogTitle>Past Meetings Locked</DialogTitle>
+        {canUpgrade ? (
+          <>
+            <DialogBody>
+              Your plan includes 30 days of meeting history. Unlock the full meeting history of{' '}
+              <i>{orgName}</i> by upgrading.
+            </DialogBody>
+            <PrimaryButton onClick={onClick}>Unlock Past Meetings</PrimaryButton>
+          </>
+        ) : (
+          <>
+            <DialogBody>
+              The plan of <i>{orgName}</i> includes only 30 days of meeting history.
+            </DialogBody>
+          </>
+        )}
+      </DialogContainer>
+    </DialogOverlay>
+  )
+}
+
+export default MeetingLockedOverlay

--- a/packages/client/components/PokerMeeting.tsx
+++ b/packages/client/components/PokerMeeting.tsx
@@ -9,6 +9,7 @@ import useMeeting from '../hooks/useMeeting'
 import NewMeetingAvatarGroup from '../modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
 import lazyPreload, {LazyExoticPreload} from '../utils/lazyPreload'
 import MeetingControlBar from './MeetingControlBar'
+import MeetingLockedOverlay from './MeetingLockedOverlay'
 import MeetingStyles from './MeetingStyles'
 import PokerMeetingSidebar from './PokerMeetingSidebar'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
@@ -65,6 +66,7 @@ const PokerMeeting = (props: Props) => {
         handleGotoNext={handleGotoNext}
         gotoStageId={gotoStageId}
       />
+      <MeetingLockedOverlay meetingRef={meeting} />
     </MeetingStyles>
   )
 }
@@ -79,6 +81,7 @@ export default createFragmentContainer(PokerMeeting, {
       ...MeetingControlBar_meeting
       ...ScopePhase_meeting
       ...PokerEstimatePhase_meeting
+      ...MeetingLockedOverlay_meeting
       id
       # hack to initialize local state (clientField needs to be on non-id domain state. thx relay)
       init: id @__clientField(handle: "localPoker")

--- a/packages/client/components/RetroMeeting.tsx
+++ b/packages/client/components/RetroMeeting.tsx
@@ -1,5 +1,3 @@
-import styled from '@emotion/styled'
-import {Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactElement, Suspense} from 'react'
 import {useFragment} from 'react-relay'
@@ -11,82 +9,17 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import useMeeting from '../hooks/useMeeting'
 import LocalAtmosphere from '../modules/demo/LocalAtmosphere'
 import NewMeetingAvatarGroup from '../modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
-import {modalShadow} from '../styles/elevation'
-import {PALETTE} from '../styles/paletteV3'
-import {Radius, RetroDemo} from '../types/constEnums'
+import {RetroDemo} from '../types/constEnums'
 import lazyPreload, {LazyExoticPreload} from '../utils/lazyPreload'
 import MeetingControlBar from './MeetingControlBar'
+import MeetingLockedOverlay from './MeetingLockedOverlay'
 import MeetingStyles from './MeetingStyles'
-import PrimaryButton from './PrimaryButton'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
 import RetroMeetingSidebar from './RetroMeetingSidebar'
 
 interface Props {
   meeting: RetroMeeting_meeting$key
 }
-
-const DialogOverlay = styled('div')({
-  position: 'fixed',
-  width: '100%',
-  height: '100%',
-  //backgroundColor: '#aaaaaaaa',
-  backdropFilter: 'blur(3px)',
-  zIndex: 100,
-  paddingTop: '20%'
-})
-
-const DialogContainer = styled('div')({
-  display: 'flex',
-  backgroundColor: 'white',
-  borderRadius: Radius.DIALOG,
-  boxShadow: modalShadow,
-  flexDirection: 'column',
-  // overflow: 'auto', removed because react-beautiful-dnd only supports 1 scrolling parent
-  margin: '0 auto',
-  maxHeight: '90vh',
-  maxWidth: 'calc(100vw - 48px)',
-  minWidth: 280,
-  width: 512,
-  alignItems: 'center',
-  padding: 24
-})
-
-const TimelineEventTitle = styled('span')({
-  color: PALETTE.SLATE_700,
-  fontSize: 14,
-  fontWeight: 600,
-  lineHeight: '20px'
-})
-
-const TimelineEventBody = styled('div')({
-  padding: '0 16px 16px 16px',
-  fontSize: 14,
-  lineHeight: '20px',
-  textAlign: 'center'
-})
-
-const EventIcon = styled('div')({
-  borderRadius: '100%',
-  color: PALETTE.GRAPE_500,
-  display: 'block',
-  userSelect: 'none',
-  height: 40,
-  width: 40,
-  svg: {
-    height: 40,
-    width: 40
-  }
-})
-
-const HeaderText = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  fontSize: 14,
-  justifyContent: 'space-around',
-  lineHeight: '20px',
-  margin: '16px 16px 8px',
-  paddingTop: 2
-})
 
 const phaseLookup = {
   checkin: lazyPreload(
@@ -123,8 +56,8 @@ const RetroMeeting = (props: Props) => {
         ...RetroVotePhase_meeting
         ...RetroDiscussPhase_meeting
         ...NewMeetingAvatarGroup_meeting
+        ...MeetingLockedOverlay_meeting
         id
-        locked
         showSidebar
         localPhase {
           phaseType
@@ -175,20 +108,7 @@ const RetroMeeting = (props: Props) => {
         handleGotoNext={handleGotoNext}
         gotoStageId={gotoStageId}
       />
-      <DialogOverlay>
-        <DialogContainer>
-          <EventIcon>
-            <Lock />
-          </EventIcon>
-          <HeaderText>
-            <TimelineEventTitle>Past Meetings Locked</TimelineEventTitle>
-          </HeaderText>
-          <TimelineEventBody>
-            Your plan includes 30 days of meeting history. Unlock more by upgrading.
-          </TimelineEventBody>
-          <PrimaryButton>Unlock past meetings</PrimaryButton>
-        </DialogContainer>
-      </DialogOverlay>
+      <MeetingLockedOverlay meetingRef={meeting} />
     </MeetingStyles>
   )
 }

--- a/packages/client/components/RetroMeeting.tsx
+++ b/packages/client/components/RetroMeeting.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled'
+import {Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactElement, Suspense} from 'react'
 import {useFragment} from 'react-relay'
@@ -9,16 +11,82 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import useMeeting from '../hooks/useMeeting'
 import LocalAtmosphere from '../modules/demo/LocalAtmosphere'
 import NewMeetingAvatarGroup from '../modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
-import {RetroDemo} from '../types/constEnums'
+import {modalShadow} from '../styles/elevation'
+import {PALETTE} from '../styles/paletteV3'
+import {Radius, RetroDemo} from '../types/constEnums'
 import lazyPreload, {LazyExoticPreload} from '../utils/lazyPreload'
 import MeetingControlBar from './MeetingControlBar'
 import MeetingStyles from './MeetingStyles'
+import PrimaryButton from './PrimaryButton'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
 import RetroMeetingSidebar from './RetroMeetingSidebar'
 
 interface Props {
   meeting: RetroMeeting_meeting$key
 }
+
+const DialogOverlay = styled('div')({
+  position: 'fixed',
+  width: '100%',
+  height: '100%',
+  //backgroundColor: '#aaaaaaaa',
+  backdropFilter: 'blur(3px)',
+  zIndex: 100,
+  paddingTop: '20%'
+})
+
+const DialogContainer = styled('div')({
+  display: 'flex',
+  backgroundColor: 'white',
+  borderRadius: Radius.DIALOG,
+  boxShadow: modalShadow,
+  flexDirection: 'column',
+  // overflow: 'auto', removed because react-beautiful-dnd only supports 1 scrolling parent
+  margin: '0 auto',
+  maxHeight: '90vh',
+  maxWidth: 'calc(100vw - 48px)',
+  minWidth: 280,
+  width: 512,
+  alignItems: 'center',
+  padding: 24
+})
+
+const TimelineEventTitle = styled('span')({
+  color: PALETTE.SLATE_700,
+  fontSize: 14,
+  fontWeight: 600,
+  lineHeight: '20px'
+})
+
+const TimelineEventBody = styled('div')({
+  padding: '0 16px 16px 16px',
+  fontSize: 14,
+  lineHeight: '20px',
+  textAlign: 'center'
+})
+
+const EventIcon = styled('div')({
+  borderRadius: '100%',
+  color: PALETTE.GRAPE_500,
+  display: 'block',
+  userSelect: 'none',
+  height: 40,
+  width: 40,
+  svg: {
+    height: 40,
+    width: 40
+  }
+})
+
+const HeaderText = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  fontSize: 14,
+  justifyContent: 'space-around',
+  lineHeight: '20px',
+  margin: '16px 16px 8px',
+  paddingTop: 2
+})
 
 const phaseLookup = {
   checkin: lazyPreload(
@@ -56,6 +124,7 @@ const RetroMeeting = (props: Props) => {
         ...RetroDiscussPhase_meeting
         ...NewMeetingAvatarGroup_meeting
         id
+        locked
         showSidebar
         localPhase {
           phaseType
@@ -106,6 +175,20 @@ const RetroMeeting = (props: Props) => {
         handleGotoNext={handleGotoNext}
         gotoStageId={gotoStageId}
       />
+      <DialogOverlay>
+        <DialogContainer>
+          <EventIcon>
+            <Lock />
+          </EventIcon>
+          <HeaderText>
+            <TimelineEventTitle>Past Meetings Locked</TimelineEventTitle>
+          </HeaderText>
+          <TimelineEventBody>
+            Your plan includes 30 days of meeting history. Unlock more by upgrading.
+          </TimelineEventBody>
+          <PrimaryButton>Unlock past meetings</PrimaryButton>
+        </DialogContainer>
+      </DialogOverlay>
     </MeetingStyles>
   )
 }

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -95,7 +95,7 @@ const RetroMeetingSidebar = (props: Props) => {
           })!
           const showDiscussSection = isPhaseComplete('vote', phases)
           const phaseCount =
-            phaseType === 'discuss' && showDiscussSection ? discussPhase.stages.length : undefined
+            phaseType === 'discuss' && showDiscussSection ? discussPhase?.stages.length : undefined
           return (
             <Fragment key={phaseType}>
               <NewMeetingSidebarPhaseListItem

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -15,6 +15,7 @@ import ErrorBoundary from './ErrorBoundary'
 import MeetingArea from './MeetingArea'
 import MeetingContent from './MeetingContent'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
+import MeetingLockedOverlay from './MeetingLockedOverlay'
 import MeetingStyles from './MeetingStyles'
 import TeamPromptDiscussionDrawer from './TeamPrompt/TeamPromptDiscussionDrawer'
 import TeamPromptEditablePrompt from './TeamPrompt/TeamPromptEditablePrompt'
@@ -72,8 +73,10 @@ const TeamPromptMeeting = (props: Props) => {
         ...TeamPromptDiscussionDrawer_meeting
         ...TeamPromptEditablePrompt_meeting
         ...TeamPromptMeetingStatus_meeting
+        ...MeetingLockedOverlay_meeting
         id
         isRightDrawerOpen
+        endedAt
         phases {
           ... on TeamPromptResponsesPhase {
             __typename
@@ -190,6 +193,7 @@ const TeamPromptMeeting = (props: Props) => {
           </MeetingContent>
         </Suspense>
       </MeetingArea>
+      <MeetingLockedOverlay meetingRef={meeting} />
     </MeetingStyles>
   )
 }

--- a/packages/client/modules/summary/components/NewMeetingSummary.tsx
+++ b/packages/client/modules/summary/components/NewMeetingSummary.tsx
@@ -1,6 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {useEffect} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import MeetingLockedOverlay from '../../../components/MeetingLockedOverlay'
 import useDocumentTitle from '../../../hooks/useDocumentTitle'
 import useRouter from '../../../hooks/useRouter'
 import {PALETTE} from '../../../styles/paletteV3'
@@ -22,6 +23,7 @@ const query = graphql`
     viewer {
       newMeeting(meetingId: $meetingId) {
         ...MeetingSummaryEmail_meeting
+        ...MeetingLockedOverlay_meeting
         id
         team {
           id
@@ -72,6 +74,7 @@ const NewMeetingSummary = (props: Props) => {
         emailCSVUrl={emailCSVUrl}
         corsOptions={APP_CORS_OPTIONS}
       />
+      <MeetingLockedOverlay meetingRef={newMeeting} />
     </div>
   )
 }

--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -75,7 +75,7 @@ const getItemProps = (
   const agendaItemsPhase = phases.find((phase) => phase.phaseType === 'agendaitems')!
   const localStageId = (localStage && localStage.id) || ''
   const {phaseType} = localPhase
-  const {stages} = phaseType === 'agendaitems' ? localPhase : agendaItemsPhase
+  const {stages} = (phaseType === 'agendaitems' ? localPhase : agendaItemsPhase) ?? {}
   if (!stages) return fallback
   const agendaItemStage = stages.find((stage) => stage.agendaItem?.id === agendaItemId)
   if (!agendaItemStage) return fallback

--- a/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
@@ -38,8 +38,8 @@ interface Props {
 
 const getAgendaItems = (meeting: AgendaListAndInput_meeting | null) => {
   if (!meeting) return null
-  const agendaItemsPhase = meeting.phases!.find((phase) => phase.phaseType === 'agendaitems')!
-  if (!agendaItemsPhase.stages) return null
+  const agendaItemsPhase = meeting.phases!.find((phase) => phase.phaseType === 'agendaitems')
+  if (!agendaItemsPhase?.stages) return null
   return agendaItemsPhase.stages.map((stage) => stage.agendaItem)
 }
 

--- a/packages/client/utils/meetings/isPhaseComplete.ts
+++ b/packages/client/utils/meetings/isPhaseComplete.ts
@@ -4,7 +4,7 @@ const isPhaseComplete = (
   phaseType: NewMeetingPhaseTypeEnum,
   phases: ReadonlyArray<{phaseType: string; stages: ReadonlyArray<{isComplete: boolean}>}>
 ) => {
-  const phase = phases.find((p) => p.phaseType === phaseType)!
+  const phase = phases.find((p) => p.phaseType === phaseType)
   return phase ? phase.stages.every((stage) => stage && stage.isComplete === true) : true
 }
 

--- a/packages/client/utils/meetings/isPhaseComplete.ts
+++ b/packages/client/utils/meetings/isPhaseComplete.ts
@@ -5,7 +5,7 @@ const isPhaseComplete = (
   phases: ReadonlyArray<{phaseType: string; stages: ReadonlyArray<{isComplete: boolean}>}>
 ) => {
   const phase = phases.find((p) => p.phaseType === phaseType)!
-  return phase.stages.every((stage) => stage && stage.isComplete === true)
+  return phase ? phase.stages.every((stage) => stage && stage.isComplete === true) : true
 }
 
 export default isPhaseComplete

--- a/packages/client/utils/relay/updateLocalStage.ts
+++ b/packages/client/utils/relay/updateLocalStage.ts
@@ -18,7 +18,6 @@ export const setLocalStageAndPhase = (
     )
 
   if (!facilitatorPhaseProxy) return
-  console.log('GEORG set localPhase', facilitatorPhaseProxy)
   meetingProxy
     .setLinkedRecord(stage, 'localStage')
     .setLinkedRecord(facilitatorPhaseProxy, 'localPhase')

--- a/packages/client/utils/relay/updateLocalStage.ts
+++ b/packages/client/utils/relay/updateLocalStage.ts
@@ -18,6 +18,7 @@ export const setLocalStageAndPhase = (
     )
 
   if (!facilitatorPhaseProxy) return
+  console.log('GEORG set localPhase', facilitatorPhaseProxy)
   meetingProxy
     .setLinkedRecord(stage, 'localStage')
     .setLinkedRecord(facilitatorPhaseProxy, 'localPhase')

--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -107,24 +107,45 @@ export const newMeetingFields = () => ({
   phases: {
     type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(NewMeetingPhase))),
     description: 'The phases the meeting will go through, including all phase-specific state',
-    resolve: ({
+    resolve: async ({
       phases,
       id: meetingId,
       teamId,
-      facilitatorStageId
+      facilitatorStageId,
+      endedAt
     }: {
       phases: any
       id: string
       teamId: string
       facilitatorStageId: string
-    }) => {
-      return phases
+      endedAt: Date
+    }, _args: unknown,
+      {authToken, dataLoader}: GQLContext) => {
+      const viewerId = getUserId(authToken)
+      const locked = await isMeetingLocked(dataLoader, viewerId, teamId, endedAt)
+
+      const resolvedPhases = phases
         .map((phase: any) => ({
           ...phase,
           meetingId,
           teamId
         }))
-        .filter((phase: any) => phase.stages.find((stage: any) => stage.id === facilitatorStageId))
+
+      if (locked) {
+        // only return current phase and make all stages non-navigable so even if the user removes the overlay they cannot see all meeting data
+        return resolvedPhases
+          .filter((phase: any) => phase.stages.find(({id}: any) => id === facilitatorStageId))
+          .map((phase: any) => ({
+            ...phase,
+            stages: phase.stages
+              .map((stage: any) => ({
+                ...stage,
+                isNavigable: false,
+                isNavigableByFacilitator: false
+              }))
+          }))
+      }
+      return resolvedPhases
     }
   },
   showConversionModal: {

--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -107,43 +107,40 @@ export const newMeetingFields = () => ({
   phases: {
     type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(NewMeetingPhase))),
     description: 'The phases the meeting will go through, including all phase-specific state',
-    resolve: async ({
-      phases,
-      id: meetingId,
-      teamId,
-      facilitatorStageId,
-      endedAt
-    }: {
-      phases: any
-      id: string
-      teamId: string
-      facilitatorStageId: string
-      endedAt: Date
-    }, _args: unknown,
-      {authToken, dataLoader}: GQLContext) => {
+    resolve: async (
+      {
+        phases,
+        id: meetingId,
+        teamId,
+        endedAt
+      }: {
+        phases: any
+        id: string
+        teamId: string
+        endedAt: Date
+      },
+      _args: unknown,
+      {authToken, dataLoader}: GQLContext
+    ) => {
       const viewerId = getUserId(authToken)
       const locked = await isMeetingLocked(dataLoader, viewerId, teamId, endedAt)
 
-      const resolvedPhases = phases
-        .map((phase: any) => ({
-          ...phase,
-          meetingId,
-          teamId
-        }))
+      const resolvedPhases = phases.map((phase: any) => ({
+        ...phase,
+        meetingId,
+        teamId
+      }))
 
       if (locked) {
-        // only return current phase and make all stages non-navigable so even if the user removes the overlay they cannot see all meeting data
-        return resolvedPhases
-          .filter((phase: any) => phase.stages.find(({id}: any) => id === facilitatorStageId))
-          .map((phase: any) => ({
-            ...phase,
-            stages: phase.stages
-              .map((stage: any) => ({
-                ...stage,
-                isNavigable: false,
-                isNavigableByFacilitator: false
-              }))
+        // make all stages non-navigable so even if the user removes the overlay they cannot see all meeting data
+        return resolvedPhases.map((phase: any) => ({
+          ...phase,
+          stages: phase.stages.map((stage: any) => ({
+            ...stage,
+            isNavigable: false,
+            isNavigableByFacilitator: false
           }))
+        }))
       }
       return resolvedPhases
     }

--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -123,7 +123,7 @@ export const newMeetingFields = () => ({
       {authToken, dataLoader}: GQLContext
     ) => {
       const viewerId = getUserId(authToken)
-      const locked = await isMeetingLocked(dataLoader, viewerId, teamId, endedAt)
+      const locked = await isMeetingLocked(viewerId, teamId, endedAt, dataLoader)
 
       const resolvedPhases = phases.map((phase: any) => ({
         ...phase,

--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -107,12 +107,24 @@ export const newMeetingFields = () => ({
   phases: {
     type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(NewMeetingPhase))),
     description: 'The phases the meeting will go through, including all phase-specific state',
-    resolve: ({phases, id: meetingId, teamId}: {phases: any; id: string; teamId: string}) => {
-      return phases.map((phase: any) => ({
-        ...phase,
-        meetingId,
-        teamId
-      }))
+    resolve: ({
+      phases,
+      id: meetingId,
+      teamId,
+      facilitatorStageId
+    }: {
+      phases: any
+      id: string
+      teamId: string
+      facilitatorStageId: string
+    }) => {
+      return phases
+        .map((phase: any) => ({
+          ...phase,
+          meetingId,
+          teamId
+        }))
+        .filter((phase: any) => phase.stages.find((stage: any) => stage.id === facilitatorStageId))
     }
   },
   showConversionModal: {


### PR DESCRIPTION
# Description

Fixes #7373 
When a locked meeting or its summary is accessed using a direct link, an overlay and an upgrade modal is shown. When the user is not in the organization anymore, the modal has no CTA, otherwise it will lead to the billing page. All phases are returned non-navigable, however spoofing of the network traffic currently would reveal all data.

## Demo

https://www.loom.com/share/0a04af90726646368dd8368fdd6c96e2

## Testing scenarios

Easiest way to get to the locked meetings is replacing `locked` with `false` in those places:
* https://github.com/ParabolInc/parabol/blob/dc139a292dd739cd121d18aed0b1b686bb4e40b4/packages/client/components/TimelineEventCompletedRetroMeeting.tsx#L79
* https://github.com/ParabolInc/parabol/blob/dc139a292dd739cd121d18aed0b1b686bb4e40b4/packages/client/components/TimelineEventCompletedActionMeeting.tsx#L74
* https://github.com/ParabolInc/parabol/blob/dc139a292dd739cd121d18aed0b1b686bb4e40b4/packages/client/components/TimelineEventTeamPromptComplete.tsx#L106
* https://github.com/ParabolInc/parabol/blob/dc139a292dd739cd121d18aed0b1b686bb4e40b4/packages/client/components/TimelineEventPokerComplete.tsx#L62

and then these can be reached from the timeline.

- visit the **summary** of a locked meeting with a user who is **member** of the organization for
  - [ ] retro
  - [ ] checkin
  - [ ] poker
  - [ ] standup

- visit the locked meeting **discussion** directly with a user who is **member** of the organization
  - [ ] retro
  - [ ] checkin
  - [ ] poker
  - [ ] standup

- repeat with a user who is **no member**, i.e. left the org (same as archiving the org)

- check visiting with paid account still works

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
