### PR TITLE
chore(relay): Fix convertToUseFragment naming conflict bug

### DIFF
--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -52,7 +52,10 @@ const transform: Transform = (fileInfo, api, options) => {
   const fragmentProps = functionExpression.arguments[1]
   const propMap = {}
   fragmentProps.properties.forEach((prop) => {
-    if (root.find(j.Identifier, {name: `${prop.key.name}Ref`}).length > 0) {
+    const conflicts = root
+      .find(j.Identifier, {name: `${prop.key.name}Ref`})
+      .filter((path) => j.JSXAttribute.check(path.parent))
+    if (conflicts.length > 0) {
       throw new Error(`Naming conflict with ${prop.key.name}Ref`)
     }
     propMap[prop.key.name] = prop.value


### PR DESCRIPTION
# Description
Fixes an issue where JSX that looks like
```
<NewMeetingAvatarGroup meetingRef={meeting} />
```
would cause the script to fail when checking for conflicts with the `meetingRef` identifier.

## Testing scenarios
N/A

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
