### PR TITLE
fix(ai-summary): remove AI comment from comment count

### DIFF
--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -82,7 +82,6 @@ export const commentCountByDiscussionId = (parent: RootDataLoader) => {
         r
           .table('Comment')
           .getAll(r.args(discussionIds as string[]), {index: 'discussionId'})
-
           .filter((row: RDatum) =>
             row('isActive').eq(true).and(row('createdBy').ne(PARABOL_AI_USER_ID))
           )

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -1,4 +1,5 @@
 import DataLoader from 'dataloader'
+import {PARABOL_AI_USER_ID} from '../../client/utils/constants'
 import getRethink, {RethinkSchema} from '../database/rethinkDriver'
 import {RDatum} from '../database/stricterR'
 import MeetingSettingsTeamPrompt from '../database/types/MeetingSettingsTeamPrompt'
@@ -81,7 +82,10 @@ export const commentCountByDiscussionId = (parent: RootDataLoader) => {
         r
           .table('Comment')
           .getAll(r.args(discussionIds as string[]), {index: 'discussionId'})
-          .filter({isActive: true})
+
+          .filter((row: RDatum) =>
+            row('isActive').eq(true).and(row('createdBy').ne(PARABOL_AI_USER_ID))
+          )
           .group('discussionId') as any
       )
         .count()

--- a/packages/server/dataloader/rethinkForeignKeyLoaderMakers.ts
+++ b/packages/server/dataloader/rethinkForeignKeyLoaderMakers.ts
@@ -1,5 +1,6 @@
 import TimelineEventCheckinComplete from 'parabol-server/database/types/TimelineEventCheckinComplete'
 import TimelineEventRetroComplete from 'parabol-server/database/types/TimelineEventRetroComplete'
+import {PARABOL_AI_USER_ID} from '../../client/utils/constants'
 import getRethink from '../database/rethinkDriver'
 import {RDatum} from '../database/stricterR'
 import RethinkForeignKeyLoaderMaker from './RethinkForeignKeyLoaderMaker'
@@ -54,6 +55,7 @@ export const commentsByDiscussionId = new RethinkForeignKeyLoaderMaker(
       r
         .table('Comment')
         .getAll(r.args(discussionIds), {index: 'discussionId'})
+        .filter((row: RDatum) => row('createdBy').ne(PARABOL_AI_USER_ID))
         // include deleted comments so we can replace them with tombstones
         // .filter({isActive: true})
         .run()

--- a/packages/server/dataloader/rethinkForeignKeyLoaderMakers.ts
+++ b/packages/server/dataloader/rethinkForeignKeyLoaderMakers.ts
@@ -1,6 +1,5 @@
 import TimelineEventCheckinComplete from 'parabol-server/database/types/TimelineEventCheckinComplete'
 import TimelineEventRetroComplete from 'parabol-server/database/types/TimelineEventRetroComplete'
-import {PARABOL_AI_USER_ID} from '../../client/utils/constants'
 import getRethink from '../database/rethinkDriver'
 import {RDatum} from '../database/stricterR'
 import RethinkForeignKeyLoaderMaker from './RethinkForeignKeyLoaderMaker'
@@ -55,7 +54,6 @@ export const commentsByDiscussionId = new RethinkForeignKeyLoaderMaker(
       r
         .table('Comment')
         .getAll(r.args(discussionIds), {index: 'discussionId'})
-        .filter((row: RDatum) => row('createdBy').ne(PARABOL_AI_USER_ID))
         // include deleted comments so we can replace them with tombstones
         // .filter({isActive: true})
         .run()

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -1,10 +1,11 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {DISCUSS} from 'parabol-client/utils/constants'
+import {DISCUSS, PARABOL_AI_USER_ID} from 'parabol-client/utils/constants'
 import getMeetingPhase from 'parabol-client/utils/getMeetingPhase'
 import findStageById from 'parabol-client/utils/meetings/findStageById'
 import {checkTeamsLimit} from '../../billing/helpers/teamLimitsCheck'
 import getRethink from '../../database/rethinkDriver'
+import {RDatum} from '../../database/stricterR'
 import MeetingRetrospective from '../../database/types/MeetingRetrospective'
 import TimelineEventRetroComplete from '../../database/types/TimelineEventRetroComplete'
 import removeSuggestedAction from '../../safeMutations/removeSuggestedAction'
@@ -49,7 +50,9 @@ const finishRetroMeeting = async (
           commentCount: r
             .table('Comment')
             .getAll(r.args(discussionIds), {index: 'discussionId'})
-            .filter({isActive: true})
+            .filter((row: RDatum) =>
+              row('isActive').eq(true).and(row('createdBy').ne(PARABOL_AI_USER_ID))
+            )
             .count()
             .default(0) as unknown as number,
           taskCount: r


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7647

### To test

- [ ] Create a retro meeting, and add two reflection groups, add comments to one reflection topic, and don't add comments to the other
- [ ] In the meeting summary, see that the comment count is correct. The reflection topic with no comments says "No comments"
- [ ] Go to the timeline and see the correct comment count