### PR TITLE
fix(ai-summary): summary references "the text"

### DIFF
--- a/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
@@ -29,7 +29,8 @@ const generateDiscussionSummary = async (
   const tasksContent = tasks.map(({plaintextContent}) => plaintextContent)
   const contentToSummarize = [...commentsContent, ...tasksContent]
   if (contentToSummarize.length <= 1) return
-  const summary = await manager.getSummary(contentToSummarize)
+
+  const summary = await manager.getSummary(contentToSummarize, 'discussion thread')
   if (!summary) return
   await updateDiscussions({summary}, discussionId)
   // when we end the meeting, we don't wait for the OpenAI response as we want to see the meeting summary immediately, so publish the subscription

--- a/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
@@ -29,7 +29,6 @@ const generateDiscussionSummary = async (
   const tasksContent = tasks.map(({plaintextContent}) => plaintextContent)
   const contentToSummarize = [...commentsContent, ...tasksContent]
   if (contentToSummarize.length <= 1) return
-
   const summary = await manager.getSummary(contentToSummarize, 'discussion thread')
   if (!summary) return
   await updateDiscussions({summary}, discussionId)

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -16,12 +16,13 @@ class OpenAIServerManager {
     this.openAIApi = new OpenAIApi(configuration)
   }
 
-  async getSummary(text: string | string[]) {
+  async getSummary(text: string | string[], summaryLocation?: 'discussion thread') {
     if (!this.openAIApi) return null
     try {
+      const location = summaryLocation ?? 'retro meeting'
       const response = await this.openAIApi.createCompletion({
         model: 'text-davinci-003',
-        prompt: `Below is a comma-separated list of text. Summarize the text for a second-grade student in one or two sentences.
+        prompt: `Below is a comma-separated list of text from a ${location}. Summarize the text for a second-grade student in one or two sentences.
 
         Text: """
         ${text}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7738

This PR updates the OpenAI prompt with the location. This makes it more likely that the summary refers to the meeting or discussion thread rather than "the text".

To test, I went through some of the examples in the issue, copying and pasting the discussion thread comments & tasks. The results seem to be better:

![Screenshot 2023-02-08 at 18 13 22](https://user-images.githubusercontent.com/39854876/217617499-63edf378-3d63-49b1-a7e9-376f2683074e.png)
![Screenshot 2023-02-08 at 18 13 33](https://user-images.githubusercontent.com/39854876/217617512-a8d02a69-b305-4423-9c45-025f1b6f4cdf.png)
![Screenshot 2023-02-08 at 18 13 49](https://user-images.githubusercontent.com/39854876/217617527-25f84e1b-8ec2-40c0-8083-30a07710cd2b.png)
![Screenshot 2023-02-08 at 18 14 05](https://user-images.githubusercontent.com/39854876/217617536-f0b1c16f-b4f5-49ee-8005-3c2b615ea827.png)

### To test

- [ ] Create a retro meeting and make sure the AI Summary flag is switched on for the facilitator
- [ ] Add a bunch of reflections, comments, and tasks. See if the summaries look good