### PR TITLE
chore(ai-summary): track no stats in Slack summary

### DIFF
--- a/packages/server/graphql/mutations/helpers/notifications/getSummaryText.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/getSummaryText.ts
@@ -5,10 +5,18 @@ import {isMeetingAction} from '../../../../database/types/MeetingAction'
 import {isMeetingPoker} from '../../../../database/types/MeetingPoker'
 import {isMeetingRetrospective} from '../../../../database/types/MeetingRetrospective'
 import {isMeetingTeamPrompt} from '../../../../database/types/MeetingTeamPrompt'
+import sendToSentry from '../../../../utils/sendToSentry'
 
 const getSummaryText = (meeting: Meeting) => {
   if (isMeetingRetrospective(meeting)) {
     const {commentCount = 0, reflectionCount = 0, topicCount = 0, taskCount = 0} = meeting
+    const hasNonZeroStat = commentCount || reflectionCount || topicCount || taskCount
+    if (!hasNonZeroStat && meeting.summary) {
+      sendToSentry(new Error('No stats found for meeting'), {
+        tags: {meetingId: meeting.id, summary: meeting.summary}
+      })
+    }
+
     return `Your team shared ${reflectionCount} ${plural(
       reflectionCount,
       'reflection'

--- a/packages/server/graphql/mutations/helpers/notifications/getSummaryText.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/getSummaryText.ts
@@ -16,7 +16,6 @@ const getSummaryText = (meeting: Meeting) => {
         tags: {meetingId: meeting.id, summary: meeting.summary}
       })
     }
-
     return `Your team shared ${reflectionCount} ${plural(
       reflectionCount,
       'reflection'


### PR DESCRIPTION
Related to https://github.com/ParabolInc/parabol/issues/7674

If there's an AI Summary and there are no meeting stats, send an error to Sentry.

This will let us know how often it's happening and provide more info about the bug. 