### PR TITLE
feat(standups/notifications): Generalized notification toasts + new toasts

### DIFF
--- a/packages/client/components/NotificationPicker.tsx
+++ b/packages/client/components/NotificationPicker.tsx
@@ -1,14 +1,13 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
 import {createFragmentContainer} from 'react-relay'
-import {ValueOf} from '~/types/generics'
 import lazyPreload, {LazyExoticPreload} from '~/utils/lazyPreload'
 import {
   NotificationEnum,
   NotificationPicker_notification
 } from '~/__generated__/NotificationPicker_notification.graphql'
 
-const typePicker = {
+const typePicker: Record<NotificationEnum, LazyExoticPreload<any>> = {
   KICKED_OUT: lazyPreload(() => import(/* webpackChunkName: 'KickedOut' */ './KickedOut')),
   PAYMENT_REJECTED: lazyPreload(
     () => import(/* webpackChunkName: 'PaymentRejected' */ './PaymentRejected')
@@ -36,7 +35,7 @@ const typePicker = {
   RESPONSE_REPLIED: lazyPreload(
     () => import(/* webpackChunkName: 'ResponseReplied' */ './ResponseReplied')
   )
-} as Record<NotificationEnum, LazyExoticPreload<any>>
+}
 
 interface Props {
   notification: NotificationPicker_notification
@@ -45,7 +44,7 @@ interface Props {
 const NotificationPicker = (props: Props) => {
   const {notification} = props
   const {type} = notification
-  const SpecificNotification = typePicker[type] as ValueOf<typeof typePicker>
+  const SpecificNotification = typePicker[type]
   return (
     <Suspense fallback={''}>
       <SpecificNotification notification={notification} />

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -134,9 +134,10 @@ const TeamPromptMeeting = (props: Props) => {
   const {safeRoute, isDesktop} = useMeeting(meeting)
   const history = useHistory()
   const {isRightDrawerOpen, id: meetingId} = meeting
+  const params = new URLSearchParams(history.location.search)
+  const responseId = params.get('responseId')
   useEffect(() => {
-    const params = new URLSearchParams(history.location.search)
-    if (!params.get('responseId')) {
+    if (!responseId) {
       return
     }
 
@@ -151,7 +152,7 @@ const TeamPromptMeeting = (props: Props) => {
       meetingProxy.setValue(stage.id, 'localStageId')
       meetingProxy.setValue(true, 'isRightDrawerOpen')
     })
-  }, [])
+  }, [responseId])
   if (!safeRoute) return null
 
   return (

--- a/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
@@ -1,0 +1,43 @@
+import graphql from 'babel-plugin-relay/macro'
+import {Snack} from '../../components/Snackbar'
+import {OnNextHistoryContext} from '../../types/relayMutations'
+import {mapResponseMentionedToToast_notification} from '../../__generated__/mapResponseMentionedToToast_notification.graphql'
+
+graphql`
+  fragment mapResponseMentionedToToast_notification on NotifyResponseMentioned {
+    response {
+      id
+      user {
+        preferredName
+      }
+    }
+    meeting {
+      id
+      name
+    }
+  }
+`
+
+const mapResponseMentionedToToast = (
+  notification: mapResponseMentionedToToast_notification,
+  {history}: OnNextHistoryContext
+): Snack | null => {
+  if (!notification) return null
+  const {meeting, response} = notification
+  const {preferredName: authorName} = response.user
+
+  const {id: meetingId, name: meetingName} = meeting
+  return {
+    key: `responseMentioned:${response.id}`,
+    autoDismiss: 10,
+    message: `${authorName} mentioned you in their response in ${meetingName}.`,
+    action: {
+      label: 'See their response',
+      callback: () => {
+        history.push(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
+      }
+    }
+  }
+}
+
+export default mapResponseMentionedToToast

--- a/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
@@ -25,8 +25,11 @@ const mapResponseMentionedToToast = (
   if (!notification) return null
   const {meeting, response} = notification
   const {preferredName: authorName} = response.user
-
   const {id: meetingId, name: meetingName} = meeting
+
+  // :TODO: (jmtaber129): Check if we're already open to the relevant standup response discussion
+  // thread, and do nothing if we are.
+
   return {
     key: `responseMentioned:${response.id}`,
     autoDismiss: 10,

--- a/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
@@ -28,6 +28,9 @@ const mapResponseRepliedToToast = (
   const {preferredName: authorName} = author
   const {id: meetingId, name: meetingName} = meeting
 
+  // :TODO: (jmtaber129): Check if we're already open to the relevant standup response discussion
+  // thread, and do nothing if we are.
+
   return {
     key: `responseReplied:${response.id}:${author.id}`,
     autoDismiss: 10,

--- a/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
@@ -1,0 +1,44 @@
+import graphql from 'babel-plugin-relay/macro'
+import {Snack} from '../../components/Snackbar'
+import {OnNextHistoryContext} from '../../types/relayMutations'
+import {mapResponseRepliedToToast_notification} from '../../__generated__/mapResponseRepliedToToast_notification.graphql'
+
+graphql`
+  fragment mapResponseRepliedToToast_notification on NotifyResponseReplied {
+    author {
+      id
+      preferredName
+    }
+    response {
+      id
+    }
+    meeting {
+      id
+      name
+    }
+  }
+`
+
+const mapResponseRepliedToToast = (
+  notification: mapResponseRepliedToToast_notification,
+  {history}: OnNextHistoryContext
+): Snack | null => {
+  if (!notification) return null
+  const {meeting, author, response} = notification
+  const {preferredName: authorName} = author
+  const {id: meetingId, name: meetingName} = meeting
+
+  return {
+    key: `responseReplied:${response.id}:${author.id}`,
+    autoDismiss: 10,
+    message: `${authorName} replied to your response in ${meetingName}.`,
+    action: {
+      label: 'See the discussion',
+      callback: () => {
+        history.push(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
+      }
+    }
+  }
+}
+
+export default mapResponseRepliedToToast

--- a/packages/client/mutations/toasts/popNotificationToast.ts
+++ b/packages/client/mutations/toasts/popNotificationToast.ts
@@ -1,0 +1,80 @@
+import graphql from 'babel-plugin-relay/macro'
+import {Snack} from '../../components/Snackbar'
+import {ValueOf} from '../../types/generics'
+import {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
+import {
+  NotificationEnum,
+  popNotificationToast_notification
+} from '../../__generated__/popNotificationToast_notification.graphql'
+import SetNotificationStatusMutation from '../SetNotificationStatusMutation'
+import mapResponseMentionedToToast from './mapResponseMentionedToToast'
+import mapResponseRepliedToToast from './mapResponseRepliedToToast'
+
+const typePicker = {
+  KICKED_OUT: null,
+  PAYMENT_REJECTED: null,
+  TASK_INVOLVES: null,
+  PROMOTE_TO_BILLING_LEADER: null,
+  TEAMS_LIMIT_EXCEEDED: null,
+  TEAM_ARCHIVED: null,
+  TEAM_INVITATION: null,
+  MEETING_STAGE_TIME_LIMIT_END: null,
+  RESPONSE_MENTIONED: mapResponseMentionedToToast,
+  RESPONSE_REPLIED: mapResponseRepliedToToast
+} as Record<
+  NotificationEnum,
+  ((notification: any, context: OnNextHistoryContext) => Snack | null) | null
+>
+
+graphql`
+  fragment popNotificationToast_notification on AddedNotification {
+    addedNotification {
+      type
+      id
+      ...mapResponseMentionedToToast_notification @relay(mask: false)
+      ...mapResponseRepliedToToast_notification @relay(mask: false)
+    }
+  }
+`
+
+export const popNotificationToastOnNext: OnNextHandler<
+  popNotificationToast_notification,
+  OnNextHistoryContext
+> = (payload, {atmosphere, history}) => {
+  const {addedNotification} = payload
+  const {type} = addedNotification
+  const specificNotificationToastMapper = typePicker[type] as ValueOf<typeof typePicker>
+  if (!specificNotificationToastMapper) {
+    return
+  }
+
+  const notificationSnack = specificNotificationToastMapper(addedNotification, {
+    atmosphere,
+    history
+  })
+
+  if (!notificationSnack) {
+    return
+  }
+
+  if (notificationSnack.action) {
+    const callback = notificationSnack.action.callback
+    notificationSnack.action = {
+      ...notificationSnack.action,
+      callback: () => {
+        const {id: notificationId} = addedNotification
+        SetNotificationStatusMutation(
+          atmosphere,
+          {
+            notificationId,
+            status: 'CLICKED'
+          },
+          {}
+        )
+
+        callback()
+      }
+    }
+  }
+  atmosphere.eventEmitter.emit('addSnackbar', notificationSnack)
+}

--- a/packages/client/mutations/toasts/popNotificationToast.ts
+++ b/packages/client/mutations/toasts/popNotificationToast.ts
@@ -1,6 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
 import {Snack} from '../../components/Snackbar'
-import {ValueOf} from '../../types/generics'
 import {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
 import {
   NotificationEnum,
@@ -10,21 +9,12 @@ import SetNotificationStatusMutation from '../SetNotificationStatusMutation'
 import mapResponseMentionedToToast from './mapResponseMentionedToToast'
 import mapResponseRepliedToToast from './mapResponseRepliedToToast'
 
-const typePicker = {
-  KICKED_OUT: null,
-  PAYMENT_REJECTED: null,
-  TASK_INVOLVES: null,
-  PROMOTE_TO_BILLING_LEADER: null,
-  TEAMS_LIMIT_EXCEEDED: null,
-  TEAM_ARCHIVED: null,
-  TEAM_INVITATION: null,
-  MEETING_STAGE_TIME_LIMIT_END: null,
+const typePicker: Partial<
+  Record<NotificationEnum, (notification: any, context: OnNextHistoryContext) => Snack | null>
+> = {
   RESPONSE_MENTIONED: mapResponseMentionedToToast,
   RESPONSE_REPLIED: mapResponseRepliedToToast
-} as Record<
-  NotificationEnum,
-  ((notification: any, context: OnNextHistoryContext) => Snack | null) | null
->
+}
 
 graphql`
   fragment popNotificationToast_notification on AddedNotification {
@@ -43,7 +33,7 @@ export const popNotificationToastOnNext: OnNextHandler<
 > = (payload, {atmosphere, history}) => {
   const {addedNotification} = payload
   const {type} = addedNotification
-  const specificNotificationToastMapper = typePicker[type] as ValueOf<typeof typePicker>
+  const specificNotificationToastMapper = typePicker[type]
   if (!specificNotificationToastMapper) {
     return
   }

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -25,6 +25,7 @@ import {
   removeOrgUserNotificationOnNext,
   removeOrgUserNotificationUpdater
 } from '../mutations/RemoveOrgUserMutation'
+import {popNotificationToastOnNext} from '../mutations/toasts/popNotificationToast'
 import {LocalStorageKey} from '../types/constEnums'
 import {OnNextHandler, OnNextHistoryContext, SharedUpdater} from '../types/relayMutations'
 import {
@@ -86,6 +87,7 @@ const subscription = graphql`
           ...NotificationPicker_notification @relay(mask: false)
         }
       }
+      ...popNotificationToast_notification @relay(mask: false)
 
       ... on AuthTokenPayload {
         id
@@ -232,7 +234,8 @@ const onNextHandlers = {
   RemoveOrgUserPayload: removeOrgUserNotificationOnNext,
   StripeFailPaymentPayload: stripeFailPaymentNotificationOnNext,
   MeetingStageTimeLimitPayload: meetingStageTimeLimitOnNext,
-  InvalidateSessionsPayload: invalidateSessionsNotificationOnNext
+  InvalidateSessionsPayload: invalidateSessionsNotificationOnNext,
+  AddedNotification: popNotificationToastOnNext
 } as const
 
 const NotificationSubscription = (


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7559
This does a couple things:
* Brings the generalized `AddedNotification` pattern into our toasts, such that a new notification simply needs to map the notification fragment to toast's `Snack` object, and add the fragment to the `popNotificationToast` fragment
  * This automatically marks the notification as `CLICKED` when the user clicks into the notification via the action button (similar to a subset of existing toasts).
* Implement the mapping for a few of the new notifications:
  * Standup response replied-to toasts
  * Standup response mentioned toasts

Once either this PR or https://github.com/ParabolInc/parabol/pull/7596 lands, we'll want to incorporate relevant changes into the not-merged PR.

## Demo
<img width="669" alt="Screen Shot 2022-12-20 at 4 09 04 PM" src="https://user-images.githubusercontent.com/9013217/208776312-4afc2bef-3cdc-43c6-b623-f3bb8ab46a77.png">
<img width="674" alt="Screen Shot 2022-12-20 at 4 08 47 PM" src="https://user-images.githubusercontent.com/9013217/208776315-e387d35a-85bf-4bb7-9bd6-fc138a817011.png">

## Testing scenarios
- [ ] Generalized logic
  - [ ] Unimplemented toasts + toasts implemented elsewhere are not affected
  - [ ] When a notification with an implemented toast mapping is triggered, the notification appears as a toast
  - [ ] Clicking the action button on the notification both performs the correct action, and marks the notification as read
- [ ] New notifications
  - [ ] Log in as user A and user B
  - [ ] User A responds to user B's standup response
  - [ ] User B sees a toast, and can click directly to the response
  - [ ] User A mentioned user B in their standup response
  - [ ] User B sees a toast, and can click directly to the response

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
