### PR TITLE
perf: Moved global style creation outside of the React render cycle

### DIFF
--- a/packages/client/components/Action/Action.tsx
+++ b/packages/client/components/Action/Action.tsx
@@ -31,17 +31,17 @@ const InvitationLink = lazy(
   () => import(/* webpackChunkName: 'InvitationLinkRoot' */ '../InvitationLinkRoot')
 )
 
+const GlobalCSS = css`
+  ${globalStyles}
+`
+
 const Action = memo(() => {
   useTrebuchetEvents()
   useServiceWorkerUpdater()
   const isInternalAuthEnabled = window.__ACTION__.AUTH_INTERNAL_ENABLED
   return (
     <>
-      <Global
-        styles={css`
-          ${globalStyles}
-        `}
-      />
+      <Global styles={GlobalCSS} />
       <ErrorBoundary>
         <Snackbar />
         <Suspense fallback={<LoadingComponent spinnerSize={LoaderSize.WHOLE_PAGE} />}>
@@ -92,5 +92,7 @@ const Action = memo(() => {
     </>
   )
 })
+
+Action.displayName = 'Action'
 
 export default Action


### PR DESCRIPTION
# Description

This PR moves global styles creation outside of `Action` component render cycle. As this component rerenders on every route update, the performance gain for each render is around ~50%. Without that fix, the initial render time of `Action` component varies between 1.5 ms to 3 ms (calculated ~40 times). With the fix, it's not more than 1 ms - 1.1 ms (same number of calculations). See the example screenshots from React profiler below. This was tested on M1 Max, so I'd assume the time difference will be higher for an average machine. 

~Before:
<img width="1024" alt="Screenshot 2022-12-17 at 14 34 09" src="https://user-images.githubusercontent.com/1017620/208245082-71be80e3-259a-4a26-80b0-8c025e91f303.png">

~After:
<img width="1024" alt="Screenshot 2022-12-17 at 14 35 26" src="https://user-images.githubusercontent.com/1017620/208245077-35b431e0-02f2-4839-91e6-6bf6d40dbb6b.png">


## Testing scenarios

- [ ] see if app renders correctly

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
