### PR TITLE
chore: select best platform for the job

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -2,7 +2,6 @@ version: "3.7"
 
 services:
   db:
-    platform: linux/x86_64
     image: rethinkdb:latest
     restart: unless-stopped
     ports:
@@ -40,7 +39,6 @@ services:
       - parabol-network
     restart: unless-stopped
   redis:
-    platform: linux/x86_64
     image: redis:latest
     restart: unless-stopped
     ports:
@@ -51,7 +49,7 @@ services:
       - parabol-network
   redis-commander:
     container_name: redis_commander
-    image: rediscommander/redis-commander:latest
+    image: ghcr.io/joeferner/redis-commander:latest
     hostname: redis-commander
     restart: unless-stopped
     environment:


### PR DESCRIPTION
# Description

fix #7785 

All dev containers run on the architecture as the host machine. no rosetta required.

## Demo

On an M1:
```sh
yarn db:stop
docker image rm redis && docker image rm rethinkdb && docker image rm rediscommander/redis-commander
yarn db:start
```

check docker desktop, see all images are ARM.