### PR TITLE
fix: emoji length check

### DIFF
--- a/packages/client/validation/Legitity.ts
+++ b/packages/client/validation/Legitity.ts
@@ -38,7 +38,6 @@ class Legitity {
   max(len: number, msg?: string) {
     // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
     // Spreading the string into an array gives us the correct string length in codepoints (characters): https://stackoverflow.com/a/54369605
-
     const value = [...this.value]
     if (!this.error && value.length > len) {
       this.error = msg || 'max'

--- a/packages/client/validation/Legitity.ts
+++ b/packages/client/validation/Legitity.ts
@@ -36,14 +36,21 @@ class Legitity {
   }
 
   max(len: number, msg?: string) {
-    if (!this.error && this.value && this.value.length > len) {
+    // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
+    // Spreading the string into an array gives us the correct string length in codepoints (characters): https://stackoverflow.com/a/54369605
+
+    const value = [...this.value]
+    if (!this.error && value.length > len) {
       this.error = msg || 'max'
     }
     return this
   }
 
   min(len: number, msg?: string) {
-    if (!this.error && this.value && this.value.length < len) {
+    // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
+    // Spreading the string into an array gives us the correct string length in codepoints (characters): https://stackoverflow.com/a/54369605
+    const value = [...this.value]
+    if (!this.error && value.length < len) {
       this.error = msg || 'min'
     }
     return this

--- a/packages/client/validation/Legitity.ts
+++ b/packages/client/validation/Legitity.ts
@@ -37,7 +37,7 @@ class Legitity {
 
   max(len: number, msg?: string) {
     // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
-    // Spreading the string into an array gives us the correct string length in codepoints (characters): https://stackoverflow.com/a/54369605
+    // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
     const value = [...this.value]
     if (!this.error && value.length > len) {
       this.error = msg || 'max'
@@ -47,7 +47,7 @@ class Legitity {
 
   min(len: number, msg?: string) {
     // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
-    // Spreading the string into an array gives us the correct string length in codepoints (characters): https://stackoverflow.com/a/54369605
+    // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
     const value = [...this.value]
     if (!this.error && value.length < len) {
       this.error = msg || 'min'

--- a/packages/server/graphql/mutations/helpers/validateScaleValue.ts
+++ b/packages/server/graphql/mutations/helpers/validateScaleValue.ts
@@ -7,7 +7,10 @@ const validateColorValue = (color: string) => {
 }
 
 const validateScaleLabel = (label: string) => {
-  return 0 < label.length && label.length <= 2
+  // label.length gives us the count of UTF-16 units, so 🔥 has a length of 2
+  // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
+  const labelArr = [...label]
+  return 0 < labelArr.length && labelArr.length <= 2
 }
 
 const validateScaleLabelValueUniqueness = (scaleValues: TemplateScaleValue[]) => {


### PR DESCRIPTION
Fix: https://github.com/ParabolInc/parabol/issues/7577

Demo: https://www.loom.com/share/e50282aaa8294da28070bb530ea31df3

### To test

- [ ] Paste an emoji, e.g. 🔥, into the template picker value field. See that it counts the emoji as one character instead of two
- [ ] Other min/max string length calculations continue to work as expected