### PR TITLE
chore: Invert meetingHistoryLimit feature flag

### DIFF
--- a/packages/server/graphql/public/typeDefs/addFeatureFlag.graphql
+++ b/packages/server/graphql/public/typeDefs/addFeatureFlag.graphql
@@ -9,7 +9,7 @@ enum UserFlagEnum {
   recurrence
   templateLimit
   aiSummary
-  meetingHistoryLimit
+  noMeetingHistoryLimit
   checkoutFlow
 }
 
@@ -24,7 +24,7 @@ type UserFeatureFlags {
   recurrence: Boolean!
   templateLimit: Boolean!
   aiSummary: Boolean!
-  meetingHistoryLimit: Boolean!
+  noMeetingHistoryLimit: Boolean!
   checkoutFlow: Boolean!
 }
 

--- a/packages/server/graphql/public/types/UserFeatureFlags.ts
+++ b/packages/server/graphql/public/types/UserFeatureFlags.ts
@@ -6,7 +6,7 @@ const UserFeatureFlags: UserFeatureFlagsResolvers = {
   insights: ({insights}) => !!insights,
   templateLimit: ({templateLimit}) => !!templateLimit,
   aiSummary: ({aiSummary}) => !!aiSummary,
-  meetingHistoryLimit: ({meetingHistoryLimit}) => !!meetingHistoryLimit,
+  noMeetingHistoryLimit: ({noMeetingHistoryLimit}) => !!noMeetingHistoryLimit,
   checkoutFlow: ({checkoutFlow}) => !!checkoutFlow
 }
 

--- a/packages/server/graphql/types/UserFlagEnum.ts
+++ b/packages/server/graphql/types/UserFlagEnum.ts
@@ -8,7 +8,7 @@ const UserFlagEnum = new GraphQLEnumType({
     msTeams: {},
     templateLimit: {},
     aiSummary: {},
-    meetingHistoryLimit: {},
+    noMeetingHistoryLimit: {},
     checkoutFlow: {}
   }
 })

--- a/packages/server/graphql/types/helpers/isMeetingLocked.ts
+++ b/packages/server/graphql/types/helpers/isMeetingLocked.ts
@@ -19,7 +19,7 @@ const isMeetingLocked = async (
   const {featureFlags} = viewer
   const {tier, isPaid, orgId, isArchived} = team
 
-  if (!featureFlags.includes('meetingHistoryLimit')) {
+  if (featureFlags.includes('noMeetingHistoryLimit')) {
     return false
   }
 


### PR DESCRIPTION
# Description

Fixes #7666 

Limit is enabled by default now.

## Testing scenarios

- [ ] Check meeting history with starter tier
- [ ] see meetings older than 30 days locked