### PR TITLE
feat(retros-in-disguise): Base activity library + stubbed cards

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -46,6 +46,7 @@
           "Discussion": "../../postgres/queries/generated/getDiscussionsByIdsQuery#IGetDiscussionsByIdsQueryResult",
           "JiraRemoteProject": "../types/JiraRemoteProject#JiraRemoteProjectSource",
           "LoginWithGooglePayload": "./types/LoginWithGooglePayload#LoginWithGooglePayloadSource",
+          "MeetingTemplate": "../../database/types/MeetingTemplate#default",
           "MeetingSeries": "../../postgres/types/MeetingSeries#MeetingSeries",
           "NewMeeting": "../../postgres/types/Meeting#AnyMeeting",
           "NotificationMeetingStageTimeLimitEnd": "../../database/types/NotificationMeetingStageTimeLimitEnd#default as NotificationMeetingStageTimeLimitEndDB",

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -1,16 +1,18 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {useEffect, useRef} from 'react'
+import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {Redirect} from 'react-router'
 import {ActivityLibraryQuery, MeetingTypeEnum} from '~/__generated__/ActivityLibraryQuery.graphql'
-import useRouter from '../../hooks/useRouter'
-import sortByTier from '../../utils/sortByTier'
 import ActivityLibrarySideBar from './ActivityLibrarySideBar'
 import ActivityLibraryCard from './ActivityLibraryCard'
 
 graphql`
   fragment ActivityLibrary_template on MeetingTemplate {
     id
+    teamId
+    team {
+      name
+    }
     name
     type
   }
@@ -19,58 +21,15 @@ graphql`
 const query = graphql`
   query ActivityLibraryQuery {
     viewer {
+      availableTemplates(first: 100) @connection(key: "ActivityLibrary_availableTemplates") {
+        edges {
+          node {
+            ...ActivityLibrary_template @relay(mask: false)
+          }
+        }
+      }
       featureFlags {
         retrosInDisguise
-      }
-      teams {
-        id
-        name
-        tier
-        retroSettings: meetingSettings(meetingType: retrospective) {
-          ... on RetrospectiveMeetingSettings {
-            teamTemplates {
-              ...ActivityLibrary_template @relay(mask: false)
-            }
-            organizationTemplates(first: 20)
-              @connection(key: "ReflectTemplateListOrg_organizationTemplates") {
-              edges {
-                node {
-                  ...ActivityLibrary_template @relay(mask: false)
-                }
-              }
-            }
-            publicTemplates(first: 50)
-              @connection(key: "ReflectTemplateListPublic_publicTemplates") {
-              edges {
-                node {
-                  ...ActivityLibrary_template @relay(mask: false)
-                }
-              }
-            }
-          }
-        }
-        pokerSettings: meetingSettings(meetingType: poker) {
-          ... on PokerMeetingSettings {
-            teamTemplates {
-              ...ActivityLibrary_template @relay(mask: false)
-            }
-            organizationTemplates(first: 20)
-              @connection(key: "PokerTemplateListOrg_organizationTemplates") {
-              edges {
-                node {
-                  ...ActivityLibrary_template @relay(mask: false)
-                }
-              }
-            }
-            publicTemplates(first: 50) @connection(key: "PokerTemplateListOrg_publicTemplates") {
-              edges {
-                node {
-                  ...ActivityLibrary_template @relay(mask: false)
-                }
-              }
-            }
-          }
-        }
       }
     }
   }
@@ -78,41 +37,26 @@ const query = graphql`
 
 interface Props {
   queryRef: PreloadedQuery<ActivityLibraryQuery>
-  teamId?: string | null
 }
 
 export const ActivityLibrary = (props: Props) => {
-  const {queryRef, teamId} = props
+  const {queryRef} = props
   const data = usePreloadedQuery<ActivityLibraryQuery>(query, queryRef, {
     UNSTABLE_renderPolicy: 'full'
   })
   const {viewer} = data
-  const {teams, featureFlags} = viewer
-
-  const {history, location} = useRouter()
-
-  const sendToMeRef = useRef(false)
-  useEffect(() => {
-    if (!teamId) {
-      sendToMeRef.current = true
-      const [firstTeam] = sortByTier(teams)
-      const nextPath = firstTeam ? `/activity-library/${firstTeam.id}` : '/newteam'
-      history.replace(nextPath, location.state)
-    }
-  }, [])
-
-  const selectedTeam = teams.find((team) => team.id === teamId)
+  const {featureFlags, availableTemplates} = viewer
 
   const templates = [
-    {id: 'action', type: 'action', name: 'Check-in'},
-    {id: 'teamPrompt', type: 'teamPrompt', name: 'Standup'},
-    ...(selectedTeam?.pokerSettings.teamTemplates ?? []),
-    ...(selectedTeam?.retroSettings.teamTemplates ?? []),
-    ...(selectedTeam?.pokerSettings.organizationTemplates?.edges?.map((edge) => edge.node) ?? []),
-    ...(selectedTeam?.retroSettings.organizationTemplates?.edges?.map((edge) => edge.node) ?? []),
-    ...(selectedTeam?.pokerSettings.publicTemplates?.edges?.map((edge) => edge.node) ?? []),
-    ...(selectedTeam?.retroSettings.publicTemplates?.edges?.map((edge) => edge.node) ?? [])
-  ] as {id: string; name: string; type: MeetingTypeEnum}[]
+    {id: 'action', type: 'action', name: 'Check-in', team: {name: 'Parabol'}},
+    {id: 'teamPrompt', type: 'teamPrompt', name: 'Standup', team: {name: 'Parabol'}},
+    ...availableTemplates.edges.map((edge) => edge.node)
+  ] as {
+    id: string
+    name: string
+    type: MeetingTypeEnum
+    team: {name: string}
+  }[]
 
   if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />
