### PR TITLE
feat(search): add search ability to meeting view

### DIFF
--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -7,7 +7,7 @@ import useBreakpoint from '../hooks/useBreakpoint'
 import useCardsPerRow from '../hooks/useCardsPerRow'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useTransition from '../hooks/useTransition'
-import {Breakpoint, Layout} from '../types/constEnums'
+import {Breakpoint, EmptyMeetingViewMessage, Layout} from '../types/constEnums'
 import getSafeRegex from '../utils/getSafeRegex'
 import DemoMeetingCard from './DemoMeetingCard'
 import MeetingCard from './MeetingCard'
@@ -80,7 +80,17 @@ const MeetingsDash = (props: Props) => {
         </Wrapper>
       ) : (
         <EmptyContainer>
-          <MeetingsDashEmpty name={preferredName} />
+          {dashSearch ? (
+            <MeetingsDashEmpty
+              name={preferredName}
+              message={EmptyMeetingViewMessage.NO_SEARCH_RESULTS}
+            />
+          ) : (
+            <MeetingsDashEmpty
+              name={preferredName}
+              message={EmptyMeetingViewMessage.NO_ACTIVE_MEETINGS}
+            />
+          )}
           <Wrapper maybeTabletPlus={maybeTabletPlus}>
             <DemoMeetingCard />
             <TutorialMeetingCard />

--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -80,17 +80,14 @@ const MeetingsDash = (props: Props) => {
         </Wrapper>
       ) : (
         <EmptyContainer>
-          {dashSearch ? (
-            <MeetingsDashEmpty
-              name={preferredName}
-              message={EmptyMeetingViewMessage.NO_SEARCH_RESULTS}
-            />
-          ) : (
-            <MeetingsDashEmpty
-              name={preferredName}
-              message={EmptyMeetingViewMessage.NO_ACTIVE_MEETINGS}
-            />
-          )}
+          <MeetingsDashEmpty
+            name={preferredName}
+            message={
+              dashSearch
+                ? EmptyMeetingViewMessage.NO_SEARCH_RESULTS
+                : EmptyMeetingViewMessage.NO_ACTIVE_MEETINGS
+            }
+          />
           <Wrapper maybeTabletPlus={maybeTabletPlus}>
             <DemoMeetingCard />
             <TutorialMeetingCard />

--- a/packages/client/components/MeetingsDashEmpty.tsx
+++ b/packages/client/components/MeetingsDashEmpty.tsx
@@ -29,16 +29,14 @@ const Copy = styled('p')({
 
 interface Props {
   name: string
+  message: string
 }
 const MeetingsDashNewUser = (props: Props) => {
-  const {name} = props
+  const {name, message} = props
   return (
     <Section>
       <Heading>{`Hi ${name},`}</Heading>
-      <Copy>
-        Looks like you have no upcoming meetings 😎 Start one now or check out these tips and
-        tricks.
-      </Copy>
+      <Copy>{`${message}`}</Copy>
     </Section>
   )
 }

--- a/packages/client/components/TopBarSearch.tsx
+++ b/packages/client/components/TopBarSearch.tsx
@@ -24,6 +24,11 @@ const getShowSearch = (location: NonNullable<RouteProps['location']>) => {
       path: '/team/:teamId/archive',
       exact: true,
       strict: false
+    }) ||
+    !!matchPath(pathname, {
+      path: '/meetings',
+      exact: true,
+      strict: false
     })
   )
 }

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -496,3 +496,8 @@ export const enum AIExplainer {
   PREMIUM_MEETING = `Our friendly AI 🤖 is here to save you time by summarizing your meeting`,
   PREMIUM_REFLECTIONS = `Our friendly AI 🤖 is here to save you time by summarizing your reflections`
 }
+
+export const enum EmptyMeetingViewMessage {
+  NO_ACTIVE_MEETINGS = `Looks like you have no upcoming meetings 😎 Start one now or check out these tips and tricks.`,
+  NO_SEARCH_RESULTS = `Sorry we could not find any meetings matched with your query. Would you like to checkout these tips and tricks?`
+}


### PR DESCRIPTION
# Description

Add a search bar in meeting view

## Demo
![2023-01-19 16 45 04](https://user-images.githubusercontent.com/1879975/213594716-6c21c6b9-9528-4184-87de-beeb5f00e3c3.gif)


## Testing scenarios

- [ ] Search works on meeting view
  - Type a query word in the search bar
  - Meeting cards only show matched ones

- [ ] Empty query
  - Remove everything from the search bar
  - Meeting view show all active meetings

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
