### PR TITLE
fix(standups): 'next activity' -> 'current activity'

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptEndedBadge.tsx
@@ -13,7 +13,7 @@ interface NextMeetingLinkProps {
 
 export const NextMeetingLink = (props: NextMeetingLinkProps) => {
   const {closestActiveMeetingId} = props
-  return <StyledLink to={`/meet/${closestActiveMeetingId}`}>Go to the next activity.</StyledLink>
+  return <StyledLink to={`/meet/${closestActiveMeetingId}`}>Go to the current activity.</StyledLink>
 }
 
 interface NextMeetingCountdownProps {


### PR DESCRIPTION
# Description
The "Go to the next activity" link actually goes to the current activity (which is the correct behavior). Change the copy to read "Go to the current activity".

https://parabol.slack.com/archives/C043AHXNB32/p1675097875327929

## Demo
<img width="400" alt="Screen Shot 2023-01-30 at 8 07 34 PM" src="https://user-images.githubusercontent.com/9013217/215571620-93668f45-ef72-4440-a770-4b6787ddb151.png">

## Testing scenarios
N/A

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
