### PR TITLE
chore(DX): Show a warning on switching branch with migrations

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -3,10 +3,10 @@
 
 yarn postcheckout
 
-CURRENT_BRANCH=$(git branch --show-current)
 DELETED_POSTGRES_MIGRATIONS=$(git diff $1 $2 --name-only --diff-filter=D -- packages/server/postgres/migrations/)
 DELETED_RETHINK_MIGRATIONS=$(git diff $1 $2 --name-only --diff-filter=D -- packages/server/database/migrations/)
 if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" -o ! -z "$DELETED_RETHINK_MIGRATIONS" ]; then
+    CURRENT_BRANCH=$(git branch --show-current)
     NUM_POSTGRES_MIGRATIONS=$(echo $DELETED_POSTGRES_MIGRATIONS | wc -w)
     echo "WARNING: You're leaving behind the following migrations not present on the current branch:"
     echo

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -2,3 +2,27 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn postcheckout
+
+CURRENT_BRANCH=$(git branch --show-current)
+DELETED_POSTGRES_MIGRATIONS=$(git diff $1 $2 --name-only --diff-filter=D -- packages/server/postgres/migrations/)
+DELETED_RETHINK_MIGRATIONS=$(git diff $1 $2 --name-only --diff-filter=D -- packages/server/database/migrations/)
+if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" -o ! -z "$DELETED_RETHINK_MIGRATIONS" ]; then
+    NUM_POSTGRES_MIGRATIONS=$(echo $DELETED_POSTGRES_MIGRATIONS | wc -w)
+    echo "WARNING: You're leaving behind the following migrations not present on the current branch:"
+    echo
+    for X in $DELETED_POSTGRES_MIGRATIONS $DELETED_RETHINK_MIGRATIONS; do
+        echo "  ${X##*/}"
+    done
+    echo
+    echo "Consider running:"
+    echo
+    echo "  git checkout ${1} &&"
+    if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
+        echo "  yarn pg:migrate down ${NUM_POSTGRES_MIGRATIONS} &&"
+    fi
+    for X in $DELETED_RETHINK_MIGRATIONS; do
+        echo "  yarn db:migrate down &&"
+    done
+    echo "  git checkout ${CURRENT_BRANCH:-$2}"
+    echo
+fi


### PR DESCRIPTION
Fixes: #6286 

When switching branches where the target branch is missing some migrations, print a warning with the migration files which will not be present there and steps to run the down migration. The down migrations are not run automatically.

## Demo

https://www.loom.com/share/f05d16bb86ee432984e4a86d6591759d

## Testing scenarios

See demo
* [ ] with the hook change switch to a branch which does not have all current migrations
  * [ ] check with different postgres and rethink migrations
* [ ] warning message is printed in this case
