### PR TITLE
fix: align search bar with meeting cards

### DIFF
--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -33,7 +33,7 @@ const EmptyContainer = styled('div')({
   flexDirection: 'column',
   height: '100%',
   maxWidth: Layout.TASK_COLUMNS_MAX_WIDTH,
-  padding: 16,
+  padding: '16px 8px',
   position: 'relative'
 })
 

--- a/packages/client/components/TopBarSearch.tsx
+++ b/packages/client/components/TopBarSearch.tsx
@@ -43,7 +43,7 @@ const Wrapper = styled('div')<{location: any}>(({location}) => ({
   display: 'flex',
   flex: 1,
   height: 40,
-  margin: '8px 16px',
+  margin: 8,
   maxWidth: 480,
   visibility: getShowSearch(location) ? undefined : 'hidden'
 }))


### PR DESCRIPTION
# Description

No issue, it's just a small UI improvement to visually align search bar and meeting cards. See the conversation [🔒 here.](https://parabol.slack.com/archives/C02438U0VJ4/p1677246806926119)

## Demo

Before
<img width="1395" alt="Screenshot 2023-03-02 at 13 54 09" src="https://user-images.githubusercontent.com/1017620/222434456-baa06359-07ce-493c-acb6-6adb8ba1f9ba.png">

After
<img width="1453" alt="Screenshot 2023-02-28 at 16 05 29" src="https://user-images.githubusercontent.com/1017620/222434512-8f69f820-fc9d-4091-9e0f-46fe0edaea97.png">

## Testing scenarios

- [ ] Open dashboard, check different screen sizes and make sure the one where cards are aligned with search bar looks good

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
