### PR TITLE
chore: sendToSentry if unable to create topic summary

### DIFF
--- a/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
@@ -38,7 +38,6 @@ const generateGroupSummaries = async (
           userId: facilitator.id,
           tags: {summaryText, reflectionGroupId: group.id, meetingId}
         })
-
         return
       }
       return r.table('RetroReflectionGroup').get(group.id).update({summary}).run()

--- a/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
@@ -1,5 +1,6 @@
 import getRethink from '../../../database/rethinkDriver'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
+import sendToSentry from '../../../utils/sendToSentry'
 import {DataLoaderWorker} from '../../graphql'
 
 const generateGroupSummaries = async (
@@ -15,6 +16,11 @@ const generateGroupSummaries = async (
   if (!facilitator.featureFlags.includes('aiSummary')) return
   const r = await getRethink()
   const manager = new OpenAIServerManager()
+  if (!reflectionGroups.length) {
+    const error = new Error('No reflection groups in generateGroupSummaries')
+    sendToSentry(error, {userId: facilitator.id, tags: {meetingId}})
+    return
+  }
   await Promise.all(
     reflectionGroups.map(async (group) => {
       const reflectionsByGroupId = reflections.filter(
@@ -25,7 +31,16 @@ const generateGroupSummaries = async (
         ({plaintextContent}) => plaintextContent
       )
       const summary = await manager.getSummary(reflectionTextByGroupId)
-      if (!summary) return
+      if (!summary) {
+        const error = new Error('Failed to create the AI topic summary')
+        const summaryText = JSON.stringify(reflectionTextByGroupId)
+        sendToSentry(error, {
+          userId: facilitator.id,
+          tags: {summaryText, reflectionGroupId: group.id, meetingId}
+        })
+
+        return
+      }
       return r.table('RetroReflectionGroup').get(group.id).update({summary}).run()
     })
   )


### PR DESCRIPTION
Related to https://github.com/ParabolInc/parabol/issues/7655

I'm not sure why the topic summary wasn't generated in the meeting shared in the issue, but either the `summary` wasn't generated or there were no `reflectionGroups`. 

This PR adds two `sendToSentry` functions which should help with debugging if it happens again.