### PR TITLE
chore(relay): createFragmentContainer -> useFragment 1/N

### DIFF
--- a/packages/client/components/ActionMeeting.tsx
+++ b/packages/client/components/ActionMeeting.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactElement, Suspense, useEffect} from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {ActionMeeting_meeting} from '~/__generated__/ActionMeeting_meeting.graphql'
+import {useFragment} from 'react-relay'
+import {ActionMeeting_meeting$key} from '~/__generated__/ActionMeeting_meeting.graphql'
 import useMeeting from '../hooks/useMeeting'
 import NewMeetingAvatarGroup from '../modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
 import lazyPreload, {LazyExoticPreload} from '../utils/lazyPreload'
@@ -14,7 +14,7 @@ import MeetingStyles from './MeetingStyles'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
 
 interface Props {
-  meeting: ActionMeeting_meeting
+  meeting: ActionMeeting_meeting$key
 }
 
 const phaseLookup = {
@@ -41,7 +41,33 @@ export interface ActionMeetingPhaseProps {
 }
 
 const ActionMeeting = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ActionMeeting_meeting on ActionMeeting {
+        ...useMeeting_meeting
+        ...ActionMeetingSidebar_meeting
+        ...NewMeetingCheckIn_meeting
+        ...ActionMeetingUpdates_meeting
+        ...ActionMeetingFirstCall_meeting
+        ...ActionMeetingAgendaItems_meeting
+        ...ActionMeetingLastCall_meeting
+        ...NewMeetingAvatarGroup_meeting
+        ...MeetingControlBar_meeting
+        ...MeetingLockedOverlay_meeting
+        localPhase {
+          id
+          phaseType
+        }
+        phases {
+          id
+          phaseType
+        }
+        showSidebar
+      }
+    `,
+    meetingRef
+  )
   const {localPhase, showSidebar} = meeting
   const {toggleSidebar, handleGotoNext, gotoStageId, safeRoute, handleMenuClick} =
     useMeeting(meeting)
@@ -80,28 +106,4 @@ const ActionMeeting = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ActionMeeting, {
-  meeting: graphql`
-    fragment ActionMeeting_meeting on ActionMeeting {
-      ...useMeeting_meeting
-      ...ActionMeetingSidebar_meeting
-      ...NewMeetingCheckIn_meeting
-      ...ActionMeetingUpdates_meeting
-      ...ActionMeetingFirstCall_meeting
-      ...ActionMeetingAgendaItems_meeting
-      ...ActionMeetingLastCall_meeting
-      ...NewMeetingAvatarGroup_meeting
-      ...MeetingControlBar_meeting
-      ...MeetingLockedOverlay_meeting
-      localPhase {
-        id
-        phaseType
-      }
-      phases {
-        id
-        phaseType
-      }
-      showSidebar
-    }
-  `
-})
+export default ActionMeeting

--- a/packages/client/components/ActionMeetingAgendaItems.tsx
+++ b/packages/client/components/ActionMeetingAgendaItems.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useRef} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useBreakpoint from '~/hooks/useBreakpoint'
-import {ActionMeetingAgendaItems_meeting} from '~/__generated__/ActionMeetingAgendaItems_meeting.graphql'
+import {ActionMeetingAgendaItems_meeting$key} from '~/__generated__/ActionMeetingAgendaItems_meeting.graphql'
 import EditorHelpModalContainer from '../containers/EditorHelpModalContainer/EditorHelpModalContainer'
 import MeetingCopy from '../modules/meeting/components/MeetingCopy/MeetingCopy'
 import MeetingPhaseHeading from '../modules/meeting/components/MeetingPhaseHeading/MeetingPhaseHeading'
@@ -21,7 +21,7 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PhaseWrapper from './PhaseWrapper'
 
 interface Props extends ActionMeetingPhaseProps {
-  meeting: ActionMeetingAgendaItems_meeting
+  meeting: ActionMeetingAgendaItems_meeting$key
 }
 
 const AgendaVerbatim = styled('div')({
@@ -53,7 +53,25 @@ const ThreadColumn = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
 }))
 
 const ActionMeetingAgendaItems = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ActionMeetingAgendaItems_meeting on ActionMeeting {
+        showSidebar
+        endedAt
+        facilitatorUserId
+        phases {
+          stages {
+            ...ActionMeetingAgendaItemsStage @relay(mask: false)
+          }
+        }
+        localStage {
+          ...ActionMeetingAgendaItemsStage @relay(mask: false)
+        }
+      }
+    `,
+    meetingRef
+  )
   const {showSidebar, endedAt, localStage} = meeting
   const {agendaItem, discussionId} = localStage
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
@@ -115,20 +133,4 @@ graphql`
   }
 `
 
-export default createFragmentContainer(ActionMeetingAgendaItems, {
-  meeting: graphql`
-    fragment ActionMeetingAgendaItems_meeting on ActionMeeting {
-      showSidebar
-      endedAt
-      facilitatorUserId
-      phases {
-        stages {
-          ...ActionMeetingAgendaItemsStage @relay(mask: false)
-        }
-      }
-      localStage {
-        ...ActionMeetingAgendaItemsStage @relay(mask: false)
-      }
-    }
-  `
-})
+export default ActionMeetingAgendaItems

--- a/packages/client/components/ActionMeetingFirstCall.tsx
+++ b/packages/client/components/ActionMeetingFirstCall.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import AgendaShortcutHint from '../modules/meeting/components/AgendaShortcutHint/AgendaShortcutHint'
 import MeetingCopy from '../modules/meeting/components/MeetingCopy/MeetingCopy'
@@ -9,7 +9,7 @@ import MeetingFacilitationHint from '../modules/meeting/components/MeetingFacili
 import MeetingPhaseHeading from '../modules/meeting/components/MeetingPhaseHeading/MeetingPhaseHeading'
 import {AGENDA_ITEMS, AGENDA_ITEM_LABEL} from '../utils/constants'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
-import {ActionMeetingFirstCall_meeting} from '../__generated__/ActionMeetingFirstCall_meeting.graphql'
+import {ActionMeetingFirstCall_meeting$key} from '../__generated__/ActionMeetingFirstCall_meeting.graphql'
 import {ActionMeetingPhaseProps} from './ActionMeeting'
 import MeetingContent from './MeetingContent'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
