### PR TITLE
fix: do not run removeOrgUserTaskUpdater for undefined tasks

### DIFF
--- a/packages/client/mutations/RemoveOrgUserMutation.ts
+++ b/packages/client/mutations/RemoveOrgUserMutation.ts
@@ -131,6 +131,7 @@ export const removeOrgUserTeamUpdater: SharedUpdater<RemoveOrgUserMutation_team>
 ) => {
   const removedUserId = payload.getLinkedRecord('user').getValue('id')
   const {viewerId} = atmosphere
+
   if (removedUserId === viewerId) {
     const teams = payload.getLinkedRecords('teams')
     const teamIds = teams.map((team) => team.getValue('id'))
@@ -148,6 +149,8 @@ export const removeOrgUserTaskUpdater: SharedUpdater<RemoveOrgUserMutation_task>
 ) => {
   const removedUserId = payload.getLinkedRecord('user').getValue('id')
   const tasks = payload.getLinkedRecords('updatedTasks')
+  if (!tasks) return
+
   if (removedUserId === atmosphere.viewerId) {
     const taskIds = tasks.map((task) => task.getValue('id'))
     handleRemoveTasks(taskIds, store)
@@ -171,7 +174,9 @@ export const removeOrgUserTeamOnNext: OnNextHandler<RemoveOrgUserMutation_team> 
       commitLocalUpdate(atmosphere, (store) => {
         const meetingProxy = store.get(meetingId)
         if (!meetingProxy) return
-        const viewerStageId = meetingProxy.getLinkedRecord('localStage')!.getValue('id') as string
+        const localStage = meetingProxy.getLinkedRecord('localStage')
+        if (!localStage) return
+        const viewerStageId = localStage.getValue('id') as string
         const stageRes = findStageById(phases, viewerStageId)
         if (!stageRes) {
           setLocalStageAndPhase(store, meetingId, facilitatorStageId)

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -267,6 +267,8 @@ const NotificationSubscription = (
           break
         case 'UpdateFeatureFlagPayload':
           break
+        case 'AuthTokenPayload':
+          break
         case 'AddNewFeaturePayload':
           addNewFeatureNotificationUpdater(payload, context)
           break


### PR DESCRIPTION
# Description

Fixes #7381 

## Demo

No demo

## Testing scenarios

- [ ] User removing during the meeting
 - user A is an org billing leader, user B is a user in the user's A org
 - start a check in meeting
 - from a different browser window, join with user B, set a stage to user's B update
 - as a user A, go to org settings and remove user B from org
 - user B should be redirected to the dashboard

- [ ] User with no tasks removed 
 - user B has no tasks
 - user A is an org billing leader
 - user A removes user B
 - users B app doesn't crash

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
