### PR TITLE
feat(teams-limit): implement organization locked modal

### DIFF
--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -43,13 +43,15 @@ interface Props {
   onClick?: () => void
 }
 
+type Team = DashNavList_viewer['teams'][0]
+
 const DashNavList = (props: Props) => {
   const {className, onClick, viewer} = props
   const teams = viewer?.teams
 
   const teamsByOrgKey = useMemo(() => {
     if (!teams) return null
-    const teamsByOrgId = {} as {[key: string]: DashNavList_viewer['teams'][0][]}
+    const teamsByOrgId = {} as {[key: string]: Team[]}
     teams.forEach((team) => {
       const {organization} = team
       const {id: orgId, name: orgName} = organization
@@ -69,6 +71,11 @@ const DashNavList = (props: Props) => {
 
   // const team = Object.values(teamsByOrgKey)
   const isSingleOrg = teamsByOrgKey.length === 1
+
+  const showWarningIcon = (team: Team) => {
+    return team.isPaid && !team.organization.lockedAt ? 'group' : 'warning'
+  }
+
   return (
     <DashNavListStyles>
       {isSingleOrg
@@ -77,7 +84,7 @@ const DashNavList = (props: Props) => {
               className={className}
               onClick={onClick}
               key={team.id}
-              icon={team.isPaid && !team.organization.lockedAt ? 'group' : 'warning'}
+              icon={showWarningIcon(team)}
               href={`/team/${team.id}`}
               label={team.name}
             />
@@ -93,7 +100,7 @@ const DashNavList = (props: Props) => {
                     className={className}
                     onClick={onClick}
                     key={team.id}
-                    icon={team.isPaid && !team.organization.lockedAt ? 'group' : 'warning'}
+                    icon={showWarningIcon(team)}
                     href={`/team/${team.id}`}
                     label={team.name}
                   />

--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -77,7 +77,7 @@ const DashNavList = (props: Props) => {
               className={className}
               onClick={onClick}
               key={team.id}
-              icon={team.isPaid ? 'group' : 'warning'}
+              icon={team.isPaid && !team.organization.lockedAt ? 'group' : 'warning'}
               href={`/team/${team.id}`}
               label={team.name}
             />
@@ -93,7 +93,7 @@ const DashNavList = (props: Props) => {
                     className={className}
                     onClick={onClick}
                     key={team.id}
-                    icon={team.isPaid ? 'group' : 'warning'}
+                    icon={team.isPaid && !team.organization.lockedAt ? 'group' : 'warning'}
                     href={`/team/${team.id}`}
                     label={team.name}
                   />
@@ -114,6 +114,7 @@ graphql`
     organization {
       id
       name
+      lockedAt
     }
   }
 `

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useEffect} from 'react'
 import {useFragment} from 'react-relay'
 import {NewMeetingActions_team$key} from '~/__generated__/NewMeetingActions_team.graphql'
+import useAtmosphere from '../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import {Breakpoint, Threshold} from '../types/constEnums'
 import FlatPrimaryButton from './FlatPrimaryButton'
 import NewMeetingActionsCurrentMeetings from './NewMeetingActionsCurrentMeetings'
@@ -72,6 +74,7 @@ const NewMeetingActions = (props: Props) => {
         ...NewMeetingActionsCurrentMeetings_team
         id
         organization {
+          id
           name
           lockedAt
         }
@@ -80,11 +83,22 @@ const NewMeetingActions = (props: Props) => {
     teamRef
   )
 
+  const atmosphere = useAtmosphere()
+
   const {organization} = team
 
-  const {lockedAt, name: organizationName} = organization
+  const {lockedAt, name: organizationName, id: orgId} = organization
 
   const isLocked = !!lockedAt
+
+  useEffect(() => {
+    if (isLocked) {
+      SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Viewed', {
+        upgradeCTALocation: 'startNewMeetingOrganizationLockedError',
+        orgId
+      })
+    }
+  }, [isLocked])
 
   return (
     <ActionRow>

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -52,7 +52,9 @@ const StartButton = styled(FlatPrimaryButton)({
 })
 
 const ErrorBlock = styled(StyledError)({
-  paddingBottom: 24
+  paddingBottom: 24,
+  width: '100%',
+  textAlign: 'center'
 })
 
 interface Props {

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -51,6 +51,10 @@ const StartButton = styled(FlatPrimaryButton)({
   height: 50
 })
 
+const ErrorBlock = styled(StyledError)({
+  paddingBottom: 24
+})
+
 interface Props {
   error?: {message: string}
   teamRef: NewMeetingActions_team$key
@@ -72,9 +76,9 @@ const NewMeetingActions = (props: Props) => {
 
   return (
     <ActionRow>
+      {error && <ErrorBlock>{error.message}</ErrorBlock>}
       <ActiveMeetingsBlock>
         <NewMeetingActionsCurrentMeetings team={team} />
-        {error && <StyledError>{error.message}</StyledError>}
       </ActiveMeetingsBlock>
       <ButtonBlock>
         <StartButton onClick={onStartMeetingClick} waiting={submitting}>

--- a/packages/client/components/NewMeetingActions.tsx
+++ b/packages/client/components/NewMeetingActions.tsx
@@ -3,7 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {NewMeetingActions_team$key} from '~/__generated__/NewMeetingActions_team.graphql'
-import {Breakpoint} from '../types/constEnums'
+import {Breakpoint, Threshold} from '../types/constEnums'
 import FlatPrimaryButton from './FlatPrimaryButton'
 import NewMeetingActionsCurrentMeetings from './NewMeetingActionsCurrentMeetings'
 import StyledError from './StyledError'
@@ -69,19 +69,37 @@ const NewMeetingActions = (props: Props) => {
       fragment NewMeetingActions_team on Team {
         ...NewMeetingActionsCurrentMeetings_team
         id
+        organization {
+          name
+          lockedAt
+        }
       }
     `,
     teamRef
   )
 
+  const {organization} = team
+
+  const {lockedAt, name: organizationName} = organization
+
+  const isLocked = !!lockedAt
+
   return (
     <ActionRow>
       {error && <ErrorBlock>{error.message}</ErrorBlock>}
+      {isLocked && (
+        <ErrorBlock>
+          Unfortunately, {organizationName} has exceeded the {Threshold.MAX_PERSONAL_TIER_TEAMS}{' '}
+          teams limit on the Starter Plan for more than {Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS}{' '}
+          days, and your account has been locked. You can re-activate your teams by upgrading your
+          account.
+        </ErrorBlock>
+      )}
       <ActiveMeetingsBlock>
         <NewMeetingActionsCurrentMeetings team={team} />
       </ActiveMeetingsBlock>
       <ButtonBlock>
-        <StartButton onClick={onStartMeetingClick} waiting={submitting}>
+        <StartButton onClick={onStartMeetingClick} waiting={submitting} disabled={isLocked}>
           Start Meeting
         </StartButton>
       </ButtonBlock>

--- a/packages/client/modules/teamDashboard/components/Team/Team.tsx
+++ b/packages/client/modules/teamDashboard/components/Team/Team.tsx
@@ -60,16 +60,17 @@ const Team = (props: Props) => {
   const {children, isSettings, team} = props
   const teamId = team?.id
   if (!team || !teamId) return null
-  const {isPaid} = team
+  const {isPaid, organization} = team
+  const {lockedAt} = organization
 
   const goToTeamDashboard = () => {
     history.push(`/team/${teamId}/`)
   }
 
-  const hasOverlay = !isPaid
+  const isLocked = !isPaid || !!lockedAt
   return (
     <>
-      <Suspense fallback={''}>{!isPaid && <UnpaidTeamModalRoot teamId={teamId} />}</Suspense>
+      <Suspense fallback={''}>{isLocked && <UnpaidTeamModalRoot teamId={teamId} />}</Suspense>
       {isSettings && (
         <SettingsHeader>
           <TeamDashHeaderInner>
@@ -82,7 +83,7 @@ const Team = (props: Props) => {
           </TeamDashHeaderInner>
         </SettingsHeader>
       )}
-      <DashContent hasOverlay={hasOverlay}>{children}</DashContent>
+      <DashContent hasOverlay={isLocked}>{children}</DashContent>
     </>
   )
 }
@@ -92,6 +93,9 @@ export default createFragmentContainer(Team, {
     fragment Team_team on Team {
       id
       isPaid
+      organization {
+        lockedAt
+      }
       ...EditableTeamName_team
     }
   `

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -90,7 +90,7 @@ const UnpaidTeamModal = (props: Props) => {
           You can re-activate your teams by upgrading your account.
           <br />
           <br />
-          If you’d like to keep using Parabol with Starter Plan, please{' '}
+          If you’d like to keep using Parabol on the Starter Plan, please{' '}
           <ContactUsLink href={ExternalLinks.CONTACT} target='_blank' rel='noopener noreferrer'>
             contact us
           </ContactUsLink>{' '}

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -9,8 +9,10 @@ import IconLabel from '../../../../components/IconLabel'
 import PrimaryButton from '../../../../components/PrimaryButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useRouter from '../../../../hooks/useRouter'
+import SendClientSegmentEventMutation from '../../../../mutations/SendClientSegmentEventMutation'
 import {PALETTE} from '../../../../styles/paletteV3'
 import {ExternalLinks, Threshold} from '../../../../types/constEnums'
+import {UpgradeCTALocationEnum} from '../../../../__generated__/SendClientSegmentEventMutation.graphql'
 import {UnpaidTeamModalQuery} from '../../../../__generated__/UnpaidTeamModalQuery.graphql'
 
 const StyledButton = styled(PrimaryButton)({
@@ -75,7 +77,13 @@ const UnpaidTeamModal = (props: Props) => {
   const billingLeaderName = firstBillingLeader?.preferredName ?? 'Unknown'
   const email = firstBillingLeader?.email ?? 'Unknown'
   const isALeader = billingLeaders.findIndex((leader) => leader.id === viewerId) !== -1
-  const handleClick = () => history.push(`/me/organizations/${orgId}`)
+
+  const goToBilling = (upgradeCTALocation: UpgradeCTALocationEnum) => {
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation
+    })
+    history.push(`/me/organizations/${orgId}`)
+  }
 
   if (organization.lockedAt) {
     return (
@@ -96,7 +104,7 @@ const UnpaidTeamModal = (props: Props) => {
           </ContactUsLink>{' '}
           to let us know which teams you’d like to delete to fit within the two-team limit.
           {isALeader && (
-            <StyledButton size='medium' onClick={handleClick}>
+            <StyledButton size='medium' onClick={() => goToBilling('organizationLockedModal')}>
               <IconLabel icon='arrow_forward' iconAfter label='Upgrade' />
             </StyledButton>
           )}
@@ -125,7 +133,7 @@ const UnpaidTeamModal = (props: Props) => {
         <br />
         {solution}
         {isALeader && (
-          <StyledButton size='medium' onClick={handleClick}>
+          <StyledButton size='medium' onClick={() => goToBilling('unpaidTeamModal')}>
             <IconLabel icon='arrow_forward' iconAfter label='Take me there' />
           </StyledButton>
         )}

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useEffect} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import DashModal from '../../../../components/Dashboard/DashModal'
 import DialogContent from '../../../../components/DialogContent'
@@ -70,6 +70,16 @@ const UnpaidTeamModal = (props: Props) => {
   const {history} = useRouter()
   const {viewerId} = atmosphere
   const {team} = viewer
+
+  useEffect(() => {
+    if (team?.organization.lockedAt) {
+      SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Viewed', {
+        upgradeCTALocation: 'organizationLockedModal',
+        orgId: team.organization.id
+      })
+    }
+  }, [])
+
   if (!team) return null
   const {name: teamName, organization, lockMessageHTML} = team
 

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -9,10 +9,21 @@ import IconLabel from '../../../../components/IconLabel'
 import PrimaryButton from '../../../../components/PrimaryButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useRouter from '../../../../hooks/useRouter'
+import {PALETTE} from '../../../../styles/paletteV3'
+import {ExternalLinks, Threshold} from '../../../../types/constEnums'
 import {UnpaidTeamModalQuery} from '../../../../__generated__/UnpaidTeamModalQuery.graphql'
 
 const StyledButton = styled(PrimaryButton)({
   margin: '1.5rem auto 0'
+})
+
+const LockedAtContent = styled(DialogContent)({
+  textAlign: 'left'
+})
+
+const ContactUsLink = styled('a')({
+  color: PALETTE.SKY_500,
+  textDecoration: 'underline'
 })
 
 interface Props {
@@ -26,6 +37,8 @@ const query = graphql`
         lockMessageHTML
         organization {
           id
+          lockedAt
+          name
           billingLeaders {
             id
             preferredName
@@ -54,6 +67,44 @@ const UnpaidTeamModal = (props: Props) => {
   const {team} = viewer
   if (!team) return null
   const {name: teamName, organization, lockMessageHTML} = team
+
+  const {name: organizationName} = organization
+
+  const {id: orgId, billingLeaders, name: orgName} = organization
+  const [firstBillingLeader] = billingLeaders
+  const billingLeaderName = firstBillingLeader?.preferredName ?? 'Unknown'
+  const email = firstBillingLeader?.email ?? 'Unknown'
+  const isALeader = billingLeaders.findIndex((leader) => leader.id === viewerId) !== -1
+  const handleClick = () => history.push(`/me/organizations/${orgId}`)
+
+  if (organization.lockedAt) {
+    return (
+      <DashModal>
+        <DialogTitle>{'Organization Locked'}</DialogTitle>
+        <LockedAtContent>
+          Unfortunately, <strong>{organizationName}</strong> has exceeded the{' '}
+          {Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than{' '}
+          {Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked.
+          <br />
+          <br />
+          You can re-activate your teams by upgrading your account.
+          <br />
+          <br />
+          If you’d like to keep using Parabol with Starter Plan, please{' '}
+          <ContactUsLink href={ExternalLinks.CONTACT} target='_blank' rel='noopener noreferrer'>
+            contact us
+          </ContactUsLink>{' '}
+          to let us know which teams you’d like to delete to fit within the two-team limit.
+          {isALeader && (
+            <StyledButton size='medium' onClick={handleClick}>
+              <IconLabel icon='arrow_forward' iconAfter label='Upgrade' />
+            </StyledButton>
+          )}
+        </LockedAtContent>
+      </DashModal>
+    )
+  }
+
   if (lockMessageHTML) {
     return (
       <DashModal>
@@ -62,12 +113,6 @@ const UnpaidTeamModal = (props: Props) => {
     )
   }
 
-  const {id: orgId, billingLeaders, name: orgName} = organization
-  const [firstBillingLeader] = billingLeaders
-  const billingLeaderName = firstBillingLeader?.preferredName ?? 'Unknown'
-  const email = firstBillingLeader?.email ?? 'Unknown'
-  const isALeader = billingLeaders.findIndex((leader) => leader.id === viewerId) !== -1
-  const handleClick = () => history.push(`/me/organizations/${orgId}`)
   const problem = `There in an unpaid invoice for ${teamName}.`
   const solution = isALeader
     ? `Head over to ${orgName} Settings to add a payment method`

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -20,7 +20,10 @@ const StyledButton = styled(PrimaryButton)({
 })
 
 const LockedAtContent = styled(DialogContent)({
-  textAlign: 'left'
+  textAlign: 'left',
+  p: {
+    marginBottom: 16
+  }
 })
 
 const ContactUsLink = styled('a')({
@@ -90,14 +93,12 @@ const UnpaidTeamModal = (props: Props) => {
       <DashModal>
         <DialogTitle>{'Organization Locked'}</DialogTitle>
         <LockedAtContent>
-          Unfortunately, <strong>{organizationName}</strong> has exceeded the{' '}
-          {Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than{' '}
-          {Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked.
-          <br />
-          <br />
-          You can re-activate your teams by upgrading your account.
-          <br />
-          <br />
+          <p>
+            Unfortunately, <strong>{organizationName}</strong> has exceeded the{' '}
+            {Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than{' '}
+            {Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked.
+          </p>
+          <p>You can re-activate your teams by upgrading your account.</p>
           If you’d like to keep using Parabol on the Starter Plan, please{' '}
           <ContactUsLink href={ExternalLinks.CONTACT} target='_blank' rel='noopener noreferrer'>
             contact us

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -98,16 +98,20 @@ const UnpaidTeamModal = (props: Props) => {
             {Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than{' '}
             {Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked.
           </p>
-          <p>You can re-activate your teams by upgrading your account.</p>
-          If you’d like to keep using Parabol on the Starter Plan, please{' '}
-          <ContactUsLink href={ExternalLinks.CONTACT} target='_blank' rel='noopener noreferrer'>
-            contact us
-          </ContactUsLink>{' '}
-          to let us know which teams you’d like to delete to fit within the two-team limit.
-          {isALeader && (
-            <StyledButton size='medium' onClick={() => goToBilling('organizationLockedModal')}>
-              <IconLabel icon='arrow_forward' iconAfter label='Upgrade' />
-            </StyledButton>
+          {isALeader ? (
+            <>
+              <p>You can re-activate your teams by upgrading your account.</p>
+              If you’d like to keep using Parabol on the Starter Plan, please{' '}
+              <ContactUsLink href={ExternalLinks.CONTACT} target='_blank' rel='noopener noreferrer'>
+                contact us
+              </ContactUsLink>{' '}
+              to let us know which teams you’d like to delete to fit within the two-team limit.
+              <StyledButton size='medium' onClick={() => goToBilling('organizationLockedModal')}>
+                <IconLabel icon='arrow_forward' iconAfter label='Upgrade' />
+              </StyledButton>
+            </>
+          ) : (
+            `Try reaching out to ${billingLeaderName} at ${email}`
           )}
         </LockedAtContent>
       </DashModal>

--- a/packages/client/mutations/UpgradeToTeamTierMutation.ts
+++ b/packages/client/mutations/UpgradeToTeamTierMutation.ts
@@ -18,6 +18,7 @@ graphql`
       periodEnd
       periodStart
       updatedAt
+      lockedAt
     }
     meetings {
       showConversionModal

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -1,7 +1,16 @@
+import {Threshold} from '~/types/constEnums'
 import {DataLoaderWorker} from '../../graphql'
 
 const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const team = await dataLoader.get('teams').loadNonNull(teamId)
+  const organization = await dataLoader.get('organizations').load(team.orgId)
+
+  const {lockedAt, name: organizationName} = organization
+
+  if (lockedAt) {
+    return `Unfortunately, ${organizationName} has exceeded the ${Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than ${Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked.  You can re-activate your teams by upgrading your account.`
+  }
+
   const {isPaid, lockMessageHTML} = team
   if (isPaid) return null
   return lockMessageHTML

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -8,7 +8,7 @@ const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker
   const {lockedAt, name: organizationName} = organization
 
   if (lockedAt) {
-    return `Unfortunately, ${organizationName} has exceeded the ${Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than ${Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked.  You can re-activate your teams by upgrading your account.`
+    return `Unfortunately, ${organizationName} has exceeded the ${Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than ${Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked. You can re-activate your teams by upgrading your account.`
   }
 
   const {isPaid, lockMessageHTML} = team

--- a/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
+++ b/packages/server/graphql/mutations/helpers/isStartMeetingLocked.ts
@@ -5,17 +5,18 @@ const isStartMeetingLocked = async (teamId: string, dataLoader: DataLoaderWorker
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   const organization = await dataLoader.get('organizations').load(team.orgId)
 
-  const {lockedAt, name: organizationName} = organization
+  const {lockedAt: organizationLockedAt, name: organizationName} = organization
+  const {isPaid, lockMessageHTML} = team
 
-  if (lockedAt) {
+  if (!isPaid) {
+    return lockMessageHTML
+      ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
+      : 'Sorry! We are unable to start your meeting because your team has an overdue payment'
+  } else if (organizationLockedAt) {
     return `Unfortunately, ${organizationName} has exceeded the ${Threshold.MAX_PERSONAL_TIER_TEAMS} teams limit on the Starter Plan for more than ${Threshold.PERSONAL_TIER_LOCK_AFTER_DAYS} days, and your account has been locked. You can re-activate your teams by upgrading your account.`
   }
 
-  const {isPaid, lockMessageHTML} = team
-  if (isPaid) return null
-  return lockMessageHTML
-    ? 'Wow, you’re determined to use Parabol! That’s awesome! Do you want to keep sneaking over the gate, or walk through the door with our Sales team?'
-    : 'Sorry! We are unable to start your meeting because your team has an overdue payment'
+  return null
 }
 
 export default isStartMeetingLocked

--- a/packages/server/graphql/types/UpgradeCTALocationEnum.ts
+++ b/packages/server/graphql/types/UpgradeCTALocationEnum.ts
@@ -11,6 +11,7 @@ export type UpgradeCTALocationEnumType =
   | 'timelineHistoryLock'
   | 'unpaidTeamModal'
   | 'organizationLockedModal'
+  | 'startNewMeetingOrganizationLockedError'
 
 const UpgradeCTALocationEnum = new GraphQLEnumType({
   name: 'UpgradeCTALocationEnum',
@@ -25,7 +26,8 @@ const UpgradeCTALocationEnum = new GraphQLEnumType({
     directMeetingLinkLock: {},
     timelineHistoryLock: {},
     unpaidTeamModal: {},
-    organizationLockedModal: {}
+    organizationLockedModal: {},
+    startNewMeetingOrganizationLockedError: {}
   }
 })
 

--- a/packages/server/graphql/types/UpgradeCTALocationEnum.ts
+++ b/packages/server/graphql/types/UpgradeCTALocationEnum.ts
@@ -9,6 +9,8 @@ export type UpgradeCTALocationEnumType =
   | 'usageStats'
   | 'directMeetingLinkLock'
   | 'timelineHistoryLock'
+  | 'unpaidTeamModal'
+  | 'organizationLockedModal'
 
 const UpgradeCTALocationEnum = new GraphQLEnumType({
   name: 'UpgradeCTALocationEnum',
@@ -21,7 +23,9 @@ const UpgradeCTALocationEnum = new GraphQLEnumType({
     createTeam: {},
     usageStats: {},
     directMeetingLinkLock: {},
-    timelineHistoryLock: {}
+    timelineHistoryLock: {},
+    unpaidTeamModal: {},
+    organizationLockedModal: {}
   }
 })
 


### PR DESCRIPTION
Fixes #7638

Billing leader:

<img width="1737" alt="image" src="https://user-images.githubusercontent.com/466991/211776708-1dc424c7-c9f9-4b68-b973-f1815fd871fa.png">

Non billing leader:

<img width="1735" alt="image" src="https://user-images.githubusercontent.com/466991/211776952-5db04892-4951-4f80-babd-0d82e2f7fb32.png">

Meeting creation error:

<img width="879" alt="image" src="https://user-images.githubusercontent.com/466991/211983837-e13b0534-0ef8-4fff-848b-ed81c9678d22.png">

How to test

- Set `lockedAt` value on organization 
- See that all teams locked and modal is shown
- See that modal is different for billing leader and non billing leader user
- See that you can't create a new meeting
- See that you can still create a meeting on non-locked teams
- See that after upgrading org the lock is gone
