### PR TITLE
feat(recurrence): Copy meeting series permalink

### DIFF
--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import {Close as CloseIcon, PersonAdd as PersonAddIcon} from '@mui/icons-material'
+import {Close as CloseIcon, Link, PersonAdd as PersonAddIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
@@ -15,6 +15,7 @@ import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventM
 import {PALETTE} from '../styles/paletteV3'
 import {HistoryMaybeLocalHandler, StandardMutation} from '../types/relayMutations'
 import getMassInvitationUrl from '../utils/getMassInvitationUrl'
+import makeAppURL from '../utils/makeAppURL'
 import {MeetingCardOptionsMenuQuery} from '../__generated__/MeetingCardOptionsMenuQuery.graphql'
 import {MeetingTypeEnum} from '../__generated__/SendClientSegmentEventMutation.graphql'
 import Menu from './Menu'
@@ -37,9 +38,14 @@ const StyledIcon = styled('div')({
   marginRight: 8
 })
 
+const LinkIcon = styled(Link)({
+  color: PALETTE.SLATE_600,
+  marginRight: 8
+})
+
 const OptionMenuItem = styled('div')({
   ...MenuItemLabelStyle,
-  width: '200px'
+  minWidth: '200px'
 })
 
 const EndMeetingMutationLookup: Record<
@@ -66,6 +72,11 @@ const query = graphql`
         id
         meetingType
         facilitatorUserId
+        ... on TeamPromptMeeting {
+          meetingSeries {
+            cancelledAt
+          }
+        }
       }
     }
   }
@@ -80,16 +91,40 @@ const MeetingCardOptionsMenu = (props: Props) => {
   const {id: viewerId, team, meeting} = viewer
   const {massInvitation} = team!
   const {id: token} = massInvitation
-  const {id: meetingId, meetingType, facilitatorUserId} = meeting!
+  const {id: meetingId, meetingType, facilitatorUserId, meetingSeries} = meeting!
   const isViewerFacilitator = facilitatorUserId === viewerId
   const canEndMeeting = meetingType === 'teamPrompt' || isViewerFacilitator
   const atmosphere = useAtmosphere()
   const {onCompleted, onError} = useMutationProps()
   const {history} = useRouter()
 
+  const hasRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
+
   const {closePortal} = menuProps
   return (
     <Menu ariaLabel={'Edit the meeting'} {...menuProps}>
+      {hasRecurrenceEnabled && (
+        <MenuItem
+          key='link'
+          label={
+            <OptionMenuItem>
+              <LinkIcon />
+              Copy meeting permalink
+            </OptionMenuItem>
+          }
+          onClick={async () => {
+            popTooltip()
+            closePortal()
+            const copyUrl = makeAppURL(window.location.origin, `meeting-series/${meetingId}`)
+            await navigator.clipboard.writeText(copyUrl)
+
+            SendClientSegmentEventMutation(atmosphere, 'Copied Meeting Series Link', {
+              teamId: team?.id,
+              meetingId: meetingId
+            })
+          }}
+        />
+      )}
       <MenuItem
         key='copy'
         label={

--- a/packages/client/components/MenuItemLabel.tsx
+++ b/packages/client/components/MenuItemLabel.tsx
@@ -8,7 +8,7 @@ export const MenuItemLabelStyle = {
   flex: 1,
   fontSize: 14,
   lineHeight: '24px',
-  padding: `4px 8px 4px 16px`
+  padding: `4px 16px 4px 16px`
 }
 
 const MenuItemLabel = styled('div')(MenuItemLabelStyle)

--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -33,11 +33,17 @@ interface Props {
 const TeamPromptOptions = (props: Props) => {
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
   const {
-    tooltipPortal,
-    openTooltip,
-    closeTooltip,
-    originRef: tooltipOriginRef
+    tooltipPortal: optionsTooltipPortal,
+    openTooltip: openOptionsTooltip,
+    closeTooltip: closeOptionsTooltip,
+    originRef: optionsTooltipOriginRef
   } = useTooltip<HTMLButtonElement>(MenuPosition.UPPER_CENTER)
+  const {
+    tooltipPortal: copiedTooltipPortal,
+    openTooltip: openCopiedTooltip,
+    closeTooltip: closeCopiedTooltip,
+    originRef: copiedTooltipRef
+  } = useTooltip<HTMLButtonElement>(MenuPosition.UPPER_RIGHT)
   const {meetingRef, openRecurrenceSettingsModal} = props
 
   const meeting = useFragment(
@@ -49,22 +55,31 @@ const TeamPromptOptions = (props: Props) => {
     meetingRef
   )
 
+  const popTooltip = () => {
+    openCopiedTooltip()
+    setTimeout(() => {
+      closeCopiedTooltip()
+    }, 2000)
+  }
+
   return (
     <>
       <OptionsButton
-        ref={mergeRefs(originRef, tooltipOriginRef)}
+        ref={mergeRefs(originRef, optionsTooltipOriginRef, copiedTooltipRef)}
         onClick={togglePortal}
-        onMouseEnter={openTooltip}
-        onMouseLeave={closeTooltip}
+        onMouseEnter={openOptionsTooltip}
+        onMouseLeave={closeOptionsTooltip}
       >
         <IconLabel ref={originRef} icon='more_vert' iconLarge />
       </OptionsButton>
-      {tooltipPortal('Options')}
+      {optionsTooltipPortal('Options')}
+      {copiedTooltipPortal('Copied!')}
       {menuPortal(
         <TeamPromptOptionsMenu
           meetingRef={meeting}
           menuProps={menuProps}
           openRecurrenceSettingsModal={openRecurrenceSettingsModal}
+          popTooltip={popTooltip}
         />
       )}
     </>

--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -12,6 +12,8 @@ import BaseButton from '../BaseButton'
 import IconLabel from '../IconLabel'
 import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
 
+const COPIED_TOOLTIP_DURATION_MS = 2000
+
 const OptionsButton = styled(BaseButton)({
   color: PALETTE.SLATE_600,
   height: '100%',
@@ -59,7 +61,7 @@ const TeamPromptOptions = (props: Props) => {
     openCopiedTooltip()
     setTimeout(() => {
       closeCopiedTooltip()
-    }, 2000)
+    }, COPIED_TOOLTIP_DURATION_MS)
   }
 
   return (

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -40,10 +40,11 @@ interface Props {
   meetingRef: TeamPromptOptionsMenu_meeting$key
   menuProps: MenuProps
   openRecurrenceSettingsModal: () => void
+  popTooltip: () => void
 }
 
 const TeamPromptOptionsMenu = (props: Props) => {
-  const {meetingRef, menuProps, openRecurrenceSettingsModal} = props
+  const {meetingRef, menuProps, openRecurrenceSettingsModal, popTooltip} = props
 
   const meeting = useFragment(
     graphql`
@@ -92,6 +93,8 @@ const TeamPromptOptionsMenu = (props: Props) => {
             </OptionMenuItem>
           }
           onClick={async () => {
+            popTooltip()
+            menuProps.closePortal()
             const copyUrl = makeAppURL(window.location.origin, `meeting-series/${meetingId}`)
             await navigator.clipboard.writeText(copyUrl)
 


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7703

Allow copying a meeting series' permalink from either the meeting card or the in-meeting options menu.

## Demo
https://www.loom.com/share/6f5e01dca25f4ae982c3320b66a58c4f

<img width="357" alt="Screen Shot 2023-02-15 at 2 29 03 PM" src="https://user-images.githubusercontent.com/9013217/219040669-8308e888-bde6-4da1-8295-94b574ee7682.png">
<img width="282" alt="Screen Shot 2023-02-15 at 2 29 19 PM" src="https://user-images.githubusercontent.com/9013217/219040679-f3daaa6e-e72f-4d91-a767-87e7b522e0fc.png">

## Testing scenarios
For both meeting card and in-meeting options menu, including previous meeting in a series:
- [ ] Click "copy meeting permalink"
- [ ] See tooltip "copied!"
- [ ] Paste the link into the browser navigation bar and confirm the link redirects to the most recent meeting in the series.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
