### PR TITLE
fix: Legitity min/max failed on undefined value

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,0 +1,20 @@
+const tsJestPresets = require('ts-jest/presets')
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      diagnostics: false
+    }
+  },
+  transform: {
+    '\\.(gql|graphql)$': 'jest-transform-graphql',
+    ...tsJestPresets.jsWithBabel.transform
+  },
+  modulePaths: ['<rootDir>/packages/'],
+  moduleNameMapper: {
+    '~/(.*)': ['<rootDir>/../client/$1']
+  },
+  testRegex: '/__tests__/.*.test\\.[jt]sx?$'
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,6 +21,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier --config ../../.prettierrc --ignore-path ./.eslintignore --write \"**/*.{ts,tsx,graphql}\"",
     "prettier:check": "prettier --config ../../.prettierrc --ignore-path ./.eslintignore --check \"**/*.{ts,tsx,graphql}\"",
+    "test": "jest --verbose --runInBand",
     "typecheck": "yarn tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {
@@ -28,6 +29,7 @@
     "@types/cleave.js": "^1.4.7",
     "@types/dompurify": "^2.4.0",
     "@types/draft-js": "^0.10.24",
+    "@types/jest": "^27.0.1",
     "@types/json2csv": "^4.4.0",
     "@types/jwt-decode": "^2.1.0",
     "@types/linkify-it": "^3.0.2",
@@ -53,6 +55,7 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^1.6.1",
     "html-webpack-plugin": "5.0.0-beta.1",
+    "jest": "^27.0.6",
     "lint-staged": "^10.1.7",
     "prettier": "^2.6.1",
     "react-refresh": "^0.9.0",
@@ -129,11 +132,5 @@
     "tlds": "^1.192.0",
     "tslib": "^2.4.0",
     "unicode-substring": "^1.0.0"
-  },
-  "jest": {
-    "modulePaths": [
-      "<rootDir>/packages/"
-    ],
-    "testRegex": "/__tests__/.*.test\\.jsx?$"
   }
 }

--- a/packages/client/utils/__tests__/parseEmailAddressList.test.ts
+++ b/packages/client/utils/__tests__/parseEmailAddressList.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import parseEmailAddressList from '../parseEmailAddressList'
 
-const getAddressStr = (res) => res && res.map((val) => val.address).join(', ')
+const getAddressStr = (res) => res && res.parsedInvitees.map((val) => val.address).join(', ')
 
 describe('parseEmailAddressList', () => {
   it('validates a simple single email', () => {

--- a/packages/client/validation/Legitity.ts
+++ b/packages/client/validation/Legitity.ts
@@ -2,7 +2,7 @@ class Legitity {
   value: any
   error: undefined | string
 
-  constructor(value: string) {
+  constructor(value: string | undefined) {
     this.value = value
     this.error = undefined
   }
@@ -36,21 +36,25 @@ class Legitity {
   }
 
   max(len: number, msg?: string) {
-    // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
-    // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
-    const value = [...this.value]
-    if (!this.error && value.length > len) {
-      this.error = msg || 'max'
+    if (this.value !== undefined) {
+      // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
+      // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
+      const value = [...this.value]
+      if (!this.error && value.length > len) {
+        this.error = msg || 'max'
+      }
     }
     return this
   }
 
   min(len: number, msg?: string) {
-    // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
-    // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
-    const value = [...this.value]
-    if (!this.error && value.length < len) {
-      this.error = msg || 'min'
+    if (this.value !== undefined) {
+      // this.value.length gives us the count of UTF-16 units, so 🔥 has a length of 2
+      // Spreading the string into an array gives us the desired length in codepoints (characters): https://stackoverflow.com/a/54369605
+      const value = [...this.value]
+      if (!this.error && value.length < len) {
+        this.error = msg || 'min'
+      }
     }
     return this
   }

--- a/packages/client/validation/__tests__/Legitity.test.ts
+++ b/packages/client/validation/__tests__/Legitity.test.ts
@@ -1,0 +1,21 @@
+import Legitity from '../Legitity'
+
+test('Legitity.max succeeds with undefined', async () => {
+  const legitity = new Legitity(undefined).max(12, 'too long')
+  expect(legitity.error).toBe(undefined)
+})
+
+test('Legitity.max fails with message when too long', async () => {
+  const legitity = new Legitity('Haftpflichtversicherung').max(12, 'too long')
+  expect(legitity.error).toBe('too long')
+})
+
+test('Legitity.min succeeds with undefined', async () => {
+  const legitity = new Legitity(undefined).min(2, 'too short')
+  expect(legitity.error).toBe(undefined)
+})
+
+test('Legitity.min fails with message when too long', async () => {
+  const legitity = new Legitity('a').min(2, 'too short')
+  expect(legitity.error).toBe('too short')
+})


### PR DESCRIPTION
Fixes: #7622 

Legitity has a separate `required` test which checks for non-undefined, thus all other checks need to be able to cope with undefined values.

Added tests to simplify verification of the fix.

## Demo
![Peek 2023-01-05 13-57](https://user-images.githubusercontent.com/7331043/210785390-10073ae6-7703-4158-8b95-a8a28248bec7.gif)

## Testing scenarios

- in a Check-In meeting
  - [ ] reorder, pin and unpin agenda items

- run client tests
  - `yarn workspace parabol-client test`

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
