### PR TITLE
fix(standups): Autofocus the input in the discussion drawer when opened

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -289,6 +289,7 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
             setEditorState={setEditorState}
             teamId={teamId}
             readOnly={!allowComments}
+            discussionId={discussion.id}
           />
         </EditorWrap>
         <SendCommentButton

--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -123,7 +123,7 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
   const {picture} = viewer
   const isReply = !!props.isReply
   const isDisabled = !!props.isDisabled
-  const {id: discussionId, meetingId, isAnonymousComment, teamId} = discussion
+  const {id: discussionId, meetingId, isAnonymousComment, teamId, discussionTopicType} = discussion
   const [editorState, setEditorState] = useReplyEditorState(replyMention, setReplyMention)
   const atmosphere = useAtmosphere()
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
@@ -310,6 +310,7 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
             teamId={teamId}
             readOnly={!allowComments}
             discussionId={discussion.id}
+            autofocus={discussionTopicType === 'teamPromptResponse'}
           />
         </EditorWrap>
         <SendCommentButton

--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {ContentState, convertToRaw, EditorState} from 'draft-js'
 import React, {forwardRef, RefObject, useEffect, useState} from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import useReplyEditorState from '~/hooks/useReplyEditorState'
@@ -13,8 +13,8 @@ import {SORT_STEP} from '~/utils/constants'
 import dndNoise from '~/utils/dndNoise'
 import {convertStateToRaw} from '~/utils/draftjs/convertToTaskContent'
 import isAndroid from '~/utils/draftjs/isAndroid'
-import {DiscussionThreadInput_discussion} from '~/__generated__/DiscussionThreadInput_discussion.graphql'
-import {DiscussionThreadInput_viewer} from '~/__generated__/DiscussionThreadInput_viewer.graphql'
+import {DiscussionThreadInput_discussion$key} from '~/__generated__/DiscussionThreadInput_discussion.graphql'
+import {DiscussionThreadInput_viewer$key} from '~/__generated__/DiscussionThreadInput_viewer.graphql'
 import {useBeforeUnload} from '../hooks/useBeforeUnload'
 import useInitialLocalState from '../hooks/useInitialLocalState'
 import CreateTaskMutation from '../mutations/CreateTaskMutation'
@@ -74,8 +74,8 @@ interface Props {
   allowedThreadables: DiscussionThreadables[]
   editorRef: RefObject<HTMLTextAreaElement>
   getMaxSortOrder: () => number
-  discussion: DiscussionThreadInput_discussion
-  viewer: DiscussionThreadInput_viewer
+  discussion: DiscussionThreadInput_discussion$key
+  viewer: DiscussionThreadInput_viewer$key
   onSubmitCommentSuccess?: () => void
   threadParentId?: string
   isReply?: boolean
@@ -91,15 +91,35 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
     allowedThreadables,
     editorRef,
     getMaxSortOrder,
-    discussion,
+    discussion: discussionRef,
     onSubmitCommentSuccess,
     threadParentId,
     replyMention,
     setReplyMention,
     dataCy,
-    viewer,
+    viewer: viewerRef,
     isCreatingPoll
   } = props
+  const viewer = useFragment(
+    graphql`
+      fragment DiscussionThreadInput_viewer on User {
+        picture
+      }
+    `,
+    viewerRef
+  )
+  const discussion = useFragment(
+    graphql`
+      fragment DiscussionThreadInput_discussion on Discussion {
+        id
+        meetingId
+        teamId
+        isAnonymousComment
+        discussionTopicType
+      }
+    `,
+    discussionRef
+  )
   const {picture} = viewer
   const isReply = !!props.isReply
   const isDisabled = !!props.isDisabled
@@ -320,18 +340,4 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
   )
 })
 
-export default createFragmentContainer(DiscussionThreadInput, {
-  viewer: graphql`
-    fragment DiscussionThreadInput_viewer on User {
-      picture
-    }
-  `,
-  discussion: graphql`
-    fragment DiscussionThreadInput_discussion on Discussion {
-      id
-      meetingId
-      teamId
-      isAnonymousComment
-    }
-  `
-})
+export default DiscussionThreadInput

