### PR TITLE
chore: Add reviewer for PRs and assignee for issues on mention

### DIFF
--- a/.github/workflows/assign_mentioned.yml
+++ b/.github/workflows/assign_mentioned.yml
@@ -1,0 +1,42 @@
+name: Assign and add reviewers on mention
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  pr_commented:
+    name: Add mentioned user as reviewer
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          MENTIONS=$(echo "$BODY" | grep -oh "@[[:alnum:]-]*")
+          for X in $MENTIONS; do
+            gh pr edit $ISSUE --add-reviewer ${X#@} || true
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.html_url }}
+          BODY: ${{ github.event.comment.body }}
+
+  issue_commented:
+    name: Add mentioned user to issue assignees
+    if: ${{ !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          MENTIONS=$(echo "$BODY" | grep -oh "@[[:alnum:]-]*")
+          for X in $MENTIONS; do
+            gh issue edit $ISSUE --add-assignee ${X#@} || true
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.html_url }}
+          BODY: ${{ github.event.comment.body }}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+


### PR DESCRIPTION
If a user is mentioned in a PR or issue, then the author/current assignee probably needs something from them. In order to not loose track add the users as reviewer/assignee.