### PR TITLE
chore(ai-summary): update meeting summary url

### DIFF
--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -28,6 +28,13 @@ graphql`
       reflectionCount
       taskCount
       topicCount
+      facilitator {
+        user {
+          featureFlags {
+            aiSummary
+          }
+        }
+      }
     }
     team {
       id
@@ -82,7 +89,7 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
   const {isKill, meeting} = payload
   const {atmosphere, history} = context
   if (!meeting) return
-  const {id: meetingId, teamId} = meeting
+  const {id: meetingId, teamId, facilitator} = meeting
   if (meetingId === RetroDemo.MEETING_ID) {
     if (isKill) {
       window.localStorage.removeItem('retroDemo')
@@ -95,7 +102,14 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
       history.push(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else {
-      history.push(`/new-summary/${meetingId}`)
+      const {user} = facilitator
+      const {featureFlags} = user
+      const pathname = `/new-summary/${meetingId}`
+      const search = featureFlags.aiSummary ? '?ai=true' : ''
+      history.push({
+        pathname,
+        search
+      })
     }
   }
 }

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -89,7 +89,7 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
   const {isKill, meeting} = payload
   const {atmosphere, history} = context
   if (!meeting) return
-  const {id: meetingId, teamId, facilitator} = meeting
+  const {id: meetingId, facilitator, teamId} = meeting
   if (meetingId === RetroDemo.MEETING_ID) {
     if (isKill) {
       window.localStorage.removeItem('retroDemo')


### PR DESCRIPTION
We want to add the HubSpot chatbot to meeting summaries that have the AI Summary. To do that, we can update the URL so HubSpot knows when it has an AI Summary.

Related to https://github.com/ParabolInc/parabol/issues/7474

### To test

- [ ] End a retro meeting where the facilitator has access to the AI Summary. See that the URL ends in `?ai=true`
- [ ] End a retro meeting where the facilitator does not have access to the AI Summary. See that the URL ends in `/new-summary/${meetingId}`