### PR TITLE
feat(standups): Email Summaries

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -20,7 +20,6 @@ import PromptResponseEditor from '../promptResponse/PromptResponseEditor'
 import ReactjiSection from '../ReflectionCard/ReactjiSection'
 import ResponsiveDashSidebar from '../ResponsiveDashSidebar'
 import TeamPromptLastUpdatedTime from './TeamPromptLastUpdatedTime'
-import {TeamMemberName} from './TeamPromptResponseCard'
 
 const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
   boxShadow: isDesktop ? desktopSidebarShadow : undefined,
@@ -94,6 +93,11 @@ const StyledReactjis = styled(ReactjiSection)({
 
 const DiscussionHeaderWrapper = styled('div')({
   padding: '0px 12px 20px 12px'
+})
+
+const TeamMemberName = styled('h3')({
+  padding: '0 8px',
+  margin: 0
 })
 
 interface Props {

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -64,7 +64,7 @@ const CancelButton = styled(SubmitButton)({
   color: PALETTE.SLATE_700
 })
 
-const StyledEditor = styled('div')`
+export const StyledEditor = styled('div')`
   .ProseMirror {
     min-height: 40px;
     line-height: 20px;

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -64,7 +64,7 @@ const CancelButton = styled(SubmitButton)({
   color: PALETTE.SLATE_700
 })
 
-export const StyledEditor = styled('div')`
+const StyledEditor = styled('div')`
   .ProseMirror {
     min-height: 40px;
     line-height: 20px;

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -90,7 +90,7 @@ const StyledEditor = styled('div')`
   }
 
   .ProseMirror [data-type='mention'] {
-    background-color: #faebd3;
+    background-color: ${PALETTE.GOLD_100};
     border-radius: 2;
     font-weight: 600;
   }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -5,7 +5,6 @@ import {ACTION} from 'parabol-client/utils/constants'
 import {SummarySheet_meeting} from 'parabol-client/__generated__/SummarySheet_meeting.graphql'
 import React from 'react'
 import {createFragmentContainer} from 'react-relay'
-import lazyPreload from '~/utils/lazyPreload'
 import {CorsOptions} from '../../../../../types/cors'
 import ExportToCSV from '../ExportToCSV'
 import ContactUsFooter from './ContactUsFooter'
@@ -18,6 +17,7 @@ import RetroTopics from './RetroTopics'
 import SummaryHeader from './SummaryHeader'
 import SummaryPokerStories from './SummaryPokerStories'
 import SummarySheetCTA from './SummarySheetCTA'
+import TeamPromptResponseSummary from './TeamPromptResponseSummary'
 import WholeMeetingSummary from './WholeMeetingSummary'
 
 interface Props {
@@ -41,11 +41,6 @@ const SummarySheet = (props: Props) => {
   const {emailCSVUrl, urlAction, meeting, referrer, teamDashUrl, appOrigin, corsOptions} = props
   const {id: meetingId, meetingType} = meeting
   const isDemo = !!props.isDemo
-
-  // 'TeamPromptResponseSummary' includes client-side-only code that breaks SSR, so lazy-load it.
-  // :TODO: (jmtaber129): Change this to a normal import once 'TeamPromptResponseSummary' supports
-  // SSR.
-  const TeamPromptResponseSummary = lazyPreload(() => import('./TeamPromptResponseSummary'))
 
   return (
     <table width='100%' height='100%' align='center' bgcolor='#FFFFFF' style={sheetStyle}>

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummary.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import useEmailItemGrid from 'parabol-client/hooks/useEmailItemGrid'
 import {TeamPromptResponseSummary_meeting$key} from 'parabol-client/__generated__/TeamPromptResponseSummary_meeting.graphql'
@@ -8,13 +7,6 @@ import getPhaseByTypename from '~/utils/getPhaseByTypename'
 import {isNotNull} from '~/utils/predicates'
 import sortByISO8601Date from '~/utils/sortByISO8601Date'
 import TeamPromptResponseSummaryCard from './TeamPromptResponseSummaryCard'
-
-const ResponseSummaryGrid = styled('div')({
-  display: 'flex',
-  flexWrap: 'wrap',
-  padding: '24px',
-  justifyContent: 'center'
-})
 
 interface Props {
   meetingRef: TeamPromptResponseSummary_meeting$key
@@ -55,11 +47,17 @@ const TeamPromptResponseSummary = (props: Props) => {
   const grid = useEmailItemGrid(orderedNonEmptyStages, 2)
 
   return (
-    <ResponseSummaryGrid>
-      {grid((stage) => {
-        return <TeamPromptResponseSummaryCard key={stage.id} stageRef={stage} />
-      })}
-    </ResponseSummaryGrid>
+    <tr>
+      <td style={{padding: '24px'}}>
+        {grid((stage) => (
+          <tr key={stage.id}>
+            <td>
+              <TeamPromptResponseSummaryCard stageRef={stage} />
+            </td>
+          </tr>
+        ))}
+      </td>
+    </tr>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
@@ -1,39 +1,79 @@
 import styled from '@emotion/styled'
+import {generateHTML} from '@tiptap/html'
 import graphql from 'babel-plugin-relay/macro'
 import {TeamPromptResponseSummaryCard_stage$key} from 'parabol-client/__generated__/TeamPromptResponseSummaryCard_stage.graphql'
 import React from 'react'
 import {useFragment} from 'react-relay'
-import Avatar from '~/components/Avatar/Avatar'
-import PromptResponseEditor from '~/components/promptResponse/PromptResponseEditor'
 import {PALETTE} from '~/styles/paletteV3'
+import {createEditorExtensions} from '../../../../../components/promptResponse/tiptapConfig'
 
-const ResponseSummaryCard = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
+const responseSummaryCardStyles: React.CSSProperties = {
   margin: '12px',
   width: '251px'
-})
+}
 
-const ResponseHeader = styled('div')({
-  display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  padding: '0 8px',
-  marginBottom: 12
-})
-
-const PromptResponseWrapper = styled('div')({
+const promptResponseStyles = {
+  minHeight: '40px',
+  lineHeight: '20px',
   border: 'solid',
   borderWidth: '1px',
   borderColor: PALETTE.SLATE_300,
   borderRadius: '4px',
   padding: '12px 16px 12px 16px'
-})
+}
 
-export const TeamMemberName = styled('h3')({
-  padding: '0 8px',
-  margin: 0
-})
+const avatarStyles = {
+  borderRadius: '100%',
+  minWidth: 48
+}
+
+const StyledEditor = styled('div')`
+  min-height: 40px;
+  line-height: 20px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  white-space: break-spaces;
+  -webkit-font-variant-ligatures: none;
+  font-variant-ligatures: none;
+  font-feature-settings: 'liga' 0;
+
+  :is(ul, ol) {
+    list-style-position: outside;
+    padding-inline-start: 16px;
+    margin-block-start: 4px;
+    margin-block-end: 4px;
+  }
+
+  :is(ol) {
+    margin-inline-start: 2px;
+  }
+
+  p.is-editor-empty:first-of-type::before {
+    color: #adb5bd;
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+  }
+
+  p:empty::after {
+    content: '\\00A0';
+  }
+
+  [data-type='mention'] {
+    background-color: #faebd3;
+    border-radius: 2;
+    font-weight: 600;
+  }
+
+  a {
+    text-decoration: underline;
+    color: ${PALETTE.SLATE_600};
+    :hover {
+      cursor: pointer;
+    }
+  }
+`
 
 interface Props {
   stageRef: TeamPromptResponseSummaryCard_stage$key
@@ -47,7 +87,9 @@ const TeamPromptResponseSummaryCard = (props: Props) => {
         id
         teamMember {
           userId
-          picture
+          user {
+            rasterPicture
+          }
           preferredName
         }
         response {
@@ -60,18 +102,21 @@ const TeamPromptResponseSummaryCard = (props: Props) => {
     stageRef
   )
   const {teamMember, response} = stage
-  const {picture, preferredName} = teamMember
+  const {user, preferredName} = teamMember
+  const {rasterPicture} = user
   const contentJSON = response ? JSON.parse(response.content) : null
+  const html = generateHTML(contentJSON, createEditorExtensions())
+
   return (
-    <ResponseSummaryCard>
-      <ResponseHeader>
-        <Avatar picture={picture} size={48} />
-        <TeamMemberName>{preferredName}</TeamMemberName>
-      </ResponseHeader>
-      <PromptResponseWrapper>
-        <PromptResponseEditor autoFocus={false} content={contentJSON} readOnly={true} />
-      </PromptResponseWrapper>
-    </ResponseSummaryCard>
+    <div style={responseSummaryCardStyles}>
+      <div style={{display: 'flex', alignItems: 'center', padding: '0 8px', marginBottom: 12}}>
+        <img height='48' src={rasterPicture} style={avatarStyles} width='48' />
+        <h3 style={{padding: '0 8px', margin: 'auto auto auto 0'}}>{preferredName}</h3>
+      </div>
+      <div style={promptResponseStyles}>
+        <StyledEditor dangerouslySetInnerHTML={{__html: html}} />
+      </div>
+    </div>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
@@ -27,15 +27,10 @@ const avatarStyles = {
   minWidth: 48
 }
 
+// Note: Emotion doesn't work in email, so these styles will only be present in the app.
 const StyledEditor = styled('div')`
   min-height: 40px;
   line-height: 20px;
-  word-wrap: break-word;
-  white-space: pre-wrap;
-  white-space: break-spaces;
-  -webkit-font-variant-ligatures: none;
-  font-variant-ligatures: none;
-  font-feature-settings: 'liga' 0;
 
   :is(ul, ol) {
     list-style-position: outside;

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
@@ -56,7 +56,7 @@ const StyledEditor = styled('div')`
   }
 
   [data-type='mention'] {
-    background-color: #faebd3;
+    background-color: ${PALETTE.GOLD_100};
     border-radius: 2;
     font-weight: 600;
   }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
@@ -109,7 +109,7 @@ const TeamPromptResponseSummaryCard = (props: Props) => {
 
   return (
     <div style={responseSummaryCardStyles}>
-      <div style={{display: 'flex', alignItems: 'center', padding: '0 8px', marginBottom: 12}}>
+      <div style={{display: 'flex', padding: '0 8px', marginBottom: 12}}>
         <img height='48' src={rasterPicture} style={avatarStyles} width='48' />
         <h3 style={{padding: '0 8px', margin: 'auto auto auto 0'}}>{preferredName}</h3>
       </div>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -79,6 +79,7 @@
     "@tiptap/extension-link": "^2.0.0-beta.38",
     "@tiptap/extension-mention": "^2.0.0-beta.102",
     "@tiptap/extension-placeholder": "^2.0.0-beta.48",
+    "@tiptap/html": "^2.0.0-beta.209",
     "@tiptap/react": "^2.0.0-beta.109",
     "@tiptap/starter-kit": "^2.0.0-beta.185",
     "@tiptap/suggestion": "^2.0.0-beta.97",

--- a/packages/server/email/newMeetingSummaryEmailCreator.tsx
+++ b/packages/server/email/newMeetingSummaryEmailCreator.tsx
@@ -8,7 +8,7 @@ import renderSSRElement from './renderSSRElement'
 import ServerEnvironment from './ServerEnvironment'
 interface Props {
   meetingId: string
-  context: GQLContext
+  context: Pick<GQLContext, 'authToken' | 'dataLoader'>
 }
 
 const newMeetingSummaryEmailCreator = async (props: Props) => {

--- a/packages/server/graphql/mutations/endTeamPrompt.ts
+++ b/packages/server/graphql/mutations/endTeamPrompt.ts
@@ -35,7 +35,7 @@ const endTeamPrompt = {
     if (!isTeamMember(authToken, teamId) && authToken.rol !== 'su') {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    return safeEndTeamPrompt({meeting, now, r, dataLoader, subOptions, viewerId})
+    return safeEndTeamPrompt({meeting, now, r, context, subOptions, viewerId})
   }
 }
 

--- a/packages/server/graphql/mutations/helpers/endMeeting/sendNewMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/endMeeting/sendNewMeetingSummary.ts
@@ -5,7 +5,10 @@ import newMeetingSummaryEmailCreator from '../../../../email/newMeetingSummaryEm
 import {GQLContext} from '../../../graphql'
 import isValid from '../../../isValid'
 
-export default async function sendNewMeetingSummary(newMeeting: Meeting, context: GQLContext) {
+export default async function sendNewMeetingSummary(
+  newMeeting: Meeting,
+  context: Pick<GQLContext, 'dataLoader' | 'authToken'>
+) {
   const {id: meetingId, teamId, summarySentAt} = newMeeting
   if (summarySentAt) return
   const now = new Date()

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -7,23 +7,26 @@ import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTe
 import {analytics} from '../../../utils/analytics/analytics'
 import publish, {SubOptions} from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
-import {DataLoaderWorker} from '../../graphql'
+import {GQLContext} from '../../graphql'
+import sendNewMeetingSummary from './endMeeting/sendNewMeetingSummary'
 
 const safeEndTeamPrompt = async ({
   meeting,
   now,
   viewerId,
   r,
-  dataLoader,
+  context,
   subOptions
 }: {
   meeting: MeetingTeamPrompt
   now: Date
   viewerId?: string
   r: ParabolR
-  dataLoader: DataLoaderWorker
+  context: GQLContext
   subOptions: SubOptions
 }) => {
+  const {dataLoader} = context
+
   const {endedAt, id: meetingId, teamId} = meeting
 
   if (endedAt) return standardError(new Error('Meeting already ended'), {userId: viewerId})
@@ -65,11 +68,7 @@ const safeEndTeamPrompt = async ({
   )
   const timelineEventId = events[0]!.id
   await r.table('TimelineEvent').insert(events).run()
-  // Due to a reference to 'window' deep in the current summary hierarchy, we're not currently
-  // able to render the summary view on the server-side for emails.
-  // :TODO: (jmtaber129): Refactor the prompt response editor such that we're able to render
-  // TipTap-formatted responses on the server-side.
-  // sendNewMeetingSummary(completedTeamPrompt, context).catch(console.log)
+  sendNewMeetingSummary(completedTeamPrompt, context).catch(console.log)
   checkTeamsLimit(team.orgId, dataLoader)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses)
   dataLoader.get('newMeetings').clear(meetingId)

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -51,11 +51,8 @@ const startRecurringTeamPrompt = async (
   publish(SubscriptionChannel.TEAM, teamId, 'StartTeamPromptSuccess', data, subOptions)
 }
 
-const processRecurrence: MutationResolvers['processRecurrence'] = async (
-  _source,
-  {},
-  {dataLoader, socketId: mutatorId}
-) => {
+const processRecurrence: MutationResolvers['processRecurrence'] = async (_source, {}, context) => {
+  const {dataLoader, socketId: mutatorId} = context
   const r = await getRethink()
   const now = new Date()
   const operationId = dataLoader.share()
@@ -71,7 +68,7 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (
 
   const res = await Promise.all(
     teamPromptMeetingsToEnd.map(async (meeting) => {
-      return await safeEndTeamPrompt({meeting, now, dataLoader, r, subOptions})
+      return await safeEndTeamPrompt({meeting, now, context, r, subOptions})
     })
   )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4988,6 +4988,13 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.0.0-beta.15.tgz#f08cff1b78f1c6996464dfba1fef8ec1e107617f"
   integrity sha512-S3j2+HyV2gsXZP8Wg/HA+YVXQsZ3nrXgBM9HmGAxB0ESOO50l7LWfip0f3qcw1oRlh5H3iLPkA6/f7clD2/TFA==
 
+"@tiptap/html@^2.0.0-beta.209":
+  version "2.0.0-beta.209"
+  resolved "https://registry.yarnpkg.com/@tiptap/html/-/html-2.0.0-beta.209.tgz#4e26c17b84f5447d07727c52f4726abacaeb83df"
+  integrity sha512-KE3zwFQmRW9h6RJu5/5P6/AinIhBmSuISgkWeiC5jkMytNtOJkmB33bU87qZq82lErincFUwKsVBRSlwvqlBmQ==
+  dependencies:
+    zeed-dom "^0.9.19"
+
 "@tiptap/react@^2.0.0-beta.109":
   version "2.0.0-beta.109"
   resolved "https://registry.yarnpkg.com/@tiptap/react/-/react-2.0.0-beta.109.tgz#0998989f7f81e2f90a10fb37c55d531d7015bbee"
@@ -8153,6 +8160,11 @@ css-what@^5.0.1, css-what@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
   integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -19261,3 +19273,10 @@ yup@^0.31.0:
     lodash-es "^4.17.11"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+zeed-dom@^0.9.19:
+  version "0.9.26"
+  resolved "https://registry.yarnpkg.com/zeed-dom/-/zeed-dom-0.9.26.tgz#f0127d1024b34a1233a321bd6d0275b3ba998b30"
+  integrity sha512-HWjX8rA3Y/RI32zby3KIN1D+mgskce+She4K7kRyyx62OiVxJ5FnYm8vWq0YVAja3Tf2S1M0XAc6O2lRFcMgcQ==
+  dependencies:
+    css-what "^6.1.0"


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7640

Makes standup summaries compatible with SSR + email styling.

Note that tiptap styling in emails doesn't work currently - I investigated how to apply the desired styling to the rendered HTML from tiptap, but couldn't figure it out in a reasonable amount of time. If reviewers don't have any immediate leads on how to resolve this, I'll create a follow-up issue for this.

## Demo
In-app
<img width="703" alt="Screen Shot 2023-01-12 at 7 37 35 PM" src="https://user-images.githubusercontent.com/9013217/212151356-35f3e2ae-ad68-4cd1-9755-7d383a8ad5f1.png">

In email
<img width="660" alt="Screen Shot 2023-01-12 at 7 37 52 PM" src="https://user-images.githubusercontent.com/9013217/212151373-a006c455-619d-428d-961a-60cb1dba00f3.png">


## Testing scenarios
- [ ] Submit responses in a standup meeting
- [ ] End the meeting
- [ ] Confirm that in-app and email summaries look reasonable.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
