### PR TITLE
fix(metrics): enable send_page_view on ReactGA initialization

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -96,7 +96,11 @@ const AnalyticsPage = () => {
       if (!res) return
       const {viewer} = res
       const {id, segmentId} = viewer
-      ReactGA.initialize(gaMeasurementId)
+      ReactGA.initialize(gaMeasurementId, {
+        gtagOptions: {
+          send_page_view: true
+        }
+      })
       ReactGA.set({
         userId: id,
         clientId: segmentId ?? getAnonymousId()


### PR DESCRIPTION
# Description

After my last [PR](https://github.com/ParabolInc/parabol/pull/7356) deployed to production I found no `page_view` events sent to GA4. Turns out `send_page_view` [is disabled by default  in react-ga4](https://github.com/PriceRunner/react-ga4/blob/master/src/ga4.js#L190). This PR overrides the default config value.

## Demo
**Production**
`send_page_view` is false:
<img width="503" alt="Screenshot 2022-12-12 at 11 14 16 AM" src="https://user-images.githubusercontent.com/1879975/206931945-2f9a61ba-71f1-4a9c-9812-940286ef04d1.png">


**Local**
`send_page_view` is set to true after initialization:
<img width="566" alt="Screenshot 2022-12-12 at 11 13 09 AM" src="https://user-images.githubusercontent.com/1879975/206931972-f024329b-21dc-482c-ad8a-244039e930bf.png">


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
