### PR TITLE
feat(recurrence): Added standups time left indicator

### DIFF
--- a/packages/client/components/TeamPrompt/Recurrence/TimeLeftBadge.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/TimeLeftBadge.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import useRefreshInterval from '../../../hooks/useRefreshInterval'
+import {humanReadableCountdown} from '../../../utils/date/relativeDate'
+import {TeamPromptBadge} from '../TeamPromptBadge'
+
+interface Props {
+  meetingEndTime: string
+}
+
+export const TimeLeftBadge = (props: Props) => {
+  const {meetingEndTime} = props
+
+  useRefreshInterval(1000)
+  const fromNow = humanReadableCountdown(meetingEndTime)
+  if (!fromNow) return null
+
+  return <TeamPromptBadge>{fromNow}</TeamPromptBadge>
+}

--- a/packages/client/components/TeamPrompt/Recurrence/TimeLeftBadge.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/TimeLeftBadge.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
+import {MenuPosition} from '../../../hooks/useCoords'
 import useRefreshInterval from '../../../hooks/useRefreshInterval'
+import useTooltip from '../../../hooks/useTooltip'
 import {humanReadableCountdown} from '../../../utils/date/relativeDate'
 import {TeamPromptBadge} from '../TeamPromptBadge'
 
@@ -10,9 +12,20 @@ interface Props {
 export const TimeLeftBadge = (props: Props) => {
   const {meetingEndTime} = props
 
+  const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
+    MenuPosition.UPPER_CENTER
+  )
   useRefreshInterval(1000)
+  const meetingEndTimeDate = new Date(meetingEndTime)
   const fromNow = humanReadableCountdown(meetingEndTime)
   if (!fromNow) return null
 
-  return <TeamPromptBadge>{fromNow}</TeamPromptBadge>
+  return (
+    <>
+      <TeamPromptBadge onMouseEnter={openTooltip} onMouseLeave={closeTooltip} ref={originRef}>
+        {fromNow}
+      </TeamPromptBadge>
+      {tooltipPortal(`Ends at ${meetingEndTimeDate.toLocaleString()}`)}
+    </>
+  )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptBadge.tsx
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled'
+import {PALETTE} from '~/styles/paletteV3'
+
+export const TeamPromptBadge = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  fontSize: 14,
+  fontWeight: 600,
+  padding: '4px 16px 4px 16px',
+  backgroundColor: PALETTE.WHITE,
+  color: PALETTE.SLATE_700,
+  borderRadius: 26,
+  height: 32
+})

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -1,21 +1,6 @@
-import styled from '@emotion/styled'
 import React from 'react'
-import {PALETTE} from '~/styles/paletteV3'
-
-const TeamPromptEndedRoot = styled('div')({
-  borderRadius: 24,
-  height: 48,
-  backgroundColor: PALETTE.WHITE,
-  color: PALETTE.SLATE_700,
-  fontWeight: 500,
-  fontSize: 14,
-  padding: '8px 16px 8px 16px',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  margin: 'auto 0'
-})
+import {TeamPromptBadge} from './TeamPromptBadge'
 
 export const TeamPromptEndedBadge = () => {
-  return <TeamPromptEndedRoot>✅ This activity has ended.</TeamPromptEndedRoot>
+  return <TeamPromptBadge>✅ This activity has ended.</TeamPromptBadge>
 }