--- a/packages/client/components/TaskEditor/CommentEditor.tsx
+++ b/packages/client/components/TaskEditor/CommentEditor.tsx
@@ -7,7 +7,7 @@ import {
   EditorState,
   getDefaultKeyBinding
 } from 'draft-js'
-import React, {RefObject, Suspense, useRef} from 'react'
+import React, {RefObject, Suspense, useEffect, useRef} from 'react'
 import {AriaLabels, Card} from '../../types/constEnums'
 import {textTags} from '../../utils/constants'
 import completeEntity from '../../utils/draftjs/completeEntity'
@@ -53,6 +53,7 @@ interface Props extends DraftProps {
   onSubmit: () => void
   teamId: string
   dataCy: string
+  discussionId?: string
 }
 
 const CommentEditor = (props: Props) => {
@@ -66,6 +67,7 @@ const CommentEditor = (props: Props) => {
     onSubmit,
     onBlur,
     onFocus,
+    discussionId,
     dataCy
   } = props
   const entityPasteStartRef = useRef<{anchorOffset: number; anchorKey: string} | undefined>()
@@ -188,6 +190,12 @@ const CommentEditor = (props: Props) => {
     if (renderModal || !onBlur) return
     onBlur(e)
   }
+
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.focus()
+    }
+  }, [editorRef, discussionId])
 
   const useFallback = isAndroid && !readOnly
   const showFallback = useFallback && !isRichDraft(editorState)

--- a/packages/client/components/TaskEditor/CommentEditor.tsx
+++ b/packages/client/components/TaskEditor/CommentEditor.tsx
@@ -54,6 +54,7 @@ interface Props extends DraftProps {
   teamId: string
   dataCy: string
   discussionId?: string
+  autofocus?: boolean
 }
 
 const CommentEditor = (props: Props) => {
@@ -68,6 +69,7 @@ const CommentEditor = (props: Props) => {
     onBlur,
     onFocus,
     discussionId,
+    autofocus,
     dataCy
   } = props
   const entityPasteStartRef = useRef<{anchorOffset: number; anchorKey: string} | undefined>()
@@ -192,10 +194,14 @@ const CommentEditor = (props: Props) => {
   }
 
   useEffect(() => {
+    if (!autofocus) {
+      return
+    }
+
     if (editorRef.current) {
       editorRef.current.focus()
     }
-  }, [editorRef, discussionId])
+  }, [editorRef, discussionId, autofocus])
 
   const useFallback = isAndroid && !readOnly
   const showFallback = useFallback && !isRichDraft(editorState)

--- a/packages/client/components/TaskEditor/CommentEditor.tsx
+++ b/packages/client/components/TaskEditor/CommentEditor.tsx
@@ -201,7 +201,7 @@ const CommentEditor = (props: Props) => {
     if (editorRef.current) {
       editorRef.current.focus()
     }
-  }, [editorRef, discussionId, autofocus])
+  }, [discussionId, autofocus])
 
   const useFallback = isAndroid && !readOnly
   const showFallback = useFallback && !isRichDraft(editorState)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6873

Autofocus discussion drawer input in standup meetings.

This was previously fixed, but reverted because the autofocus was applied to _all_ meetings (not just standups), which broke facilitator-following in other activities. This PR specifically limits the autofocus to standup meetings.

Also migrates `DiscussionThreadInput` to `useFragment` via the [codeshift](https://github.com/ParabolInc/parabol/pull/7135)

## Demo

https://www.loom.com/share/5cfe7f8a464f418690b32ed7e54942e1

## Testing scenarios
- [ ] In a standup meeting, click the "reply" button, and confirm that the discussion autofocuses.
- [ ] Sign in as two different users in a different meeting type, and confirm that the non-facilitator follows the facilitator (see https://github.com/ParabolInc/parabol/issues/7268)

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
