### PR TITLE
fix: Change facilitator randomization to include current facilitator

### DIFF
--- a/packages/client/components/FacilitatorMenu.tsx
+++ b/packages/client/components/FacilitatorMenu.tsx
@@ -20,7 +20,7 @@ const FacilitatorMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
   const facilitatorCandidateIds = meetingMembers
-    .filter(({user}) => user.id !== facilitatorUserId && user.isConnected)
+    .filter(({user}) => user.isConnected)
     .map(({user}) => user.id)
   const promoteViewerToFacilitator = () => {
     PromoteNewMeetingFacilitatorMutation(atmosphere, {facilitatorUserId: viewerId, meetingId})


### PR DESCRIPTION
# Description

At the moment, picking a new facilitator is not truly random because the current facilitator is always excluded. 

It seems more intuitive (and fair) to pick from all meeting members.

-> Add current facilitator to facilitator candidates.

## Demo
- 

## Testing scenarios

-

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
