### PR TITLE
chore(ai-summary): improve prompt

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -18,7 +18,6 @@ class OpenAIServerManager {
 
   async getSummary(text: string | string[]) {
     if (!this.openAIApi) return null
-
     try {
       const response = await this.openAIApi.createCompletion({
         model: 'text-davinci-003',

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -18,10 +18,15 @@ class OpenAIServerManager {
 
   async getSummary(text: string | string[]) {
     if (!this.openAIApi) return null
+
     try {
       const response = await this.openAIApi.createCompletion({
         model: 'text-davinci-003',
-        prompt: `Summarize this for a second-grade student in one or two sentences: ${text}`,
+        prompt: `Below is a comma separated list of text. Summarise the text for a second-grade student in one or two sentences.
+
+        Text: """
+        ${text}
+        """`,
         temperature: 0.7,
         max_tokens: 256,
         top_p: 1,

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -21,7 +21,7 @@ class OpenAIServerManager {
     try {
       const response = await this.openAIApi.createCompletion({
         model: 'text-davinci-003',
-        prompt: `Below is a comma separated list of text. Summarise the text for a second-grade student in one or two sentences.
+        prompt: `Below is a comma-separated list of text. Summarize the text for a second-grade student in one or two sentences.
 
         Text: """
         ${text}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7615

After following suggestion number 2 in this article (https://help.openai.com/en/articles/6654000-best-practices-for-prompt-engineering-with-openai-api), I'm getting better results from the summary.

Here is a comparison of the most recent Squad retro in prod vs the summaries with this new prompt. The first image is from prod and the second with the new prompt:

Example 1:
![prod](https://user-images.githubusercontent.com/39854876/211859551-b2cb6241-f09d-47ac-a301-0365a548abd2.png)
![new-prompt](https://user-images.githubusercontent.com/39854876/211859600-9db11358-c2ae-4d0f-a70d-511f82d825b0.png)

Example 2:
![prod-2](https://user-images.githubusercontent.com/39854876/211859839-a7d91aef-953e-45e6-b695-554e90466f0b.png)
![prompt-2](https://user-images.githubusercontent.com/39854876/211859869-45008399-5ff7-4c2c-a662-09dcae52126c.png)

Example 3:
![prod-3](https://user-images.githubusercontent.com/39854876/211859908-e7b14472-ae99-476e-abaa-6f23a4ce4e51.png)
![prompt-3](https://user-images.githubusercontent.com/39854876/211859922-739b2eb2-be79-47ec-a3bd-2a6b7491e65e.png)
