### PR TITLE
fix: Broken summary pages

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -40,28 +40,32 @@ const WholeMeetingSummary = (props: Props) => {
   const {meetingRef} = props
   const meeting = useFragment(
     graphql`
-      fragment WholeMeetingSummary_meeting on RetrospectiveMeeting {
-        summary
-        reflectionGroups(sortBy: voteCount) {
+      fragment WholeMeetingSummary_meeting on NewMeeting {
+        ... on RetrospectiveMeeting {
+          __typename
           summary
-        }
-        phases {
-          phaseType
-          ... on DiscussPhase {
-            stages {
-              discussion {
-                summary
+          reflectionGroups(sortBy: voteCount) {
+            summary
+          }
+          phases {
+            phaseType
+            ... on DiscussPhase {
+              stages {
+                discussion {
+                  summary
+                }
               }
             }
           }
-        }
-        team {
-          tier
+          team {
+            tier
+          }
         }
       }
     `,
     meetingRef
   )
+  if (meeting.__typename !== 'RetrospectiveMeeting') return null
   const {summary: wholeMeetingSummary, team, reflectionGroups, phases} = meeting
   const discussPhase = phases.find((phase) => phase.phaseType === 'discuss')
   const {stages} = discussPhase ?? {}


### PR DESCRIPTION
# Description
Non-retro summary pages are broken on `master` (not yet in prod) due to a retro-only meeting fragment that could refer to a non-retro meetings.

Update the fragment, and check the meeting type in the component.

## Testing scenarios
Pre-fix:
Go through any non-retro/non-standup meeting to the summary, and get a `Cannot read properties of undefined (reading 'some')` error.

Post-fix:
Go through any non-retro/non-standup meeting to the summary, and see the summary without error.
Go through a retro with AI summaries and see the summaries on the summary page.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
