### PR TITLE
fix(recurrence): Don't restart meetings on archived teams

### DIFF
--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -7,7 +7,7 @@ import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTe
 import {analytics} from '../../../utils/analytics/analytics'
 import publish, {SubOptions} from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
-import {GQLContext} from '../../graphql'
+import {InternalContext} from '../../graphql'
 import sendNewMeetingSummary from './endMeeting/sendNewMeetingSummary'
 
 const safeEndTeamPrompt = async ({
@@ -22,7 +22,7 @@ const safeEndTeamPrompt = async ({
   now: Date
   viewerId?: string
   r: ParabolR
-  context: GQLContext
+  context: InternalContext
   subOptions: SubOptions
 }) => {
   const {dataLoader} = context

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -82,7 +82,7 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
   await Promise.all(
     activeMeetingSeries.map(async (meetingSeries) => {
       const seriesTeam = await dataLoader.get('teams').loadNonNull(meetingSeries.teamId)
-      if (seriesTeam.isArchived) {
+      if (seriesTeam.isArchived || !seriesTeam.isPaid) {
         return
       }
 

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -81,6 +81,11 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
   const activeMeetingSeries = await getActiveMeetingSeries()
   await Promise.all(
     activeMeetingSeries.map(async (meetingSeries) => {
+      const seriesTeam = await dataLoader.get('teams').loadNonNull(meetingSeries.teamId)
+      if (seriesTeam.isArchived) {
+        return
+      }
+
       const lastMeeting = await r
         .table('NewMeeting')
         .getAll(meetingSeries.id, {index: 'meetingSeriesId'})

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -86,6 +86,11 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
         return
       }
 
+      const seriesOrg = await dataLoader.get('organizations').load(seriesTeam.orgId)
+      if (seriesOrg.lockedAt) {
+        return
+      }
+
       const lastMeeting = await r
         .table('NewMeeting')
         .getAll(meetingSeries.id, {index: 'meetingSeriesId'})


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7735

When a team is archived, we don't close any meetings or meeting series (presumably to make undoing that action possible by Parabol employees for support cases). This has a negligible impact for one-off meetings, but because we don't check if a team is active when processing recurrence, recurring meetings on archived teams will continue to recur.

## Testing scenarios
- [ ] Set up a recurring meeting such that the meeting will be stopped + restarted on the next `processRecurrence` run (I just temporarily changed my local machines date to tomorrow after starting a recurring meeting)
- [ ] Archive the team with the recurring meeting
- [ ] Run `processRecurrence`
- [ ] Confirm that the number of meetings started + ended reflects that the meeting was ended but not restarted
- [ ] Optionally, step forward an additional day, run `processRecurrence` again, and confirm that no email summary is sent for the recurring meeting on the archived team.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
