### PR TITLE
feat(recurrence): Recurrence-specific meeting card

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -233,9 +233,7 @@ const MeetingCard = (props: Props) => {
   const {id: teamId, name: teamName} = team
 
   const isRecurring = !!(meetingSeries && !meetingSeries.cancelledAt)
-  const meetingLink = isRecurring
-    ? `/meeting-series/${encodeURIComponent(meetingSeries.id)}`
-    : `/meet/${meetingId}`
+  const meetingLink = isRecurring ? `/meeting-series/${meetingId}` : `/meet/${meetingId}`
 
   return (
     <CardWrapper

--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -30,9 +30,7 @@ const CardWrapper = styled('div')<{
   maybeTabletPlus: boolean
   status: TransitionStatus
 }>(({maybeTabletPlus, status}) => ({
-  background: Card.BACKGROUND_COLOR,
-  borderRadius: Card.BORDER_RADIUS,
-  boxShadow: Elevation.CARD_SHADOW,
+  position: 'relative',
   flexShrink: 0,
   maxWidth: '100%',
   transition: `box-shadow 100ms ${BezierCurve.DECELERATE}, opacity 300ms ${BezierCurve.DECELERATE}`,
@@ -45,6 +43,42 @@ const CardWrapper = styled('div')<{
     boxShadow: Elevation.CARD_SHADOW_HOVER
   }
 }))
+
+const STACK_DEGREES = {
+  0: 1,
+  1: -2
+}
+
+const STACK_OFFSET_LEFT = {
+  0: 4,
+  1: 2
+}
+
+const STACK_OFFSET_TOP = {
+  0: 3,
+  1: 2
+}
+
+const StackedCard = styled('div')<{stackIndex: 0 | 1}>(({stackIndex}) => ({
+  content: '""',
+  display: 'block',
+  position: 'absolute',
+  width: '100%',
+  height: '100%',
+  left: `${STACK_OFFSET_LEFT[stackIndex]}px`,
+  top: `${STACK_OFFSET_TOP[stackIndex]}px`,
+  transform: `rotate(${STACK_DEGREES[stackIndex]}deg)`,
+  background: Card.BACKGROUND_COLOR,
+  borderRadius: Card.BORDER_RADIUS,
+  boxShadow: Elevation.CARD_SHADOW
+}))
+
+const InnerCard = styled('div')({
+  position: 'relative',
+  background: Card.BACKGROUND_COLOR,
+  borderRadius: Card.BORDER_RADIUS,
+  boxShadow: Elevation.CARD_SHADOW
+})
 
 const MeetingInfo = styled('div')({
   // tighter padding for options, meta, avatars
@@ -89,6 +123,19 @@ const MeetingImgBackground = styled.div<{meetingType: keyof typeof BACKGROUND_CO
     width: '100%'
   })
 )
+
+const RecurringLabel = styled.span({
+  color: PALETTE.JADE_500,
+  background: PALETTE.JADE_300,
+  fontSize: 11,
+  lineHeight: '12px',
+  fontWeight: 500,
+  position: 'absolute',
+  right: 8,
+  top: 8,
+  padding: '4px 8px 4px 8px',
+  borderRadius: '64px'
+})
 
 const MeetingImgWrapper = styled('div')({
   borderRadius: `${Card.BORDER_RADIUS}px ${Card.BORDER_RADIUS}px 0 0`,
@@ -155,7 +202,7 @@ const MEETING_TYPE_LABEL = {
 
 const MeetingCard = (props: Props) => {
   const {meeting, status, onTransitionEnd, displayIdx} = props
-  const {name, team, id: meetingId, meetingType, phases} = meeting
+  const {name, team, id: meetingId, meetingType, phases, meetingSeries} = meeting
   const connectedUsers = useMeetingMemberAvatars(meeting)
   const meetingPhase = getMeetingPhase(phases)
   const meetingPhaseLabel = (meetingPhase && phaseLabelLookup[meetingPhase.phaseType]) || 'Complete'
@@ -185,6 +232,11 @@ const MeetingCard = (props: Props) => {
   }
   const {id: teamId, name: teamName} = team
 
+  const isRecurring = !!(meetingSeries && !meetingSeries.cancelledAt)
+  const meetingLink = isRecurring
+    ? `/meeting-series/${encodeURIComponent(meetingSeries.id)}`
+    : `/meet/${meetingId}`
+
   return (
     <CardWrapper
       ref={ref}
@@ -192,38 +244,61 @@ const MeetingCard = (props: Props) => {
       status={status}
       onTransitionEnd={onTransitionEnd}
     >
-      <MeetingImgWrapper>
-        <MeetingImgBackground meetingType={meetingType} />
-        <MeetingTypeLabel>{MEETING_TYPE_LABEL[meetingType]}</MeetingTypeLabel>
-        <Link to={`/meet/${meetingId}`}>
-          <MeetingImg src={ILLUSTRATIONS[meetingType]} alt='' />
-        </Link>
-      </MeetingImgWrapper>
-      <MeetingInfo>
-        <TopLine>
-          <Link to={`/meet/${meetingId}`}>
-            <Name>{name}</Name>
-          </Link>
-          <Options ref={originRef} onClick={togglePortal}>
-            <IconLabel ref={tooltipRef} icon='more_vert' />
-          </Options>
-        </TopLine>
-        <Link to={`/meet/${meetingId}`}>
-          <Meta>
-            {teamName} • {meetingPhaseLabel}
-          </Meta>
-        </Link>
-        <AvatarList users={connectedUsers} size={28} />
-      </MeetingInfo>
-      {menuPortal(
-        <MeetingCardOptionsMenuRoot
-          meetingId={meetingId}
-          teamId={teamId}
-          menuProps={menuProps}
-          popTooltip={popTooltip}
-        />
-      )}
-      {tooltipPortal('Copied!')}
+      <div style={{position: 'relative'}}>
+        {isRecurring && (
+          <>
+            <StackedCard stackIndex={0}>
+              <MeetingImgWrapper>
+                <MeetingImgBackground meetingType={meetingType} />
+                <MeetingImg src={ILLUSTRATIONS[meetingType]} alt='' />
+              </MeetingImgWrapper>
+            </StackedCard>
+            <StackedCard stackIndex={1}>
+              <MeetingImgWrapper>
+                <MeetingImgBackground meetingType={meetingType} />
+                <MeetingImg src={ILLUSTRATIONS[meetingType]} alt='' />
+              </MeetingImgWrapper>
+            </StackedCard>
+          </>
+        )}
+        <InnerCard>
+          <MeetingImgWrapper>
+            <MeetingImgBackground meetingType={meetingType} />
+            <MeetingTypeLabel>{MEETING_TYPE_LABEL[meetingType]}</MeetingTypeLabel>
+            {meetingType === 'teamPrompt' && isRecurring && (
+              <RecurringLabel>Recurring</RecurringLabel>
+            )}
+            <Link to={meetingLink}>
+              <MeetingImg src={ILLUSTRATIONS[meetingType]} alt='' />
+            </Link>
+          </MeetingImgWrapper>
+          <MeetingInfo>
+            <TopLine>
+              <Link to={meetingLink}>
+                <Name>{isRecurring ? meetingSeries.title : name}</Name>
+              </Link>
+              <Options ref={originRef} onClick={togglePortal}>
+                <IconLabel ref={tooltipRef} icon='more_vert' />
+              </Options>
+            </TopLine>
+            <Link to={meetingLink}>
+              <Meta>
+                {teamName} • {meetingPhaseLabel}
+              </Meta>
+            </Link>
+            <AvatarList users={connectedUsers} size={28} />
+          </MeetingInfo>
+          {menuPortal(
+            <MeetingCardOptionsMenuRoot
+              meetingId={meetingId}
+              teamId={teamId}
+              menuProps={menuProps}
+              popTooltip={popTooltip}
+            />
+          )}
+          {tooltipPortal('Copied!')}
+        </InnerCard>
+      </div>
     </CardWrapper>
   )
 }
@@ -248,6 +323,13 @@ export default createFragmentContainer(MeetingCard, {
       meetingMembers {
         user {
           ...AvatarListUser_user
+        }
+      }
+      ... on TeamPromptMeeting {
+        meetingSeries {
+          id
+          title
+          cancelledAt
         }
       }
     }

--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -54,6 +54,12 @@ const MeetingsDash = (props: Props) => {
           return 1
         }
 
+        if (aRecurring && bRecurring) {
+          // When ordering recurring meetings, sort based on when the series was created to maintain
+          // consistency when meetings are restarted.
+          return a.meetingSeries.createdAt > b.meetingSeries.createdAt ? -1 : 1
+        }
+
         return a.createdAt > b.createdAt ? -1 : 1
       })
     const filteredMeetings = dashSearch
@@ -126,6 +132,7 @@ graphql`
       }
       ... on TeamPromptMeeting {
         meetingSeries {
+          createdAt
           cancelledAt
         }
       }

--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -44,7 +44,18 @@ const MeetingsDash = (props: Props) => {
     const meetings = teams
       .flatMap((team) => team.activeMeetings)
       .filter(Boolean)
-      .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
+      .sort((a, b) => {
+        const aRecurring = !!(a.meetingSeries && !a.meetingSeries.cancelledAt)
+        const bRecurring = !!(b.meetingSeries && !b.meetingSeries.cancelledAt)
+        if (aRecurring && !bRecurring) {
+          return -1
+        }
+        if (bRecurring && !aRecurring) {
+          return 1
+        }
+
+        return a.createdAt > b.createdAt ? -1 : 1
+      })
     const filteredMeetings = dashSearch
       ? meetings.filter(({name}) => name && name.match(getSafeRegex(dashSearch, 'i')))
       : meetings
@@ -111,6 +122,11 @@ graphql`
         user {
           isConnected
           lastSeenAtURLs
+        }
+      }
+      ... on TeamPromptMeeting {
+        meetingSeries {
+          cancelledAt
         }
       }
     }

--- a/packages/client/styles/paletteV3.ts
+++ b/packages/client/styles/paletteV3.ts
@@ -37,6 +37,7 @@ export const enum PALETTE {
 
   JADE_400_30 = '#66BC8C4D',
 
+  JADE_500 = '#116931',
   JADE_400 = '#66BC8C',
   JADE_300 = '#91E8B7',
 


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7702

~Needs rebase once https://github.com/ParabolInc/parabol/pull/7707 lands~. Rebase complete

Recommend reviewers to set `?w=1` to avoid whitespace-only diffs.

Updates meeting cards for recurring meetings according to designs:
* Recurring label
* Recurring meetings shown before non-recurring meetings on dash
* Meeting series title instead of meeting name
* Meeting card stack
* Links to meeting series (link will need to be updated once stable link is changed in https://github.com/ParabolInc/parabol/pull/7707)

## Demo

<img width="1132" alt="Screen Shot 2023-02-08 at 6 40 59 PM" src="https://user-images.githubusercontent.com/9013217/217609701-20fb5a72-c10b-4129-bcec-9b24e7193336.png">

When a meeting changes from one-time to recurring and back:
https://www.loom.com/share/1226748129da4c3885a83f74dd6e43c8

## Testing scenarios
- [ ] Non-recurring meeting cards are unchanged
- [ ] Recurring meeting card matches designs
- [ ] Recurring meeting card links to stable link instead of meeting link
- [ ] From a different window, change the meeting to recur and see the meeting card animate to the start of the meeting cards. Set it to no longer recur and see it go to its original position.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
