### PR TITLE
feat: slack uses oatuh2 redirect

### DIFF
--- a/packages/client/utils/SlackClientManager.ts
+++ b/packages/client/utils/SlackClientManager.ts
@@ -2,7 +2,6 @@ import Atmosphere from '../Atmosphere'
 import {MenuMutationProps} from '../hooks/useMutationProps'
 import AddSlackAuthMutation from '../mutations/AddSlackAuthMutation'
 import getOAuthPopupFeatures from './getOAuthPopupFeatures'
-import makeHref from './makeHref'
 import SlackManager from './SlackManager'
 
 class SlackClientManager extends SlackManager {
@@ -13,9 +12,7 @@ class SlackClientManager extends SlackManager {
     const providerState = btoa(
       JSON.stringify({hash, origin: window.location.origin, service: 'slack'})
     )
-    const redirect = makeHref('/auth/slack')
-    // use this when slack approves our app
-    // const redirect = window.__ACTION__.oauth2Redirect
+    const redirect = window.__ACTION__.oauth2Redirect
     const uri = `https://slack.com/oauth/v2/authorize?client_id=${window.__ACTION__.slack}&scope=${SlackClientManager.SCOPE}&state=${providerState}&redirect_uri=${redirect}`
     const popup = window.open(
       uri,

--- a/packages/server/utils/SlackServerManager.ts
+++ b/packages/server/utils/SlackServerManager.ts
@@ -1,8 +1,6 @@
 import fetch from 'node-fetch'
 import SlackManager from 'parabol-client/utils/SlackManager'
 import {stringify} from 'querystring'
-import makeAppURL from '../../client/utils/makeAppURL'
-import appOrigin from '../appOrigin'
 
 interface IncomingWebhook {
   url: string
@@ -39,9 +37,7 @@ class SlackServerManager extends SlackManager {
       client_id: process.env.SLACK_CLIENT_ID,
       client_secret: process.env.SLACK_CLIENT_SECRET,
       code,
-      redirect_uri: makeAppURL(appOrigin, 'auth/slack')
-      // use this after slack approves our app
-      // redirect_uri: process.env.OAUTH2_REDIRECT!
+      redirect_uri: process.env.OAUTH2_REDIRECT!
     }
 
     const uri = `https://slack.com/api/oauth.v2.access?${stringify(queryParams)}`


### PR DESCRIPTION
Signed-off-by: Matt Krick <matt.krick@gmail.com>

# Description

Uses our cloudflare worker to handle Oauth2 redirects for slack.
This was blocked behind slack approving our app again.
This is the latest in the saga. For the previous PR, see #7514

## Demo
- set `OAUTH2_REDIRECT='https://oauth2redirect.parabol.co'` in your .env
- Add Slack as an integration :tada: 

This was already tested in #7446, so I don't think it needs testing again.