### PR TITLE
fix(ci): Fix 'Check Code Style' action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,13 +9,13 @@ jobs:
   install-deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "^16.16.0"
+          node-version: "16.16.0"
           cache: "yarn"
       - name: Cache node modules
         id: cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Check Code Style
 on: [push]
 
 env:
-  DEPENDENCIES_CACHE: cache-node-modules-v0
+  DEPENDENCIES_CACHE: cache-node-modules-v1
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16.16.0"
+          node-version: "^16.16.0"
           cache: "yarn"
       - name: Cache node modules
         id: cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v2
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -50,8 +52,6 @@ jobs:
       - name: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
       - name: Build Databases
         run: |
           cp .env.example .env

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,30 +3,9 @@ name: Check Code Style
 on: [push]
 
 env:
-  DEPENDENCIES_CACHE: cache-node-modules-v0
+  DEPENDENCIES_CACHE: cache-node-modules
 
 jobs:
-  install-deps:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16.16.0"
-          cache: "yarn"
-      - name: Cache node modules
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ env.DEPENDENCIES_CACHE }}-${{ hashFiles('yarn.lock') }}
-      - name: yarn install
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
   build:
     services:
       rethinkdb:
@@ -52,7 +31,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     runs-on: ubuntu-latest
-    needs: install-deps
     steps:
       - uses: actions/checkout@v2
         with:
@@ -62,6 +40,16 @@ jobs:
         with:
           node-version: "16.16.0"
           cache: "yarn"
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+          key: ${{ env.DEPENDENCIES_CACHE }}-${{ hashFiles('yarn.lock') }}
+      - name: yarn install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
       - name: Get cached node modules

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Check Code Style
 on: [push]
 
 env:
-  DEPENDENCIES_CACHE: cache-node-modules
+  DEPENDENCIES_CACHE: cache-node-modules-v0
 
 jobs:
   install-deps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,6 +57,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.16.0"
+          cache: "yarn"
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
       - name: Get cached node modules

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Check Code Style
 on: [push]
 
 env:
-  DEPENDENCIES_CACHE: cache-node-modules
+  DEPENDENCIES_CACHE: cache-node-modules-v0
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ name: Check Code Style
 on: [push]
 
 env:
-  DEPENDENCIES_CACHE: cache-node-modules-v1
+  DEPENDENCIES_CACHE: cache-node-modules
 
 jobs:
   build:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,12 +52,6 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2
-      - name: Get cached node modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ env.DEPENDENCIES_CACHE }}-${{ hashFiles('yarn.lock') }}
       - name: Build Databases
         run: |
           cp .env.example .env


### PR DESCRIPTION
# Description
The "Check Code Style / build" GitHub action is currently broken, likely due to the default node version used by Actions being changed from v16 to v18 at some point. We currently specify the node version as v16 in "Install Deps", but not "Build".

Fold "Install deps" logic into the "Build" step for simplicity and consistency (i.e. to ensure that the node versions and cache keys are the same between the two).

Commit history is a mess - I strongly recommend just reviewing the code as-is.

## Testing scenarios
N/A

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
