### PR TITLE
fix: missing prompts in starfish retro template

### DIFF
--- a/packages/server/database/migrations/20230116165620-fixStarfishTemplate.ts
+++ b/packages/server/database/migrations/20230116165620-fixStarfishTemplate.ts
@@ -1,0 +1,40 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function (r: R) {
+  const now = new Date()
+  const missingLessOfPrompt = {
+    createdAt: now,
+    description: 'What are we over-doing or doing too much of?',
+    groupColor: '#D9D916',
+    id: 'starfishTemplate:lessOfPrompt',
+    isActive: true,
+    question: 'Less Of ➖',
+    sortOrder: 1,
+    teamId: 'aGhostTeam',
+    templateId: 'starfishTemplate',
+    title: 'Less Of ➖',
+    updatedAt: now
+  }
+  const missingMoreOfPrompt = {
+    createdAt: now,
+    description: 'What are we not taking enough advantage of?',
+    groupColor: '#45E5E5',
+    id: 'starfishTemplate:moreOfPrompt',
+    isActive: true,
+    question: 'More Of ➕',
+    sortOrder: 2,
+    teamId: 'aGhostTeam',
+    templateId: 'starfishTemplate',
+    title: 'More Of ➕',
+    updatedAt: now
+  }
+  await r.table('ReflectPrompt').insert([missingLessOfPrompt, missingMoreOfPrompt]).run()
+}
+
+export const down = async function (r: R) {
+  await r
+    .table('ReflectPrompt')
+    .getAll(r.args(['starfishTemplate:lessOfPrompt', 'starfishTemplate:moreOfPrompt']))
+    .delete()
+    .run()
+}

--- a/packages/server/database/migrations/20230116165620-fixStarfishTemplate.ts
+++ b/packages/server/database/migrations/20230116165620-fixStarfishTemplate.ts
@@ -29,7 +29,10 @@ export const up = async function (r: R) {
     updatedAt: now
   }
 
-  await r.table('ReflectPrompt').insert([missingLessOfPrompt, missingMoreOfPrompt]).run()
+  await r
+    .table('ReflectPrompt')
+    .insert([missingLessOfPrompt, missingMoreOfPrompt], {conflict: 'error'})
+    .run()
 }
 
 export const down = async function (r: R) {

--- a/packages/server/database/migrations/20230116165620-fixStarfishTemplate.ts
+++ b/packages/server/database/migrations/20230116165620-fixStarfishTemplate.ts
@@ -28,6 +28,7 @@ export const up = async function (r: R) {
     title: 'More Of ➕',
     updatedAt: now
   }
+
   await r.table('ReflectPrompt').insert([missingLessOfPrompt, missingMoreOfPrompt]).run()
 }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7466

It looks like the Starfish template had missing prompts because it was using the duplicated prompt id [here](https://github.com/ParabolInc/parabol/issues/7466). It was inserted at the same time as the DAKI template, which also had the same bug. I've checked the other templates that were added, Lean Coffee and What Went Well, and those are working as expected.

### Testing steps

- [ ] Run the migration and see the template now includes the two missing prompts