### PR TITLE
fix(Jira): fix Sprint Poker voting for projects with duplicate fields

### DIFF
--- a/packages/client/components/JiraFieldDimensionDropdown.tsx
+++ b/packages/client/components/JiraFieldDimensionDropdown.tsx
@@ -57,7 +57,10 @@ const JiraFieldDimensionDropdown = (props: Props) => {
         task {
           integration {
             ... on JiraIssue {
-              possibleEstimationFieldNames
+              possibleEstimationFields {
+                fieldId
+                fieldName
+              }
             }
           }
         }
@@ -67,7 +70,7 @@ const JiraFieldDimensionDropdown = (props: Props) => {
   )
 
   const {serviceField, task} = stage
-  const possibleEstimationFieldNames = task?.integration?.possibleEstimationFieldNames ?? []
+  const possibleEstimationFields = task?.integration?.possibleEstimationFields ?? []
   const {name: serviceFieldName} = serviceField
   const {togglePortal, menuPortal, originRef, menuProps} = useMenu<HTMLButtonElement>(
     MenuPosition.UPPER_RIGHT,
@@ -85,7 +88,7 @@ const JiraFieldDimensionDropdown = (props: Props) => {
   const validFields = [
     SprintPokerDefaults.SERVICE_FIELD_COMMENT,
     SprintPokerDefaults.SERVICE_FIELD_NULL,
-    ...possibleEstimationFieldNames
+    ...possibleEstimationFields.map(({fieldName}) => fieldName)
   ]
   const lookupServiceFieldName = validFields.includes(serviceFieldName)
     ? serviceFieldName

--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -651,13 +651,6 @@ export default abstract class AtlassianManager {
     ) as any
   }
 
-  // This function returns fields from all projects and issue types which is not useful in most cases
-  /*
-  async getFields(cloudId: string) {
-    return this.get<JiraField[]>(`https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/field`)
-  }
-  */
-
   async getFieldScreens(cloudId: string, fieldId: string) {
     return this.get(
       `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/field/${fieldId}/screens`
@@ -673,38 +666,6 @@ export default abstract class AtlassianManager {
       payload
     )
   }
-
-  /*
-  async getFirstValidJiraField(
-    cloudId: string,
-    possibleFieldNames: string[],
-    testIssueKeyId: string
-  ) {
-    const fields = await this.getFields(cloudId)
-    if (fields instanceof Error || fields instanceof RateLimitError) return null
-
-    const possibleFields = possibleFieldNames
-      .map((fieldName) => {
-        return fields.find((field) => field.name === fieldName)
-      })
-      .filter(Boolean) as JiraField[]
-    const updateResArr = await Promise.all(
-      possibleFields.map((field) => {
-        return this.put(
-          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${testIssueKeyId}`,
-          {
-            fields: {
-              [field.id]: 0
-            }
-          }
-        )
-      })
-    )
-    const firstValidUpdateIdx = updateResArr.indexOf(null)
-    if (firstValidUpdateIdx === -1) return null
-    return possibleFields[firstValidUpdateIdx]
-  }
-  */
 
   async updateStoryPoints(
     cloudId: string,

--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -225,6 +225,7 @@ interface JiraSearchResponse<T = {summary: string; description: string; issuetyp
   }[]
 }
 
+/*
 interface JiraField {
   issuetype: {
     id: string
@@ -244,6 +245,7 @@ interface JiraField {
   searchable: boolean
   untranslatedName: string
 }
+*/
 
 export interface JiraScreen {
   id: string
@@ -649,9 +651,12 @@ export default abstract class AtlassianManager {
     ) as any
   }
 
+  // This function returns fields from all projects and issue types which is not useful in most cases
+  /*
   async getFields(cloudId: string) {
     return this.get<JiraField[]>(`https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/field`)
   }
+  */
 
   async getFieldScreens(cloudId: string, fieldId: string) {
     return this.get(
@@ -669,6 +674,7 @@ export default abstract class AtlassianManager {
     )
   }
 
+  /*
   async getFirstValidJiraField(
     cloudId: string,
     possibleFieldNames: string[],
@@ -698,6 +704,7 @@ export default abstract class AtlassianManager {
     if (firstValidUpdateIdx === -1) return null
     return possibleFields[firstValidUpdateIdx]
   }
+  */
 
   async updateStoryPoints(
     cloudId: string,

--- a/packages/server/dataloader/atlassianLoaders.ts
+++ b/packages/server/dataloader/atlassianLoaders.ts
@@ -257,7 +257,6 @@ export const jiraIssue = (
                 }
               }
             )
-            console.log('GEORG possibleEstimationFields', possibleEstimationFields)
             possibleEstimationFields.sort((a, b) => a.fieldName.localeCompare(b.fieldName))
 
             const simplified = !!issueRes.fields.project?.simplified

--- a/packages/server/graphql/mutations/setTaskEstimate.ts
+++ b/packages/server/graphql/mutations/setTaskEstimate.ts
@@ -129,14 +129,12 @@ const setTaskEstimate = {
 
         // Find the best match
         const {possibleEstimationFields} = jiraIssue
-        const validFields = [
+        const validFieldIds = [
           SprintPokerDefaults.SERVICE_FIELD_COMMENT,
           SprintPokerDefaults.SERVICE_FIELD_NULL,
-          ...possibleEstimationFields.map(({fieldName}) => fieldName)
+          ...possibleEstimationFields.map(({fieldId}) => fieldId)
         ]
-        const dimensionField = dimensionFields.find(({fieldName}) =>
-          validFields.includes(fieldName)
-        )
+        const dimensionField = dimensionFields.find(({fieldId}) => validFieldIds.includes(fieldId))
 
         // If we're using a field stored for a different issueType, update the DB to store the new match
         if (dimensionField && dimensionField.issueType !== issueType) {

--- a/packages/server/graphql/mutations/setTaskEstimate.ts
+++ b/packages/server/graphql/mutations/setTaskEstimate.ts
@@ -128,11 +128,11 @@ const setTaskEstimate = {
           .load({teamId, cloudId, projectKey, issueType, dimensionName})
 
         // Find the best match
-        const {possibleEstimationFieldNames} = jiraIssue
+        const {possibleEstimationFields} = jiraIssue
         const validFields = [
           SprintPokerDefaults.SERVICE_FIELD_COMMENT,
           SprintPokerDefaults.SERVICE_FIELD_NULL,
-          ...possibleEstimationFieldNames
+          ...possibleEstimationFields.map(({fieldName}) => fieldName)
         ]
         const dimensionField = dimensionFields.find(({fieldName}) =>
           validFields.includes(fieldName)

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -2030,16 +2030,6 @@ type AtlassianIntegration {
   projects: [JiraRemoteProject!]!
 
   """
-  The list of field names that can be used as a
-  """
-  jiraFields(
-    """
-    Filter the fields to single cloudId
-    """
-    cloudId: ID!
-  ): [String!]!
-
-  """
   the list of suggested search queries, sorted by most recent. Guaranteed to be < 60 days old
   """
   jiraSearchQueries: [JiraSearchQuery!]!
@@ -2074,81 +2064,6 @@ type JiraIssueEdge {
   """
   node: JiraIssue!
   cursor: DateTime
-}
-
-"""
-The Jira Issue that comes direct from Jira
-"""
-type JiraIssue implements TaskIntegration {
-  """
-  GUID cloudId:issueKey
-  """
-  id: ID!
-
-  """
-  The parabol teamId this issue was fetched for
-  """
-  teamId: ID!
-
-  """
-  The parabol userId this issue was fetched for
-  """
-  userId: ID!
-
-  """
-  The ID of the jira cloud where the issue lives
-  """
-  cloudId: ID!
-
-  """
-  The name of the jira cloud where the issue lives
-  """
-  cloudName: ID!
-
-  """
-  The url to access the issue
-  """
-  url: URL!
-
-  """
-  The key of the issue as found in Jira
-  """
-  issueKey: ID!
-
-  """
-  Type id of the issue
-  """
-  issueType: ID!
-
-  """
-  The key of the project, which is the prefix to the issueKey
-  """
-  projectKey: ID!
-
-  """
-  The project fetched from jira
-  """
-  project: JiraRemoteProject
-
-  """
-  The plaintext summary of the jira issue
-  """
-  summary: String!
-
-  """
-  Field names that exists on the issue and can be used as estimation fields
-  """
-  possibleEstimationFieldNames: [String!]!
-
-  """
-  The stringified ADF of the jira issue description
-  """
-  description: String!
-
-  """
-  The description converted into raw HTML
-  """
-  descriptionHTML: String!
 }
 
 interface TaskIntegration {

--- a/packages/server/graphql/public/typeDefs/JiraIssue.graphql
+++ b/packages/server/graphql/public/typeDefs/JiraIssue.graphql
@@ -4,6 +4,21 @@ enum JiraIssueMissingEstimationFieldHintEnum {
 }
 
 """
+Possible voting field
+"""
+type JiraIssueField {
+  """
+  ID of the field in Jira
+  """
+  fieldId: ID!
+
+  """
+  Name of the field
+  """
+  fieldName: String!
+}
+
+"""
 The Jira Issue that comes direct from Jira
 """
 type JiraIssue implements TaskIntegration {
@@ -65,7 +80,7 @@ type JiraIssue implements TaskIntegration {
   """
   Field names that exists on the issue and can be used as estimation fields
   """
-  possibleEstimationFieldNames: [String!]!
+  possibleEstimationFields: [JiraIssueField!]!
 
   """
   Missing estimation field

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -1501,16 +1501,6 @@ type AtlassianIntegration {
   projects: [JiraRemoteProject!]!
 
   """
-  The list of field names that can be used as a
-  """
-  jiraFields(
-    """
-    Filter the fields to single cloudId
-    """
-    cloudId: ID!
-  ): [String!]!
-
-  """
   the list of suggested search queries, sorted by most recent. Guaranteed to be < 60 days old
   """
   jiraSearchQueries: [JiraSearchQuery!]!

--- a/packages/server/graphql/public/typeDefs/updateJiraDimensionField.graphql
+++ b/packages/server/graphql/public/typeDefs/updateJiraDimensionField.graphql
@@ -4,26 +4,19 @@ extend type Mutation {
   """
   updateJiraDimensionField(
     """
-    The cloudId the field lives on
+    Id of the parabol task on which the dimension was updated
     """
-    cloudId: ID!
+    taskId: ID!
 
     """
-    The project the field lives on
+    Dimension name from the template used
     """
-    projectKey: ID!
-
-    """
-    The Jira issue type for which to update the field
-    """
-    issueType: ID!
-
     dimensionName: String!
 
     """
-    The jira field name that we should push estimates to
+    The jira field id that we should push estimates to
     """
-    fieldName: String!
+    fieldId: ID!
 
     """
     The meeting the update happend in. Returns a meeting object with updated serviceField

--- a/packages/server/graphql/types/EstimateStage.ts
+++ b/packages/server/graphql/types/EstimateStage.ts
@@ -87,19 +87,19 @@ const EstimateStage = new GraphQLObjectType<Source, GQLContext>({
               .load({teamId, userId: accessUserId, cloudId, issueKey, taskId, viewerId})
           ])
           if (!jiraIssue) return NULL_FIELD
-          const {issueType, possibleEstimationFieldNames} = jiraIssue
+          const {issueType, possibleEstimationFields} = jiraIssue
 
           const dimensionFields = await dataLoader
             .get('jiraDimensionFieldMap')
             .load({teamId, cloudId, projectKey, issueType, dimensionName})
 
-          const validFields = [
+          const validFieldIds = [
             SprintPokerDefaults.SERVICE_FIELD_COMMENT,
             SprintPokerDefaults.SERVICE_FIELD_NULL,
-            ...possibleEstimationFieldNames
+            ...possibleEstimationFields.map(({fieldId}) => fieldId)
           ]
-          const dimensionField = dimensionFields.find(({fieldName}) =>
-            validFields.includes(fieldName)
+          const dimensionField = dimensionFields.find(({fieldId}) =>
+            validFieldIds.includes(fieldId)
           )
           if (dimensionField) {
             return {


### PR DESCRIPTION
Resolves: #7560 

Jira allows to have multiple fields with the same name in a project, even on the same issue. While this does not make sense from a usability standpoint, this backfired for us, because we were selecting fields based on their name and could end up selecting fields which belonged to a different issue type altogether. Now even multiple fields called "Story Points" on one issue are allowed and work.

## Demo

https://www.loom.com/share/b56ce436c22b4eeb870957e3d3592a94

## Testing scenarios

See demo

- Create at least 2 fields with the name "Story Points" in a Jira project
- Assign 1 field to the issue type "Bug" and the other one to the issue type "Story"
- [ ] Start a Sprint Poker with an issue of each type and vote to both "Story Points" fields and see the vote works