@@ -123,7 +67,12 @@ export const ActivityLibrary = (props: Props) => {
       <ActivityLibrarySideBar />
       <div className='flex flex-wrap'>
         {templates.map((template) => (
-          <ActivityLibraryCard key={template.id} type={template.type} name={template.name} />
+          <ActivityLibraryCard
+            key={template.id}
+            type={template.type}
+            name={template.name}
+            teamName={template.team.name}
+          />
         ))}
       </div>
     </div>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {Redirect} from 'react-router'
-import {ActivityLibraryQuery, MeetingTypeEnum} from '~/__generated__/ActivityLibraryQuery.graphql'
+import {ActivityLibraryQuery} from '~/__generated__/ActivityLibraryQuery.graphql'
 import ActivityLibrarySideBar from './ActivityLibrarySideBar'
 import ActivityLibraryCard from './ActivityLibraryCard'
 
@@ -51,12 +51,7 @@ export const ActivityLibrary = (props: Props) => {
     {id: 'action', type: 'action', name: 'Check-in', team: {name: 'Parabol'}},
     {id: 'teamPrompt', type: 'teamPrompt', name: 'Standup', team: {name: 'Parabol'}},
     ...availableTemplates.edges.map((edge) => edge.node)
-  ] as {
-    id: string
-    name: string
-    type: MeetingTypeEnum
-    team: {name: string}
-  }[]
+  ]
 
   if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -1,8 +1,20 @@
-import React from 'react'
 import graphql from 'babel-plugin-relay/macro'
+import React, {useEffect, useRef} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {ActivityLibraryQuery} from '~/__generated__/ActivityLibraryQuery.graphql'
 import {Redirect} from 'react-router'
+import {ActivityLibraryQuery, MeetingTypeEnum} from '~/__generated__/ActivityLibraryQuery.graphql'
+import useRouter from '../../hooks/useRouter'
+import sortByTier from '../../utils/sortByTier'
+import ActivityLibrarySideBar from './ActivityLibrarySideBar'
+import ActivityLibraryCard from './ActivityLibraryCard'
+
+graphql`
+  fragment ActivityLibrary_template on MeetingTemplate {
+    id
+    name
+    type
+  }
+`
 
 const query = graphql`
   query ActivityLibraryQuery {
@@ -10,23 +22,110 @@ const query = graphql`
       featureFlags {
         retrosInDisguise
       }
