### PR TITLE
chore(metrics): emit sign_up events from GA4 client side

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -3,7 +3,7 @@
 import {datadogRum} from '@datadog/browser-rum'
 import * as Sentry from '@sentry/browser'
 import graphql from 'babel-plugin-relay/macro'
-import {useEffect, useRef, useState} from 'react'
+import {useEffect, useRef} from 'react'
 import ReactGA from 'react-ga4'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {LocalStorageKey} from '~/types/constEnums'
@@ -89,39 +89,39 @@ const TIME_TO_RENDER_TREE = 100
 
 const AnalyticsPage = () => {
   const atmosphere = useAtmosphere()
-  const [isGAInitialized, setIsGAInitialized] = useState(false)
+  if (gaMeasurementId) {
+    ReactGA.initialize(gaMeasurementId, {
+      gtagOptions: {
+        send_page_view: true
+      }
+    })
+  }
+
   useEffect(() => {
-    const initializeGA = async () => {
-      const res = await atmosphere.fetchQuery<AnalyticsPageQuery>(query)
-      if (!res) return
-      const {viewer} = res
-      const {id, segmentId} = viewer
-      ReactGA.initialize(gaMeasurementId, {
-        gtagOptions: {
-          send_page_view: true
-        }
-      })
-      ReactGA.set({
-        userId: id,
-        clientId: segmentId ?? getAnonymousId()
-      })
-    }
-    if (atmosphere.viewerId && !isGAInitialized && gaMeasurementId) {
-      initializeGA()
-        .catch()
-        .then(() => {
-          setIsGAInitialized(true)
+    const configGA = async () => {
+      if (!ReactGA.isInitialized || !isSegmentLoaded) {
+        return
+      }
+
+      const {viewerId} = atmosphere
+      if (viewerId) {
+        const res = await atmosphere.fetchQuery<AnalyticsPageQuery>(query)
+        if (!res) return
+        const {viewer} = res
+        const {id, segmentId} = viewer
+        ReactGA.set({
+          userId: id,
+          clientId: segmentId ?? getAnonymousId()
         })
+      } else {
+        ReactGA.set({
+          userId: null,
+          clientId: getAnonymousId()
+        })
+      }
     }
-    if (!atmosphere.viewerId && isGAInitialized) {
-      ReactGA.reset()
-      ReactGA.set({
-        userId: null,
-        clientId: null
-      })
-      setIsGAInitialized(false)
-    }
-  }, [isGAInitialized, atmosphere.viewerId])
+    configGA()
+  }, [ReactGA.isInitialized, atmosphere.viewerId])
 
   /* eslint-disable */
   const {href, pathname} = location

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -89,13 +89,15 @@ const TIME_TO_RENDER_TREE = 100
 
 const AnalyticsPage = () => {
   const atmosphere = useAtmosphere()
-  if (gaMeasurementId) {
-    ReactGA.initialize(gaMeasurementId, {
-      gtagOptions: {
-        send_page_view: true
-      }
-    })
-  }
+  useEffect(() => {
+    if (gaMeasurementId) {
+      ReactGA.initialize(gaMeasurementId, {
+        gtagOptions: {
+          send_page_view: true
+        }
+      })
+    }
+  }, [ReactGA.isInitialized, gaMeasurementId])
 
   useEffect(() => {
     const configGA = async () => {

--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useState} from 'react'
+import ReactGA from 'react-ga4'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useRouter from '../hooks/useRouter'
 import DialogContent from './DialogContent'
@@ -15,6 +16,10 @@ const SAMLRedirect = () => {
     const params = new URLSearchParams(location.search)
     const token = params.get('token')
     const error = params.get('error')
+    const isNewUser = params.get('isNewUser') === 'true'
+    if (isNewUser) {
+      ReactGA.event('sign_up')
+    }
     let isSameOriginPopup = false
     if (window.opener) {
       try {

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -5,6 +5,7 @@ import {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
 import {LoginWithGoogleMutation as TLoginWithGoogleMutation} from '../__generated__/LoginWithGoogleMutation.graphql'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
+import ReactGA from 'react-ga4'
 
 const mutation = graphql`
   mutation LoginWithGoogleMutation(

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
+import ReactGA from 'react-ga4'
 import {commitMutation} from 'react-relay'
 import handleSuccessfulLogin from '~/utils/handleSuccessfulLogin'
 import {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
 import {LoginWithGoogleMutation as TLoginWithGoogleMutation} from '../__generated__/LoginWithGoogleMutation.graphql'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
-import ReactGA from 'react-ga4'
 
 const mutation = graphql`
   mutation LoginWithGoogleMutation(
@@ -19,6 +19,7 @@ const mutation = graphql`
         message
       }
       authToken
+      isNewUser
       user {
         tms
         ...UserAnalyticsFrag @relay(mask: false)
@@ -43,7 +44,10 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, loginWithGoogle} = res
       onCompleted({loginWithGoogle}, errors)
-      const {error: uiError} = loginWithGoogle
+      const {error: uiError, isNewUser} = loginWithGoogle
+      if (isNewUser) {
+        ReactGA.event('sign_up')
+      }
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
         handleSuccessfulLogin(loginWithGoogle)

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
+import ReactGA from 'react-ga4'
 import {commitMutation} from 'react-relay'
 import handleSuccessfulLogin from '~/utils/handleSuccessfulLogin'
 import {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
 import {SignUpWithPasswordMutation as TSignUpWithPasswordMutation} from '../__generated__/SignUpWithPasswordMutation.graphql'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
-import ReactGA from 'react-ga4'
 
 const mutation = graphql`
   mutation SignUpWithPasswordMutation(
@@ -48,7 +48,7 @@ const SignUpWithPasswordMutation: StandardMutation<
       const {error: uiError} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
-      ReactGA.event("sign_up")
+      ReactGA.event('sign_up')
       if (!uiError && !errors) {
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -5,6 +5,7 @@ import {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
 import {SignUpWithPasswordMutation as TSignUpWithPasswordMutation} from '../__generated__/SignUpWithPasswordMutation.graphql'
 import {handleAcceptTeamInvitationErrors} from './AcceptTeamInvitationMutation'
 import handleAuthenticationRedirect from './handlers/handleAuthenticationRedirect'
+import ReactGA from 'react-ga4'
 
 const mutation = graphql`
   mutation SignUpWithPasswordMutation(
@@ -47,6 +48,7 @@ const SignUpWithPasswordMutation: StandardMutation<
       const {error: uiError} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
+      ReactGA.event("sign_up")
       if (!uiError && !errors) {
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken

--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -75,7 +75,8 @@ const loginSAML: MutationResolvers['loginSAML'] = async (_source, {samlName, que
   const user = await getUserByEmail(email)
   if (user) {
     return {
-      authToken: encodeAuthToken(new AuthToken({sub: user.id, tms: user.tms, rol: user.rol}))
+      authToken: encodeAuthToken(new AuthToken({sub: user.id, tms: user.tms, rol: user.rol})),
+      isNewUser: false
     }
   }
 
@@ -89,7 +90,8 @@ const loginSAML: MutationResolvers['loginSAML'] = async (_source, {samlName, que
 
   const authToken = await bootstrapNewUser(newUser, !isInvited)
   return {
-    authToken: encodeAuthToken(authToken)
+    authToken: encodeAuthToken(authToken),
+    isNewUser: true
   }
 }
 

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -7656,6 +7656,11 @@ type LoginSAMLPayload {
   The new JWT
   """
   authToken: ID
+
+  """
+  if a new user is created
+  """
+  isNewUser: Boolean
 }
 
 type ErrorPayload {

--- a/packages/server/graphql/public/mutations/loginWithGoogle.ts
+++ b/packages/server/graphql/public/mutations/loginWithGoogle.ts
@@ -76,7 +76,8 @@ const loginWithGoogle: MutationResolvers['loginWithGoogle'] = async (
     return {
       userId: viewerId,
       // create a brand new auth token using the tms in our DB
-      authToken: encodeAuthToken(context.authToken)
+      authToken: encodeAuthToken(context.authToken),
+      isNewUser: false
     }
   }
 
@@ -99,7 +100,8 @@ const loginWithGoogle: MutationResolvers['loginWithGoogle'] = async (
   context.authToken = await bootstrapNewUser(newUser, !invitationToken)
   return {
     userId,
-    authToken: encodeAuthToken(context.authToken)
+    authToken: encodeAuthToken(context.authToken),
+    isNewUser: true
   }
 }
 

--- a/packages/server/graphql/public/typeDefs/loginWithGoogle.graphql
+++ b/packages/server/graphql/public/typeDefs/loginWithGoogle.graphql
@@ -28,9 +28,13 @@ type LoginWithGooglePayload {
   """
   authToken: ID
   userId: ID
+  """
+  if a new user is created
+  """
+  isNewUser: Boolean
 
   """
-  the newly created user
+  the newly created user, or the existing user
   """
   user: User
 }

--- a/packages/server/graphql/public/types/LoginWithGooglePayload.ts
+++ b/packages/server/graphql/public/types/LoginWithGooglePayload.ts
@@ -4,6 +4,7 @@ export type LoginWithGooglePayloadSource =
   | {
       userId: string
       authToken: string
+      isNewUser: boolean
     }
   | {error: {message: string}}
 

--- a/packages/server/utils/SAMLHandler.ts
+++ b/packages/server/utils/SAMLHandler.ts
@@ -10,6 +10,7 @@ mutation LoginSAML($queryString: String!, $samlName: ID!) {
       message
     }
     authToken
+    isNewUser
   }
 }
 `
@@ -36,14 +37,17 @@ const SAMLHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) 
     return
   }
   const {loginSAML} = data
-  const {error, authToken} = loginSAML
+  const {error, authToken, isNewUser} = loginSAML
   if (!authToken) {
     const message = error?.message || GENERIC_ERROR
     redirectOnError(res, message)
     return
   }
   res.cork(() => {
-    res.writeStatus('302').writeHeader('location', `/saml-redirect?token=${authToken}`).end()
+    res
+      .writeStatus('302')
+      .writeHeader('location', `/saml-redirect?token=${authToken}&isNewUser=${isNewUser}`)
+      .end()
   })
 })
 


### PR DESCRIPTION
# Description

Today, we sent `sign_up` events from Segment to GA4. However, due to limitation of Segment, these events have no session information (or any info):

<img width="1003" alt="Screenshot 2023-01-09 at 3 56 12 PM" src="https://user-images.githubusercontent.com/1879975/211431539-ad8945dc-c068-4599-a5cc-be6520963523.png">

As a result, `sign_up` events cannot be attributed to previous `page_view` events in GA4:

<img width="1083" alt="211431799-ecd7bbd7-eef0-4a23-89a2-0353f06454ee" src="https://user-images.githubusercontent.com/1879975/211432231-034118fd-677f-4d91-90d4-4ce1cc91541f.png">

<img width="955" alt="Screenshot 2023-01-09 at 4 01 24 PM" src="https://user-images.githubusercontent.com/1879975/211432066-a0aa082a-d220-49ea-b543-9fd271122923.png">

Basically no useful analysis can be performed...😢

This PR emits `sign_up` events directly from GA4 client side. This way all relevant info (session, geo, ...) are automatically populated.

## Demo

The GA4 client side emitted `sign_up` events look like these in BigQuery:

<img width="1003" alt="Screenshot 2023-01-09 at 4 06 29 PM" src="https://user-images.githubusercontent.com/1879975/211432510-8e0957bb-840e-4836-95b9-53b4563f0263.png">

Attribution seems to work afterwards:

<img width="951" alt="Screenshot 2023-01-09 at 4 08 06 PM" src="https://user-images.githubusercontent.com/1879975/211432738-a0f9892c-5667-40b5-8fa7-3f31a9b58001.png">

<img width="942" alt="Screenshot 2023-01-09 at 4 07 26 PM" src="https://user-images.githubusercontent.com/1879975/211432747-f8a769c5-fbfb-4927-885a-7e2246be70c0.png">


## Testing scenarios

- [ ] Sign up with username and password
  - Verify a `sign_up` event is emitted to GA4

- [ ] Sign up with Google
  - Verify a `sign_up` event is emitted to GA4

- [ ] Log in with Google
  - Verify **NO** `sign_up` event is emitted to GA4

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