@@ -18,7 +18,7 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PhaseWrapper from './PhaseWrapper'
 
 interface Props extends ActionMeetingPhaseProps {
-  meeting: ActionMeetingFirstCall_meeting
+  meeting: ActionMeetingFirstCall_meeting$key
 }
 
 const FirstCallWrapper = styled('div')({
@@ -30,7 +30,26 @@ const FirstCallWrapper = styled('div')({
 })
 
 const ActionMeetingFirstCall = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ActionMeetingFirstCall_meeting on ActionMeeting {
+        showSidebar
+        endedAt
+        facilitatorUserId
+        facilitator {
+          preferredName
+        }
+        phases {
+          phaseType
+          stages {
+            isComplete
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
   const {endedAt, facilitator, facilitatorUserId, phases, showSidebar} = meeting
@@ -79,21 +98,4 @@ const ActionMeetingFirstCall = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ActionMeetingFirstCall, {
-  meeting: graphql`
-    fragment ActionMeetingFirstCall_meeting on ActionMeeting {
-      showSidebar
-      endedAt
-      facilitatorUserId
-      facilitator {
-        preferredName
-      }
-      phases {
-        phaseType
-        stages {
-          isComplete
-        }
-      }
-    }
-  `
-})
+export default ActionMeetingFirstCall

--- a/packages/client/components/ActionMeetingLastCall.tsx
+++ b/packages/client/components/ActionMeetingLastCall.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import EndCheckInMutation from '~/mutations/EndCheckInMutation'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
@@ -13,7 +13,7 @@ import MeetingPhaseHeading from '../modules/meeting/components/MeetingPhaseHeadi
 import {AGENDA_ITEM_LABEL} from '../utils/constants'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import plural from '../utils/plural'
-import {ActionMeetingLastCall_meeting} from '../__generated__/ActionMeetingLastCall_meeting.graphql'
+import {ActionMeetingLastCall_meeting$key} from '../__generated__/ActionMeetingLastCall_meeting.graphql'
 import {ActionMeetingPhaseProps} from './ActionMeeting'
 import ErrorBoundary from './ErrorBoundary'
 import MeetingContent from './MeetingContent'
@@ -22,7 +22,7 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PrimaryButton from './PrimaryButton'
 
 interface Props extends ActionMeetingPhaseProps {
-  meeting: ActionMeetingLastCall_meeting
+  meeting: ActionMeetingLastCall_meeting$key
 }
 
 const LastCallWrapper = styled('div')({
@@ -35,7 +35,28 @@ const LastCallWrapper = styled('div')({
 })
 
 const ActionMeetingLastCall = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ActionMeetingLastCall_meeting on ActionMeeting {
+        id
+        endedAt
+        showSidebar
+        id
+        facilitatorUserId
+        facilitator {
+          preferredName
+        }
+        phases {
+          phaseType
+          stages {
+            isComplete
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
@@ -118,23 +139,4 @@ const ActionMeetingLastCall = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ActionMeetingLastCall, {
-  meeting: graphql`
-    fragment ActionMeetingLastCall_meeting on ActionMeeting {
-      id
-      endedAt
-      showSidebar
-      id
-      facilitatorUserId
-      facilitator {
-        preferredName
-      }
-      phases {
-        phaseType
-        stages {
-          isComplete
-        }
-      }
-    }
-  `
-})
+export default ActionMeetingLastCall

--- a/packages/client/components/ActionSidebarAgendaItemsSection.tsx
+++ b/packages/client/components/ActionSidebarAgendaItemsSection.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useGotoStageId from '../hooks/useGotoStageId'
 import AgendaListAndInput from '../modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput'
-import {ActionSidebarAgendaItemsSection_meeting} from '../__generated__/ActionSidebarAgendaItemsSection_meeting.graphql'
+import {ActionSidebarAgendaItemsSection_meeting$key} from '../__generated__/ActionSidebarAgendaItemsSection_meeting.graphql'
 import MeetingSidebarPhaseItemChild from './MeetingSidebarPhaseItemChild'
 
 const StyledRoot = styled(MeetingSidebarPhaseItemChild)({
@@ -15,11 +15,25 @@ const StyledRoot = styled(MeetingSidebarPhaseItemChild)({
 interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
   handleMenuClick: () => void
-  meeting: ActionSidebarAgendaItemsSection_meeting
+  meeting: ActionSidebarAgendaItemsSection_meeting$key
 }
 
 const ActionSidebarAgendaItemsSection = (props: Props) => {
-  const {gotoStageId, handleMenuClick, meeting} = props
+  const {gotoStageId, handleMenuClick, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ActionSidebarAgendaItemsSection_meeting on ActionMeeting {
+        ...AgendaListAndInput_meeting
+        phases {
+          ...ActionSidebarAgendaItemsSectionAgendaItemPhase @relay(mask: false)
+        }
+        team {
+          ...AgendaListAndInput_team
+        }
+      }
+    `,
+    meetingRef
+  )
   const {team} = meeting
   const handleClick = async (stageId: string) => {
     gotoStageId(stageId).catch()
@@ -53,16 +67,4 @@ graphql`
   }
 `
 
-export default createFragmentContainer(ActionSidebarAgendaItemsSection, {
-  meeting: graphql`
-    fragment ActionSidebarAgendaItemsSection_meeting on ActionMeeting {
-      ...AgendaListAndInput_meeting
-      phases {
-        ...ActionSidebarAgendaItemsSectionAgendaItemPhase @relay(mask: false)
-      }
-      team {
-        ...AgendaListAndInput_team
-      }
-    }
-  `
-})
+export default ActionSidebarAgendaItemsSection

--- a/packages/client/components/ActionSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/ActionSidebarPhaseListItemChildren.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {ActionSidebarPhaseListItemChildren_meeting} from '~/__generated__/ActionSidebarPhaseListItemChildren_meeting.graphql'
+import {useFragment} from 'react-relay'
+import {ActionSidebarPhaseListItemChildren_meeting$key} from '~/__generated__/ActionSidebarPhaseListItemChildren_meeting.graphql'
 import useGotoStageId from '../hooks/useGotoStageId'
 import {NewMeetingPhaseTypeEnum} from '../__generated__/ActionSidebarAgendaItemsSection_meeting.graphql'
 import ActionSidebarAgendaItemsSection from './ActionSidebarAgendaItemsSection'
@@ -11,13 +11,22 @@ interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
   handleMenuClick: () => void
   phaseType: NewMeetingPhaseTypeEnum
-  meeting: ActionSidebarPhaseListItemChildren_meeting
+  meeting: ActionSidebarPhaseListItemChildren_meeting$key
 }
 
 const teamMemberPhases: NewMeetingPhaseTypeEnum[] = ['checkin', 'updates']
 
 const ActionSidebarPhaseListItemChildren = (props: Props) => {
-  const {gotoStageId, handleMenuClick, phaseType, meeting} = props
+  const {gotoStageId, handleMenuClick, phaseType, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ActionSidebarPhaseListItemChildren_meeting on ActionMeeting {
+        ...MeetingSidebarTeamMemberStageItems_meeting
+        ...ActionSidebarAgendaItemsSection_meeting
+      }
+    `,
+    meetingRef
+  )
   if (teamMemberPhases.includes(phaseType)) {
     return (
       <MeetingSidebarTeamMemberStageItems
@@ -40,11 +49,4 @@ const ActionSidebarPhaseListItemChildren = (props: Props) => {
   return null
 }
 
-export default createFragmentContainer(ActionSidebarPhaseListItemChildren, {
-  meeting: graphql`
-    fragment ActionSidebarPhaseListItemChildren_meeting on ActionMeeting {
-      ...MeetingSidebarTeamMemberStageItems_meeting
-      ...ActionSidebarAgendaItemsSection_meeting
-    }
-  `
-})
+export default ActionSidebarPhaseListItemChildren

--- a/packages/client/components/AddTeamMemberAvatarButton.tsx
+++ b/packages/client/components/AddTeamMemberAvatarButton.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import {PersonAdd} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {PALETTE} from '~/styles/paletteV3'
 import {MenuPosition} from '../hooks/useCoords'
 import useModal from '../hooks/useModal'
@@ -10,13 +10,13 @@ import useTooltip from '../hooks/useTooltip'
 import {meetingAvatarMediaQueries} from '../styles/meeting'
 import isDemoRoute from '../utils/isDemoRoute'
 import lazyPreload from '../utils/lazyPreload'
-import {AddTeamMemberAvatarButton_teamMembers} from '../__generated__/AddTeamMemberAvatarButton_teamMembers.graphql'
+import {AddTeamMemberAvatarButton_teamMembers$key} from '../__generated__/AddTeamMemberAvatarButton_teamMembers.graphql'
 import OutlinedButton from './OutlinedButton'
 
 interface Props {
   meetingId?: string
   teamId: string
-  teamMembers: AddTeamMemberAvatarButton_teamMembers
+  teamMembers: AddTeamMemberAvatarButton_teamMembers$key
 }
 
 const AddButton = styled(OutlinedButton)<{isMeeting: boolean | undefined}>(
@@ -84,7 +84,15 @@ const AddTeamMemberModalDemo = lazyPreload(
 )
 
 const AddTeamMemberAvatarButton = (props: Props) => {
-  const {meetingId, teamId, teamMembers} = props
+  const {meetingId, teamId, teamMembers: teamMembersRef} = props
+  const teamMembers = useFragment(
+    graphql`
+      fragment AddTeamMemberAvatarButton_teamMembers on TeamMember @relay(plural: true) {
+        ...AddTeamMemberModal_teamMembers
+      }
+    `,
+    teamMembersRef
+  )
   const isMeeting = !!meetingId
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLButtonElement>(
     MenuPosition.UPPER_CENTER
@@ -118,10 +126,4 @@ const AddTeamMemberAvatarButton = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AddTeamMemberAvatarButton, {
-  teamMembers: graphql`
-    fragment AddTeamMemberAvatarButton_teamMembers on TeamMember @relay(plural: true) {
-      ...AddTeamMemberModal_teamMembers
-    }
-  `
-})
+export default AddTeamMemberAvatarButton

--- a/packages/client/components/AddTeamMemberModal.tsx
+++ b/packages/client/components/AddTeamMemberModal.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import {Error as ErrorIcon, Warning} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import {PALETTE} from '~/styles/paletteV3'
@@ -12,7 +12,7 @@ import InviteToTeamMutation from '../mutations/InviteToTeamMutation'
 import {CompletedHandler} from '../types/relayMutations'
 import parseEmailAddressList from '../utils/parseEmailAddressList'
 import plural from '../utils/plural'
-import {AddTeamMemberModal_teamMembers} from '../__generated__/AddTeamMemberModal_teamMembers.graphql'
+import {AddTeamMemberModal_teamMembers$key} from '../__generated__/AddTeamMemberModal_teamMembers.graphql'
 import AddTeamMemberModalSuccess from './AddTeamMemberModalSuccess'
 import DialogContainer from './DialogContainer'
 import DialogContent from './DialogContent'
@@ -24,7 +24,7 @@ import PrimaryButton from './PrimaryButton'
 interface Props {
   closePortal: () => void
   meetingId?: string | undefined
-  teamMembers: AddTeamMemberModal_teamMembers
+  teamMembers: AddTeamMemberModal_teamMembers$key
   teamId: string
 }
 
@@ -122,7 +122,15 @@ const IllustrationBlock = () => {
 }
 
 const AddTeamMemberModal = (props: Props) => {
-  const {closePortal, meetingId, teamMembers, teamId} = props
+  const {closePortal, meetingId, teamMembers: teamMembersRef, teamId} = props
+  const teamMembers = useFragment(
+    graphql`
+      fragment AddTeamMemberModal_teamMembers on TeamMember @relay(plural: true) {
+        email
+      }
+    `,
+    teamMembersRef
+  )
   const [pendingSuccessfulInvitations, setPendingSuccessfulInvitations] = useState([] as string[])
   const [successfulInvitations, setSuccessfulInvitations] = useState<string[] | null>(null)
   const [isSubmitted, setIsSubmitted] = useState(false)
@@ -262,10 +270,4 @@ const AddTeamMemberModal = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AddTeamMemberModal, {
-  teamMembers: graphql`
-    fragment AddTeamMemberModal_teamMembers on TeamMember @relay(plural: true) {
-      email
-    }
-  `
-})
+export default AddTeamMemberModal

--- a/packages/client/components/AvatarList.tsx
+++ b/packages/client/components/AvatarList.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactElement, useLayoutEffect, useRef, useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useResizeObserver from '~/hooks/useResizeObserver'
 import useOverflowAvatars from '../hooks/useOverflowAvatars'
 import {TransitionStatus} from '../hooks/useTransition'
 import {BezierCurve} from '../types/constEnums'
-import {AvatarList_users} from '../__generated__/AvatarList_users.graphql'
+import {AvatarList_users$key} from '../__generated__/AvatarList_users.graphql'
 import AvatarListUser from './AvatarListUser'
 import OverflowAvatar from './OverflowAvatar'
 
@@ -36,7 +36,7 @@ const sizeToHeightBump = {
 }
 
 interface Props {
-  users: AvatarList_users
+  users: AvatarList_users$key
   onUserClick?: (userId: string) => void
   onOverflowClick?: () => void
   size: 28 | 46
@@ -47,7 +47,24 @@ interface Props {
 }
 
 const AvatarList = (props: Props) => {
-  const {users, onUserClick, onOverflowClick, size, emptyEl, isAnimated, borderColor} = props
+  const {
+    users: usersRef,
+    onUserClick,
+    onOverflowClick,
+    size,
+    emptyEl,
+    isAnimated,
+    borderColor
+  } = props
+  const users = useFragment(
+    graphql`
+      fragment AvatarList_users on User @relay(plural: true) {
+        id
+        ...AvatarListUser_user
+      }
+    `,
+    usersRef
+  )
   const rowRef = useRef<HTMLDivElement>(null)
   const overlap = widthToOverlap[size]
   const offsetSize = size - overlap
@@ -109,11 +126,4 @@ const AvatarList = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AvatarList, {
-  users: graphql`
-    fragment AvatarList_users on User @relay(plural: true) {
-      id
-      ...AvatarListUser_user
-    }
-  `
-})
+export default AvatarList

--- a/packages/client/components/AvatarListUser.tsx
+++ b/packages/client/components/AvatarListUser.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {TransitionStatus} from '~/hooks/useTransition'
 import {MenuPosition} from '../hooks/useCoords'
 import useTooltip from '../hooks/useTooltip'
 import {BezierCurve} from '../types/constEnums'
-import {AvatarListUser_user} from '../__generated__/AvatarListUser_user.graphql'
+import {AvatarListUser_user$key} from '../__generated__/AvatarListUser_user.graphql'
 import Avatar from './Avatar/Avatar'
 
 const Wrapper = styled('div')<{offset: number; isColumn?: boolean}>(({offset, isColumn}) => ({
@@ -42,7 +42,7 @@ interface Props {
   isAnimated: boolean
   onTransitionEnd?: () => void
   status?: TransitionStatus
-  user: AvatarListUser_user
+  user: AvatarListUser_user$key
   width: number
   onClick?: () => void
   borderColor?: string
@@ -52,7 +52,7 @@ const AvatarListUser = (props: Props) => {
   const {
     className,
     isColumn,
-    user,
+    user: userRef,
     onTransitionEnd,
     status,
     offset,
@@ -61,6 +61,15 @@ const AvatarListUser = (props: Props) => {
     onClick,
     borderColor
   } = props
+  const user = useFragment(
+    graphql`
+      fragment AvatarListUser_user on User {
+        picture
+        preferredName
+      }
+    `,
+    userRef
+  )
   const {picture, preferredName} = user
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER
@@ -89,11 +98,4 @@ const AvatarListUser = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AvatarListUser, {
-  user: graphql`
-    fragment AvatarListUser_user on User {
-      picture
-      preferredName
-    }
-  `
-})
+export default AvatarListUser

--- a/packages/client/components/AzureDevOpsScopingSearchFilterMenu.tsx
+++ b/packages/client/components/AzureDevOpsScopingSearchFilterMenu.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
-import {AzureDevOpsScopingSearchFilterMenu_meeting} from '../__generated__/AzureDevOpsScopingSearchFilterMenu_meeting.graphql'
+import {
+  AzureDevOpsScopingSearchFilterMenu_meeting$key,
+  AzureDevOpsScopingSearchFilterMenu_meeting
+} from '../__generated__/AzureDevOpsScopingSearchFilterMenu_meeting.graphql'
 import Checkbox from './Checkbox'
 import DropdownMenuLabel from './DropdownMenuLabel'
 import Menu from './Menu'
@@ -30,7 +33,7 @@ const UseWIQLLabel = styled('span')({
 
 interface Props {
   menuProps: MenuProps
-  meeting: AzureDevOpsScopingSearchFilterMenu_meeting
+  meeting: AzureDevOpsScopingSearchFilterMenu_meeting$key
 }
 
 type AzureDevOpsSearchQuery = NonNullable<
@@ -38,7 +41,31 @@ type AzureDevOpsSearchQuery = NonNullable<
 >
 
 const AzureDevOpsScopingSearchFilterMenu = (props: Props) => {
-  const {meeting, menuProps} = props
+  const {meeting: meetingRef, menuProps} = props
+  const meeting = useFragment(
+    graphql`
+      fragment AzureDevOpsScopingSearchFilterMenu_meeting on PokerMeeting {
+        id
+        azureDevOpsSearchQuery {
+          projectKeyFilters
+          isWIQL
+        }
+        viewerMeetingMember {
+          teamMember {
+            integrations {
+              azureDevOps {
+                projects {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {portalStatus, isDropdown} = menuProps
   const {viewerMeetingMember, azureDevOpsSearchQuery, id: meetingId} = meeting
   const {isWIQL, projectKeyFilters} = azureDevOpsSearchQuery
@@ -112,26 +139,4 @@ const AzureDevOpsScopingSearchFilterMenu = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AzureDevOpsScopingSearchFilterMenu, {
-  meeting: graphql`
-    fragment AzureDevOpsScopingSearchFilterMenu_meeting on PokerMeeting {
-      id
-      azureDevOpsSearchQuery {
-        projectKeyFilters
-        isWIQL
-      }
-      viewerMeetingMember {
-        teamMember {
-          integrations {
-            azureDevOps {
-              projects {
-                id
-                name
-              }
-            }
-          }
-        }
-      }
-    }
-  `
-})
+export default AzureDevOpsScopingSearchFilterMenu

--- a/packages/client/components/AzureDevOpsScopingSearchFilterToggle.tsx
+++ b/packages/client/components/AzureDevOpsScopingSearchFilterToggle.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/styled'
 import {FilterList} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import {PALETTE} from '~/styles/paletteV3'
-import {AzureDevOpsScopingSearchFilterToggle_meeting} from '../__generated__/AzureDevOpsScopingSearchFilterToggle_meeting.graphql'
+import {AzureDevOpsScopingSearchFilterToggle_meeting$key} from '../__generated__/AzureDevOpsScopingSearchFilterToggle_meeting.graphql'
 import AzureDevOpsScopingSearchFilterMenu from './AzureDevOpsScopingSearchFilterMenu'
 import FlatButton from './FlatButton'
 
@@ -28,11 +28,20 @@ const FilterIcon = styled(FilterList)({
 })
 
 interface Props {
-  meeting: AzureDevOpsScopingSearchFilterToggle_meeting
+  meeting: AzureDevOpsScopingSearchFilterToggle_meeting$key
 }
 
 const AzureDevOpsScopingSearchFilterToggle = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment AzureDevOpsScopingSearchFilterToggle_meeting on PokerMeeting {
+        id
+        ...AzureDevOpsScopingSearchFilterMenu_meeting
+      }
+    `,
+    meetingRef
+  )
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT, {
     loadingWidth: 200,
     noClose: true
@@ -47,11 +56,4 @@ const AzureDevOpsScopingSearchFilterToggle = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AzureDevOpsScopingSearchFilterToggle, {
-  meeting: graphql`
-    fragment AzureDevOpsScopingSearchFilterToggle_meeting on PokerMeeting {
-      id
-      ...AzureDevOpsScopingSearchFilterMenu_meeting
-    }
-  `
-})
+export default AzureDevOpsScopingSearchFilterToggle

--- a/packages/client/components/AzureDevOpsScopingSearchInput.tsx
+++ b/packages/client/components/AzureDevOpsScopingSearchInput.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/styled'
 import {Close} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import {PALETTE} from '~/styles/paletteV3'
 import Atmosphere from '../Atmosphere'
 import useAtmosphere from '../hooks/useAtmosphere'
-import {AzureDevOpsScopingSearchInput_meeting} from '../__generated__/AzureDevOpsScopingSearchInput_meeting.graphql'
+import {AzureDevOpsScopingSearchInput_meeting$key} from '../__generated__/AzureDevOpsScopingSearchInput_meeting.graphql'
 
 const Wrapper = styled('div')({
   alignItems: 'center',
@@ -42,11 +42,23 @@ const setSearch = (atmosphere: Atmosphere, meetingId: string, value: string) => 
 }
 
 interface Props {
-  meeting: AzureDevOpsScopingSearchInput_meeting
+  meeting: AzureDevOpsScopingSearchInput_meeting$key
 }
 
 const AzureDevOpsScopingSearchInput = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment AzureDevOpsScopingSearchInput_meeting on PokerMeeting {
+        id
+        azureDevOpsSearchQuery {
+          queryString
+          isWIQL
+        }
+      }
+    `,
+    meetingRef
+  )
   const {id: meetingId, azureDevOpsSearchQuery} = meeting
   const {isWIQL, queryString} = azureDevOpsSearchQuery
   const isEmpty = !queryString
@@ -66,14 +78,4 @@ const AzureDevOpsScopingSearchInput = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AzureDevOpsScopingSearchInput, {
-  meeting: graphql`
-    fragment AzureDevOpsScopingSearchInput_meeting on PokerMeeting {
-      id
-      azureDevOpsSearchQuery {
-        queryString
-        isWIQL
-      }
-    }
-  `
-})
+export default AzureDevOpsScopingSearchInput

--- a/packages/client/components/AzureDevOpsScopingSelectAllIssues.tsx
+++ b/packages/client/components/AzureDevOpsScopingSelectAllIssues.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useUnusedRecords from '~/hooks/useUnusedRecords'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
@@ -11,7 +11,7 @@ import {PALETTE} from '../styles/paletteV3'
 import {Threshold} from '../types/constEnums'
 import AzureDevOpsClientManager from '../utils/AzureDevOpsClientManager'
 import getSelectAllTitle from '../utils/getSelectAllTitle'
-import {AzureDevOpsScopingSelectAllIssues_workItems} from '../__generated__/AzureDevOpsScopingSelectAllIssues_workItems.graphql'
+import {AzureDevOpsScopingSelectAllIssues_workItems$key} from '../__generated__/AzureDevOpsScopingSelectAllIssues_workItems.graphql'
 import Checkbox from './Checkbox'
 
 const Item = styled('div')({
@@ -36,13 +36,26 @@ const ErrorMessage = styled('div')({
 })
 interface Props {
   meetingId: string
-  workItems: AzureDevOpsScopingSelectAllIssues_workItems
+  workItems: AzureDevOpsScopingSelectAllIssues_workItems$key
   usedServiceTaskIds: Set<string>
   providerId: string
 }
 
 const AzureDevOpsScopingSelectAllIssues = (props: Props) => {
-  const {meetingId, usedServiceTaskIds, workItems, providerId} = props
+  const {meetingId, usedServiceTaskIds, workItems: workItemsRef, providerId} = props
+  const workItems = useFragment(
+    graphql`
+      fragment AzureDevOpsScopingSelectAllIssues_workItems on AzureDevOpsWorkItemEdge
+      @relay(plural: true) {
+        node {
+          id
+          title
+          url
+        }
+      }
+    `,
+    workItemsRef
+  )
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, submitting, error} = useMutationProps()
   const getProjectId = (url: URL) => {
@@ -104,15 +117,4 @@ const AzureDevOpsScopingSelectAllIssues = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(AzureDevOpsScopingSelectAllIssues, {
-  workItems: graphql`
-    fragment AzureDevOpsScopingSelectAllIssues_workItems on AzureDevOpsWorkItemEdge
-    @relay(plural: true) {
-      node {
-        id
-        title
-        url
-      }
-    }
-  `
-})
+export default AzureDevOpsScopingSelectAllIssues

--- a/packages/client/components/DashboardAvatars/DashboardAvatar.tsx
+++ b/packages/client/components/DashboardAvatars/DashboardAvatar.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import {MenuPosition} from '../../hooks/useCoords'
 import useMutationProps from '../../hooks/useMutationProps'
@@ -10,11 +10,11 @@ import ToggleTeamDrawerMutation from '../../mutations/ToggleTeamDrawerMutation'
 import {PALETTE} from '../../styles/paletteV3'
 import defaultUserAvatar from '../../styles/theme/images/avatar-user.svg'
 import {ElementWidth} from '../../types/constEnums'
-import {DashboardAvatar_teamMember} from '../../__generated__/DashboardAvatar_teamMember.graphql'
+import {DashboardAvatar_teamMember$key} from '../../__generated__/DashboardAvatar_teamMember.graphql'
 import Avatar from '../Avatar/Avatar'
 
 interface Props {
-  teamMember: DashboardAvatar_teamMember
+  teamMember: DashboardAvatar_teamMember$key
 }
 
 const AvatarWrapper = styled('div')({
@@ -36,7 +36,25 @@ const StyledAvatar = styled(Avatar)<{isConnected: boolean; picture: string}>(
 )
 
 const DashboardAvatar = (props: Props) => {
-  const {teamMember} = props
+  const {teamMember: teamMemberRef} = props
+  const teamMember = useFragment(
+    graphql`
+      fragment DashboardAvatar_teamMember on TeamMember {
+        ...TeamMemberAvatarMenu_teamMember
+        ...LeaveTeamModal_teamMember
+        ...PromoteTeamMemberModal_teamMember
+        ...RemoveTeamMemberModal_teamMember
+        id
+        picture
+        teamId
+        preferredName
+        user {
+          isConnected
+        }
+      }
+    `,
+    teamMemberRef
+  )
   const {id: teamMemberId, picture, teamId, preferredName} = teamMember
   const {user} = teamMember
   if (!user) {
@@ -81,20 +99,4 @@ const DashboardAvatar = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(DashboardAvatar, {
-  teamMember: graphql`
-    fragment DashboardAvatar_teamMember on TeamMember {
-      ...TeamMemberAvatarMenu_teamMember
-      ...LeaveTeamModal_teamMember
-      ...PromoteTeamMemberModal_teamMember
-      ...RemoveTeamMemberModal_teamMember
-      id
-      picture
-      teamId
-      preferredName
-      user {
-        isConnected
-      }
-    }
-  `
-})
+export default DashboardAvatar

--- a/packages/client/components/DashboardAvatars/TeamMemberAvatarMenu.tsx
+++ b/packages/client/components/DashboardAvatars/TeamMemberAvatarMenu.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuProps} from '../../hooks/useMenu'
-import {TeamMemberAvatarMenu_teamMember} from '../../__generated__/TeamMemberAvatarMenu_teamMember.graphql'
+import {TeamMemberAvatarMenu_teamMember$key} from '../../__generated__/TeamMemberAvatarMenu_teamMember.graphql'
 import Menu from '../Menu'
 import MenuItem from '../MenuItem'
 import MenuItemLabel from '../MenuItemLabel'
@@ -12,7 +12,7 @@ import MenuItemLabel from '../MenuItemLabel'
 interface Props {
   isLead: boolean
   isViewerLead: boolean
-  teamMember: TeamMemberAvatarMenu_teamMember
+  teamMember: TeamMemberAvatarMenu_teamMember$key
   menuProps: MenuProps
   handleNavigate?: () => void
   togglePromote: () => void
@@ -25,7 +25,25 @@ const StyledLabel = styled(MenuItemLabel)({
 })
 
 const TeamMemberAvatarMenu = (props: Props) => {
-  const {isViewerLead, teamMember, menuProps, togglePromote, toggleRemove, toggleLeave} = props
+  const {
+    isViewerLead,
+    teamMember: teamMemberRef,
+    menuProps,
+    togglePromote,
+    toggleRemove,
+    toggleLeave
+  } = props
+  const teamMember = useFragment(
+    graphql`
+      fragment TeamMemberAvatarMenu_teamMember on TeamMember {
+        isSelf
+        preferredName
+        userId
+        isLead
+      }
+    `,
+    teamMemberRef
+  )
   const atmosphere = useAtmosphere()
   const {preferredName, userId} = teamMember
   const {viewerId} = atmosphere
@@ -54,13 +72,4 @@ const TeamMemberAvatarMenu = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamMemberAvatarMenu, {
-  teamMember: graphql`
-    fragment TeamMemberAvatarMenu_teamMember on TeamMember {
-      isSelf
-      preferredName
-      userId
-      isLead
-    }
-  `
-})
+export default TeamMemberAvatarMenu

--- a/packages/client/components/DeckActivityAvatars.tsx
+++ b/packages/client/components/DeckActivityAvatars.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useTransition, {TransitionStatus} from '../hooks/useTransition'
 import {PokerCards} from '../types/constEnums'
-import {DeckActivityAvatars_stage} from '../__generated__/DeckActivityAvatars_stage.graphql'
+import {DeckActivityAvatars_stage$key} from '../__generated__/DeckActivityAvatars_stage.graphql'
 import AvatarListUser from './AvatarListUser'
 
 const DeckActivityPanel = styled('div')({
@@ -30,12 +30,28 @@ const PeekingAvatar = styled(AvatarListUser)<{status?: TransitionStatus}>(({stat
 }))
 
 interface Props {
-  stage: DeckActivityAvatars_stage
+  stage: DeckActivityAvatars_stage$key
 }
 
 const MAX_PEEKERS = 5
 const DeckActivityAvatars = (props: Props) => {
-  const {stage} = props
+  const {stage: stageRef} = props
+  const stage = useFragment(
+    graphql`
+      fragment DeckActivityAvatars_stage on EstimateStage {
+        id
+        hoveringUsers {
+          ...AvatarListUser_user
+          id
+          picture
+        }
+        scores {
+          userId
+        }
+      }
+    `,
+    stageRef
+  )
   const {hoveringUsers, scores} = stage
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
@@ -78,18 +94,4 @@ const DeckActivityAvatars = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(DeckActivityAvatars, {
-  stage: graphql`
-    fragment DeckActivityAvatars_stage on EstimateStage {
-      id
-      hoveringUsers {
-        ...AvatarListUser_user
-        id
-        picture
-      }
-      scores {
-        userId
-      }
-    }
-  `
-})
+export default DeckActivityAvatars

--- a/packages/client/components/DiscussPhaseReflectionGrid.tsx
+++ b/packages/client/components/DiscussPhaseReflectionGrid.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useRef} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {useCoverable} from '~/hooks/useControlBarCovers'
 import {MeetingControlBarEnum} from '~/types/constEnums'
-import {DiscussPhaseReflectionGrid_meeting} from '~/__generated__/DiscussPhaseReflectionGrid_meeting.graphql'
+import {DiscussPhaseReflectionGrid_meeting$key} from '~/__generated__/DiscussPhaseReflectionGrid_meeting.graphql'
 import {meetingGridMinWidth} from '../styles/meeting'
 import MasonryCSSGrid from './MasonryCSSGrid'
 import ReflectionCard from './ReflectionCard/ReflectionCard'
@@ -17,11 +17,41 @@ const GridWrapper = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
 }))
 
 interface Props {
-  meeting: DiscussPhaseReflectionGrid_meeting
+  meeting: DiscussPhaseReflectionGrid_meeting$key
 }
 
 const DiscussPhaseReflectionGrid = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment DiscussPhaseReflectionGrid_meeting on RetrospectiveMeeting {
+        ...ReflectionCard_meeting
+        localStage {
+          ... on RetroDiscussStage {
+            reflectionGroup {
+              reflections {
+                ...ReflectionCard_reflection
+                id
+              }
+            }
+          }
+        }
+        phases {
+          stages {
+            ... on RetroDiscussStage {
+              reflectionGroup {
+                reflections {
+                  ...ReflectionCard_reflection
+                  id
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {localStage} = meeting
   const {reflectionGroup} = localStage
   const {reflections} = reflectionGroup!
@@ -45,32 +75,4 @@ const DiscussPhaseReflectionGrid = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(DiscussPhaseReflectionGrid, {
-  meeting: graphql`
-    fragment DiscussPhaseReflectionGrid_meeting on RetrospectiveMeeting {
-      ...ReflectionCard_meeting
-      localStage {
-        ... on RetroDiscussStage {
-          reflectionGroup {
-            reflections {
-              ...ReflectionCard_reflection
-              id
-            }
-          }
-        }
-      }
-      phases {
-        stages {
-          ... on RetroDiscussStage {
-            reflectionGroup {
-              reflections {
-                ...ReflectionCard_reflection
-                id
-              }
-            }
-          }
-        }
-      }
-    }
-  `
-})
+export default DiscussPhaseReflectionGrid

--- a/packages/client/components/DiscussPhaseSqueeze.tsx
+++ b/packages/client/components/DiscussPhaseSqueeze.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {useEffect} from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {DiscussPhaseSqueeze_meeting} from '~/__generated__/DiscussPhaseSqueeze_meeting.graphql'
-import {DiscussPhaseSqueeze_organization} from '~/__generated__/DiscussPhaseSqueeze_organization.graphql'
+import {useFragment} from 'react-relay'
+import {DiscussPhaseSqueeze_meeting$key} from '~/__generated__/DiscussPhaseSqueeze_meeting.graphql'
+import {DiscussPhaseSqueeze_organization$key} from '~/__generated__/DiscussPhaseSqueeze_organization.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useModal from '../hooks/useModal'
 import CreditCardModal from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
@@ -10,12 +10,36 @@ import {PALETTE} from '../styles/paletteV3'
 import WaitingForFacilitatorToPay from './WaitingForFacilitatorToPay'
 
 interface Props {
-  meeting: DiscussPhaseSqueeze_meeting
-  organization: DiscussPhaseSqueeze_organization
+  meeting: DiscussPhaseSqueeze_meeting$key
+  organization: DiscussPhaseSqueeze_organization$key
 }
 
 const DiscussPhaseSqueeze = (props: Props) => {
-  const {organization, meeting} = props
+  const {organization: organizationRef, meeting: meetingRef} = props
+  const organization = useFragment(
+    graphql`
+      fragment DiscussPhaseSqueeze_organization on Organization {
+        id
+        orgUserCount {
+          activeUserCount
+        }
+      }
+    `,
+    organizationRef
+  )
+  const meeting = useFragment(
+    graphql`
+      fragment DiscussPhaseSqueeze_meeting on RetrospectiveMeeting {
+        id
+        facilitatorUserId
+        facilitator {
+          preferredName
+        }
+        showConversionModal
+      }
+    `,
+    meetingRef
+  )
   const {id: meetingId, facilitatorUserId, facilitator, showConversionModal} = meeting
   const {id: orgId, orgUserCount} = organization
   const {preferredName: facilitatorName} = facilitator
@@ -50,23 +74,4 @@ const DiscussPhaseSqueeze = (props: Props) => {
   return modalPortal(<WaitingForFacilitatorToPay facilitatorName={facilitatorName} />)
 }
 
-export default createFragmentContainer(DiscussPhaseSqueeze, {
-  organization: graphql`
-    fragment DiscussPhaseSqueeze_organization on Organization {
-      id
-      orgUserCount {
-        activeUserCount
-      }
-    }
-  `,
-  meeting: graphql`
-    fragment DiscussPhaseSqueeze_meeting on RetrospectiveMeeting {
-      id
-      facilitatorUserId
-      facilitator {
-        preferredName
-      }
-      showConversionModal
-    }
-  `
-})
+export default DiscussPhaseSqueeze

--- a/packages/client/components/DueDatePicker.tsx
+++ b/packages/client/components/DueDatePicker.tsx
@@ -2,19 +2,19 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {DayModifiers, DayPicker} from 'react-day-picker'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import useMutationProps from '../hooks/useMutationProps'
 import {UseTaskChild} from '../hooks/useTaskChildFocus'
 import UpdateTaskDueDateMutation from '../mutations/UpdateTaskDueDateMutation'
 import {PALETTE} from '../styles/paletteV3'
-import {DueDatePicker_task} from '../__generated__/DueDatePicker_task.graphql'
+import {DueDatePicker_task$key} from '../__generated__/DueDatePicker_task.graphql'
 import Menu from './Menu'
 
 interface Props {
   menuProps: MenuProps
-  task: DueDatePicker_task
+  task: DueDatePicker_task$key
   useTaskChild: UseTaskChild
 }
 
@@ -37,7 +37,16 @@ const Hint = styled('div')({
 })
 
 const DueDatePicker = (props: Props) => {
-  const {menuProps, task, useTaskChild} = props
+  const {menuProps, task: taskRef, useTaskChild} = props
+  const task = useFragment(
+    graphql`
+      fragment DueDatePicker_task on Task {
+        id
+        dueDate
+      }
+    `,
+    taskRef
+  )
   const {id: taskId, dueDate} = task
   useTaskChild('dueDate')
   const atmosphere = useAtmosphere()
@@ -73,11 +82,4 @@ const DueDatePicker = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(DueDatePicker, {
-  task: graphql`
-    fragment DueDatePicker_task on Task {
-      id
-      dueDate
-    }
-  `
-})
+export default DueDatePicker

--- a/packages/client/components/DueDateToggle.tsx
+++ b/packages/client/components/DueDateToggle.tsx
@@ -3,7 +3,7 @@ import {AccessTime} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import ms from 'ms'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useTooltip from '~/hooks/useTooltip'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
@@ -11,7 +11,7 @@ import {UseTaskChild} from '../hooks/useTaskChildFocus'
 import {PALETTE} from '../styles/paletteV3'
 import lazyPreload from '../utils/lazyPreload'
 import {shortMonths} from '../utils/makeDateString'
-import {DueDateToggle_task} from '../__generated__/DueDateToggle_task.graphql'
+import {DueDateToggle_task$key} from '../__generated__/DueDateToggle_task.graphql'
 import CardButton from './CardButton'
 
 interface StyleProps {
@@ -100,7 +100,7 @@ const DateString = styled('span')({
 
 interface Props {
   cardIsActive: boolean
-  task: DueDateToggle_task
+  task: DueDateToggle_task$key
   useTaskChild: UseTaskChild
   isArchived?: boolean
 }
@@ -134,7 +134,16 @@ const DueDatePicker = lazyPreload(
 )
 
 const DueDateToggle = (props: Props) => {
-  const {cardIsActive, task, useTaskChild, isArchived} = props
+  const {cardIsActive, task: taskRef, useTaskChild, isArchived} = props
+  const task = useFragment(
+    graphql`
+      fragment DueDateToggle_task on Task {
+        dueDate
+        ...DueDatePicker_task
+      }
+    `,
+    taskRef
+  )
   const {dueDate} = task
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu(MenuPosition.UPPER_RIGHT)
   const {
@@ -174,11 +183,4 @@ const DueDateToggle = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(DueDateToggle, {
-  task: graphql`
-    fragment DueDateToggle_task on Task {
-      dueDate
-      ...DueDatePicker_task
-    }
-  `
-})
+export default DueDateToggle

--- a/packages/client/components/EditingStatus/EditingStatus.tsx
+++ b/packages/client/components/EditingStatus/EditingStatus.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactNode, useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useTooltip from '~/hooks/useTooltip'
-import {EditingStatus_task} from '~/__generated__/EditingStatus_task.graphql'
+import {EditingStatus_task$key} from '~/__generated__/EditingStatus_task.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import {UseTaskChild} from '../../hooks/useTaskChildFocus'
 import {PALETTE} from '../../styles/paletteV3'
@@ -38,13 +38,27 @@ export type TimestampType = 'createdAt' | 'updatedAt'
 interface Props {
   children: ReactNode
   isTaskHovered: boolean
-  task: EditingStatus_task
+  task: EditingStatus_task$key
   useTaskChild: UseTaskChild
   isArchived?: boolean
 }
 
 const EditingStatus = (props: Props) => {
-  const {children, isTaskHovered, task, useTaskChild, isArchived} = props
+  const {children, isTaskHovered, task: taskRef, useTaskChild, isArchived} = props
+  const task = useFragment(
+    graphql`
+      fragment EditingStatus_task on Task {
+        createdAt
+        updatedAt
+        editors {
+          userId
+          preferredName
+        }
+        ...DueDateToggle_task
+      }
+    `,
+    taskRef
+  )
   const {createdAt, updatedAt, editors} = task
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
@@ -94,16 +108,4 @@ const EditingStatus = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(EditingStatus, {
-  task: graphql`
-    fragment EditingStatus_task on Task {
-      createdAt
-      updatedAt
-      editors {
-        userId
-        preferredName
-      }
-      ...DueDateToggle_task
-    }
-  `
-})
+export default EditingStatus

--- a/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
+++ b/packages/client/components/EstimatePhaseDiscussionDrawer.tsx
@@ -2,10 +2,10 @@ import styled from '@emotion/styled'
 import {Close} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {desktopSidebarShadow} from '~/styles/elevation'
 import {PALETTE} from '~/styles/paletteV3'
-import {EstimatePhaseDiscussionDrawer_meeting} from '~/__generated__/EstimatePhaseDiscussionDrawer_meeting.graphql'
+import {EstimatePhaseDiscussionDrawer_meeting$key} from '~/__generated__/EstimatePhaseDiscussionDrawer_meeting.graphql'
 import {BezierCurve, Breakpoint, DiscussionThreadEnum, ZIndex} from '../types/constEnums'
 import {DiscussionThreadables} from './DiscussionThreadList'
 import DiscussionThreadListEmptyState from './DiscussionThreadListEmptyState'
@@ -79,12 +79,28 @@ const StyledCloseButton = styled(PlainButton)({
 interface Props {
   isDesktop: boolean
   isOpen: boolean
-  meeting: EstimatePhaseDiscussionDrawer_meeting
+  meeting: EstimatePhaseDiscussionDrawer_meeting$key
   onToggle: () => void
 }
 
 const EstimatePhaseDiscussionDrawer = (props: Props) => {
-  const {isDesktop, isOpen, meeting, onToggle} = props
+  const {isDesktop, isOpen, meeting: meetingRef, onToggle} = props
+  const meeting = useFragment(
+    graphql`
+      fragment EstimatePhaseDiscussionDrawer_meeting on PokerMeeting {
+        endedAt
+        localStage {
+          ...EstimatePhaseDiscussionDrawerEstimateStage @relay(mask: false)
+        }
+        phases {
+          stages {
+            ...EstimatePhaseDiscussionDrawerEstimateStage @relay(mask: false)
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {endedAt, localStage} = meeting
   const {discussionId} = localStage
   const allowedThreadables: DiscussionThreadables[] = endedAt ? [] : ['comment']
@@ -120,18 +136,4 @@ graphql`
     discussionId
   }
 `
-export default createFragmentContainer(EstimatePhaseDiscussionDrawer, {
-  meeting: graphql`
-    fragment EstimatePhaseDiscussionDrawer_meeting on PokerMeeting {
-      endedAt
-      localStage {
-        ...EstimatePhaseDiscussionDrawerEstimateStage @relay(mask: false)
-      }
-      phases {
-        stages {
-          ...EstimatePhaseDiscussionDrawerEstimateStage @relay(mask: false)
-        }
-      }
-    }
-  `
-})
+export default EstimatePhaseDiscussionDrawer

--- a/packages/client/components/FacilitatorMenu.tsx
+++ b/packages/client/components/FacilitatorMenu.tsx
@@ -1,21 +1,36 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import Menu from '../components/Menu'
 import MenuItem from '../components/MenuItem'
 import MenuItemLabel from '../components/MenuItemLabel'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import PromoteNewMeetingFacilitatorMutation from '../mutations/PromoteNewMeetingFacilitatorMutation'
-import {FacilitatorMenu_meeting} from '../__generated__/FacilitatorMenu_meeting.graphql'
+import {FacilitatorMenu_meeting$key} from '../__generated__/FacilitatorMenu_meeting.graphql'
 
 interface Props {
   menuProps: MenuProps
-  meeting: FacilitatorMenu_meeting
+  meeting: FacilitatorMenu_meeting$key
 }
 
 const FacilitatorMenu = (props: Props) => {
-  const {menuProps, meeting} = props
+  const {menuProps, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment FacilitatorMenu_meeting on NewMeeting {
+        id
+        facilitatorUserId
+        meetingMembers {
+          user {
+            id
+            isConnected
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {id: meetingId, facilitatorUserId, meetingMembers} = meeting
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
@@ -52,17 +67,4 @@ const FacilitatorMenu = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(FacilitatorMenu, {
-  meeting: graphql`
-    fragment FacilitatorMenu_meeting on NewMeeting {
-      id
-      facilitatorUserId
-      meetingMembers {
-        user {
-          id
-          isConnected
-        }
-      }
-    }
-  `
-})
+export default FacilitatorMenu

--- a/packages/client/components/IntegratedTaskContent.tsx
+++ b/packages/client/components/IntegratedTaskContent.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {IntegratedTaskContent_task} from '../__generated__/IntegratedTaskContent_task.graphql'
+import {useFragment} from 'react-relay'
+import {IntegratedTaskContent_task$key} from '../__generated__/IntegratedTaskContent_task.graphql'
 
 const Content = styled('div')({
   paddingLeft: 16,
@@ -17,11 +17,41 @@ const Summary = styled('div')({
   fontWeight: 600
 })
 interface Props {
-  task: IntegratedTaskContent_task
+  task: IntegratedTaskContent_task$key
 }
 
 const IntegratedTaskContent = (props: Props) => {
-  const {task} = props
+  const {task: taskRef} = props
+  const task = useFragment(
+    graphql`
+      fragment IntegratedTaskContent_task on Task {
+        integration {
+          __typename
+          ... on JiraIssue {
+            descriptionHTML
+            summary
+          }
+          ... on _xGitHubIssue {
+            bodyHTML
+            title
+          }
+          ... on JiraServerIssue {
+            descriptionHTML
+            summary
+          }
+          ... on _xGitLabIssue {
+            descriptionHtml
+            title
+          }
+          ... on AzureDevOpsWorkItem {
+            descriptionHTML
+            title
+          }
+        }
+      }
+    `,
+    taskRef
+  )
   const {integration} = task
   if (!integration) return null
   if (integration.__typename === 'JiraIssue') {
@@ -68,32 +98,4 @@ const IntegratedTaskContent = (props: Props) => {
   return null
 }
 
-export default createFragmentContainer(IntegratedTaskContent, {
-  task: graphql`
-    fragment IntegratedTaskContent_task on Task {
-      integration {
-        __typename
-        ... on JiraIssue {
-          descriptionHTML
-          summary
-        }
-        ... on _xGitHubIssue {
-          bodyHTML
-          title
-        }
-        ... on JiraServerIssue {
-          descriptionHTML
-          summary
-        }
-        ... on _xGitLabIssue {
-          descriptionHtml
-          title
-        }
-        ... on AzureDevOpsWorkItem {
-          descriptionHTML
-          title
-        }
-      }
-    }
-  `
-})
+export default IntegratedTaskContent

--- a/packages/client/components/InvitationLinkErrorExpired.tsx
+++ b/packages/client/components/InvitationLinkErrorExpired.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useRouter from '../hooks/useRouter'
 import hasToken from '../utils/hasToken'
-import {InvitationLinkErrorExpired_massInvitation} from '../__generated__/InvitationLinkErrorExpired_massInvitation.graphql'
+import {InvitationLinkErrorExpired_massInvitation$key} from '../__generated__/InvitationLinkErrorExpired_massInvitation.graphql'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import FlatPrimaryButton from './FlatPrimaryButton'
@@ -13,7 +13,7 @@ import InvitationDialogCopy from './InvitationDialogCopy'
 import InviteDialog from './InviteDialog'
 
 interface Props {
-  massInvitation: InvitationLinkErrorExpired_massInvitation
+  massInvitation: InvitationLinkErrorExpired_massInvitation$key
 }
 
 const TeamName = styled('span')({
@@ -28,7 +28,16 @@ const DialogActions = styled('div')({
 })
 
 const InvitationLinkErrorExpired = (props: Props) => {
-  const {massInvitation} = props
+  const {massInvitation: massInvitationRef} = props
+  const massInvitation = useFragment(
+    graphql`
+      fragment InvitationLinkErrorExpired_massInvitation on MassInvitationPayload {
+        teamName
+        teamId
+      }
+    `,
+    massInvitationRef
+  )
   const {teamName} = massInvitation
   useDocumentTitle(`Token Expired | Invitation Link`, 'Invitation Link')
 
@@ -62,11 +71,4 @@ const InvitationLinkErrorExpired = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(InvitationLinkErrorExpired, {
-  massInvitation: graphql`
-    fragment InvitationLinkErrorExpired_massInvitation on MassInvitationPayload {
-      teamName
-      teamId
-    }
-  `
-})
+export default InvitationLinkErrorExpired

--- a/packages/client/components/JiraScopingSearchResults.tsx
+++ b/packages/client/components/JiraScopingSearchResults.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer, PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {useFragment, PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import useGetUsedServiceTaskIds from '~/hooks/useGetUsedServiceTaskIds'
 import useAtmosphere from '../hooks/useAtmosphere'
 import PersistJiraSearchQueryMutation from '../mutations/PersistJiraSearchQueryMutation'
 import {JiraScopingSearchResultsQuery} from '../__generated__/JiraScopingSearchResultsQuery.graphql'
-import {JiraScopingSearchResults_meeting} from '../__generated__/JiraScopingSearchResults_meeting.graphql'
+import {JiraScopingSearchResults_meeting$key} from '../__generated__/JiraScopingSearchResults_meeting.graphql'
 import IntegrationScopingNoResults from './IntegrationScopingNoResults'
 import JiraScopingSelectAllIssues from './JiraScopingSelectAllIssues'
 import NewIntegrationRecordButton from './NewIntegrationRecordButton'
@@ -19,7 +19,7 @@ const ResultScroller = styled('div')({
 
 interface Props {
   queryRef: PreloadedQuery<JiraScopingSearchResultsQuery>
-  meeting: JiraScopingSearchResults_meeting
+  meeting: JiraScopingSearchResults_meeting$key
 }
 
 const query = graphql`
@@ -67,7 +67,26 @@ const query = graphql`
 `
 
 const JiraScopingSearchResults = (props: Props) => {
-  const {queryRef, meeting} = props
+  const {queryRef, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment JiraScopingSearchResults_meeting on PokerMeeting {
+        ...NewJiraIssueInput_meeting
+        id
+        teamId
+        jiraSearchQuery {
+          isJQL
+          projectKeyFilters
+          queryString
+        }
+        phases {
+          ...useGetUsedServiceTaskIds_phase
+          phaseType
+        }
+      }
+    `,
+    meetingRef
+  )
   const data = usePreloadedQuery<JiraScopingSearchResultsQuery>(query, queryRef, {
     UNSTABLE_renderPolicy: 'full'
   })
@@ -155,21 +174,4 @@ const JiraScopingSearchResults = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(JiraScopingSearchResults, {
-  meeting: graphql`
-    fragment JiraScopingSearchResults_meeting on PokerMeeting {
-      ...NewJiraIssueInput_meeting
-      id
-      teamId
-      jiraSearchQuery {
-        isJQL
-        projectKeyFilters
-        queryString
-      }
-      phases {
-        ...useGetUsedServiceTaskIds_phase
-        phaseType
-      }
-    }
-  `
-})
+export default JiraScopingSearchResults

--- a/packages/client/components/JiraScopingSearchResultsRoot.tsx
+++ b/packages/client/components/JiraScopingSearchResultsRoot.tsx
@@ -1,21 +1,35 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import MockScopingList from '~/modules/meeting/components/MockScopingList'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
 import jiraScopingSearchResultsQuery, {
   JiraScopingSearchResultsQuery
 } from '../__generated__/JiraScopingSearchResultsQuery.graphql'
-import {JiraScopingSearchResultsRoot_meeting} from '../__generated__/JiraScopingSearchResultsRoot_meeting.graphql'
+import {JiraScopingSearchResultsRoot_meeting$key} from '../__generated__/JiraScopingSearchResultsRoot_meeting.graphql'
 import ErrorBoundary from './ErrorBoundary'
 import JiraScopingSearchResults from './JiraScopingSearchResults'
 
 interface Props {
-  meeting: JiraScopingSearchResultsRoot_meeting
+  meeting: JiraScopingSearchResultsRoot_meeting$key
 }
 
 const JiraScopingSearchResultsRoot = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment JiraScopingSearchResultsRoot_meeting on PokerMeeting {
+        ...JiraScopingSearchResults_meeting
+        teamId
+        jiraSearchQuery {
+          queryString
+          projectKeyFilters
+          isJQL
+        }
+      }
+    `,
+    meetingRef
+  )
   const {teamId, jiraSearchQuery} = meeting
   const {queryString, projectKeyFilters, isJQL} = jiraSearchQuery
   const normalizedQueryString = queryString.trim()
@@ -35,16 +49,4 @@ const JiraScopingSearchResultsRoot = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(JiraScopingSearchResultsRoot, {
-  meeting: graphql`
-    fragment JiraScopingSearchResultsRoot_meeting on PokerMeeting {
-      ...JiraScopingSearchResults_meeting
-      teamId
-      jiraSearchQuery {
-        queryString
-        projectKeyFilters
-        isJQL
-      }
-    }
-  `
-})
+export default JiraScopingSearchResultsRoot

--- a/packages/client/components/JiraScopingSelectAllIssues.tsx
+++ b/packages/client/components/JiraScopingSelectAllIssues.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useUnusedRecords from '~/hooks/useUnusedRecords'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
@@ -9,7 +9,7 @@ import UpdatePokerScopeMutation from '../mutations/UpdatePokerScopeMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {Threshold} from '../types/constEnums'
 import getSelectAllTitle from '../utils/getSelectAllTitle'
-import {JiraScopingSelectAllIssues_issues} from '../__generated__/JiraScopingSelectAllIssues_issues.graphql'
+import {JiraScopingSelectAllIssues_issues$key} from '../__generated__/JiraScopingSelectAllIssues_issues.graphql'
 import Checkbox from './Checkbox'
 
 const Item = styled('div')({
@@ -34,12 +34,23 @@ const ErrorMessage = styled('div')({
 })
 interface Props {
   meetingId: string
-  issues: JiraScopingSelectAllIssues_issues
+  issues: JiraScopingSelectAllIssues_issues$key
   usedServiceTaskIds: Set<string>
 }
 
 const JiraScopingSelectAllIssues = (props: Props) => {
-  const {meetingId, usedServiceTaskIds, issues} = props
+  const {meetingId, usedServiceTaskIds, issues: issuesRef} = props
+  const issues = useFragment(
+    graphql`
+      fragment JiraScopingSelectAllIssues_issues on JiraIssueEdge @relay(plural: true) {
+        node {
+          id
+          summary
+        }
+      }
+    `,
+    issuesRef
+  )
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, error} = useMutationProps()
   const serviceTaskIds = issues.map((issueEdge) => issueEdge.node.id)
@@ -90,13 +101,4 @@ const JiraScopingSelectAllIssues = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(JiraScopingSelectAllIssues, {
-  issues: graphql`
-    fragment JiraScopingSelectAllIssues_issues on JiraIssueEdge @relay(plural: true) {
-      node {
-        id
-        summary
-      }
-    }
-  `
-})
+export default JiraScopingSelectAllIssues


### PR DESCRIPTION
# Description
refs https://github.com/ParabolInc/parabol/issues/6283

Converted using the process described in https://www.notion.so/parabol/How-to-Migrate-createFragmentContainer-useFragment-with-codeshift-d534e7d0b8674089a2075f2835544558 🔒 

## Testing scenarios
- [ ] Smoke test the app

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
