### PR TITLE
fix: bump sanitize-svg version

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -67,7 +67,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^10.0.27",
     "@mattkrick/graphql-trebuchet-client": "^2.2.1",
-    "@mattkrick/sanitize-svg": "0.3.1",
+    "@mattkrick/sanitize-svg": "0.4.0",
     "@mattkrick/trebuchet-client": "^3.0.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -89,7 +89,7 @@
     "@graphql-tools/merge": "^8.2.3",
     "@graphql-tools/schema": "^8.3.2",
     "@graphql-tools/wrap": "^7.0.6",
-    "@mattkrick/sanitize-svg": "0.3.1",
+    "@mattkrick/sanitize-svg": "0.4.0",
     "@octokit/graphql-schema": "^10.36.0",
     "@pgtyped/query": "^0.11.0",
     "@sentry/integrations": "^5.8.0",


### PR DESCRIPTION
Signed-off-by: Matt Krick <matt.krick@gmail.com>

# Description

Fixes a security hole allowing for XSS via SVG upload.
The way we use it today, you'd only be able to XSS yourself, meaning the attacker would have to get the victim to upload a nefarious profile picture.
 
## Demo

Not gonna publish too much about this until it is in prod :sweat_smile: 