### PR TITLE
chore(ai-summary): track when the summaries are viewed

### DIFF
--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -92,14 +92,11 @@ const ThreadedCommentBase = (props: Props) => {
 
   useEffect(() => {
     if (createdByUserNullable?.id === PARABOL_AI_USER_ID) {
-      const contentState = editorState.getCurrentContent()
-      const summary = contentState.getPlainText()
       SendClientSegmentEventMutation(atmosphere, 'AI Summary Viewed', {
         source: 'Discussion',
         tier: viewer.tier,
         meetingId,
-        discussionTopicId,
-        summary
+        discussionTopicId
       })
     }
   }, [])

--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -63,7 +63,7 @@ const ThreadedCommentBase = (props: Props) => {
     viewer
   } = props
   const isReply = !!props.isReply
-  const {id: discussionId, meetingId, replyingToCommentId, teamId} = discussion
+  const {id: discussionId, meetingId, replyingToCommentId, teamId, discussionTopicId} = discussion
   const {
     id: commentId,
     content,
@@ -92,11 +92,14 @@ const ThreadedCommentBase = (props: Props) => {
 
   useEffect(() => {
     if (createdByUserNullable?.id === PARABOL_AI_USER_ID) {
+      const contentState = editorState.getCurrentContent()
+      const summary = contentState.getPlainText()
       SendClientSegmentEventMutation(atmosphere, 'AI Summary Viewed', {
         source: 'Discussion',
         tier: viewer.tier,
         meetingId,
-        commentId
+        discussionTopicId,
+        summary
       })
     }
   }, [])
@@ -236,6 +239,7 @@ export default createFragmentContainer(ThreadedCommentBase, {
       meetingId
       replyingToCommentId
       teamId
+      discussionTopicId
     }
   `,
   comment: graphql`

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -1,38 +1,9 @@
 import graphql from 'babel-plugin-relay/macro'
-import {PALETTE} from 'parabol-client/styles/paletteV3'
-import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
 import {WholeMeetingSummary_meeting$key} from 'parabol-client/__generated__/WholeMeetingSummary_meeting.graphql'
-import React, {useEffect} from 'react'
+import React from 'react'
 import {useFragment} from 'react-relay'
-import Ellipsis from '../../../../../components/Ellipsis/Ellipsis'
-import useAtmosphere from '../../../../../hooks/useAtmosphere'
-import SendClientSegmentEventMutation from '../../../../../mutations/SendClientSegmentEventMutation'
-import {AIExplainer} from '../../../../../types/constEnums'
-import EmailBorderBottom from './EmailBorderBottom'
-
-const topicTitleStyle = {
-  color: PALETTE.SLATE_700,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontWeight: 600,
-  lineHeight: '22px',
-  fontSize: 14,
-  padding: '8px 48px'
-}
-
-const explainerStyle = {
-  color: PALETTE.SLATE_700,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontStyle: 'italic',
-  padding: '8px 48px',
-  fontSize: 14
-}
-
-const textStyle = {
-  color: PALETTE.SLATE_700,
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  padding: '0px 48px 8px 48px',
-  fontSize: 14
-}
+import WholeMeetingSummaryLoading from './WholeMeetingSummaryLoading'
+import WholeMeetingSummaryResult from './WholeMeetingSummaryResult'
 
 interface Props {
   meetingRef: WholeMeetingSummary_meeting$key
@@ -44,6 +15,7 @@ const WholeMeetingSummary = (props: Props) => {
     graphql`
       fragment WholeMeetingSummary_meeting on NewMeeting {
         ... on RetrospectiveMeeting {
+          ...WholeMeetingSummaryResult_meeting
           __typename
           id
           summary
@@ -60,78 +32,21 @@ const WholeMeetingSummary = (props: Props) => {
               }
             }
           }
-          team {
-            tier
-          }
         }
       }
     `,
     meetingRef
   )
-  const atmosphere = useAtmosphere()
-
-  useEffect(() => {
-    if (hasOpenAISummary && meeting.__typename === 'RetrospectiveMeeting') {
-      SendClientSegmentEventMutation(atmosphere, 'AI Summary Viewed', {
-        source: 'Meeting Summary',
-        tier: meeting.team.tier,
-        meetingId: meeting.id
-      })
-    }
-  }, [])
   if (meeting.__typename !== 'RetrospectiveMeeting') return null
-  const {summary: wholeMeetingSummary, team, reflectionGroups, phases} = meeting
+  const {summary: wholeMeetingSummary, reflectionGroups, phases} = meeting
   const discussPhase = phases.find((phase) => phase.phaseType === 'discuss')
   const {stages} = discussPhase ?? {}
-  const explainerText = team?.tier === 'starter' ? AIExplainer.STARTER : AIExplainer.PREMIUM_MEETING
   const hasTopicSummary = reflectionGroups.some((group) => group.summary)
   const hasDiscussionSummary = !!stages?.some((stage) => stage.discussion?.summary)
   const hasOpenAISummary = hasTopicSummary || hasDiscussionSummary
   if (!hasOpenAISummary) return null
-  if (hasOpenAISummary && !wholeMeetingSummary) {
-    return (
-      <tr
-        style={{
-          borderBottom: `1px solid ${PALETTE.SLATE_400}`
-        }}
-      >
-        <td
-          align='center'
-          style={{
-            padding: '20px 0px',
-            borderBottom: `1px solid ${PALETTE.SLATE_400}`
-          }}
-        >
-          <tr>
-            <td style={explainerStyle}>
-              {'Hold tight! Our AI 🤖 is generating your meeting summary'}
-              <Ellipsis />
-            </td>
-          </tr>
-        </td>
-      </tr>
-    )
-  }
-  return (
-    <>
-      <tr>
-        <td align='center' style={{paddingTop: 20}}>
-          <tr>
-            <td style={explainerStyle}>{explainerText}</td>
-          </tr>
-          <tr>
-            <td align='center' style={topicTitleStyle}>
-              {'🤖 Meeting Summary'}
-            </td>
-          </tr>
-          <tr>
-            <td style={textStyle}>{wholeMeetingSummary}</td>
-          </tr>
-        </td>
-      </tr>
-      <EmailBorderBottom />
-    </>
-  )
+  if (hasOpenAISummary && !wholeMeetingSummary) return <WholeMeetingSummaryLoading />
+  return <WholeMeetingSummaryResult meetingRef={meeting} />
 }
 
 export default WholeMeetingSummary

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryLoading.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryLoading.tsx
@@ -1,0 +1,39 @@
+import {PALETTE} from 'parabol-client/styles/paletteV3'
+import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
+import React from 'react'
+import Ellipsis from '../../../../../components/Ellipsis/Ellipsis'
+
+const explainerStyle = {
+  color: PALETTE.SLATE_700,
+  fontFamily: FONT_FAMILY.SANS_SERIF,
+  fontStyle: 'italic',
+  padding: '8px 48px',
+  fontSize: 14
+}
+
+const WholeMeetingSummary = () => {
+  return (
+    <tr
+      style={{
+        borderBottom: `1px solid ${PALETTE.SLATE_400}`
+      }}
+    >
+      <td
+        align='center'
+        style={{
+          padding: '20px 0px',
+          borderBottom: `1px solid ${PALETTE.SLATE_400}`
+        }}
+      >
+        <tr>
+          <td style={explainerStyle}>
+            {'Hold tight! Our AI 🤖 is generating your meeting summary'}
+            <Ellipsis />
+          </td>
+        </tr>
+      </td>
+    </tr>
+  )
+}
+
+export default WholeMeetingSummary

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryResult.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryResult.tsx
@@ -1,0 +1,103 @@
+import graphql from 'babel-plugin-relay/macro'
+import {PALETTE} from 'parabol-client/styles/paletteV3'
+import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
+import {WholeMeetingSummaryResult_meeting$key} from 'parabol-client/__generated__/WholeMeetingSummaryResult_meeting.graphql'
+import React, {useEffect} from 'react'
+import {useFragment} from 'react-relay'
+import useAtmosphere from '../../../../../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../../../../../mutations/SendClientSegmentEventMutation'
+import {AIExplainer} from '../../../../../types/constEnums'
+import {isNotNull} from '../../../../../utils/predicates'
+import EmailBorderBottom from './EmailBorderBottom'
+
+const topicTitleStyle = {
+  color: PALETTE.SLATE_700,
+  fontFamily: FONT_FAMILY.SANS_SERIF,
+  fontWeight: 600,
+  lineHeight: '22px',
+  fontSize: 14,
+  padding: '8px 48px'
+}
+
+const explainerStyle = {
+  color: PALETTE.SLATE_700,
+  fontFamily: FONT_FAMILY.SANS_SERIF,
+  fontStyle: 'italic',
+  padding: '8px 48px',
+  fontSize: 14
+}
+
+const textStyle = {
+  color: PALETTE.SLATE_700,
+  fontFamily: FONT_FAMILY.SANS_SERIF,
+  padding: '0px 48px 8px 48px',
+  fontSize: 14
+}
+
+interface Props {
+  meetingRef: WholeMeetingSummaryResult_meeting$key
+}
+
+const WholeMeetingSummaryResult = (props: Props) => {
+  const {meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment WholeMeetingSummaryResult_meeting on RetrospectiveMeeting {
+        __typename
+        id
+        summary
+        phases {
+          phaseType
+          ... on DiscussPhase {
+            stages {
+              discussion {
+                summary
+              }
+            }
+          }
+        }
+        team {
+          tier
+        }
+      }
+    `,
+    meetingRef
+  )
+  const atmosphere = useAtmosphere()
+  const {summary: wholeMeetingSummary, team, phases} = meeting
+  const discussPhase = phases.find((phase) => phase.phaseType === 'discuss')
+  const {stages} = discussPhase ?? {}
+  const explainerText = team?.tier === 'starter' ? AIExplainer.STARTER : AIExplainer.PREMIUM_MEETING
+  useEffect(() => {
+    const discussionSummaries = stages?.map((stage) => stage.discussion?.summary).filter(isNotNull)
+    SendClientSegmentEventMutation(atmosphere, 'AI Summary Viewed', {
+      source: 'Meeting Summary',
+      tier: meeting.team.tier,
+      meetingId: meeting.id,
+      discussionSummaries,
+      summary: wholeMeetingSummary
+    })
+  }, [])
+  return (
+    <>
+      <tr>
+        <td align='center' style={{paddingTop: 20}}>
+          <tr>
+            <td style={explainerStyle}>{explainerText}</td>
+          </tr>
+          <tr>
+            <td align='center' style={topicTitleStyle}>
+              {'🤖 Meeting Summary'}
+            </td>
+          </tr>
+          <tr>
+            <td style={textStyle}>{wholeMeetingSummary}</td>
+          </tr>
+        </td>
+      </tr>
+      <EmailBorderBottom />
+    </>
+  )
+}
+
+export default WholeMeetingSummaryResult

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryResult.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryResult.tsx
@@ -7,7 +7,6 @@ import {useFragment} from 'react-relay'
 import useAtmosphere from '../../../../../hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '../../../../../mutations/SendClientSegmentEventMutation'
 import {AIExplainer} from '../../../../../types/constEnums'
-import {isNotNull} from '../../../../../utils/predicates'
 import EmailBorderBottom from './EmailBorderBottom'
 
 const topicTitleStyle = {
@@ -46,16 +45,6 @@ const WholeMeetingSummaryResult = (props: Props) => {
         __typename
         id
         summary
-        phases {
-          phaseType
-          ... on DiscussPhase {
-            stages {
-              discussion {
-                summary
-              }
-            }
-          }
-        }
         team {
           tier
         }
@@ -64,18 +53,13 @@ const WholeMeetingSummaryResult = (props: Props) => {
     meetingRef
   )
   const atmosphere = useAtmosphere()
-  const {summary: wholeMeetingSummary, team, phases} = meeting
-  const discussPhase = phases.find((phase) => phase.phaseType === 'discuss')
-  const {stages} = discussPhase ?? {}
+  const {summary: wholeMeetingSummary, team} = meeting
   const explainerText = team?.tier === 'starter' ? AIExplainer.STARTER : AIExplainer.PREMIUM_MEETING
   useEffect(() => {
-    const discussionSummaries = stages?.map((stage) => stage.discussion?.summary).filter(isNotNull)
     SendClientSegmentEventMutation(atmosphere, 'AI Summary Viewed', {
       source: 'Meeting Summary',
       tier: meeting.team.tier,
-      meetingId: meeting.id,
-      discussionSummaries,
-      summary: wholeMeetingSummary
+      meetingId: meeting.id
     })
   }, [])
   return (

--- a/packages/server/graphql/mutations/addReactjiToReactable.ts
+++ b/packages/server/graphql/mutations/addReactjiToReactable.ts
@@ -3,6 +3,7 @@ import TeamPromptResponseId from 'parabol-client/shared/gqlIds/TeamPromptRespons
 import {SubscriptionChannel, Threshold} from 'parabol-client/types/constEnums'
 import {ValueOf} from 'parabol-client/types/generics'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
+import {PARABOL_AI_USER_ID} from '../../../client/utils/constants'
 import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import Comment from '../../database/types/Comment'
@@ -164,13 +165,16 @@ const addReactjiToReactable = {
 
     const data = {reactableId, reactableType}
     const {meetingType} = await dataLoader.get('newMeetings').load(meetingId)
+    const isAIComment = reactable instanceof Comment && reactable.createdBy === PARABOL_AI_USER_ID
     analytics.reactjiInteracted(
       viewerId,
       meetingId,
       meetingType,
       reactableId,
       reactableType,
-      !!isRemove
+      reactji,
+      !!isRemove,
+      isAIComment
     )
     if (meetingId) {
       publish(

--- a/packages/server/graphql/mutations/addReactjiToReactable.ts
+++ b/packages/server/graphql/mutations/addReactjiToReactable.ts
@@ -3,7 +3,6 @@ import TeamPromptResponseId from 'parabol-client/shared/gqlIds/TeamPromptRespons
 import {SubscriptionChannel, Threshold} from 'parabol-client/types/constEnums'
 import {ValueOf} from 'parabol-client/types/generics'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
-import {PARABOL_AI_USER_ID} from '../../../client/utils/constants'
 import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import Comment from '../../database/types/Comment'
@@ -165,16 +164,14 @@ const addReactjiToReactable = {
 
     const data = {reactableId, reactableType}
     const {meetingType} = await dataLoader.get('newMeetings').load(meetingId)
-    const isAIComment = reactable instanceof Comment && reactable.createdBy === PARABOL_AI_USER_ID
     analytics.reactjiInteracted(
       viewerId,
       meetingId,
       meetingType,
-      reactableId,
+      reactable,
       reactableType,
       reactji,
-      !!isRemove,
-      isAIComment
+      !!isRemove
     )
     if (meetingId) {
       publish(

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -46,7 +46,9 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     upgradeTier: {type: TierEnum},
     notificationType: {type: NotificationEnum},
     tier: {type: TierEnum},
-    commentId: {type: GraphQLID}
+    discussionTopicId: {type: GraphQLID},
+    summary: {type: GraphQLString},
+    discussionSummaries: {type: GraphQLList(GraphQLString)}
   })
 })
 

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -44,7 +44,8 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     isFree: {type: GraphQLBoolean},
     source: {type: GraphQLString},
     upgradeTier: {type: TierEnum},
-    notificationType: {type: NotificationEnum}
+    notificationType: {type: NotificationEnum},
+    tier: {type: TierEnum}
   })
 })
 

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -46,9 +46,7 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     upgradeTier: {type: TierEnum},
     notificationType: {type: NotificationEnum},
     tier: {type: TierEnum},
-    discussionTopicId: {type: GraphQLID},
-    summary: {type: GraphQLString},
-    discussionSummaries: {type: GraphQLList(GraphQLString)}
+    discussionTopicId: {type: GraphQLID}
   })
 })
 

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -45,7 +45,8 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     source: {type: GraphQLString},
     upgradeTier: {type: TierEnum},
     notificationType: {type: NotificationEnum},
-    tier: {type: TierEnum}
+    tier: {type: TierEnum},
+    commentId: {type: GraphQLID}
   })
 })
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -226,14 +226,18 @@ class Analytics {
     meetingType: MeetingTypeEnum,
     reactableId: string,
     reactableType: ReactableEnum,
-    isRemove: boolean
+    reactji: string,
+    isRemove: boolean,
+    isAIComment: boolean
   ) => {
     this.track(userId, 'Reactji Interacted', {
       meetingId,
       meetingType,
       reactableId,
       reactableType,
-      isRemove
+      reactji,
+      isRemove,
+      isAIComment
     })
   }
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -1,9 +1,11 @@
+import {PARABOL_AI_USER_ID} from '../../../client/utils/constants'
 import Meeting from '../../database/types/Meeting'
 import MeetingMember from '../../database/types/MeetingMember'
 import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import MeetingTemplate from '../../database/types/MeetingTemplate'
-import {ReactableEnum} from '../../database/types/Reactable'
+import {Reactable} from '../../database/types/Reactable'
 import {TaskServiceEnum} from '../../database/types/Task'
+import {ReactableEnum} from '../../graphql/private/resolverTypes'
 import {IntegrationProviderServiceEnumType} from '../../graphql/types/IntegrationProviderServiceEnum'
 import {UpgradeCTALocationEnumType} from '../../graphql/types/UpgradeCTALocationEnum'
 import {TeamPromptResponse} from '../../postgres/queries/getTeamPromptResponsesByIds'
@@ -224,12 +226,13 @@ class Analytics {
     userId: string,
     meetingId: string,
     meetingType: MeetingTypeEnum,
-    reactableId: string,
+    reactable: Reactable,
     reactableType: ReactableEnum,
     reactji: string,
-    isRemove: boolean,
-    isAIComment: boolean
+    isRemove: boolean
   ) => {
+    const isAIComment = 'createdBy' in reactable && reactable.createdBy === PARABOL_AI_USER_ID
+    const {id: reactableId} = reactable
     this.track(userId, 'Reactji Interacted', {
       meetingId,
       meetingType,


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7467

### To test

- [ ] When the meeting summary is viewed with an AI Summary, an event is tracked in Segment
- [ ] When the discussion thread is viewed with an AI Topic Summary, an event is tracked in Segment
- [ ] Track adding an emoji to the AI comment in the discussion thread