### PR TITLE
feat(standups): Save response as draft

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -106,6 +106,12 @@ const ReplyButton = styled(PlainButton)({
   }
 })
 
+const DraftNote = styled('div')({
+  color: PALETTE.SLATE_600,
+  fontWeight: 600,
+  fontSize: 12
+})
+
 interface Props {
   stageRef: TeamPromptResponseCard_stage$key
   status: TransitionStatus
@@ -241,12 +247,13 @@ const TeamPromptResponseCard = (props: Props) => {
         <Avatar picture={picture} size={48} />
         <TeamMemberName>
           {preferredName}
-          {response && (
+          {response && !response.isDraft && (
             <TeamPromptLastUpdatedTime
               updatedAt={response.updatedAt}
               createdAt={response.createdAt}
             />
           )}
+          {response && response.isDraft && <DraftNote>Draft</DraftNote>}
         </TeamMemberName>
       </ResponseHeader>
       <ResponseCard

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -145,6 +145,7 @@ const TeamPromptResponseCard = (props: Props) => {
           userId
           content
           plaintextContent
+          isDraft
           updatedAt
           createdAt
           reactjis {
@@ -199,7 +200,7 @@ const TeamPromptResponseCard = (props: Props) => {
   const nonViewerEmptyResponsePlaceholder = isMeetingEnded ? 'No response' : 'No response yet...'
 
   const {onError, onCompleted, submitMutation, submitting} = useMutationProps()
-  const handleSubmit = useEventCallback((editorState: EditorState) => {
+  const handleSubmit = useEventCallback((editorState: EditorState, isDraft: boolean) => {
     if (submitting) return
     submitMutation()
 
@@ -208,7 +209,7 @@ const TeamPromptResponseCard = (props: Props) => {
 
     UpsertTeamPromptResponseMutation(
       atmosphere,
-      {teamPromptResponseId: response?.id, meetingId, content},
+      {teamPromptResponseId: response?.id, meetingId, content, isDraft},
       {plaintextContent, onError, onCompleted}
     )
   })
@@ -261,6 +262,7 @@ const TeamPromptResponseCard = (props: Props) => {
               autoFocus={isViewerResponse}
               handleSubmit={handleSubmit}
               content={contentJSON}
+              isDraft={response?.isDraft || false}
               readOnly={!isViewerResponse || isMeetingEnded}
               placeholder={viewerEmptyResponsePlaceholder}
             />

--- a/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
+++ b/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
@@ -13,6 +13,7 @@ graphql`
       userId
       content
       plaintextContent
+      isDraft
       updatedAt
       createdAt
     }
@@ -24,11 +25,13 @@ const mutation = graphql`
     $teamPromptResponseId: ID
     $meetingId: ID!
     $content: String!
+    $isDraft: Boolean!
   ) @raw_response_type {
     upsertTeamPromptResponse(
       teamPromptResponseId: $teamPromptResponseId
       meetingId: $meetingId
       content: $content
+      isDraft: $isDraft
     ) {
       ... on ErrorPayload {
         error {

--- a/packages/server/graphql/public/typeDefs/upsertTeamPromptResponse.graphql
+++ b/packages/server/graphql/public/typeDefs/upsertTeamPromptResponse.graphql
@@ -17,6 +17,11 @@ extend type Mutation {
     The stringified content of the team prompt response
     """
     content: String!
+
+    """
+    Whether this response should be saved as a draft
+    """
+    isDraft: Boolean!
   ): UpsertTeamPromptResponsePayload!
 }
 

--- a/packages/server/graphql/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/types/TeamPromptMeeting.ts
@@ -30,8 +30,11 @@ const TeamPromptMeeting = new GraphQLObjectType<any, GQLContext>({
     responses: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(TeamPromptResponse))),
       description: 'The responses created in the meeting',
-      resolve: ({id: meetingId}: {id: string}, _args: unknown, {}) => {
-        return getTeamPromptResponsesByMeetingId(meetingId)
+      resolve: async ({id: meetingId}: {id: string}, _args: unknown, {authToken}) => {
+        const viewerId = getUserId(authToken)
+        return (await getTeamPromptResponsesByMeetingId(meetingId)).filter(
+          (response) => response.userId === viewerId || !response.isDraft
+        )
       }
     },
     viewerMeetingMember: {
@@ -49,7 +52,7 @@ const TeamPromptMeeting = new GraphQLObjectType<any, GQLContext>({
       description: 'The number of responses generated in the meeting',
       resolve: async ({id: meetingId}) => {
         return (await getTeamPromptResponsesByMeetingId(meetingId)).filter(
-          (response) => !!response.plaintextContent
+          (response) => !!response.plaintextContent && !response.isDraft
         ).length
       }
     },

--- a/packages/server/graphql/types/TeamPromptResponse.ts
+++ b/packages/server/graphql/types/TeamPromptResponse.ts
@@ -1,5 +1,12 @@
 import {JSONContent} from '@tiptap/core'
-import {GraphQLFloat, GraphQLID, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'graphql'
+import {
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString
+} from 'graphql'
 import {GQLContext} from '../graphql'
 import GraphQLISO8601Type from './GraphQLISO8601Type'
 import Reactable, {reactableFields} from './Reactable'
@@ -56,6 +63,10 @@ const TeamPromptResponse: GraphQLObjectType = new GraphQLObjectType<any, GQLCont
       resolve: ({teamId}: {teamId: string}, _args: unknown, {dataLoader}) => {
         return dataLoader.get('teams').load(teamId)
       }
+    },
+    isDraft: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether this response is a draft'
     }
   })
 })

--- a/packages/server/postgres/migrations/1671148154411_addIsDraftToResponse.ts
+++ b/packages/server/postgres/migrations/1671148154411_addIsDraftToResponse.ts
@@ -1,0 +1,22 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+  ALTER TABLE "TeamPromptResponse"
+  ADD COLUMN IF NOT EXISTS "isDraft" BOOLEAN NOT NULL DEFAULT FALSE
+  `)
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+  ALTER TABLE "TeamPromptResponse"
+  DROP COLUMN IF EXISTS "isDraft"
+  `)
+  await client.end()
+}

--- a/packages/server/postgres/queries/src/getTeamPromptResponsesByIdsQuery.sql
+++ b/packages/server/postgres/queries/src/getTeamPromptResponsesByIdsQuery.sql
@@ -2,5 +2,5 @@
   @name getTeamPromptResponsesByIdsQuery
   @param ids -> (...)
 */
-SELECT "id", "createdAt", "updatedAt", "meetingId", "userId", "sortOrder", "content", "plaintextContent", to_json("reactjis") as "reactjis" FROM "TeamPromptResponse"
+SELECT "id", "createdAt", "updatedAt", "meetingId", "userId", "sortOrder", "content", "plaintextContent", "isDraft", to_json("reactjis") as "reactjis" FROM "TeamPromptResponse"
 WHERE id in :ids;

--- a/packages/server/postgres/queries/src/getTeamPromptResponsesByMeetingIdQuery.sql
+++ b/packages/server/postgres/queries/src/getTeamPromptResponsesByMeetingIdQuery.sql
@@ -2,5 +2,5 @@
   @name getTeamPromptResponsesByMeetingIdQuery
   @param meetingIds -> (...)
 */
-SELECT "id", "createdAt", "updatedAt", "meetingId", "userId", "sortOrder", "content", "plaintextContent", to_json("reactjis") as "reactjis" FROM "TeamPromptResponse"
+SELECT "id", "createdAt", "updatedAt", "meetingId", "userId", "sortOrder", "content", "plaintextContent", "isDraft", to_json("reactjis") as "reactjis" FROM "TeamPromptResponse"
 WHERE "meetingId" in :meetingIds;

--- a/packages/server/postgres/queries/src/upsertTeamPromptResponsesQuery.sql
+++ b/packages/server/postgres/queries/src/upsertTeamPromptResponsesQuery.sql
@@ -1,10 +1,11 @@
 /*
   @name upsertTeamPromptResponsesQuery
-  @param responses -> ((meetingId, userId, sortOrder, content, plaintextContent)...)
+  @param responses -> ((meetingId, userId, sortOrder, content, plaintextContent, isDraft)...)
 */
-INSERT INTO "TeamPromptResponse" ("meetingId", "userId", "sortOrder", "content", "plaintextContent")
+INSERT INTO "TeamPromptResponse" ("meetingId", "userId", "sortOrder", "content", "plaintextContent", "isDraft")
 VALUES :responses
 ON CONFLICT ("meetingId", "userId") DO UPDATE SET
   "content" = EXCLUDED."content",
-  "plaintextContent" = EXCLUDED."plaintextContent"
+  "plaintextContent" = EXCLUDED."plaintextContent",
+  "isDraft" = "TeamPromptResponse"."isDraft" AND EXCLUDED."isDraft"
 RETURNING id;

--- a/packages/server/postgres/queries/src/upsertTeamPromptResponsesQuery.sql
+++ b/packages/server/postgres/queries/src/upsertTeamPromptResponsesQuery.sql
@@ -7,5 +7,7 @@ VALUES :responses
 ON CONFLICT ("meetingId", "userId") DO UPDATE SET
   "content" = EXCLUDED."content",
   "plaintextContent" = EXCLUDED."plaintextContent",
-  "isDraft" = "TeamPromptResponse"."isDraft" AND EXCLUDED."isDraft"
+  "isDraft" = "TeamPromptResponse"."isDraft" AND EXCLUDED."isDraft",
+  "createdAt" = CASE WHEN NOT EXCLUDED."isDraft" AND "TeamPromptResponse"."isDraft" THEN CURRENT_TIMESTAMP ELSE "TeamPromptResponse"."createdAt" END,
+  "updatedAt" = CASE WHEN NOT EXCLUDED."isDraft" AND "TeamPromptResponse"."isDraft" THEN CURRENT_TIMESTAMP ELSE "TeamPromptResponse"."updatedAt" END
 RETURNING id;


### PR DESCRIPTION
# Description
Refs https://github.com/ParabolInc/parabol/issues/7094, https://github.com/ParabolInc/parabol/issues/6871

Allow users to save a WIP response as a private draft, instead of publishing as WIP for their full team to see

## Demo
Before any response is submitted:
<img width="508" alt="Screen Shot 2022-12-16 at 1 13 16 PM" src="https://user-images.githubusercontent.com/9013217/208172240-785b71cb-dd5d-4d2a-9061-0a8bde1154e0.png">
After a response is submitted as a draft:
<img width="491" alt="Screen Shot 2022-12-16 at 1 13 22 PM" src="https://user-images.githubusercontent.com/9013217/208172249-b8e040d8-57c8-4b70-b32f-f11e836e8bb3.png">
When a draft is edited:
<img width="491" alt="Screen Shot 2022-12-16 at 1 13 55 PM" src="https://user-images.githubusercontent.com/9013217/208172248-96b2dc10-32cf-4146-8dbd-153f7699834c.png">
When a former draft is submitted:
<img width="481" alt="Screen Shot 2022-12-16 at 1 14 03 PM" src="https://user-images.githubusercontent.com/9013217/208172243-e642127b-90bc-45f2-8bc8-80488b16086d.png">


## Testing scenarios
TODO

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
