### PR TITLE
feat(standups): Auto-open response discussion based on query param

### DIFF
--- a/packages/client/components/ResponseMentioned.tsx
+++ b/packages/client/components/ResponseMentioned.tsx
@@ -17,6 +17,7 @@ const ResponseMentioned = (props: Props) => {
       fragment ResponseMentioned_notification on NotifyResponseMentioned {
         ...NotificationTemplate_notification
         response {
+          id
           user {
             picture
             preferredName
@@ -37,7 +38,7 @@ const ResponseMentioned = (props: Props) => {
   const {id: meetingId, name: meetingName} = meeting
   const goThere = () => {
     // :TODO: (jmtaber129): Link directly to card once we support that.
-    history.push(`/meet/${meetingId}`)
+    history.push(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
   }
 
   // :TODO: (jmtaber129): Show mention preview.

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -133,6 +133,10 @@ const TeamPromptMeeting = (props: Props) => {
   const {isRightDrawerOpen, id: meetingId} = meeting
   useEffect(() => {
     const params = new URLSearchParams(history.location.search)
+    if (!params.get('responseId')) {
+      return
+    }
+
     const stage = stages.find((stage) => stage.response?.id === params.get('responseId'))
     if (!stage) {
       return

--- a/packages/client/modules/email/components/EmailNotifications/EmailResponseMentioned.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailResponseMentioned.tsx
@@ -18,6 +18,7 @@ const EmailResponseMentioned = (props: Props) => {
       fragment EmailResponseMentioned_notification on NotifyResponseMentioned {
         ...EmailNotificationTemplate_notification
         response {
+          id
           user {
             rasterPicture
             preferredName
@@ -36,8 +37,13 @@ const EmailResponseMentioned = (props: Props) => {
 
   const {id: meetingId, name: meetingName} = meeting
 
-  const linkUrl = makeAppURL(appOrigin, `/meet/${meetingId}`, {
-    searchParams: notificationSummaryUrlParams
+  // :TRICKY: If the URL we navigate to isn't the full URL w/ phase name (e.g. just
+  // '/meet/<meetingId>'), the URL will be overwritten and the 'responseId' will be lost.
+  const linkUrl = makeAppURL(appOrigin, `/meet/${meetingId}/responses`, {
+    searchParams: {
+      ...notificationSummaryUrlParams,
+      responseId: response.id
+    }
   })
 
   // :TODO: (jmtaber129): Show mention preview.

--- a/packages/client/utils/makeAppURL.ts
+++ b/packages/client/utils/makeAppURL.ts
@@ -4,6 +4,7 @@ interface Options {
     utm_medium: string
     utm_campaign: string
     openNotifs?: string
+    responseId?: string
   }
 }
 


### PR DESCRIPTION
# Description
If a `responseId` query param is present when the Team Prompt Meeting is initially rendered, try to find the corresponding response card, and open its discussion.

Update the in-app and email notifications for standup mentions to include this query param.

In the future, we could use this to enable share-ability by either adding "copy link" buttons to response cards and/or keeping the query param in-sync with open discussion drawers.

Marking this as one review required because this general pattern has already been approved by maintainers in https://github.com/ParabolInc/parabol/pull/7225

## Demo
In-app - https://www.loom.com/share/45eb8249c162428faceb75f42f6351c6
From email link - https://www.loom.com/share/399f00c8e8a047c4819411ca4d69f85d

## Testing scenarios
- [ ] Trigger a standup mention notification from user B to user A
- [ ] Send notification email batch
- [ ] Click the "see their response" link in user A's email, and confirm it auto-opens user B's response
- [ ] Click the "see their response" link in user A's notifications dropdown, and confirm it auto-opens user B's response

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
