### PR TITLE
chore: add data team as reviewers for analytics changes

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -32,9 +32,10 @@ reviewers:
 files:
   '**/migrations/**':
     - data
+  '**/analytics/**':
+    - data
 options:
   ignore_draft: true
   ignored_keywords:
     - WIP
   number_of_reviewers: 1
-


### PR DESCRIPTION
# Description

I missed @nickoferrall's introduction of the `Upgrade CTA Clicked` event, which caused some event naming rework in #7592.  I'd like to add the data team as reviewers for any changes to the analytics files, so we can keep a closer eye on new Segment event definitions.

## Testing scenarios

- [ ] Confirm assignment bot works with multiple file paths
