### PR TITLE
fix: new meetings were locked with the history limit

### DIFF
--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -117,7 +117,7 @@ export const newMeetingFields = () => ({
         phases: any
         id: string
         teamId: string
-        endedAt: Date
+        endedAt?: Date | null
       },
       _args: unknown,
       {authToken, dataLoader}: GQLContext
@@ -189,7 +189,7 @@ export const newMeetingFields = () => ({
     type: new GraphQLNonNull(GraphQLBoolean),
     description: 'Is this locked for personal plans?',
     resolve: async (
-      {endedAt, teamId}: {endedAt: Date; teamId: string},
+      {endedAt, teamId}: {endedAt?: Date | null; teamId: string},
       _args: any,
       {authToken, dataLoader}: GQLContext
     ) => {

--- a/packages/server/graphql/types/helpers/isMeetingLocked.ts
+++ b/packages/server/graphql/types/helpers/isMeetingLocked.ts
@@ -3,12 +3,12 @@ import {DataLoaderWorker} from '../../graphql'
 const isMeetingLocked = async (
   viewerId: string,
   teamId: string,
-  endedAt: Date,
+  endedAt: Date | undefined | null,
   dataLoader: DataLoaderWorker
 ) => {
   const freeLimit = new Date()
   freeLimit.setDate(freeLimit.getDate() - 30)
-  if (endedAt > freeLimit) {
+  if (!endedAt || endedAt > freeLimit) {
     return false
   }
   const [team, viewer] = await Promise.all([


### PR DESCRIPTION
# Description

Relates-To #7373 
The check if a meeting is locked did not check for `null | undefined` `endedAt` values, i.e. open meetings.

## Demo

https://www.loom.com/share/ab15d5f8ece3404dbf98e99cafc84c63

## Testing scenarios

- Create and join a meeting with a free tier team

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
