### PR TITLE
chore(docker-compose): RethinkDB fixed to v2.4.2 and Redis fixed to v6 for local development and self-hosted deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
-version: '3.7'
+version: "3.7"
 
 services:
   db:
-    image: rethinkdb:latest
+    image: rethinkdb:2.4.2
     ports:
-      - '8080:8080'
-      - '29015:29015'
-      - '28015:28015'
+      - "8080:8080"
+      - "29015:29015"
+      - "28015:28015"
     volumes:
       - rethink-data:/data
     networks:
@@ -16,17 +16,17 @@ services:
     restart: always
     env_file: .env
     ports:
-      - '5432:5432'
+      - "5432:5432"
     volumes:
-      - './packages/server/postgres/postgres.conf:/usr/local/etc/postgres/postgres.conf'
-      - 'postgres-data:/data'
-    command: 'postgres -c config_file=/usr/local/etc/postgres/postgres.conf'
+      - "./packages/server/postgres/postgres.conf:/usr/local/etc/postgres/postgres.conf"
+      - "postgres-data:/data"
+    command: "postgres -c config_file=/usr/local/etc/postgres/postgres.conf"
     networks:
       - parabol-network
   redis:
-    image: redis
+    image: redis:6
     ports:
-      - '6379:6379'
+      - "6379:6379"
     volumes:
       - redis-data:/data
     networks:
@@ -38,7 +38,7 @@ services:
       target: prod
     env_file: .env
     ports:
-      - '3000:3000'
+      - "3000:3000"
     depends_on:
       - db
       - redis

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   db:
-    image: rethinkdb:2.3.7
+    image: rethinkdb:2.4.2
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
# Description
RethinkDB 2.3.7 wasn't available for arm64. We agreed on using 2.4.2 locally as there weren't breaking changes between 2.3.7 and 2.4.2 (the version in staging and production). We should upgrade RethinkDB in the future to 2.4.2.

docker-compose.yml file wasn't modified on the last PR and thus the database versions weren't fixed there. They are now.

We are aware that the Dockerfile.prod might not work anymore and we will address that in another PR.

## Testing scenarios
Before testing, it is probably better to remove volumes that can be in a newer version of Redis or RethinkDB with `yarn db:stop && docker volume rm docker_redis-data docker_rethink-data`

- First scenario: run `yarn db:start` and then `yarn dev` to test the application locally.
- Run `docker-compose -f docker-compose.yml -f ./docker/docker-compose.selfHosted.yml up -d` or `docker compose -f docker-compose.yml -f ./docker/docker-compose.selfHosted.yml up -d` (which might not work due to the **docker/Dockerfile.prod**). If the Docker image is built, you should be able to test the application.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
