### PR TITLE
fix: update non-anonymous Reflect description

### DIFF
--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -27,7 +27,8 @@ const RetroReflectPhase = (props: Props) => {
   const [callbackRef, phaseRef] = useCallbackRef()
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
-  const {localPhase, endedAt, showSidebar} = meeting
+  const {localPhase, endedAt, showSidebar, settings} = meeting
+  const {disableAnonymity} = settings
   if (!localPhase || !localPhase.reflectPrompts) return null
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId
@@ -42,7 +43,7 @@ const RetroReflectPhase = (props: Props) => {
         >
           <PhaseHeaderTitle>{phaseLabelLookup.reflect}</PhaseHeaderTitle>
           <PhaseHeaderDescription>
-            {'Add anonymous reflections for each prompt'}
+            {`Add ${disableAnonymity ? '' : 'anonymous'} reflections for each prompt`}
           </PhaseHeaderDescription>
         </MeetingTopBar>
         <PhaseWrapper>
@@ -97,6 +98,9 @@ export default createFragmentContainer(RetroReflectPhase, {
         ...RetroReflectPhase_phase @relay(mask: false)
       }
       showSidebar
+      settings {
+        disableAnonymity
+      }
     }
   `
 })

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -28,8 +28,8 @@ const RetroReflectPhase = (props: Props) => {
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
   const {localPhase, endedAt, showSidebar, settings} = meeting
-  if (!localPhase || !localPhase.reflectPrompts) return null
   const {disableAnonymity} = settings
+  if (!localPhase || !localPhase.reflectPrompts) return null
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId
   const ColumnWrapper = isDesktop ? ReflectWrapperDesktop : ReflectWrapperMobile

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -28,8 +28,8 @@ const RetroReflectPhase = (props: Props) => {
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
   const {localPhase, endedAt, showSidebar, settings} = meeting
-  const {disableAnonymity} = settings
   if (!localPhase || !localPhase.reflectPrompts) return null
+  const {disableAnonymity} = settings
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId
   const ColumnWrapper = isDesktop ? ReflectWrapperDesktop : ReflectWrapperMobile


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7650

![reflect-desc](https://user-images.githubusercontent.com/39854876/212072129-8f1495b1-7a55-49fb-a164-ee9457c9d552.png)

### To test

- [ ] Create a non-anonymous retro meeting and see that the Reflect phase description title says `Add reflections for each prompt`
- [ ] Create an anonymous retro meeting and see that the Reflect phase description title says `Add anonymous reflections for each prompt`
