### PR TITLE
fix: access custom template

### DIFF
--- a/packages/server/graphql/queries/helpers/resolveSelectedTemplate.ts
+++ b/packages/server/graphql/queries/helpers/resolveSelectedTemplate.ts
@@ -19,8 +19,8 @@ const resolveSelectedTemplate =
       dataLoader.get('meetingTemplates').load(selectedTemplateId)
     ])
     const {tier} = team
-    const hasFeatureFlag = viewer.featureFlags.includes('templateLimit')
     const {isFree, scope} = template
+    const hasFeatureFlag = viewer.featureFlags.includes('templateLimit')
     if (template && (hasFeatureFlag ? isFree || scope !== 'PUBLIC' || tier !== 'personal' : true)) {
       return template
     }

--- a/packages/server/graphql/queries/helpers/resolveSelectedTemplate.ts
+++ b/packages/server/graphql/queries/helpers/resolveSelectedTemplate.ts
@@ -20,7 +20,8 @@ const resolveSelectedTemplate =
     ])
     const {tier} = team
     const hasFeatureFlag = viewer.featureFlags.includes('templateLimit')
-    if (template && (hasFeatureFlag ? template.isFree || tier !== 'personal' : true)) {
+    const {isFree, scope} = template
+    if (template && (hasFeatureFlag ? isFree || scope !== 'PUBLIC' || tier !== 'personal' : true)) {
       return template
     }
     // there may be holes in our template deletion or reselection logic, so doing this to be safe


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7593

Demo: https://www.loom.com/share/c0702add99d249ceb40c227d7faf5b39

### Test

- [ ] Create a new user
- [ ] Create a custom poker/retro template 
- [ ] Add the `templateLimit` feature flag
- [ ] See that they can still use their custom poker/retro template