### PR TITLE
chore(docker): Redis and RethinkDB database versions fixed for the development docker-compose

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: rethinkdb:latest
+    image: rethinkdb:2.3.7
     restart: unless-stopped
     ports:
       - "8080:8080"
@@ -39,7 +39,7 @@ services:
       - parabol-network
     restart: unless-stopped
   redis:
-    image: redis:latest
+    image: redis:6
     restart: unless-stopped
     ports:
       - "6379:6379"


### PR DESCRIPTION
# Description
Using fixed versions of RethinkDB, Redis and PostgreSQL would assure that all developers have the same workstation setup. Currently, everyone might be using a different version of the databases in their workstation, and those version might be different than the ones in staging and production.

If an upgrade is performed for any of the databases, the developer would need to modify the `docker/dev.yml` and the code and libraries, pushing then all in the same PR, which will force the upgrade for all developers once is merged to master.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
