### PR TITLE
feat(recurrence): Added current meeting link to ended meeting badge in standups

### DIFF
--- a/packages/client/components/TeamPrompt/Recurrence/TimeLeftBadge.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/TimeLeftBadge.tsx
@@ -23,7 +23,7 @@ export const TimeLeftBadge = (props: Props) => {
   return (
     <>
       <TeamPromptBadge onMouseEnter={openTooltip} onMouseLeave={closeTooltip} ref={originRef}>
-        {fromNow}
+        {fromNow} left
       </TeamPromptBadge>
       {tooltipPortal(`Ends at ${meetingEndTimeDate.toLocaleString()}`)}
     </>

--- a/packages/client/components/TeamPrompt/TeamPromptBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptBadge.tsx
@@ -11,5 +11,5 @@ export const TeamPromptBadge = styled('div')({
   backgroundColor: PALETTE.WHITE,
   color: PALETTE.SLATE_700,
   borderRadius: 26,
-  height: 32
+  minHeight: 34
 })

--- a/packages/client/components/TeamPrompt/TeamPromptBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptBadge.tsx
@@ -7,9 +7,9 @@ export const TeamPromptBadge = styled('div')({
   alignItems: 'center',
   fontSize: 14,
   fontWeight: 600,
-  padding: '4px 16px 4px 16px',
+  padding: '6px 16px 6px 16px',
   backgroundColor: PALETTE.WHITE,
   color: PALETTE.SLATE_700,
-  borderRadius: 26,
+  borderRadius: '100vmax',
   minHeight: 34
 })

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import {Link} from 'react-router-dom'
+import useBreakpoint from '../../hooks/useBreakpoint'
 import useRefreshInterval from '../../hooks/useRefreshInterval'
+import {Breakpoint} from '../../types/constEnums'
 import {humanReadableCountdown} from '../../utils/date/relativeDate'
 import {TeamPromptBadge} from './TeamPromptBadge'
 
@@ -21,11 +23,18 @@ interface NextMeetingCountdownProps {
 export const NextMeetingCountdown = (props: NextMeetingCountdownProps) => {
   const {nextMeetingDate} = props
   useRefreshInterval(1000)
+
   const fromNow = humanReadableCountdown(nextMeetingDate)
   if (!fromNow) return null
 
   return <span>Next one starts in {humanReadableCountdown(nextMeetingDate)}.</span>
 }
+
+const TeamPromptEndedBadgeRoot = styled('div')({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'start'
+})
 
 const StyledLink = styled(Link)({
   textDecoration: 'underline',
@@ -33,13 +42,22 @@ const StyledLink = styled(Link)({
 })
 
 const EmojiContainer = styled('span')({
-  paddingRight: 4
+  paddingRight: 8
 })
+
+const TeamPromptEndedTextContainer = styled('span')<{isDesktop: boolean}>(({isDesktop}) => ({
+  display: 'inline-block',
+  width: isDesktop ? undefined : 220,
+  overflow: 'hidden',
+  overflowWrap: 'break-word'
+}))
 
 // here we just want one of the props to be present, never both
 type Props = {closestActiveMeetingId: string} | {nextMeetingDate: Date} | Record<string, never>
 
 export const TeamPromptEndedBadge = (props: Props) => {
+  const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
+
   const renderAdditionalInfo = () => {
     if ('closestActiveMeetingId' in props) {
       return <NextMeetingLink closestActiveMeetingId={props.closestActiveMeetingId} />
@@ -54,9 +72,12 @@ export const TeamPromptEndedBadge = (props: Props) => {
 
   return (
     <TeamPromptBadge>
-      <div>
-        <EmojiContainer>✅</EmojiContainer> This activity has ended. {renderAdditionalInfo()}
-      </div>
+      <TeamPromptEndedBadgeRoot>
+        <EmojiContainer>✅</EmojiContainer>{' '}
+        <TeamPromptEndedTextContainer isDesktop={isDesktop}>
+          This activity has ended. {renderAdditionalInfo()}
+        </TeamPromptEndedTextContainer>
+      </TeamPromptEndedBadgeRoot>
     </TeamPromptBadge>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -1,6 +1,27 @@
+import styled from '@emotion/styled'
 import React from 'react'
+import {Link} from 'react-router-dom'
 import {TeamPromptBadge} from './TeamPromptBadge'
 
-export const TeamPromptEndedBadge = () => {
-  return <TeamPromptBadge>✅ This activity has ended.</TeamPromptBadge>
+const StyledLink = styled(Link)({
+  textDecoration: 'underline'
+})
+
+interface Props {
+  closestActiveMeetingId?: string
+}
+
+export const TeamPromptEndedBadge = ({closestActiveMeetingId}: Props) => {
+  return (
+    <TeamPromptBadge>
+      <div>
+        ✅ This activity has ended.{' '}
+        {closestActiveMeetingId && (
+          <StyledLink to={`/meet/${closestActiveMeetingId}`}>
+            Go to the currenct activity.
+          </StyledLink>
+        )}
+      </div>
+    </TeamPromptBadge>
+  )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -5,7 +5,12 @@ import {humanReadableCountdown} from '../../utils/date/relativeDate'
 import {TeamPromptBadge} from './TeamPromptBadge'
 
 const StyledLink = styled(Link)({
-  textDecoration: 'underline'
+  textDecoration: 'underline',
+  fontWeight: 400
+})
+
+const EmojiContainer = styled('span')({
+  paddingRight: 4
 })
 
 // here we just want one of the props to be present, never both
@@ -30,7 +35,9 @@ export const TeamPromptEndedBadge = (props: Props) => {
 
   return (
     <TeamPromptBadge>
-      <div>✅ This activity has ended. {renderAdditionalInfo()}</div>
+      <div>
+        <EmojiContainer>✅</EmojiContainer> This activity has ended. {renderAdditionalInfo()}
+      </div>
     </TeamPromptBadge>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -1,8 +1,31 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import {Link} from 'react-router-dom'
+import useRefreshInterval from '../../hooks/useRefreshInterval'
 import {humanReadableCountdown} from '../../utils/date/relativeDate'
 import {TeamPromptBadge} from './TeamPromptBadge'
+
+interface NextMeetingLinkProps {
+  closestActiveMeetingId: string
+}
+
+export const NextMeetingLink = (props: NextMeetingLinkProps) => {
+  const {closestActiveMeetingId} = props
+  return <StyledLink to={`/meet/${closestActiveMeetingId}`}>Go to the next activity.</StyledLink>
+}
+
+interface NextMeetingCountdownProps {
+  nextMeetingDate: Date
+}
+
+export const NextMeetingCountdown = (props: NextMeetingCountdownProps) => {
+  const {nextMeetingDate} = props
+  useRefreshInterval(1000)
+  const fromNow = humanReadableCountdown(nextMeetingDate)
+  if (!fromNow) return null
+
+  return <span>Next one starts in {humanReadableCountdown(nextMeetingDate)}.</span>
+}
 
 const StyledLink = styled(Link)({
   textDecoration: 'underline',
@@ -19,15 +42,11 @@ type Props = {closestActiveMeetingId: string} | {nextMeetingDate: Date} | Record
 export const TeamPromptEndedBadge = (props: Props) => {
   const renderAdditionalInfo = () => {
     if ('closestActiveMeetingId' in props) {
-      return (
-        <StyledLink to={`/meet/${props.closestActiveMeetingId}`}>
-          Go to the next activity.
-        </StyledLink>
-      )
+      return <NextMeetingLink closestActiveMeetingId={props.closestActiveMeetingId} />
     }
 
     if ('nextMeetingDate' in props) {
-      return <span>Next one starts in {humanReadableCountdown(props.nextMeetingDate)}.</span>
+      return <NextMeetingCountdown nextMeetingDate={props.nextMeetingDate} />
     }
 
     return null

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -1,27 +1,36 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import {Link} from 'react-router-dom'
+import {humanReadableCountdown} from '../../utils/date/relativeDate'
 import {TeamPromptBadge} from './TeamPromptBadge'
 
 const StyledLink = styled(Link)({
   textDecoration: 'underline'
 })
 
-interface Props {
-  closestActiveMeetingId?: string
-}
+// here we just want one of the props to be present, never both
+type Props = {closestActiveMeetingId: string} | {nextMeetingDate: Date} | Record<string, never>
 
-export const TeamPromptEndedBadge = ({closestActiveMeetingId}: Props) => {
+export const TeamPromptEndedBadge = (props: Props) => {
+  const renderAdditionalInfo = () => {
+    if ('closestActiveMeetingId' in props) {
+      return (
+        <StyledLink to={`/meet/${props.closestActiveMeetingId}`}>
+          Go to the next activity.
+        </StyledLink>
+      )
+    }
+
+    if ('nextMeetingDate' in props) {
+      return <span>Next one starts in {humanReadableCountdown(props.nextMeetingDate)}.</span>
+    }
+
+    return null
+  }
+
   return (
     <TeamPromptBadge>
-      <div>
-        ✅ This activity has ended.{' '}
-        {closestActiveMeetingId && (
-          <StyledLink to={`/meet/${closestActiveMeetingId}`}>
-            Go to the current activity.
-          </StyledLink>
-        )}
-      </div>
+      <div>✅ This activity has ended. {renderAdditionalInfo()}</div>
     </TeamPromptBadge>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -18,7 +18,7 @@ export const TeamPromptEndedBadge = ({closestActiveMeetingId}: Props) => {
         ✅ This activity has ended.{' '}
         {closestActiveMeetingId && (
           <StyledLink to={`/meet/${closestActiveMeetingId}`}>
-            Go to the currenct activity.
+            Go to the current activity.
           </StyledLink>
         )}
       </div>

--- a/packages/client/components/TeamPrompt/TeamPromptMeetingStatus.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptMeetingStatus.tsx
@@ -1,6 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useMemo} from 'react'
 import {useFragment} from 'react-relay'
+import {RRule} from 'rrule'
 import {TeamPromptMeetingStatus_meeting$key} from '~/__generated__/TeamPromptMeetingStatus_meeting.graphql'
 import {TimeLeftBadge} from './Recurrence/TimeLeftBadge'
 import {TeamPromptEndedBadge} from './TeamPromptEndedBadge'
@@ -19,6 +20,8 @@ export const TeamPromptMeetingStatus = (props: Props) => {
         endedAt
         meetingSeries {
           id
+          recurrenceRule
+          cancelledAt
           activeMeetings {
             id
             createdAt
@@ -31,17 +34,33 @@ export const TeamPromptMeetingStatus = (props: Props) => {
   )
   const {endedAt, scheduledEndTime, meetingSeries} = meeting
   const isMeetingEnded = !!endedAt
-  const isRecurring = !!meetingSeries
+  const isRecurring = !!meetingSeries && !meetingSeries.cancelledAt
   const hasActiveMeetings = isRecurring && meetingSeries.activeMeetings?.length > 0
-  const closestActiveMeeting = hasActiveMeetings ? meetingSeries.activeMeetings[0] : null
+  const closestActiveMeetingId = hasActiveMeetings ? meetingSeries.activeMeetings[0]!.id : null
+  const nextMeetingDate = useMemo(() => {
+    if (!isRecurring) return null
+    const recurrenceRule = meetingSeries.recurrenceRule!
+    const now = new Date()
+    return RRule.fromString(recurrenceRule).after(now)
+  }, [meetingSeries])
 
-  if (isMeetingEnded) {
-    return <TeamPromptEndedBadge closestActiveMeetingId={closestActiveMeeting?.id} />
+  if (!isMeetingEnded) {
+    if (scheduledEndTime) {
+      return <TimeLeftBadge meetingEndTime={scheduledEndTime} />
+    }
+
+    return null
   }
 
-  if (scheduledEndTime) {
-    return <TimeLeftBadge meetingEndTime={scheduledEndTime} />
+  if (closestActiveMeetingId) {
+    // if there's an active meeting, show the link to it
+    return <TeamPromptEndedBadge closestActiveMeetingId={closestActiveMeetingId} />
   }
 
-  return null
+  if (nextMeetingDate) {
+    // if there's no active meeting, show when the next one starts
+    return <TeamPromptEndedBadge nextMeetingDate={nextMeetingDate} />
+  }
+
+  return <TeamPromptEndedBadge />
 }

--- a/packages/client/components/TeamPrompt/TeamPromptMeetingStatus.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptMeetingStatus.tsx
@@ -17,15 +17,26 @@ export const TeamPromptMeetingStatus = (props: Props) => {
         id
         scheduledEndTime
         endedAt
+        meetingSeries {
+          id
+          activeMeetings {
+            id
+            createdAt
+            scheduledEndTime
+          }
+        }
       }
     `,
     meetingRef
   )
-  const {endedAt, scheduledEndTime} = meeting
+  const {endedAt, scheduledEndTime, meetingSeries} = meeting
   const isMeetingEnded = !!endedAt
+  const isRecurring = !!meetingSeries
+  const hasActiveMeetings = isRecurring && meetingSeries.activeMeetings?.length > 0
+  const closestActiveMeeting = hasActiveMeetings ? meetingSeries.activeMeetings[0] : null
 
   if (isMeetingEnded) {
-    return <TeamPromptEndedBadge />
+    return <TeamPromptEndedBadge closestActiveMeetingId={closestActiveMeeting?.id} />
   }
 
   if (scheduledEndTime) {

--- a/packages/client/hooks/useAnimatedCard.ts
+++ b/packages/client/hooks/useAnimatedCard.ts
@@ -36,6 +36,8 @@ const useAnimatedCard = (displayIdx: number, status: TransitionStatus) => {
       // if exiting, keep it where it is, but don't let it take up space
       el.style.position = 'absolute'
       el.style.transform = `translate(${offsetLeft - 8}px,${offsetTop - 8}px)`
+    } else {
+      el.style.position = 'static'
     }
     lastIdxRef.current = displayIdx
     lastRectRef.current = {top: offsetTop, left: offsetLeft}

--- a/packages/client/hooks/useTransition.ts
+++ b/packages/client/hooks/useTransition.ts
@@ -73,7 +73,10 @@ const useTransition = <T extends {key: Key}>(children: T[]) => {
 
   return useMemo(() => {
     const currentTChildren = [] as TransitionChild<T>[]
-    const {current: prevTChildren} = previousTransitionChildrenRef
+    const {current: prevTChildrenTemp} = previousTransitionChildrenRef
+    const prevTChildren = prevTChildrenTemp.filter(
+      (prevTChild) => prevTChild.status !== TransitionStatus.EXITING
+    )
 
     let touched = false
     // add mounted nodes + update new orderings

--- a/packages/client/hooks/useTransition.ts
+++ b/packages/client/hooks/useTransition.ts
@@ -73,8 +73,7 @@ const useTransition = <T extends {key: Key}>(children: T[]) => {
 
   return useMemo(() => {
     const currentTChildren = [] as TransitionChild<T>[]
-    const {current: prevTChildrenTemp} = previousTransitionChildrenRef
-    const prevTChildren = prevTChildrenTemp.filter(
+    const filteredPrevTChildren = previousTransitionChildrenRef.current.filter(
       (prevTChild) => prevTChild.status !== TransitionStatus.EXITING
     )
 
@@ -82,8 +81,9 @@ const useTransition = <T extends {key: Key}>(children: T[]) => {
     // add mounted nodes + update new orderings
     const updatedKeys = [] as Key[]
     children.forEach((nextChild, idxInNext) => {
-      const idxInPrev = prevTChildren.findIndex(({child}) => child.key === nextChild.key)
-      const status = idxInPrev === -1 ? TransitionStatus.MOUNTED : prevTChildren[idxInPrev]!.status
+      const idxInPrev = filteredPrevTChildren.findIndex(({child}) => child.key === nextChild.key)
+      const status =
+        idxInPrev === -1 ? TransitionStatus.MOUNTED : filteredPrevTChildren[idxInPrev]!.status
       currentTChildren.push({
         status,
         child: nextChild,
@@ -100,7 +100,7 @@ const useTransition = <T extends {key: Key}>(children: T[]) => {
     }
 
     // add exiting nodes
-    prevTChildren.forEach((prevTChild, i) => {
+    filteredPrevTChildren.forEach((prevTChild, i) => {
       const {child} = prevTChild
       const {key} = child
       const idxInNext = children.findIndex((child) => child.key === key)

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -18,6 +18,17 @@ graphql`
     meeting {
       id
       endedAt
+      meetingSeries {
+        id
+        recurrenceRule
+        duration
+        cancelledAt
+        activeMeetings {
+          id
+          createdAt
+          scheduledEndTime
+        }
+      }
       ...TeamPromptMeeting_meeting
     }
     team {

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -18,17 +18,7 @@ graphql`
     meeting {
       id
       endedAt
-      meetingSeries {
-        id
-        recurrenceRule
-        duration
-        cancelledAt
-        activeMeetings {
-          id
-          createdAt
-          scheduledEndTime
-        }
-      }
+      ...TeamPromptMeetingStatus_meeting
       ...TeamPromptMeeting_meeting
     }
     team {

--- a/packages/client/mutations/StartTeamPromptMutation.ts
+++ b/packages/client/mutations/StartTeamPromptMutation.ts
@@ -7,6 +7,17 @@ graphql`
   fragment StartTeamPromptMutation_team on StartTeamPromptSuccess {
     meeting {
       id
+      meetingSeries {
+        id
+        recurrenceRule
+        duration
+        cancelledAt
+        activeMeetings {
+          id
+          createdAt
+          scheduledEndTime
+        }
+      }
     }
     team {
       ...MeetingsDashActiveMeetings @relay(mask: false)

--- a/packages/client/mutations/StartTeamPromptMutation.ts
+++ b/packages/client/mutations/StartTeamPromptMutation.ts
@@ -7,17 +7,7 @@ graphql`
   fragment StartTeamPromptMutation_team on StartTeamPromptSuccess {
     meeting {
       id
-      meetingSeries {
-        id
-        recurrenceRule
-        duration
-        cancelledAt
-        activeMeetings {
-          id
-          createdAt
-          scheduledEndTime
-        }
-      }
+      ...TeamPromptMeetingStatus_meeting
     }
     team {
       ...MeetingsDashActiveMeetings @relay(mask: false)

--- a/packages/client/subscriptions/TeamSubscription.ts
+++ b/packages/client/subscriptions/TeamSubscription.ts
@@ -140,6 +140,7 @@ const TeamSubscription = (
       }
     },
     onNext: (result) => {
+      console.log('TeamSubscription onNext', result)
       if (!result) return
       const {teamSubscription} = result
       const {__typename: type} = teamSubscription

--- a/packages/client/subscriptions/TeamSubscription.ts
+++ b/packages/client/subscriptions/TeamSubscription.ts
@@ -140,7 +140,6 @@ const TeamSubscription = (
       }
     },
     onNext: (result) => {
-      console.log('TeamSubscription onNext', result)
       if (!result) return
       const {teamSubscription} = result
       const {__typename: type} = teamSubscription

--- a/packages/client/utils/date/relativeDate.ts
+++ b/packages/client/utils/date/relativeDate.ts
@@ -23,7 +23,7 @@ interface Opts {
 
 /**
  * Creates a human-readable string representing the time till the given date,
- * for example: 2 days left; 13 hours left; 2 days left, etc or null if the date is in the past
+ * for example: 2 days; 13 hours; 2 days, etc or null if the date is in the past
  * @param date
  */
 export const humanReadableCountdown = (date: string | Date) => {
@@ -39,22 +39,22 @@ export const humanReadableCountdown = (date: string | Date) => {
 
   const days = Math.floor(periods['d'])
   if (days > 0) {
-    return `${days} ${plural(days, 'day', 'days')} left`
+    return `${days} ${plural(days, 'day', 'days')}`
   }
 
   const hours = Math.floor(periods['h'])
   if (hours > 0) {
-    return `${hours} ${plural(hours, 'hour', 'hours')} left`
+    return `${hours} ${plural(hours, 'hour', 'hours')}`
   }
 
   const minutes = Math.floor(periods['m'])
   if (minutes > 0) {
-    return `${minutes} ${plural(minutes, 'minute', 'minutes')} left`
+    return `${minutes} ${plural(minutes, 'minute', 'minutes')}`
   }
 
   const seconds = Math.floor(periods['s'])
   if (seconds > 0) {
-    return `${seconds} ${plural(seconds, 'second', 'seconds')} left`
+    return `${seconds} ${plural(seconds, 'second', 'seconds')}`
   }
 
   return null

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -526,6 +526,7 @@ export const activeMeetingsByMeetingSeriesId = (parent: RootDataLoader) => {
             .table('NewMeeting')
             .getAll(key, {index: 'meetingSeriesId'})
             .filter({endedAt: null}, {default: true})
+            .orderBy(r.asc('createdAt'))
             .run()
         })
       )

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -6,7 +6,7 @@ import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 import {getActiveMeetingSeries} from '../../../postgres/queries/getActiveMeetingSeries'
 import {MeetingSeries} from '../../../postgres/types/MeetingSeries'
 import {analytics} from '../../../utils/analytics/analytics'
-import publish from '../../../utils/publish'
+import publish, {SubOptions} from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
 import {DataLoaderWorker} from '../../graphql'
 import isStartMeetingLocked from '../../mutations/helpers/isStartMeetingLocked'
@@ -20,10 +20,7 @@ const startRecurringTeamPrompt = async (
   startTime: Date,
   dataLoader: DataLoaderWorker,
   r: ParabolR,
-  subOptions: {
-    mutatorId: string | undefined
-    operationId: string
-  }
+  subOptions: SubOptions
 ) => {
   const {teamId, facilitatorId} = meetingSeries
 


### PR DESCRIPTION
# Description

Fixes #7500 #7498 

## Demo

![localhost_3000_meet_iUDGs1q4tG_responses](https://user-images.githubusercontent.com/1017620/206450468-34b969e9-f47b-4254-b335-c2d171982ea2.png)
![localhost_3000_meet_iUHmzSRkuk_responses](https://user-images.githubusercontent.com/1017620/206468026-6e757531-57f7-4451-881d-c8d3f14388f3.png)


## Testing scenarios

- [ ] check if ended meeting badge is showing a link to the current meeting, if available

This scenario requires some manual db tweaking as there's no direct way to create meeting in the meeting series
-  create two standups meetings, start recurrence in one of them
-  manually update the second meeting with `meetingSeriesId` associated with the one that has recurrence started
-  now, end one of the meetings and check the ended meeting badge, there should be a link to the current meeting

- [ ] check if next meeting start time is showing, if there are no active meetings and recurrence is active
- create standup meeting, enable recurrence, end the meeting and go back to the meeting view

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
