### PR TITLE
chore(retros-in-disguise): Added retros in disguise feature flag and empty route

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {ActivityLibraryQuery} from '~/__generated__/ActivityLibraryQuery.graphql'
+import {Redirect} from 'react-router'
+
+const query = graphql`
+  query ActivityLibraryQuery {
+    viewer {
+      featureFlags {
+        retrosInDisguise
+      }
+    }
+  }
+`
+
+interface Props {
+  queryRef: PreloadedQuery<ActivityLibraryQuery>
+}
+
+export const ActivityLibrary = (props: Props) => {
+  const {queryRef} = props
+  const data = usePreloadedQuery<ActivityLibraryQuery>(query, queryRef, {
+    UNSTABLE_renderPolicy: 'full'
+  })
+
+  if (!data.viewer.featureFlags.retrosInDisguise) {
+    return <Redirect to='/404' />
+  }
+
+  return <div>Activity Library</div>
+}

--- a/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
@@ -1,0 +1,20 @@
+import React, {Suspense} from 'react'
+
+import {ActivityLibrary} from './ActivityLibrary'
+import activityLibraryQuery, {
+  ActivityLibraryQuery
+} from '~/__generated__/ActivityLibraryQuery.graphql'
+import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
+import {renderLoader} from '../../utils/relay/renderLoader'
+
+const ActivityLibaryRoute = () => {
+  const queryRef = useQueryLoaderNow<ActivityLibraryQuery>(activityLibraryQuery)
+
+  return (
+    <Suspense fallback={renderLoader()}>
+      {queryRef && <ActivityLibrary queryRef={queryRef} />}
+    </Suspense>
+  )
+}
+
+export default ActivityLibaryRoute

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -43,6 +43,10 @@ const NewMeetingRoot = lazy(
   () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
 )
 
+const ActivityLibraryRoute = lazy(
+  () => import(/* webpackChunkName: 'ActivityLibrary' */ './ActivityLibrary/ActivityLibraryRoute')
+)
+
 interface Props {
   queryRef: PreloadedQuery<DashboardQuery>
 }
@@ -167,6 +171,7 @@ const Dashboard = (props: Props) => {
           </Switch>
           <Switch>
             <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
+            <Route path='/activity-library' component={ActivityLibraryRoute} />
           </Switch>
         </DashMain>
       </DashPanel>

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -43,10 +43,6 @@ const NewMeetingRoot = lazy(
   () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
 )
 
-const ActivityLibraryRoute = lazy(
-  () => import(/* webpackChunkName: 'ActivityLibrary' */ './ActivityLibrary/ActivityLibraryRoute')
-)
-
 interface Props {
   queryRef: PreloadedQuery<DashboardQuery>
 }
@@ -171,7 +167,6 @@ const Dashboard = (props: Props) => {
           </Switch>
           <Switch>
             <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
-            <Route path='/activity-library' component={ActivityLibraryRoute} />
           </Switch>
         </DashMain>
       </DashPanel>

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -37,15 +37,17 @@ const ViewerNotOnTeamRoot = lazy(
   () => import(/* webpackChunkName: 'ViewerNotOnTeamRoot' */ './ViewerNotOnTeamRoot')
 )
 
+const ActivityLibraryRoute = lazy(
+  () => import(/* webpackChunkName: 'ActivityLibrary' */ './ActivityLibrary/ActivityLibraryRoute')
+)
+
 const PrivateRoutes = () => {
   useAuthRoute()
   useNoIndex()
   return (
     <Switch>
-      <Route
-        path='(/meetings|/me|/newteam|/team|/usage|/new-meeting|/activity-library)'
-        component={DashboardRoot}
-      />
+      <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
+      <Route path='/activity-library' component={ActivityLibraryRoute} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />
       <Route path='/invoice/:invoiceId' component={Invoice} />

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -42,7 +42,10 @@ const PrivateRoutes = () => {
   useNoIndex()
   return (
     <Switch>
-      <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
+      <Route
+        path='(/meetings|/me|/newteam|/team|/usage|/new-meeting|/activity-library)'
+        component={DashboardRoot}
+      />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />
       <Route path='/invoice/:invoiceId' component={Invoice} />

--- a/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
+++ b/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
@@ -11,6 +11,7 @@ enum UserFlagEnum {
   aiSummary
   noMeetingHistoryLimit
   checkoutFlow
+  retrosInDisguise
 }
 
 """
@@ -26,6 +27,7 @@ type UserFeatureFlags {
   aiSummary: Boolean!
   noMeetingHistoryLimit: Boolean!
   checkoutFlow: Boolean!
+  retrosInDisguise: Boolean!
 }
 
 extend type Mutation {

--- a/packages/server/graphql/public/types/UserFeatureFlags.ts
+++ b/packages/server/graphql/public/types/UserFeatureFlags.ts
@@ -7,7 +7,8 @@ const UserFeatureFlags: UserFeatureFlagsResolvers = {
   templateLimit: ({templateLimit}) => !!templateLimit,
   aiSummary: ({aiSummary}) => !!aiSummary,
   noMeetingHistoryLimit: ({noMeetingHistoryLimit}) => !!noMeetingHistoryLimit,
-  checkoutFlow: ({checkoutFlow}) => !!checkoutFlow
+  checkoutFlow: ({checkoutFlow}) => !!checkoutFlow,
+  retrosInDisguise: ({retrosInDisguise}) => !!retrosInDisguise
 }
 
 export default UserFeatureFlags


### PR DESCRIPTION
# Description

This PR adds `retrosInDisguise` feature flag and an empty frontend component for activity library. Empty component is accessible under `/activity-library` route, if the `retrosInDisguise` feature flag was set. If not, it'll redirect to 404.

Component names, route urls and everything else are TDB and intention of this PR is only add stub components so we can start working on the details. 

## Demo

No demo

## Testing scenarios

- [ ] Add a `retrosInDisguise` feature flag, check if `/activity-library` is accessible

- [ ] Check if a new route will redirect to 404 if user doesn't have feature flag set 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
