### PR TITLE
fix(mixed-content): change http thumbnail link to https to remove mixed content

### DIFF
--- a/packages/client/components/TutorialMeetingCard.tsx
+++ b/packages/client/components/TutorialMeetingCard.tsx
@@ -97,7 +97,7 @@ const TopLine = styled('div')({
   display: 'flex'
 })
 
-const THUMBNAIL = 'http://i.ytimg.com/vi/X_i60AMxPBU/maxresdefault.jpg'
+const THUMBNAIL = 'https://i.ytimg.com/vi/X_i60AMxPBU/maxresdefault.jpg'
 
 const TutorialMeetingCard = () => {
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)


### PR DESCRIPTION
Change http thumbnail link to https to remove mixed content-error in console/potential security trigger on some user systems.

Resolves: 
![image](https://user-images.githubusercontent.com/71724289/217639537-f0b8f23b-a0eb-4f8d-bdea-cf3c7fd7260a.png)
