### PR TITLE
fix: Fix server error when joining a team by invitation link

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -116,9 +116,10 @@ export const acceptTeamInvitationNotificationUpdater: SharedUpdater<
   const viewer = store.getRoot().getLinkedRecord('viewer')
   if (viewer) {
     const requestedMeeting = payload.getLinkedRecord('meeting')
-    const requestedMeetingId = requestedMeeting.getValue('id')
-    viewer.setLinkedRecord(requestedMeeting, 'meeting', {meetingId: requestedMeetingId})
-
+    if (requestedMeeting) {
+      const requestedMeetingId = requestedMeeting.getValue('id')
+      viewer.setLinkedRecord(requestedMeeting, 'meeting', {meetingId: requestedMeetingId})
+    }
     activeMeetings.forEach((activeMeeting) => {
       const meetingId = activeMeeting.getValue('id')
       viewer.setLinkedRecord(activeMeeting, 'meeting', {meetingId})

--- a/packages/server/graphql/types/AcceptTeamInvitationPayload.ts
+++ b/packages/server/graphql/types/AcceptTeamInvitationPayload.ts
@@ -38,7 +38,7 @@ const AcceptTeamInvitationPayload = new GraphQLObjectType<any, GQLContext>({
       type: NewMeeting,
       description: 'The requested meeting',
       resolve: async (
-        {meetingId}: {meetingId: string},
+        {meetingId}: {meetingId?: string},
         _args: unknown,
         {dataLoader, authToken}: GQLContext
       ) => {

--- a/packages/server/graphql/types/AcceptTeamInvitationPayload.ts
+++ b/packages/server/graphql/types/AcceptTeamInvitationPayload.ts
@@ -42,6 +42,9 @@ const AcceptTeamInvitationPayload = new GraphQLObjectType<any, GQLContext>({
         _args: unknown,
         {dataLoader, authToken}: GQLContext
       ) => {
+        if (!meetingId) {
+          return null
+        }
         const viewerId = getUserId(authToken)
         const meeting = await dataLoader.get('newMeetings').load(meetingId)
         if (!meeting) {


### PR DESCRIPTION
Fixes #7771

How to test:

- create a new team
- create an invite link from the team dashboard
- follow the invite link with a different user