### PR TITLE
fix(ai-summary): update Parabol AI picture

### DIFF
--- a/packages/server/postgres/migrations/1673613407246_updateAIUserPic.ts
+++ b/packages/server/postgres/migrations/1673613407246_updateAIUserPic.ts
@@ -16,7 +16,6 @@ export async function down() {
   const client = new Client(getPgConfig())
   await client.connect()
   const oldPicture = 'https://action-files.parabol.co/static/favicon.ico'
-
   await client.query(`
     UPDATE "User" SET "picture" = '${oldPicture}' WHERE "id" = 'parabolAIUser';
   `)

--- a/packages/server/postgres/migrations/1673613407246_updateAIUserPic.ts
+++ b/packages/server/postgres/migrations/1673613407246_updateAIUserPic.ts
@@ -1,0 +1,24 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+
+  const picture = 'https://action-files.parabol.co/static/favicon-with-more-padding.jpeg'
+  await client.query(`
+    UPDATE "User" SET "picture" = '${picture}' WHERE "id" = 'parabolAIUser';
+  `)
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  const oldPicture = 'https://action-files.parabol.co/static/favicon.ico'
+
+  await client.query(`
+    UPDATE "User" SET "picture" = '${oldPicture}' WHERE "id" = 'parabolAIUser';
+  `)
+  await client.end()
+}


### PR DESCRIPTION
I added a new image to S3 which is the same as the old favicon but with more padding: https://s3.console.aws.amazon.com/s3/object/action-files.parabol.co?region=us-east-1&prefix=static/favicon-with-more-padding.jpeg

This PR includes a migration to update the Parabol AI user's picture.

Old avatar: 
![old](https://user-images.githubusercontent.com/39854876/212353110-d11ebfd9-98c4-4e54-bab3-e33e7c3ff6f2.png)

New avatar: 
![new-avatar](https://user-images.githubusercontent.com/39854876/212352933-318f35c8-bc8f-451f-bb43-fb810f2f8d32.png)

### To test

- [ ] Create a retro, add a reflection group that contains two or more reflections, and proceed to the Discuss Stage
- [ ] See that the Parabol AI picture has the new image with more padding