+      teams {
+        id
+        name
+        tier
+        retroSettings: meetingSettings(meetingType: retrospective) {
+          ... on RetrospectiveMeetingSettings {
+            teamTemplates {
+              ...ActivityLibrary_template @relay(mask: false)
+            }
+            organizationTemplates(first: 20)
+              @connection(key: "ReflectTemplateListOrg_organizationTemplates") {
+              edges {
+                node {
+                  ...ActivityLibrary_template @relay(mask: false)
+                }
+              }
+            }
+            publicTemplates(first: 50)
+              @connection(key: "ReflectTemplateListPublic_publicTemplates") {
+              edges {
+                node {
+                  ...ActivityLibrary_template @relay(mask: false)
+                }
+              }
+            }
+          }
+        }
+        pokerSettings: meetingSettings(meetingType: poker) {
+          ... on PokerMeetingSettings {
+            teamTemplates {
+              ...ActivityLibrary_template @relay(mask: false)
+            }
+            organizationTemplates(first: 20)
+              @connection(key: "PokerTemplateListOrg_organizationTemplates") {
+              edges {
+                node {
+                  ...ActivityLibrary_template @relay(mask: false)
+                }
+              }
+            }
+            publicTemplates(first: 50) @connection(key: "PokerTemplateListOrg_publicTemplates") {
+              edges {
+                node {
+                  ...ActivityLibrary_template @relay(mask: false)
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 `
 
 interface Props {
   queryRef: PreloadedQuery<ActivityLibraryQuery>
+  teamId?: string | null
 }
 
 export const ActivityLibrary = (props: Props) => {
-  const {queryRef} = props
+  const {queryRef, teamId} = props
   const data = usePreloadedQuery<ActivityLibraryQuery>(query, queryRef, {
     UNSTABLE_renderPolicy: 'full'
   })
+  const {viewer} = data
+  const {teams, featureFlags} = viewer
 
-  if (!data.viewer.featureFlags.retrosInDisguise) {
+  const {history, location} = useRouter()
+
+  const sendToMeRef = useRef(false)
+  useEffect(() => {
+    if (!teamId) {
+      sendToMeRef.current = true
+      const [firstTeam] = sortByTier(teams)
+      const nextPath = firstTeam ? `/activity-library/${firstTeam.id}` : '/newteam'
+      history.replace(nextPath, location.state)
+    }
+  }, [])
+
+  const selectedTeam = teams.find((team) => team.id === teamId)
+
+  const templates = [
+    {id: 'action', type: 'action', name: 'Check-in'},
+    {id: 'teamPrompt', type: 'teamPrompt', name: 'Standup'},
+    ...(selectedTeam?.pokerSettings.teamTemplates ?? []),
+    ...(selectedTeam?.retroSettings.teamTemplates ?? []),
+    ...(selectedTeam?.pokerSettings.organizationTemplates?.edges?.map((edge) => edge.node) ?? []),
+    ...(selectedTeam?.retroSettings.organizationTemplates?.edges?.map((edge) => edge.node) ?? []),
+    ...(selectedTeam?.pokerSettings.publicTemplates?.edges?.map((edge) => edge.node) ?? []),
+    ...(selectedTeam?.retroSettings.publicTemplates?.edges?.map((edge) => edge.node) ?? [])
+  ] as {id: string; name: string; type: MeetingTypeEnum}[]
+
+  if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />
   }
 
-  return <div>Activity Library</div>
+  return (
+    <div className='flex'>
+      <ActivityLibrarySideBar />
+      <div className='flex flex-wrap'>
+        {templates.map((template) => (
+          <ActivityLibraryCard key={template.id} type={template.type} name={template.name} />
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
@@ -3,13 +3,16 @@ import React from 'react'
 interface Props {
   name: string
   type: string
+  teamName: string
 }
 
 const ActivityLibraryCard = (props: Props) => {
-  const {type, name} = props
+  const {type, name, teamName} = props
   return (
     <div className='m-2 border-solid p-2'>
-      <div>{type}</div>
+      <div>
+        {type} on team {teamName}
+      </div>
       <div className='text-lg font-bold'>{name}</div>
     </div>
   )

--- a/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface Props {
+  name: string
+  type: string
+}
+
+const ActivityLibraryCard = (props: Props) => {
+  const {type, name} = props
+  return (
+    <div className='m-2 border-solid p-2'>
+      <div>{type}</div>
+      <div className='text-lg font-bold'>{name}</div>
+    </div>
+  )
+}
+
+export default ActivityLibraryCard

--- a/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
@@ -1,18 +1,21 @@
 import React, {Suspense} from 'react'
-
-import {ActivityLibrary} from './ActivityLibrary'
 import activityLibraryQuery, {
   ActivityLibraryQuery
 } from '~/__generated__/ActivityLibraryQuery.graphql'
 import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
+import useRouter from '../../hooks/useRouter'
 import {renderLoader} from '../../utils/relay/renderLoader'
+import {ActivityLibrary} from './ActivityLibrary'
 
 const ActivityLibaryRoute = () => {
+  const {match} = useRouter<{teamId: string}>()
+  const {params} = match
+  const {teamId} = params
   const queryRef = useQueryLoaderNow<ActivityLibraryQuery>(activityLibraryQuery)
 
   return (
     <Suspense fallback={renderLoader()}>
-      {queryRef && <ActivityLibrary queryRef={queryRef} />}
+      {queryRef && <ActivityLibrary teamId={teamId} queryRef={queryRef} />}
     </Suspense>
   )
 }

--- a/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
@@ -3,19 +3,15 @@ import activityLibraryQuery, {
   ActivityLibraryQuery
 } from '~/__generated__/ActivityLibraryQuery.graphql'
 import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
-import useRouter from '../../hooks/useRouter'
 import {renderLoader} from '../../utils/relay/renderLoader'
 import {ActivityLibrary} from './ActivityLibrary'
 
 const ActivityLibaryRoute = () => {
-  const {match} = useRouter<{teamId: string}>()
-  const {params} = match
-  const {teamId} = params
   const queryRef = useQueryLoaderNow<ActivityLibraryQuery>(activityLibraryQuery)
 
   return (
     <Suspense fallback={renderLoader()}>
-      {queryRef && <ActivityLibrary teamId={teamId} queryRef={queryRef} />}
+      {queryRef && <ActivityLibrary queryRef={queryRef} />}
     </Suspense>
   )
 }

--- a/packages/client/components/ActivityLibrary/ActivityLibrarySideBar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrarySideBar.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import LogoBlock from '../LogoBlock/LogoBlock'
+
+const ActivityLibrarySideBar = () => {
+  return (
+    <div className='mr-20'>
+      <div className='flex w-max items-center'>
+        <LogoBlock className='ml-1' />
+        <div className='w-max text-xl font-semibold'>Start Activity</div>
+      </div>
+    </div>
+  )
+}
+
+export default ActivityLibrarySideBar

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -47,7 +47,7 @@ const PrivateRoutes = () => {
   return (
     <Switch>
       <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
-      <Route path='/activity-library' component={ActivityLibraryRoute} />
+      <Route path='/activity-library/:teamId?' component={ActivityLibraryRoute} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />
       <Route path='/invoice/:invoiceId' component={Invoice} />

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -47,7 +47,7 @@ const PrivateRoutes = () => {
   return (
     <Switch>
       <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
-      <Route path='/activity-library/:teamId?' component={ActivityLibraryRoute} />
+      <Route path='/activity-library' component={ActivityLibraryRoute} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />
       <Route path='/invoice/:invoiceId' component={Invoice} />

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -937,6 +937,15 @@ type User {
     """
     userId: ID!
   ): User
+
+  availableTemplates(
+    first: Int!
+
+    """
+    The cursor, which is the templateId
+    """
+    after: ID
+  ): MeetingTemplateConnection!
 }
 
 """
@@ -5232,6 +5241,36 @@ type PokerMeetingSettings implements TeamMeetingSettings {
     """
     after: ID
   ): PokerTemplateConnection!
+}
+
+"""
+A connection to a list of items.
+"""
+type MeetingTemplateConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [MeetingTemplateEdge!]!
+}
+
+"""
+An edge in a connection.
+"""
+type MeetingTemplateEdge {
+  """
+  The item at the end of the edge
+  """
+  node: MeetingTemplate!
+
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
 }
 
 """

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -16,6 +16,7 @@ import isValid from '../../isValid'
 import MeetingTemplate from '../../../database/types/MeetingTemplate'
 import db from '../../../db'
 import connectionFromTemplateArray from '../../queries/helpers/connectionFromTemplateArray'
+import {ORG_HOTNESS_FACTOR, TEAM_HOTNESS_FACTOR} from '../../../utils/getTemplateScore'
 
 const User: UserResolvers = {
   company: async ({email}, _args, {authToken}) => {
@@ -79,7 +80,10 @@ const User: UserResolvers = {
         ...teamIds.map((teamId) => ({teamId, meetingType: 'poker' as MeetingTypeEnum})),
         ...teamIds.map((teamId) => ({teamId, meetingType: 'retrospective' as MeetingTypeEnum}))
       ])
-    const scoredTeamTemplates = await getScoredTemplates(teamTemplates.filter(isValid).flat(), 0.9)
+    const scoredTeamTemplates = await getScoredTemplates(
+      teamTemplates.filter(isValid).flat(),
+      TEAM_HOTNESS_FACTOR
+    )
 
     // Get the org templates.
     const teams = await dataLoader.get('teams').loadMany(teamIds)
@@ -92,7 +96,7 @@ const User: UserResolvers = {
         (template: MeetingTemplate) =>
           template.scope !== 'TEAM' && !teamIds.includes(template.teamId)
       )
-    const scoredOrgTemplates = await getScoredTemplates(organizationTemplates, 0.8)
+    const scoredOrgTemplates = await getScoredTemplates(organizationTemplates, ORG_HOTNESS_FACTOR)
 
     // Get the public templates.
     const publicRetroTemplates = await db.read('publicTemplates', 'retrospective')

--- a/packages/server/graphql/queries/helpers/connectionFromTemplateArray.ts
+++ b/packages/server/graphql/queries/helpers/connectionFromTemplateArray.ts
@@ -1,7 +1,7 @@
-const connectionFromTemplateArray = (
-  scoredTemplates: {createdAt: Date; id: string}[],
+const connectionFromTemplateArray = <T extends {createdAt: Date; id: string}>(
+  scoredTemplates: T[],
   first: number,
-  after: string
+  after?: string | null
 ) => {
   const startIdx = after ? scoredTemplates.findIndex((template) => template.id === after) : 0
   const safeStartIdx = startIdx === -1 ? 0 : startIdx
@@ -16,7 +16,8 @@ const connectionFromTemplateArray = (
     pageInfo: {
       startCursor: firstEdge && firstEdge.cursor,
       endCursor: firstEdge ? edges[edges.length - 1]!.cursor : '',
-      hasNextPage: scoredTemplates.length > nodes.length
+      hasNextPage: scoredTemplates.length > nodes.length,
+      hasPreviousPage: false
     }
   }
 }

--- a/packages/server/graphql/queries/helpers/getScoredTemplates.ts
+++ b/packages/server/graphql/queries/helpers/getScoredTemplates.ts
@@ -1,8 +1,8 @@
 import db from '../../../db'
 import getTemplateScore from '../../../utils/getTemplateScore'
 
-const getScoredTemplates = async (
-  templates: {createdAt: Date; id: string}[],
+const getScoredTemplates = async <T extends {createdAt: Date; id: string}>(
+  templates: T[],
   newHotnessFactor: number
 ) => {
   const sharedTemplateIds = templates.map(({id}) => id)

--- a/packages/server/graphql/types/PokerMeetingSettings.ts
+++ b/packages/server/graphql/types/PokerMeetingSettings.ts
@@ -7,6 +7,7 @@ import getScoredTemplates from '../queries/helpers/getScoredTemplates'
 import resolveSelectedTemplate from '../queries/helpers/resolveSelectedTemplate'
 import PokerTemplate, {PokerTemplateConnection} from './PokerTemplate'
 import TeamMeetingSettings, {teamMeetingSettingsFields} from './TeamMeetingSettings'
+import {ORG_HOTNESS_FACTOR, TEAM_HOTNESS_FACTOR} from '../../utils/getTemplateScore'
 
 const PokerMeetingSettings = new GraphQLObjectType<any, GQLContext>({
   name: 'PokerMeetingSettings',
@@ -30,7 +31,7 @@ const PokerMeetingSettings = new GraphQLObjectType<any, GQLContext>({
         const templates = await dataLoader
           .get('meetingTemplatesByType')
           .load({teamId, meetingType: 'poker'})
-        const scoredTemplates = await getScoredTemplates(templates, 0.9)
+        const scoredTemplates = await getScoredTemplates(templates, TEAM_HOTNESS_FACTOR)
         return scoredTemplates
       }
     },
@@ -54,7 +55,7 @@ const PokerMeetingSettings = new GraphQLObjectType<any, GQLContext>({
           (template: MeetingTemplate) =>
             template.scope !== 'TEAM' && template.teamId !== teamId && template.type === 'poker'
         )
-        const scoredTemplates = await getScoredTemplates(organizationTemplates, 0.8)
+        const scoredTemplates = await getScoredTemplates(organizationTemplates, ORG_HOTNESS_FACTOR)
         return connectionFromTemplateArray(scoredTemplates, first, after)
       }
     },

--- a/packages/server/graphql/types/RetrospectiveMeetingSettings.ts
+++ b/packages/server/graphql/types/RetrospectiveMeetingSettings.ts
@@ -15,6 +15,7 @@ import getScoredTemplates from '../queries/helpers/getScoredTemplates'
 import resolveSelectedTemplate from '../queries/helpers/resolveSelectedTemplate'
 import ReflectTemplate, {ReflectTemplateConnection} from './ReflectTemplate'
 import TeamMeetingSettings, {teamMeetingSettingsFields} from './TeamMeetingSettings'
+import {ORG_HOTNESS_FACTOR, TEAM_HOTNESS_FACTOR} from '../../utils/getTemplateScore'
 
 const RetrospectiveMeetingSettings: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<
   any,
@@ -63,7 +64,7 @@ const RetrospectiveMeetingSettings: GraphQLObjectType<any, GQLContext> = new Gra
         const templates = await dataLoader
           .get('meetingTemplatesByType')
           .load({teamId, meetingType: 'retrospective' as MeetingTypeEnum})
-        const scoredTemplates = await getScoredTemplates(templates, 0.9)
+        const scoredTemplates = await getScoredTemplates(templates, TEAM_HOTNESS_FACTOR)
         return scoredTemplates
       }
     },
@@ -89,7 +90,7 @@ const RetrospectiveMeetingSettings: GraphQLObjectType<any, GQLContext> = new Gra
             template.teamId !== teamId &&
             (template.type as MeetingTypeEnum) === 'retrospective'
         )
-        const scoredTemplates = await getScoredTemplates(organizationTemplates, 0.8)
+        const scoredTemplates = await getScoredTemplates(organizationTemplates, ORG_HOTNESS_FACTOR)
         return connectionFromTemplateArray(scoredTemplates, first, after)
       }
     },

--- a/packages/server/utils/getTemplateScore.ts
+++ b/packages/server/utils/getTemplateScore.ts
@@ -17,7 +17,8 @@ export const ORG_HOTNESS_FACTOR = 0.8
 export const TEAM_HOTNESS_FACTOR = 0.9
 
 const getAgeScore = (age: number) => {
-  return SATURTION / (1 + Math.exp((Math.log(81) / GROWTH_INTERVAL) * (age - MIDPOINT)))
+  const ageDays = age / 1000 / 60 / 60 / 24
+  return SATURTION / (1 + Math.exp((Math.log(81) / GROWTH_INTERVAL) * (ageDays - MIDPOINT)))
 }
 
 // weightCreatedAt: 0-1, how important is age vs. the number of meetings run

--- a/packages/server/utils/getTemplateScore.ts
+++ b/packages/server/utils/getTemplateScore.ts
@@ -12,6 +12,10 @@ const SATURTION = 1 // max score, we want a score that is 0-1
 const MIDPOINT = 45 // after this many days, the score will be SATURATION / 2
 const GROWTH_INTERVAL = 30 // 80% of the decline happens in this many days
 
+// Default hotness factors for ranking templates
+export const ORG_HOTNESS_FACTOR = 0.8
+export const TEAM_HOTNESS_FACTOR = 0.9
+
 const getAgeScore = (age: number) => {
   return SATURTION / (1 + Math.exp((Math.log(81) / GROWTH_INTERVAL) * (age - MIDPOINT)))
 }


### PR DESCRIPTION
# Description
Create the basic layout for the activity library + stubbed activity "cards".

From here, we can implement activity card designs in parallel with categories + search (which effectively just filter the activity cards shown).

Fixes https://github.com/ParabolInc/parabol/issues/7832

## Demo
<img width="1689" alt="Screen Shot 2023-03-02 at 4 39 26 PM" src="https://user-images.githubusercontent.com/9013217/222475941-bc90252a-cfac-49e4-9977-ba567942be46.png">


## Testing scenarios
- [ ] Confirm that team, org, and public retro + poker templates appear, and that Standup and Check-in cards are present.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
