### PR TITLE
chore(metrics): change upgrade CTA events to standard definitions

### DIFF
--- a/packages/client/components/MeetingLockedOverlay.tsx
+++ b/packages/client/components/MeetingLockedOverlay.tsx
@@ -104,7 +104,7 @@ const MeetingLockedOverlay = (props: Props) => {
   useEffect(() => {
     if (locked) {
       SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Viewed', {
-        source: 'Direct Meeting Link',
+        upgradeCTALocation: 'directMeetingLinkLock',
         upgradeTier: 'pro',
         meetingId
       })
@@ -124,8 +124,8 @@ const MeetingLockedOverlay = (props: Props) => {
   }, [locked])
 
   const onClick = () => {
-    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
-      source: 'Direct Meeting Link Upgrade CTA',
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'directMeetingLinkLock',
       upgradeTier: 'pro',
       meetingId
     })

--- a/packages/client/components/TimelineEventCompletedActionMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedActionMeeting.tsx
@@ -44,8 +44,8 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
 
   const atmosphere = useAtmosphere()
   const onUpgrade = () => {
-    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
-      source: 'Timeline History Locked Meeting Upgrade CTA',
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'timelineHistoryLock',
       upgradeTier: 'pro',
       meetingId
     })

--- a/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
@@ -42,8 +42,8 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
 
   const atmosphere = useAtmosphere()
   const onUpgrade = () => {
-    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
-      source: 'Timeline History Locked Meeting Upgrade CTA',
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'timelineHistoryLock',
       upgradeTier: 'pro',
       meetingId
     })

--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -34,8 +34,8 @@ const TimelineEventPokerComplete = (props: Props) => {
 
   const atmosphere = useAtmosphere()
   const onUpgrade = () => {
-    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
-      source: 'Timeline History Locked Meeting Upgrade CTA',
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'timelineHistoryLock',
       upgradeTier: 'pro',
       meetingId
     })

--- a/packages/client/components/TimelineEventTeamPromptComplete.tsx
+++ b/packages/client/components/TimelineEventTeamPromptComplete.tsx
@@ -73,8 +73,8 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
 
   const atmosphere = useAtmosphere()
   const onUpgrade = () => {
-    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
-      source: 'Timeline History Locked Meeting Upgrade CTA',
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'timelineHistoryLock',
       upgradeTier: 'pro',
       meetingId
     })

--- a/packages/client/components/TimelineHistoryLockedCard.tsx
+++ b/packages/client/components/TimelineHistoryLockedCard.tsx
@@ -83,7 +83,7 @@ const TimelineHistoryLockedCard = (props: Props) => {
   useEffect(() => {
     if (visible) {
       SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Viewed', {
-        source: 'Timeline History Locked Card',
+        upgradeCTALocation: 'timelineHistoryLock',
         upgradeTier: 'pro',
         orgId
       })
@@ -91,8 +91,8 @@ const TimelineHistoryLockedCard = (props: Props) => {
   }, [visible])
 
   const onClick = () => {
-    SendClientSegmentEventMutation(atmosphere, 'Upgrade Intent', {
-      source: 'Timeline History Locked Upgrade CTA',
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'timelineHistoryLock',
       upgradeTier: 'pro',
       orgId
     })

--- a/packages/server/graphql/types/UpgradeCTALocationEnum.ts
+++ b/packages/server/graphql/types/UpgradeCTALocationEnum.ts
@@ -5,15 +5,19 @@ export type UpgradeCTALocationEnumType =
   | 'teamTemplate'
   | 'orgTemplate'
   | 'createNewTemplate'
+  | 'directMeetingLinkLock'
+  | 'timelineHistoryLock'
 
 const UpgradeCTALocationEnum = new GraphQLEnumType({
   name: 'UpgradeCTALocationEnum',
-  description: 'Where the upgrade to pro CTA button was clicked',
+  description: 'Where the upgrade CTA button was clicked',
   values: {
     publicTemplate: {},
     teamTemplate: {},
     orgTemplate: {},
-    createNewTemplate: {}
+    createNewTemplate: {},
+    directMeetingLinkLock: {},
+    timelineHistoryLock: {}
   }
 })
 


### PR DESCRIPTION
# Description

Fixes #7592.

## Testing scenarios

- [ ] Navigate to timeline page with `meetingLimit` feature flag set and a locked personal org meeting.  Confirm `Upgrade CTA Viewed` Segment event fires with new `upgradeCTALocation: 'timelineHistoryLock'` property set.
- [ ] Click upgrade on a locked meeting of each meeting type and confirm `Upgrade CTA Clicked` event fires with new `upgradeCTALocation: 'timelineHistoryLock'` property set.
- [ ] Navigate directly to a locked meeting and verify `Upgrade CTA Viewed` event fires with new `upgradeCTALocation: 'directMeetingLinkLock'` property set.
- [ ] Navigate directly to a locked meeting and verify `Upgrade CTA Clicked` event fires with new `upgradeCTALocation: 'directMeetingLinkLock'` property set.
