### PR TITLE
fix: emails landing in spam

### DIFF
--- a/packages/client/modules/email/components/EmailFooter/EmailFooter.tsx
+++ b/packages/client/modules/email/components/EmailFooter/EmailFooter.tsx
@@ -1,19 +1,15 @@
 import React from 'react'
-import {emailCopyStyle, emailTableBase, emailTextColorLight} from '../../styles'
+import {ContactInfo} from '../../../../types/constEnums'
+import {emailCopyStyle, emailTableBase, emailTextColor} from '../../styles'
 import EmptySpace from '../EmptySpace/EmptySpace'
 
 const copyStyle = {
   ...emailCopyStyle,
-  color: emailTextColorLight,
+  color: emailTextColor,
   fontSize: '13px',
   lineHeight: '20px',
   margin: 0,
   textAlign: 'left'
-} as const
-
-const boldCopyStyle = {
-  ...copyStyle,
-  fontWeight: 600
 } as const
 
 const linkStyle = {
@@ -23,23 +19,38 @@ const linkStyle = {
 
 const year = new Date().getFullYear()
 
+const finePrintStyle = {
+  fontSize: 12,
+  lineHeight: '1.5',
+  margin: '16px auto 0'
+}
+
 const EmailFooter = () => {
   return (
     <table align='left' width='100%' style={emailTableBase}>
       <tbody>
         <tr>
           <td>
-            <EmptySpace height={24} />
-            <div style={copyStyle}>
-              {`©${year} Parabol, Inc.`}
-              <br />
-              <span style={boldCopyStyle}>{'Get in touch'}</span>
-              {': '}
-              <a href='mailto:love@parabol.co' title='Get in touch' style={linkStyle}>
-                {'love@parabol.co'}
-              </a>
-            </div>
             <EmptySpace height={8} />
+            <div style={finePrintStyle}>
+              {'Parabol, Inc.'}
+              <br />
+              {'8605 Santa Monica Blvd'}
+              <br />
+              {'West Hollywood, CA 90069-4109'}
+              <br />
+              {'United States'}
+              <br />
+              <a
+                href={`tel:${ContactInfo.TELEPHONE.replace('-', '')}`}
+                title={`Call us: ${ContactInfo.TELEPHONE}`}
+                style={linkStyle}
+              >
+                {ContactInfo.TELEPHONE}
+              </a>
+              <br />
+              {`©${year} Parabol, Inc.`}
+            </div>
           </td>
         </tr>
       </tbody>

--- a/packages/client/modules/email/components/ResetPasswordEmail.tsx
+++ b/packages/client/modules/email/components/ResetPasswordEmail.tsx
@@ -36,7 +36,7 @@ const ResetPasswordEmail = (props: ResetPasswordEmailProps) => {
             {'love@parabol.co'}
           </a>
         </p>
-        <EmptySpace height={16} />
+        <EmptySpace height={8} />
       </EmailBlock>
       <EmailBlock hasBackgroundColor innerMaxWidth={innerMaxWidth}>
         <EmailFooter />

--- a/packages/client/modules/email/styles.ts
+++ b/packages/client/modules/email/styles.ts
@@ -40,7 +40,7 @@ export const emailCopyStyle = {
 export const emailLineHeight = 1.5
 
 export const emailLinkStyle = {
-  color: PALETTE.SKY_500,
+  color: PALETTE.SKY_600,
   fontFamily: emailFontFamily,
   fontWeight: 600,
   textDecoration: 'none'
@@ -68,8 +68,6 @@ export const emailTableBase = {
 } as const
 
 export const emailTextColor = PALETTE.SLATE_700
-export const emailTextColorLight = PALETTE.SLATE_600
-
 export const headCSS = `
   @media only screen and (max-width: 620px) {
     table[class=body] .maxWidthContainer {

--- a/packages/client/modules/invoice/components/InvoiceFooter/InvoiceFooter.tsx
+++ b/packages/client/modules/invoice/components/InvoiceFooter/InvoiceFooter.tsx
@@ -46,9 +46,9 @@ const InvoiceFooter = () => {
       <FinePrint>
         {'Parabol, Inc.'}
         <br />
-        {'2900 W Shorb St'}
+        {'8605 Santa Monica Blvd'}
         <br />
-        {'Alhambra, CA, 91803'}
+        {'West Hollywood, CA 90069-4109'}
         <br />
         {'United States'}
         <br />


### PR DESCRIPTION
Signed-off-by: Matt Krick <matt.krick@gmail.com>

# Description

We've had reports that emails land in spam.
Digging into it, I tracked it down to poor color contrast in our emails. Spam filters thought were were trying to hide invisible text in the emails. The 2 problem areas were the link colors & footer colors.

I also saw some spam filters look for a physical address & phone number, so I added those to the footer. 


## Demo

### BEFORE
![Screenshot from 2023-01-03 12-13-24](https://user-images.githubusercontent.com/5514175/210437957-efeea651-c535-4b81-a1d9-cb79530ee937.png)
![Screenshot from 2023-01-03 10-23-45](https://user-images.githubusercontent.com/5514175/210437961-5b776ef5-bbab-46a6-9a0c-e3af39397352.png)

### AFTER
![Screenshot from 2023-01-03 12-44-00](https://user-images.githubusercontent.com/5514175/210438469-3edec8d2-62c6-4d31-82d2-1d0d8a428f55.png)
![Screenshot from 2023-01-03 12-35-34](https://user-images.githubusercontent.com/5514175/210437949-d36a73c3-c275-4aa9-9746-28d3d0a2b731.png)

## Testing scenarios

- [  ] Make sure the screenshots look OK!