### PR TITLE
chore(standups): removed beta badge from standups

### DIFF
--- a/packages/client/components/NewMeetingCarousel.tsx
+++ b/packages/client/components/NewMeetingCarousel.tsx
@@ -62,19 +62,6 @@ const Card = styled('div')<{isActive: boolean; meetingType: keyof typeof BACKGRO
   })
 )
 
-const Badge = styled('div')({
-  position: 'absolute',
-  top: -8,
-  right: -8,
-  background: PALETTE.GRAPE_500,
-  color: PALETTE.WHITE,
-  fontSize: 12,
-  fontWeight: 600,
-  padding: '6px 14px',
-  borderRadius: 24,
-  textTransform: 'uppercase'
-})
-
 const ILLUSTRATIONS = {
   retrospective,
   action,
@@ -173,7 +160,6 @@ const NewMeetingCarousel = (props: Props) => {
                 <MeetingImage src={src} key={meetingType} />
                 <Title isActive={isActive}>{title}</Title>
                 <Description isActive={isActive}>{description}</Description>
-                {meetingType === 'teamPrompt' && <Badge>Beta</Badge>}
               </Card>
             </SwiperSlide>
           )

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -5,7 +5,6 @@ import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {useRenameMeeting} from '~/hooks/useRenameMeeting'
 import NewMeetingAvatarGroup from '~/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
-import {PALETTE} from '~/styles/paletteV3'
 import {TeamPromptTopBar_meeting$key} from '~/__generated__/TeamPromptTopBar_meeting.graphql'
 import useModal from '../../hooks/useModal'
 import {meetingAvatarMediaQueries, meetingTopBarMediaQuery} from '../../styles/meeting'
@@ -80,17 +79,6 @@ const ButtonContainer = styled('div')({
   }
 })
 
-const BetaBadge = styled('div')({
-  borderRadius: 44,
-  backgroundColor: PALETTE.GRAPE_500,
-  color: PALETTE.SLATE_100,
-  fontWeight: 600,
-  fontSize: 12,
-  lineHeight: '11px',
-  marginRight: 53,
-  padding: '8px 16px 8px 16px'
-})
-
 interface Props {
   meetingRef: TeamPromptTopBar_meeting$key
   isDesktop: boolean
@@ -158,7 +146,6 @@ const TeamPromptTopBar = (props: Props) => {
       )}
       <RightSection>
         <RightSectionContainer>
-          {isDesktop && <BetaBadge>BETA</BetaBadge>}
           <NewMeetingAvatarGroup meetingRef={meeting} />
           <ButtonContainer>
             <TeamPromptOptions


### PR DESCRIPTION
# Description

After shipping advanced recurrence we decided to remove standups beta badge. This PR does that.

## Demo

No demo

## Testing scenarios


- [ ] No beta badge in new meeting modal

- [ ] No beta badge in standups meeting view

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
