### PR TITLE
fix(dashboard): Meeting card shadow doesn't match card

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -38,11 +38,15 @@ const CardWrapper = styled('div')<{
   opacity: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : 1,
   margin: 8,
   width: maybeTabletPlus ? ElementWidth.MEETING_CARD : '100%',
-  userSelect: 'none',
+  userSelect: 'none'
+}))
+
+const InnerCardWrapper = styled('div')({
+  position: 'relative',
   ':hover': {
     boxShadow: Elevation.CARD_SHADOW_HOVER
   }
-}))
+})
 
 const STACK_DEGREES = {
   0: 1,
@@ -242,7 +246,7 @@ const MeetingCard = (props: Props) => {
       status={status}
       onTransitionEnd={onTransitionEnd}
     >
-      <div style={{position: 'relative'}}>
+      <InnerCardWrapper>
         {isRecurring && (
           <>
             <StackedCard stackIndex={0}>
@@ -296,7 +300,7 @@ const MeetingCard = (props: Props) => {
           )}
           {tooltipPortal('Copied!')}
         </InnerCard>
-      </div>
+      </InnerCardWrapper>
     </CardWrapper>
   )
 }


### PR DESCRIPTION
# Description
Fixes issue in [slack](https://parabol.slack.com/archives/C836NA350/p1676561100303009) 🔒 

After recent changes to the component structure of meeting cards, shadows take up the height of the tallest card in the row, instead of the height of the actual card. This leads to weird effects like this:

<img width="686" alt="Screenshot 2023-02-16 at 16 21 38" src="https://user-images.githubusercontent.com/9013217/219441364-cbd14fba-d4e2-4322-967b-7983333d5db7.png">

This PR fixes that issue.

## Demo

Meeting series card shadow:
<img width="685" alt="Screen Shot 2023-02-16 at 6 21 45 PM" src="https://user-images.githubusercontent.com/9013217/219440617-6ac91587-cb69-441c-9a14-4d95176e39c6.png">

One-off meeting card shadow:
<img width="1394" alt="Screen Shot 2023-02-16 at 6 21 50 PM" src="https://user-images.githubusercontent.com/9013217/219440620-78fac6e0-47a3-4ba2-9108-0783db836e75.png">


## Testing scenarios
- [ ] Force one meeting card in a row to have more height than others by joining that meeting in another tab
- [ ] Hover over meeting cards (both meeting series and one-off meetings) and confirm that they have reasonable shadows

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
