### PR TITLE
chore(metrics): Do not call identify() on feature flag changes

### DIFF
--- a/packages/server/graphql/public/mutations/addFeatureFlag.ts
+++ b/packages/server/graphql/public/mutations/addFeatureFlag.ts
@@ -6,7 +6,6 @@ import {getUsersByEmails} from '../../../postgres/queries/getUsersByEmails'
 import IUser from '../../../postgres/types/IUser'
 import {getUserId, isSuperUser} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
-import segmentIo from '../../../utils/segmentIo'
 import standardError from '../../../utils/standardError'
 import {MutationResolvers} from '../resolverTypes'
 
@@ -48,28 +47,6 @@ const addFeatureFlag: MutationResolvers['addFeatureFlag'] = async (
     const data = {userId}
     publish(SubscriptionChannel.NOTIFICATION, userId, 'AddFeatureFlagPayload', data, subOptions)
   })
-
-  if (isAddingFlagToViewer) {
-    const viewer = await dataLoader.get('users').loadNonNull(viewerId)
-    segmentIo.identify({
-      userId: viewerId,
-      traits: {
-        eamil: viewer.email,
-        featureFlags: viewer!.featureFlags
-      }
-    })
-  } else {
-    users.forEach(async ({id: userId, featureFlags}) => {
-      const user = await dataLoader.get('users').loadNonNull(userId)
-      segmentIo.identify({
-        userId,
-        traits: {
-          email: user.email,
-          featureFlags
-        }
-      })
-    })
-  }
 
   return {userIds}
 }


### PR DESCRIPTION
# Description

We have been doing a lot of experiments recently, which involves adding feature flags for a lot of users. We have noticed that `.identify()` on Segment will:
1. [Increase our MTU](https://parabol.slack.com/archives/C03C3J42WDU/p1673544145767659) so economically that's unsustainable 
2. Mess up downstream metrics like [GA4](https://parabol.slack.com/archives/C03C3J42WDU/p1673544145767659), where they think we do have that many of active users, but that's not the truth

This PR simply removes the `.identify()` calls from the `addFeatureFlag` mutation resolver. The only place we are using the user property is in Amplitude analysis and today we are feeding it with Segment ETL, which queries BigQuery and then update Amplitude periodically so it would continue to work.


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
