### PR TITLE
fix: delete empty reflection groups

### DIFF
--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -146,7 +146,13 @@ export default {
       dataLoader.get('teams').loadNonNull(teamId),
       dataLoader.get('teamMembersByTeamId').load(teamId),
       removeEmptyTasks(meetingId),
-      dataLoader.get('meetingTemplates').load(templateId)
+      dataLoader.get('meetingTemplates').load(templateId),
+      r
+        .table('RetroReflectionGroup')
+        .getAll(meetingId, {index: 'meetingId'})
+        .filter({isActive: false})
+        .delete()
+        .run()
     ])
     // wait for removeEmptyTasks before finishRetroMeeting
     // don't await for the OpenAI response or it'll hang for a while when ending the retro

--- a/packages/server/postgres/migrations/1674074684762_deleteEmptyGroups.ts
+++ b/packages/server/postgres/migrations/1674074684762_deleteEmptyGroups.ts
@@ -1,0 +1,22 @@
+import {r} from 'rethinkdb-ts'
+import {ParabolR} from '../../database/rethinkDriver'
+
+const connectRethinkDB = async () => {
+  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
+  await r.connectPool({
+    host,
+    port: parseInt(port, 10),
+    db: pathname.split('/')[1]
+  })
+  return r as any as ParabolR
+}
+
+export async function up() {
+  await connectRethinkDB()
+  await r.table('RetroReflectionGroup').filter({isActive: false}).delete().run()
+  await r.getPoolMaster()?.drain()
+}
+
+export async function down() {
+  // can't undo a delete
+}


### PR DESCRIPTION
# Description

Fixes #7669 frees up ~800MB

## Demo

Running this on staging the read query took about 80 seconds. When done in batches, it took ~7 seconds for 10k records, so i figured a single query is probably better.

