### PR TITLE
chore(metrics): Add `isPatient0` property to `sign_up` events emitted by GA4

### DIFF
--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -17,8 +17,9 @@ const SAMLRedirect = () => {
     const token = params.get('token')
     const error = params.get('error')
     const isNewUser = params.get('isNewUser') === 'true'
+    const isPatient0 = params.get('isPatient0') === 'true'
     if (isNewUser) {
-      ReactGA.event('sign_up')
+      ReactGA.event('sign_up', {isPatient0})
     }
     let isSameOriginPopup = false
     if (window.opener) {

--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -18,7 +18,7 @@ const SAMLRedirect = () => {
     const error = params.get('error')
     const isNewUser = params.get('isNewUser') === 'true'
     const isPatient0 = params.get('isPatient0') === 'true'
-    if (isNewUser) {
+    if (isNewUser && !error) {
       ReactGA.event('sign_up', {isPatient0})
     }
     let isSameOriginPopup = false

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -22,6 +22,7 @@ const mutation = graphql`
       isNewUser
       user {
         tms
+        isPatient0
         ...UserAnalyticsFrag @relay(mask: false)
       }
     }
@@ -44,9 +45,9 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, loginWithGoogle} = res
       onCompleted({loginWithGoogle}, errors)
-      const {error: uiError, isNewUser} = loginWithGoogle
+      const {error: uiError, isNewUser, user} = loginWithGoogle
       if (isNewUser) {
-        ReactGA.event('sign_up')
+        ReactGA.event('sign_up', {isPatient0: user?.isPatient0})
       }
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -46,11 +46,11 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
       const {acceptTeamInvitation, loginWithGoogle} = res
       onCompleted({loginWithGoogle}, errors)
       const {error: uiError, isNewUser, user} = loginWithGoogle
-      if (isNewUser) {
-        ReactGA.event('sign_up', {isPatient0: user?.isPatient0})
-      }
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
+        if (isNewUser) {
+          ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
+        }
         handleSuccessfulLogin(loginWithGoogle)
         const authToken = acceptTeamInvitation?.authToken ?? loginWithGoogle.authToken
         atmosphere.setAuthToken(authToken)

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -27,6 +27,7 @@ const mutation = graphql`
       authToken
       user {
         tms
+        isPatient0
         ...UserAnalyticsFrag @relay(mask: false)
       }
     }
@@ -45,10 +46,10 @@ const SignUpWithPasswordMutation: StandardMutation<
     onError,
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, signUpWithPassword} = res
-      const {error: uiError} = signUpWithPassword
+      const {error: uiError, user} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
-      ReactGA.event('sign_up')
+      ReactGA.event('sign_up', {isPatient0: user?.isPatient0})
       if (!uiError && !errors) {
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -49,8 +49,8 @@ const SignUpWithPasswordMutation: StandardMutation<
       const {error: uiError, user} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
-      ReactGA.event('sign_up', {isPatient0: user?.isPatient0})
       if (!uiError && !errors) {
+        ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken
         atmosphere.setAuthToken(authToken)

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -2065,7 +2065,7 @@ type LoginSAMLPayload {
   """
   if the user is patient 0
   """
-  isPatientZero: Boolean
+  isPatient0: Boolean
 }
 
 type ErrorPayload {

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -2061,6 +2061,11 @@ type LoginSAMLPayload {
   if a new user is created
   """
   isNewUser: Boolean
+
+  """
+  if the user is patient 0
+  """
+  isPatientZero: Boolean
 }
 
 type ErrorPayload {


### PR DESCRIPTION
# Description

In GA4 we would like to separate apart patient 0 sign up for attribution reports.

## Demo

<img width="620" alt="Screenshot 2023-01-31 at 17 35 53" src="https://user-images.githubusercontent.com/1879975/215923528-f3105e55-2052-4738-9d2c-01124e40c1f7.png">


## Testing scenarios

- [ ] Patient 0
  - Sign up as a patient 0
  - Check GA4 dashboard

- [ ] Not patient 0
  - Sign up using an email with existing domain
  - Check GA4 dashboard

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