--- a/packages/client/components/TeamPrompt/TeamPromptMeetingStatus.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptMeetingStatus.tsx
@@ -1,0 +1,36 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {TeamPromptMeetingStatus_meeting$key} from '~/__generated__/TeamPromptMeetingStatus_meeting.graphql'
+import {TimeLeftBadge} from './Recurrence/TimeLeftBadge'
+import {TeamPromptEndedBadge} from './TeamPromptEndedBadge'
+
+interface Props {
+  meetingRef: TeamPromptMeetingStatus_meeting$key
+}
+
+export const TeamPromptMeetingStatus = (props: Props) => {
+  const {meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment TeamPromptMeetingStatus_meeting on TeamPromptMeeting {
+        id
+        scheduledEndTime
+        endedAt
+      }
+    `,
+    meetingRef
+  )
+  const {endedAt, scheduledEndTime} = meeting
+  const isMeetingEnded = !!endedAt
+
+  if (isMeetingEnded) {
+    return <TeamPromptEndedBadge />
+  }
+
+  if (scheduledEndTime) {
+    return <TimeLeftBadge meetingEndTime={scheduledEndTime} />
+  }
+
+  return null
+}

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -12,7 +12,7 @@ import EditableText from '../EditableText'
 import LogoBlock from '../LogoBlock/LogoBlock'
 import {IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
 import {HumanReadableRecurrenceRule} from './Recurrence/HumanReadableRecurrenceRule'
-import {TeamPromptEndedBadge} from './TeamPromptEndedBadge'
+import {TeamPromptMeetingStatus} from './TeamPromptMeetingStatus'
 import TeamPromptOptions from './TeamPromptOptions'
 
 const TeamPromptLogoBlock = styled(LogoBlock)({
@@ -102,7 +102,6 @@ const TeamPromptTopBar = (props: Props) => {
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         id
         name
-        endedAt
         facilitatorUserId
         meetingSeries {
           id
@@ -111,16 +110,16 @@ const TeamPromptTopBar = (props: Props) => {
         }
         ...TeamPromptOptions_meeting
         ...NewMeetingAvatarGroup_meeting
+        ...TeamPromptMeetingStatus_meeting
       }
     `,
     meetingRef
   )
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
-  const {id: meetingId, name: meetingName, facilitatorUserId, endedAt, meetingSeries} = meeting
+  const {id: meetingId, name: meetingName, facilitatorUserId, meetingSeries} = meeting
   const isFacilitator = viewerId === facilitatorUserId
   const {handleSubmit, validate, error} = useRenameMeeting(meetingId)
-  const isMeetingEnded = !!endedAt
   const isRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
 
   return (
@@ -146,9 +145,9 @@ const TeamPromptTopBar = (props: Props) => {
           )}
         </div>
       </MeetingTitleSection>
-      {isDesktop && isMeetingEnded && (
+      {isDesktop && (
         <MiddleSection>
-          <TeamPromptEndedBadge />
+          <TeamPromptMeetingStatus meetingRef={meeting} />
         </MiddleSection>
       )}
       <RightSection>

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -17,11 +17,11 @@ import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import MeetingStyles from './MeetingStyles'
 import TeamPromptDiscussionDrawer from './TeamPrompt/TeamPromptDiscussionDrawer'
 import TeamPromptEditablePrompt from './TeamPrompt/TeamPromptEditablePrompt'
-import {TeamPromptEndedBadge} from './TeamPrompt/TeamPromptEndedBadge'
 import {
   GRID_PADDING_LEFT_RIGHT_PERCENT,
   ResponsesGridBreakpoints
 } from './TeamPrompt/TeamPromptGridDimensions'
+import {TeamPromptMeetingStatus} from './TeamPrompt/TeamPromptMeetingStatus'
 import TeamPromptResponseCard from './TeamPrompt/TeamPromptResponseCard'
 import TeamPromptTopBar from './TeamPrompt/TeamPromptTopBar'
 
@@ -47,7 +47,8 @@ const ResponsesGrid = styled('div')({
 const BadgeContainer = styled('div')({
   display: 'flex',
   justifyContent: 'center',
-  alignItems: 'center'
+  alignItems: 'center',
+  marginTop: 16
 })
 
 interface Props {
@@ -69,7 +70,7 @@ const TeamPromptMeeting = (props: Props) => {
         ...TeamPromptTopBar_meeting
         ...TeamPromptDiscussionDrawer_meeting
         ...TeamPromptEditablePrompt_meeting
-        endedAt
+        ...TeamPromptMeetingStatus_meeting
         isRightDrawerOpen
         phases {
           ... on TeamPromptResponsesPhase {
@@ -125,8 +126,7 @@ const TeamPromptMeeting = (props: Props) => {
   }, [phase])
   const transitioningStages = useTransition(stages)
   const {safeRoute, isDesktop} = useMeeting(meeting)
-  const {isRightDrawerOpen, endedAt} = meeting
-  const isMeetingEnded = !!endedAt
+  const {isRightDrawerOpen} = meeting
   if (!safeRoute) return null
 
   return (
@@ -139,10 +139,8 @@ const TeamPromptMeeting = (props: Props) => {
               hideBottomBar={true}
             >
               <TeamPromptTopBar meetingRef={meeting} isDesktop={isDesktop} />
-              {!isDesktop && isMeetingEnded && (
-                <BadgeContainer>
-                  <TeamPromptEndedBadge />
-                </BadgeContainer>
+              {!isDesktop && (
+                <BadgeContainer>{<TeamPromptMeetingStatus meetingRef={meeting} />}</BadgeContainer>
               )}
               <TeamPromptEditablePrompt meetingRef={meeting} />
               <ErrorBoundary>

--- a/packages/client/utils/date/relativeDate.ts
+++ b/packages/client/utils/date/relativeDate.ts
@@ -3,6 +3,8 @@
 // capitalized J in just now
 // set my own defaults
 
+import plural from '../plural'
+
 const SECOND = 1000
 const MIN = SECOND * 60
 const HOUR = MIN * 60
@@ -17,6 +19,45 @@ interface Opts {
   suffix?: boolean
   now?: string | Date | null
   smallDiff?: string
+}
+
+/**
+ * Creates a human-readable string representing the time till the given date,
+ * for example: 2 days left; 13 hours left; 2 days left, etc or null if the date is in the past
+ * @param date
+ */
+export const humanReadableCountdown = (date: string | Date) => {
+  const now = new Date()
+  const abs = new Date(date).getTime() - now.getTime()
+  if (abs < 0) return null
+  const periods = {
+    d: (abs % MONTH) / DAY,
+    h: (abs % DAY) / HOUR,
+    m: (abs % HOUR) / MIN,
+    s: (abs % MIN) / SECOND
+  } as const
+
+  const days = Math.floor(periods['d'])
+  if (days > 0) {
+    return `${days} ${plural(days, 'day', 'days')} left`
+  }
+
+  const hours = Math.floor(periods['h'])
+  if (hours > 0) {
+    return `${hours} ${plural(hours, 'hour', 'hours')} left`
+  }
+
+  const minutes = Math.floor(periods['m'])
+  if (minutes > 0) {
+    return `${minutes} ${plural(minutes, 'minute', 'minutes')} left`
+  }
+
+  const seconds = Math.floor(periods['s'])
+  if (seconds > 0) {
+    return `${seconds} ${plural(seconds, 'second', 'seconds')} left`
+  }
+
+  return null
 }
 
 export const countdown = (date: string | Date) => {

--- a/packages/server/graphql/public/mutations/startRecurrence.ts
+++ b/packages/server/graphql/public/mutations/startRecurrence.ts
@@ -128,10 +128,10 @@ const startRecurrence: MutationResolvers['startRecurrence'] = async (
     analytics.recurrenceStarted(viewerId, meetingSeries)
   } else {
     const newMeetingSeries = await startNewMeetingSeries(viewerId, teamId, meetingId)
-    dataLoader.get('newMeetings').clear(meetingId)
-
     analytics.recurrenceStarted(viewerId, newMeetingSeries)
   }
+
+  dataLoader.get('newMeetings').clear(meetingId)
 
   // RESOLUTION
   const data = {meetingId}


### PR DESCRIPTION
# Description

Fixes #7499 

## Demo

![localhost_3000_meet_iTnoRVBsu4_responses](https://user-images.githubusercontent.com/1017620/206264111-f8db2a76-5845-468d-8fb0-408495c08c4a.png)
![localhost_3000_meet_iTnsw3WyaI_responses](https://user-images.githubusercontent.com/1017620/206264119-bbade3d0-80f5-4e90-b5ea-b4ab5d8fb04a.png)


## Testing scenarios

- [ ] start standup meeting, enable recurrence, and check if timer is showing (checking if it works correctly may require changing the default meeting duration [here](https://github.com/ParabolInc/parabol/blob/e938186e0f31105164530844232d0adf0c098c46/packages/server/graphql/public/mutations/startRecurrence.ts#L48), otherwise it might take a while to test 🙃)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
