### PR TITLE
fix: remove font-size 18px declaration on tasks editing status label

### DIFF
--- a/packages/client/components/EditingStatus/EditingStatusText.tsx
+++ b/packages/client/components/EditingStatus/EditingStatusText.tsx
@@ -8,7 +8,6 @@ import {TimestampType} from './EditingStatus'
 const StyledWrapper = styled('span')({
   display: 'block',
   overflow: 'visible',
-  fontSize: 18,
   overflowWrap: 'break-word'
 })
 


### PR DESCRIPTION
Fixes #7761

Removes an unwanted `font-size: 18px` declaration for the task editing status label.

## Demo

**Before:**
<img width="293" alt="218534402-63b1979e-cee7-4d7b-8019-a1de6ff37870" src="https://user-images.githubusercontent.com/3276087/219465057-3a25d235-d1c7-4ae6-9215-600ded116533.png">

**After:**
<img width="274" alt="Captura de pantalla 2023-02-16 a la(s) 1 12 52 p m" src="https://user-images.githubusercontent.com/3276087/219465073-0d3afb76-970f-4fe0-b4ef-2551d0cdd97e.png">

## Testing scenarios

- [ ] Editing a task
  - Edit a task on any team
  - When one user is editing the task, impersonate another team member and check the font size of the editing status label.
  - 
## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
