### PR TITLE
chore(relay): createFragmentContainer -> useFragment 2/N

### DIFF
--- a/packages/client/components/KickedOut.tsx
+++ b/packages/client/components/KickedOut.tsx
@@ -1,15 +1,30 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {KickedOut_notification} from '~/__generated__/KickedOut_notification.graphql'
+import {useFragment} from 'react-relay'
+import {KickedOut_notification$key} from '~/__generated__/KickedOut_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
-  notification: KickedOut_notification
+  notification: KickedOut_notification$key
 }
 
 const KickedOut = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment KickedOut_notification on NotifyKickedOut {
+        ...NotificationTemplate_notification
+        evictor {
+          picture
+          preferredName
+        }
+        team {
+          name
+        }
+      }
+    `,
+    notificationRef
+  )
   const {team, evictor} = notification
   const {name: teamName} = team
   const {preferredName: evictorName, picture: evictorPicture} = evictor
@@ -22,17 +37,4 @@ const KickedOut = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(KickedOut, {
-  notification: graphql`
-    fragment KickedOut_notification on NotifyKickedOut {
-      ...NotificationTemplate_notification
-      evictor {
-        picture
-        preferredName
-      }
-      team {
-        name
-      }
-    }
-  `
-})
+export default KickedOut

--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import * as Sentry from '@sentry/browser'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
 import action from '../../../static/images/illustrations/action.png'
 import retrospective from '../../../static/images/illustrations/retrospective.png'
@@ -20,7 +20,7 @@ import {PALETTE} from '../styles/paletteV3'
 import {BezierCurve, Breakpoint, Card, ElementWidth} from '../types/constEnums'
 import getMeetingPhase from '../utils/getMeetingPhase'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
-import {MeetingCard_meeting} from '../__generated__/MeetingCard_meeting.graphql'
+import {MeetingCard_meeting$key} from '../__generated__/MeetingCard_meeting.graphql'
 import AvatarList from './AvatarList'
 import CardButton from './CardButton'
 import IconLabel from './IconLabel'
@@ -186,7 +186,7 @@ const Options = styled(CardButton)({
 
 interface Props {
   onTransitionEnd: () => void
-  meeting: MeetingCard_meeting
+  meeting: MeetingCard_meeting$key
   status: TransitionStatus
   displayIdx: number
 }
@@ -205,7 +205,40 @@ const MEETING_TYPE_LABEL = {
 }
 
 const MeetingCard = (props: Props) => {
-  const {meeting, status, onTransitionEnd, displayIdx} = props
+  const {meeting: meetingRef, status, onTransitionEnd, displayIdx} = props
+  const meeting = useFragment(
+    graphql`
+      fragment MeetingCard_meeting on NewMeeting {
+        ...useMeetingMemberAvatars_meeting
+        id
+        name
+        meetingType
+        phases {
+          phaseType
+          stages {
+            isComplete
+          }
+        }
+        team {
+          id
+          name
+        }
+        meetingMembers {
+          user {
+            ...AvatarListUser_user
+          }
+        }
+        ... on TeamPromptMeeting {
+          meetingSeries {
+            id
+            title
+            cancelledAt
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {name, team, id: meetingId, meetingType, phases, meetingSeries} = meeting
   const connectedUsers = useMeetingMemberAvatars(meeting)
   const meetingPhase = getMeetingPhase(phases)
@@ -305,35 +338,4 @@ const MeetingCard = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(MeetingCard, {
-  meeting: graphql`
-    fragment MeetingCard_meeting on NewMeeting {
-      ...useMeetingMemberAvatars_meeting
-      id
-      name
-      meetingType
-      phases {
-        phaseType
-        stages {
-          isComplete
-        }
-      }
-      team {
-        id
-        name
-      }
-      meetingMembers {
-        user {
-          ...AvatarListUser_user
-        }
-      }
-      ... on TeamPromptMeeting {
-        meetingSeries {
-          id
-          title
-          cancelledAt
-        }
-      }
-    }
-  `
-})
+export default MeetingCard

--- a/packages/client/components/MeetingSidebarTeamMemberStageItems.tsx
+++ b/packages/client/components/MeetingSidebarTeamMemberStageItems.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {MeetingSidebarTeamMemberStageItems_meeting} from '~/__generated__/MeetingSidebarTeamMemberStageItems_meeting.graphql'
+import {useFragment} from 'react-relay'
+import {MeetingSidebarTeamMemberStageItems_meeting$key} from '~/__generated__/MeetingSidebarTeamMemberStageItems_meeting.graphql'
 import Avatar from '../components/Avatar/Avatar'
 import MeetingSubnavItem from '../components/MeetingSubnavItem'
 import useAnimatedPhaseListChildren from '../hooks/useAnimatedPhaseListChildren'
@@ -29,12 +29,31 @@ const ScrollStageItems = styled('div')<{isActive: boolean}>(({isActive}) => ({
 interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
   handleMenuClick: () => void
-  meeting: MeetingSidebarTeamMemberStageItems_meeting
+  meeting: MeetingSidebarTeamMemberStageItems_meeting$key
   phaseType: NewMeetingPhaseTypeEnum
 }
 
 const MeetingSidebarTeamMemberStageItems = (props: Props) => {
-  const {gotoStageId, handleMenuClick, meeting, phaseType} = props
+  const {gotoStageId, handleMenuClick, meeting: meetingRef, phaseType} = props
+  const meeting = useFragment(
+    graphql`
+      fragment MeetingSidebarTeamMemberStageItems_meeting on NewMeeting {
+        facilitatorStageId
+        facilitatorUserId
+        id
+        localPhase {
+          ...MeetingSidebarTeamMemberStageItems_phase @relay(mask: false)
+        }
+        localStage {
+          id
+        }
+        phases {
+          ...MeetingSidebarTeamMemberStageItems_phase @relay(mask: false)
+        }
+      }
+    `,
+    meetingRef
+  )
   const {facilitatorStageId, facilitatorUserId, localPhase, localStage, phases} = meeting
   const sidebarPhase = phases.find((phase) => phase.phaseType === phaseType)
   const localStageId = (localStage && localStage.id) || ''
@@ -115,21 +134,4 @@ graphql`
   }
 `
 
-export default createFragmentContainer(MeetingSidebarTeamMemberStageItems, {
-  meeting: graphql`
-    fragment MeetingSidebarTeamMemberStageItems_meeting on NewMeeting {
-      facilitatorStageId
-      facilitatorUserId
-      id
-      localPhase {
-        ...MeetingSidebarTeamMemberStageItems_phase @relay(mask: false)
-      }
-      localStage {
-        id
-      }
-      phases {
-        ...MeetingSidebarTeamMemberStageItems_phase @relay(mask: false)
-      }
-    }
-  `
-})
+export default MeetingSidebarTeamMemberStageItems

--- a/packages/client/components/MeetingStageTimeLimitEnd.tsx
+++ b/packages/client/components/MeetingStageTimeLimitEnd.tsx
@@ -1,17 +1,33 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import NotificationAction from '~/components/NotificationAction'
 import useRouter from '../hooks/useRouter'
-import {MeetingStageTimeLimitEnd_notification} from '../__generated__/MeetingStageTimeLimitEnd_notification.graphql'
+import {MeetingStageTimeLimitEnd_notification$key} from '../__generated__/MeetingStageTimeLimitEnd_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
-  notification: MeetingStageTimeLimitEnd_notification
+  notification: MeetingStageTimeLimitEnd_notification$key
 }
 
 const MeetingStageTimeLimitEnd = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment MeetingStageTimeLimitEnd_notification on NotificationMeetingStageTimeLimitEnd {
+        ...NotificationTemplate_notification
+        id
+        meeting {
+          id
+          name
+          team {
+            name
+          }
+        }
+      }
+    `,
+    notificationRef
+  )
   const {history} = useRouter()
   const {meeting} = notification
   const {id: meetingId, name: meetingName, team} = meeting
@@ -29,18 +45,4 @@ const MeetingStageTimeLimitEnd = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(MeetingStageTimeLimitEnd, {
-  notification: graphql`
-    fragment MeetingStageTimeLimitEnd_notification on NotificationMeetingStageTimeLimitEnd {
-      ...NotificationTemplate_notification
-      id
-      meeting {
-        id
-        name
-        team {
-          name
-        }
-      }
-    }
-  `
-})
+export default MeetingStageTimeLimitEnd

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled'
 import {Forum} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 import {PALETTE} from '~/styles/paletteV3'
 import plural from '~/utils/plural'
-import {NewMeetingActionsCurrentMeetings_team} from '~/__generated__/NewMeetingActionsCurrentMeetings_team.graphql'
+import {NewMeetingActionsCurrentMeetings_team$key} from '~/__generated__/NewMeetingActionsCurrentMeetings_team.graphql'
 import FlatButton from './FlatButton'
 import SelectMeetingDropdown from './SelectMeetingDropdown'
 
@@ -25,11 +25,24 @@ const ForumIcon = styled(Forum)({
 })
 
 interface Props {
-  team: NewMeetingActionsCurrentMeetings_team
+  team: NewMeetingActionsCurrentMeetings_team$key
 }
 
 const NewMeetingActionsCurrentMeetings = (props: Props) => {
-  const {team} = props
+  const {team: teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment NewMeetingActionsCurrentMeetings_team on Team {
+        id
+        activeMeetings {
+          ...SelectMeetingDropdown_meetings
+          ...useSnacksForNewMeetings_meetings
+          id
+        }
+      }
+    `,
+    teamRef
+  )
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu<HTMLButtonElement>(
     MenuPosition.LOWER_RIGHT,
     {
@@ -57,15 +70,4 @@ const NewMeetingActionsCurrentMeetings = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(NewMeetingActionsCurrentMeetings, {
-  team: graphql`
-    fragment NewMeetingActionsCurrentMeetings_team on Team {
-      id
-      activeMeetings {
-        ...SelectMeetingDropdown_meetings
-        ...useSnacksForNewMeetings_meetings
-        id
-      }
-    }
-  `
-})
+export default NewMeetingActionsCurrentMeetings

--- a/packages/client/components/NewMeetingSidebar.tsx
+++ b/packages/client/components/NewMeetingSidebar.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactNode} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {useRenameMeeting} from '~/hooks/useRenameMeeting'
-import {NewMeetingSidebar_meeting} from '~/__generated__/NewMeetingSidebar_meeting.graphql'
+import {NewMeetingSidebar_meeting$key} from '~/__generated__/NewMeetingSidebar_meeting.graphql'
 import {PALETTE} from '../styles/paletteV3'
 import {NavSidebar} from '../types/constEnums'
 import isDemoRoute from '../utils/isDemoRoute'
@@ -73,11 +73,31 @@ interface Props {
   children: ReactNode
   handleMenuClick: () => void
   toggleSidebar: () => void
-  meeting: NewMeetingSidebar_meeting
+  meeting: NewMeetingSidebar_meeting$key
 }
 
 const NewMeetingSidebar = (props: Props) => {
-  const {children, handleMenuClick, toggleSidebar, meeting} = props
+  const {children, handleMenuClick, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment NewMeetingSidebar_meeting on NewMeeting {
+        ...Facilitator_meeting
+        id
+        endedAt
+        facilitatorUserId
+        name
+        team {
+          id
+          name
+          organization {
+            id
+            tierLimitExceededAt
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {id: meetingId, endedAt, team, name: meetingName, facilitatorUserId} = meeting
   const {id: teamId, name: teamName, organization} = team
   const {id: orgId, tierLimitExceededAt} = organization
@@ -126,22 +146,4 @@ const NewMeetingSidebar = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(NewMeetingSidebar, {
-  meeting: graphql`
-    fragment NewMeetingSidebar_meeting on NewMeeting {
-      ...Facilitator_meeting
-      id
-      endedAt
-      facilitatorUserId
-      name
-      team {
-        id
-        name
-        organization {
-          id
-          tierLimitExceededAt
-        }
-      }
-    }
-  `
-})
+export default NewMeetingSidebar

--- a/packages/client/components/NewTeamOrgDropdown.tsx
+++ b/packages/client/components/NewTeamOrgDropdown.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {MenuProps} from '../hooks/useMenu'
-import {NewTeamOrgDropdown_organizations} from '../__generated__/NewTeamOrgDropdown_organizations.graphql'
+import {NewTeamOrgDropdown_organizations$key} from '../__generated__/NewTeamOrgDropdown_organizations.graphql'
 import DropdownMenuItemLabel from './DropdownMenuItemLabel'
 import DropdownMenuLabel from './DropdownMenuLabel'
 import Menu from './Menu'
@@ -13,11 +13,21 @@ interface Props {
   menuProps: MenuProps
   defaultActiveIdx: number
   onChange: (orgId: string) => void
-  organizations: NewTeamOrgDropdown_organizations
+  organizations: NewTeamOrgDropdown_organizations$key
 }
 
 const NewTeamOrgDropdown = (props: Props) => {
-  const {defaultActiveIdx, onChange, organizations, menuProps} = props
+  const {defaultActiveIdx, onChange, organizations: organizationsRef, menuProps} = props
+  const organizations = useFragment(
+    graphql`
+      fragment NewTeamOrgDropdown_organizations on Organization @relay(plural: true) {
+        id
+        name
+        tier
+      }
+    `,
+    organizationsRef
+  )
   return (
     <Menu
       ariaLabel={'Select the organization the new team belongs to'}
@@ -46,12 +56,4 @@ const NewTeamOrgDropdown = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(NewTeamOrgDropdown, {
-  organizations: graphql`
-    fragment NewTeamOrgDropdown_organizations on Organization @relay(plural: true) {
-      id
-      name
-      tier
-    }
-  `
-})
+export default NewTeamOrgDropdown

--- a/packages/client/components/NotificationPicker.tsx
+++ b/packages/client/components/NotificationPicker.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import lazyPreload, {LazyExoticPreload} from '~/utils/lazyPreload'
 import {
   NotificationEnum,
-  NotificationPicker_notification
+  NotificationPicker_notification$key
 } from '~/__generated__/NotificationPicker_notification.graphql'
 
 const typePicker: Record<NotificationEnum, LazyExoticPreload<any>> = {
@@ -47,11 +47,32 @@ const typePicker: Record<NotificationEnum, LazyExoticPreload<any>> = {
 }
 
 interface Props {
-  notification: NotificationPicker_notification
+  notification: NotificationPicker_notification$key
 }
 
 const NotificationPicker = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment NotificationPicker_notification on Notification {
+        type
+        id
+        ...DiscussionMentioned_notification
+        ...KickedOut_notification
+        ...PaymentRejected_notification
+        ...TaskInvolves_notification
+        ...PromoteToBillingLeader_notification
+        ...TeamArchived_notification
+        ...TeamInvitationNotification_notification
+        ...MeetingStageTimeLimitEnd_notification
+        ...ResponseMentioned_notification
+        ...ResponseReplied_notification
+        ...TeamsLimitExceededNotification_notification
+        ...TeamsLimitReminderNotification_notification
+      }
+    `,
+    notificationRef
+  )
   const {type} = notification
   const SpecificNotification = typePicker[type]
   return (
@@ -61,23 +82,4 @@ const NotificationPicker = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(NotificationPicker, {
-  notification: graphql`
-    fragment NotificationPicker_notification on Notification {
-      type
-      id
-      ...DiscussionMentioned_notification
-      ...KickedOut_notification
-      ...PaymentRejected_notification
-      ...TaskInvolves_notification
-      ...PromoteToBillingLeader_notification
-      ...TeamArchived_notification
-      ...TeamInvitationNotification_notification
-      ...MeetingStageTimeLimitEnd_notification
-      ...ResponseMentioned_notification
-      ...ResponseReplied_notification
-      ...TeamsLimitExceededNotification_notification
-      ...TeamsLimitReminderNotification_notification
-    }
-  `
-})
+export default NotificationPicker

--- a/packages/client/components/NotificationTemplate.tsx
+++ b/packages/client/components/NotificationTemplate.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import ms from 'ms'
 import React, {ReactNode} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import parabolLogo from 'static/images/brand/mark-color.svg'
 import NotificationSubtitle from '~/components/NotificationSubtitle'
 import useRefreshInterval from '~/hooks/useRefreshInterval'
-import {NotificationTemplate_notification} from '~/__generated__/NotificationTemplate_notification.graphql'
+import {NotificationTemplate_notification$key} from '~/__generated__/NotificationTemplate_notification.graphql'
 import NotificationBody from './NotificationBody'
 import NotificationMessage from './NotificationMessage'
 import NotificationRow from './NotificationRow'
@@ -13,13 +13,22 @@ import NotificationRow from './NotificationRow'
 interface Props {
   avatar?: string
   message: string
-  notification: NotificationTemplate_notification
+  notification: NotificationTemplate_notification$key
   action?: ReactNode
   children?: ReactNode
 }
 
 const NotificationTemplate = (props: Props) => {
-  const {avatar, message, notification, action, children} = props
+  const {avatar, message, notification: notificationRef, action, children} = props
+  const notification = useFragment(
+    graphql`
+      fragment NotificationTemplate_notification on Notification {
+        createdAt
+        status
+      }
+    `,
+    notificationRef
+  )
   const {createdAt, status} = notification
   // keep the timestamp fresh
   useRefreshInterval(ms('1m'))
@@ -34,11 +43,4 @@ const NotificationTemplate = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(NotificationTemplate, {
-  notification: graphql`
-    fragment NotificationTemplate_notification on Notification {
-      createdAt
-      status
-    }
-  `
-})
+export default NotificationTemplate

--- a/packages/client/components/PalettePicker/PalettePicker.tsx
+++ b/packages/client/components/PalettePicker/PalettePicker.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import ReflectTemplatePromptUpdateGroupColorMutation from '~/mutations/ReflectTemplatePromptUpdateGroupColorMutation'
-import {PalettePicker_prompt} from '~/__generated__/PalettePicker_prompt.graphql'
-import {PalettePicker_prompts} from '~/__generated__/PalettePicker_prompts.graphql'
+import {PalettePicker_prompt$key} from '~/__generated__/PalettePicker_prompt.graphql'
+import {PalettePicker_prompts$key} from '~/__generated__/PalettePicker_prompts.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import {MenuProps} from '../../hooks/useMenu'
 import palettePickerOptions from '../../styles/palettePickerOptions'
@@ -12,8 +12,8 @@ import Menu from '../Menu'
 import PaletteColor from '../PaletteColor/PaletteColor'
 
 interface Props {
-  prompt: PalettePicker_prompt
-  prompts: PalettePicker_prompts
+  prompt: PalettePicker_prompt$key
+  prompts: PalettePicker_prompts$key
   menuProps: MenuProps
 }
 
@@ -33,7 +33,25 @@ const PaletteList = styled('ul')({
 })
 
 const PalettePicker = (props: Props) => {
-  const {prompt, prompts, menuProps} = props
+  const {prompt: promptRef, prompts: promptsRef, menuProps} = props
+  const prompts = useFragment(
+    graphql`
+      fragment PalettePicker_prompts on ReflectPrompt @relay(plural: true) {
+        id
+        groupColor
+      }
+    `,
+    promptsRef
+  )
+  const prompt = useFragment(
+    graphql`
+      fragment PalettePicker_prompt on ReflectPrompt {
+        id
+        groupColor
+      }
+    `,
+    promptRef
+  )
   const {closePortal} = menuProps
   const {id: promptId, groupColor} = prompt
   const atmosphere = useAtmosphere()
@@ -62,17 +80,4 @@ const PalettePicker = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PalettePicker, {
-  prompts: graphql`
-    fragment PalettePicker_prompts on ReflectPrompt @relay(plural: true) {
-      id
-      groupColor
-    }
-  `,
-  prompt: graphql`
-    fragment PalettePicker_prompt on ReflectPrompt {
-      id
-      groupColor
-    }
-  `
-})
+export default PalettePicker

--- a/packages/client/components/ParabolScopingSearchFilterMenu.tsx
+++ b/packages/client/components/ParabolScopingSearchFilterMenu.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {ParabolSearchQuery} from '~/types/clientSchema'
 import {taskScopingStatusFilters} from '~/utils/constants'
 import {MenuProps} from '../hooks/useMenu'
-import {ParabolScopingSearchFilterMenu_meeting} from '../__generated__/ParabolScopingSearchFilterMenu_meeting.graphql'
+import {ParabolScopingSearchFilterMenu_meeting$key} from '../__generated__/ParabolScopingSearchFilterMenu_meeting.graphql'
 import Checkbox from './Checkbox'
 import DropdownMenuLabel from './DropdownMenuLabel'
 import Menu from './Menu'
@@ -24,11 +24,23 @@ const FilterLabel = styled(DropdownMenuLabel)({
 
 interface Props {
   menuProps: MenuProps
-  meeting: ParabolScopingSearchFilterMenu_meeting
+  meeting: ParabolScopingSearchFilterMenu_meeting$key
 }
 
 const ParabolScopingSearchFilterMenu = (props: Props) => {
-  const {meeting, menuProps} = props
+  const {meeting: meetingRef, menuProps} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ParabolScopingSearchFilterMenu_meeting on PokerMeeting {
+        id
+        parabolSearchQuery {
+          queryString
+          statusFilters
+        }
+      }
+    `,
+    meetingRef
+  )
   const {portalStatus, isDropdown} = menuProps
   const {parabolSearchQuery, id: meetingId} = meeting
   const {statusFilters} = parabolSearchQuery
@@ -70,14 +82,4 @@ const ParabolScopingSearchFilterMenu = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ParabolScopingSearchFilterMenu, {
-  meeting: graphql`
-    fragment ParabolScopingSearchFilterMenu_meeting on PokerMeeting {
-      id
-      parabolSearchQuery {
-        queryString
-        statusFilters
-      }
-    }
-  `
-})
+export default ParabolScopingSearchFilterMenu

--- a/packages/client/components/ParabolScopingSearchFilterToggle.tsx
+++ b/packages/client/components/ParabolScopingSearchFilterToggle.tsx
@@ -1,18 +1,27 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
-import {ParabolScopingSearchFilterToggle_meeting} from '../__generated__/ParabolScopingSearchFilterToggle_meeting.graphql'
+import {ParabolScopingSearchFilterToggle_meeting$key} from '../__generated__/ParabolScopingSearchFilterToggle_meeting.graphql'
 import FilterButton from './FilterButton'
 import ParabolScopingSearchFilterMenu from './ParabolScopingSearchFilterMenu'
 
 interface Props {
-  meeting: ParabolScopingSearchFilterToggle_meeting
+  meeting: ParabolScopingSearchFilterToggle_meeting$key
 }
 
 const ParabolScopingSearchFilterToggle = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ParabolScopingSearchFilterToggle_meeting on PokerMeeting {
+        id
+        ...ParabolScopingSearchFilterMenu_meeting
+      }
+    `,
+    meetingRef
+  )
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT, {
     loadingWidth: 200,
     noClose: true
@@ -25,11 +34,4 @@ const ParabolScopingSearchFilterToggle = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ParabolScopingSearchFilterToggle, {
-  meeting: graphql`
-    fragment ParabolScopingSearchFilterToggle_meeting on PokerMeeting {
-      id
-      ...ParabolScopingSearchFilterMenu_meeting
-    }
-  `
-})
+export default ParabolScopingSearchFilterToggle

--- a/packages/client/components/ParabolScopingSearchResultItem.tsx
+++ b/packages/client/components/ParabolScopingSearchResultItem.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {convertToRaw} from 'draft-js'
 import React, {useRef} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useEditorState from '~/hooks/useEditorState'
 import useMutationProps from '~/hooks/useMutationProps'
@@ -15,7 +15,7 @@ import {PALETTE} from '~/styles/paletteV3'
 import convertToTaskContent from '~/utils/draftjs/convertToTaskContent'
 import isAndroid from '~/utils/draftjs/isAndroid'
 import {Threshold} from '../types/constEnums'
-import {ParabolScopingSearchResultItem_task} from '../__generated__/ParabolScopingSearchResultItem_task.graphql'
+import {ParabolScopingSearchResultItem_task$key} from '../__generated__/ParabolScopingSearchResultItem_task.graphql'
 import {UpdatePokerScopeMutationVariables} from '../__generated__/UpdatePokerScopeMutation.graphql'
 import {AreaEnum} from '../__generated__/UpdateTaskMutation.graphql'
 import Checkbox from './Checkbox'
@@ -45,13 +45,36 @@ const StyledTaskEditor = styled(TaskEditor)({
 interface Props {
   meetingId: string
   usedServiceTaskIds: Set<string>
-  task: ParabolScopingSearchResultItem_task
+  task: ParabolScopingSearchResultItem_task$key
   teamId: string
   setIsEditing: (isEditing: boolean) => void
 }
 
 const ParabolScopingSearchResultItem = (props: Props) => {
-  const {usedServiceTaskIds, task, meetingId, teamId, setIsEditing} = props
+  const {usedServiceTaskIds, task: taskRef, meetingId, teamId, setIsEditing} = props
+  const task = useFragment(
+    graphql`
+      fragment ParabolScopingSearchResultItem_task on Task {
+        id
+        content
+        plaintextContent
+        # grab title so the optimistic updater can use it to update sidebar
+        title
+        updatedAt
+        integration {
+          ... on JiraIssue {
+            __typename
+            summary
+          }
+          ... on _xGitHubIssue {
+            __typename
+            title
+          }
+        }
+      }
+    `,
+    taskRef
+  )
   const {id: serviceTaskId, content, plaintextContent} = task
   const isSelected = usedServiceTaskIds.has(serviceTaskId)
   const disabled = !isSelected && usedServiceTaskIds.size >= Threshold.MAX_POKER_STORIES
@@ -158,25 +181,4 @@ const ParabolScopingSearchResultItem = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ParabolScopingSearchResultItem, {
-  task: graphql`
-    fragment ParabolScopingSearchResultItem_task on Task {
-      id
-      content
-      plaintextContent
-      # grab title so the optimistic updater can use it to update sidebar
-      title
-      updatedAt
-      integration {
-        ... on JiraIssue {
-          __typename
-          summary
-        }
-        ... on _xGitHubIssue {
-          __typename
-          title
-        }
-      }
-    }
-  `
-})
+export default ParabolScopingSearchResultItem

--- a/packages/client/components/ParabolScopingSelectAllTasks.tsx
+++ b/packages/client/components/ParabolScopingSelectAllTasks.tsx
@@ -2,13 +2,13 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useMutationProps from '~/hooks/useMutationProps'
 import useUnusedRecords from '~/hooks/useUnusedRecords'
 import UpdatePokerScopeMutation from '~/mutations/UpdatePokerScopeMutation'
 import useAtmosphere from '../hooks/useAtmosphere'
 import getSelectAllTitle from '../utils/getSelectAllTitle'
-import {ParabolScopingSelectAllTasks_tasks} from '../__generated__/ParabolScopingSelectAllTasks_tasks.graphql'
+import {ParabolScopingSelectAllTasks_tasks$key} from '../__generated__/ParabolScopingSelectAllTasks_tasks.graphql'
 import Checkbox from './Checkbox'
 
 const Item = styled('div')({
@@ -23,12 +23,24 @@ const Title = styled('div')({
 })
 interface Props {
   meetingId: string
-  tasks: ParabolScopingSelectAllTasks_tasks
+  tasks: ParabolScopingSelectAllTasks_tasks$key
   usedServiceTaskIds: Set<string>
 }
 
 const ParabolScopingSelectAllTasks = (props: Props) => {
-  const {meetingId, usedServiceTaskIds, tasks} = props
+  const {meetingId, usedServiceTaskIds, tasks: tasksRef} = props
+  const tasks = useFragment(
+    graphql`
+      fragment ParabolScopingSelectAllTasks_tasks on TaskEdge @relay(plural: true) {
+        node {
+          id
+          plaintextContent
+          integrationHash
+        }
+      }
+    `,
+    tasksRef
+  )
   const taskIds = tasks.map((taskEdge) => taskEdge.node.id)
   const atmosphere = useAtmosphere()
   const [unusedTasks, allSelected] = useUnusedRecords(taskIds, usedServiceTaskIds)
@@ -71,14 +83,4 @@ const ParabolScopingSelectAllTasks = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ParabolScopingSelectAllTasks, {
-  tasks: graphql`
-    fragment ParabolScopingSelectAllTasks_tasks on TaskEdge @relay(plural: true) {
-      node {
-        id
-        plaintextContent
-        integrationHash
-      }
-    }
-  `
-})
+export default ParabolScopingSelectAllTasks

--- a/packages/client/components/PaymentRejected.tsx
+++ b/packages/client/components/PaymentRejected.tsx
@@ -1,16 +1,31 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import NotificationAction from '~/components/NotificationAction'
 import useRouter from '../hooks/useRouter'
-import {PaymentRejected_notification} from '../__generated__/PaymentRejected_notification.graphql'
+import {PaymentRejected_notification$key} from '../__generated__/PaymentRejected_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
-  notification: PaymentRejected_notification
+  notification: PaymentRejected_notification$key
 }
 const PaymentRejected = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment PaymentRejected_notification on NotifyPaymentRejected {
+        ...NotificationTemplate_notification
+        organization {
+          id
+          creditCard {
+            last4
+            brand
+          }
+        }
+      }
+    `,
+    notificationRef
+  )
   const {history} = useRouter()
   const {organization} = notification
   const {id: orgId, creditCard} = organization
@@ -27,17 +42,4 @@ const PaymentRejected = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PaymentRejected, {
-  notification: graphql`
-    fragment PaymentRejected_notification on NotifyPaymentRejected {
-      ...NotificationTemplate_notification
-      organization {
-        id
-        creditCard {
-          last4
-          brand
-        }
-      }
-    }
-  `
-})
+export default PaymentRejected

--- a/packages/client/components/PokerCard.tsx
+++ b/packages/client/components/PokerCard.tsx
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {RefObject, useEffect, useRef} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import PassSVG from '../../../static/images/icons/no_entry.svg'
 import usePokerZIndexOverride from '../hooks/usePokerZIndexOverride'
 import logoMarkWhite from '../styles/theme/images/brand/mark-white.svg'
 import {BezierCurve, Breakpoint, PokerCards} from '../types/constEnums'
 import getPokerCardBackground from '../utils/getPokerCardBackground'
-import {PokerCard_scaleValue} from '../__generated__/PokerCard_scaleValue.graphql'
+import {PokerCard_scaleValue$key} from '../__generated__/PokerCard_scaleValue.graphql'
 
 const COLLAPSE_DUR = 700
 const EXPAND_DUR = 300
@@ -108,7 +108,7 @@ const Pass = styled('img')({
 })
 
 interface Props {
-  scaleValue: PokerCard_scaleValue
+  scaleValue: PokerCard_scaleValue$key
   deckRef: RefObject<HTMLDivElement>
   idx: number
   isCollapsed: boolean
@@ -126,7 +126,7 @@ interface Props {
 
 const PokerCard = (props: Props) => {
   const {
-    scaleValue,
+    scaleValue: scaleValueRef,
     showTransition,
     isCollapsed,
     yOffset,
@@ -138,6 +138,15 @@ const PokerCard = (props: Props) => {
     rotation,
     radius
   } = props
+  const scaleValue = useFragment(
+    graphql`
+      fragment PokerCard_scaleValue on TemplateScaleValue {
+        color
+        label
+      }
+    `,
+    scaleValueRef
+  )
   const {color, label} = scaleValue
   const wasCollapsedRef = useRef(isCollapsed)
   const cardRef = useRef<HTMLDivElement>(null)
@@ -173,11 +182,4 @@ const PokerCard = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PokerCard, {
-  scaleValue: graphql`
-    fragment PokerCard_scaleValue on TemplateScaleValue {
-      color
-      label
-    }
-  `
-})
+export default PokerCard

--- a/packages/client/components/PokerDimensionValueControl.tsx
+++ b/packages/client/components/PokerDimensionValueControl.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {Dispatch, MutableRefObject, SetStateAction, useRef} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import {PALETTE} from '~/styles/paletteV3'
 import {Breakpoint} from '~/types/constEnums'
 import useResizeFontForElement from '../hooks/useResizeFontForElement'
-import {PokerDimensionValueControl_stage} from '../__generated__/PokerDimensionValueControl_stage.graphql'
+import {PokerDimensionValueControl_stage$key} from '../__generated__/PokerDimensionValueControl_stage.graphql'
 import LinkButton from './LinkButton'
 import MiniPokerCard from './MiniPokerCard'
 import PokerDimensionFinalScorePicker from './PokerDimensionFinalScorePicker'
@@ -69,7 +69,7 @@ const StyledLinkButton = styled(LinkButton)({
 interface Props {
   isFacilitator: boolean
   placeholder: string
-  stage: PokerDimensionValueControl_stage
+  stage: PokerDimensionValueControl_stage$key
   error?: {message: string | null}
   onCompleted: () => void
   onError: (error: Error) => void
@@ -84,7 +84,7 @@ const PokerDimensionValueControl = (props: Props) => {
   const {
     isFacilitator,
     placeholder,
-    stage,
+    stage: stageRef,
     onSubmitScore,
     error,
     onCompleted,
@@ -94,6 +94,37 @@ const PokerDimensionValueControl = (props: Props) => {
     setCardScore,
     cardScore
   } = props
+  const stage = useFragment(
+    graphql`
+      fragment PokerDimensionValueControl_stage on EstimateStage {
+        ...PokerDimensionFinalScorePicker_stage
+        id
+        meetingId
+        teamId
+        finalScore
+        serviceField {
+          name
+          type
+        }
+        taskId
+        task {
+          integration {
+            __typename
+          }
+        }
+        dimensionRef {
+          name
+          scale {
+            values {
+              label
+              color
+            }
+          }
+        }
+      }
+    `,
+    stageRef
+  )
   const {dimensionRef, serviceField, task} = stage
   const finalScore = stage.finalScore || ''
   const {type: serviceFieldType} = serviceField
@@ -191,33 +222,4 @@ const PokerDimensionValueControl = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PokerDimensionValueControl, {
-  stage: graphql`
-    fragment PokerDimensionValueControl_stage on EstimateStage {
-      ...PokerDimensionFinalScorePicker_stage
-      id
-      meetingId
-      teamId
-      finalScore
-      serviceField {
-        name
-        type
-      }
-      taskId
-      task {
-        integration {
-          __typename
-        }
-      }
-      dimensionRef {
-        name
-        scale {
-          values {
-            label
-            color
-          }
-        }
-      }
-    }
-  `
-})
+export default PokerDimensionValueControl

--- a/packages/client/components/PokerDiscussVoting.tsx
+++ b/packages/client/components/PokerDiscussVoting.tsx
@@ -1,13 +1,16 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useEffect, useMemo, useRef, useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useForceUpdate from '../hooks/useForceUpdate'
 import {PokerCards} from '../types/constEnums'
 import isSpecialPokerLabel from '../utils/isSpecialPokerLabel'
-import {PokerDiscussVoting_meeting} from '../__generated__/PokerDiscussVoting_meeting.graphql'
-import {PokerDiscussVoting_stage} from '../__generated__/PokerDiscussVoting_stage.graphql'
+import {PokerDiscussVoting_meeting$key} from '../__generated__/PokerDiscussVoting_meeting.graphql'
+import {
+  PokerDiscussVoting_stage$key,
+  PokerDiscussVoting_stage
+} from '../__generated__/PokerDiscussVoting_stage.graphql'
 import PokerDimensionValueControl from './PokerDimensionValueControl'
 import PokerVotingRow from './PokerVotingRow'
 import useSetTaskEstimate from './useSetTaskEstimate'
@@ -20,8 +23,8 @@ const GroupedVotes = styled('div')({
 })
 
 interface Props {
-  meeting: PokerDiscussVoting_meeting
-  stage: PokerDiscussVoting_stage
+  meeting: PokerDiscussVoting_meeting$key
+  stage: PokerDiscussVoting_stage$key
   isInitialStageRender: boolean
 }
 
@@ -30,7 +33,45 @@ const PokerDiscussVoting = (props: Props) => {
   const {setTaskEstimate, error, submitting, onCompleted, onError} = useSetTaskEstimate()
   const forceUpdate = useForceUpdate()
   const {viewerId} = atmosphere
-  const {meeting, stage, isInitialStageRender} = props
+  const {meeting: meetingRef, stage: stageRef, isInitialStageRender} = props
+  const stage = useFragment(
+    graphql`
+      fragment PokerDiscussVoting_stage on EstimateStage {
+        ...PokerDimensionValueControl_stage
+        id
+        finalScore
+        serviceField {
+          name
+          type
+        }
+        taskId
+        dimensionRef {
+          name
+          scale {
+            values {
+              ...PokerVotingRow_scaleValue
+              label
+              color
+            }
+          }
+        }
+        scores {
+          ...PokerVotingRow_scores
+          label
+        }
+      }
+    `,
+    stageRef
+  )
+  const meeting = useFragment(
+    graphql`
+      fragment PokerDiscussVoting_meeting on PokerMeeting {
+        id
+        facilitatorUserId
+      }
+    `,
+    meetingRef
+  )
   const {id: meetingId, facilitatorUserId} = meeting
   const {id: stageId, dimensionRef, scores, taskId, serviceField} = stage
   const finalScore = stage.finalScore || ''
@@ -151,37 +192,4 @@ const PokerDiscussVoting = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PokerDiscussVoting, {
-  stage: graphql`
-    fragment PokerDiscussVoting_stage on EstimateStage {
-      ...PokerDimensionValueControl_stage
-      id
-      finalScore
-      serviceField {
-        name
-        type
-      }
-      taskId
-      dimensionRef {
-        name
-        scale {
-          values {
-            ...PokerVotingRow_scaleValue
-            label
-            color
-          }
-        }
-      }
-      scores {
-        ...PokerVotingRow_scores
-        label
-      }
-    }
-  `,
-  meeting: graphql`
-    fragment PokerDiscussVoting_meeting on PokerMeeting {
-      id
-      facilitatorUserId
-    }
-  `
-})
+export default PokerDiscussVoting

--- a/packages/client/components/PokerEstimateHeaderCard.tsx
+++ b/packages/client/components/PokerEstimateHeaderCard.tsx
@@ -1,7 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {PokerEstimateHeaderCard_stage} from '../__generated__/PokerEstimateHeaderCard_stage.graphql'
+import {useFragment} from 'react-relay'
+import {
+  PokerEstimateHeaderCard_stage$key,
+  PokerEstimateHeaderCard_stage
+} from '../__generated__/PokerEstimateHeaderCard_stage.graphql'
 import PokerEstimateHeaderCardContent, {
   PokerEstimateHeaderCardContentProps
 } from './PokerEstimateHeaderCardContent'
@@ -9,7 +12,7 @@ import PokerEstimateHeaderCardError from './PokerEstimateHeaderCardError'
 import PokerEstimateHeaderCardParabol from './PokerEstimateHeaderCardParabol'
 
 interface Props {
-  stage: PokerEstimateHeaderCard_stage
+  stage: PokerEstimateHeaderCard_stage$key
 }
 
 type Integration = NonNullable<PokerEstimateHeaderCard_stage['task']>['integration']
@@ -68,7 +71,58 @@ const getHeaderFields = (
 }
 
 const PokerEstimateHeaderCard = (props: Props) => {
-  const {stage} = props
+  const {stage: stageRef} = props
+  const stage = useFragment(
+    graphql`
+      fragment PokerEstimateHeaderCard_stage on EstimateStage {
+        task {
+          ...PokerEstimateHeaderCardParabol_task
+          integrationHash
+          integration {
+            ... on AzureDevOpsWorkItem {
+              __typename
+              id
+              title
+              teamProject
+              type
+              state
+              url
+              descriptionHTML
+            }
+            ... on JiraIssue {
+              __typename
+              issueKey
+              summary
+              descriptionHTML
+              jiraUrl: url
+            }
+            ... on JiraServerIssue {
+              __typename
+              issueKey
+              summary
+              descriptionHTML
+              jiraUrl: url
+            }
+            ... on _xGitHubIssue {
+              __typename
+              number
+              title
+              bodyHTML
+              url
+            }
+            ... on _xGitLabIssue {
+              __typename
+              descriptionHtml
+              title
+              webUrl
+              iid
+            }
+          }
+        }
+      }
+    `,
+    stageRef
+  )
   const {task} = stage
   if (!task) {
     return <PokerEstimateHeaderCardError />
@@ -87,53 +141,4 @@ const PokerEstimateHeaderCard = (props: Props) => {
   return <PokerEstimateHeaderCardContent {...headerFields} />
 }
 
-export default createFragmentContainer(PokerEstimateHeaderCard, {
-  stage: graphql`
-    fragment PokerEstimateHeaderCard_stage on EstimateStage {
-      task {
-        ...PokerEstimateHeaderCardParabol_task
-        integrationHash
-        integration {
-          ... on AzureDevOpsWorkItem {
-            __typename
-            id
-            title
-            teamProject
-            type
-            state
-            url
-            descriptionHTML
-          }
-          ... on JiraIssue {
-            __typename
-            issueKey
-            summary
-            descriptionHTML
-            jiraUrl: url
-          }
-          ... on JiraServerIssue {
-            __typename
-            issueKey
-            summary
-            descriptionHTML
-            jiraUrl: url
-          }
-          ... on _xGitHubIssue {
-            __typename
-            number
-            title
-            bodyHTML
-            url
-          }
-          ... on _xGitLabIssue {
-            __typename
-            descriptionHtml
-            title
-            webUrl
-            iid
-          }
-        }
-      }
-    }
-  `
-})
+export default PokerEstimateHeaderCard

--- a/packages/client/components/PokerEstimateHeaderCardParabol.tsx
+++ b/packages/client/components/PokerEstimateHeaderCardParabol.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {convertToRaw} from 'draft-js'
 import React, {useRef, useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import useEditorState from '~/hooks/useEditorState'
 import useTaskChildFocus from '~/hooks/useTaskChildFocus'
@@ -13,7 +13,7 @@ import isAndroid from '~/utils/draftjs/isAndroid'
 import useAtmosphere from '../hooks/useAtmosphere'
 import UpdateTaskMutation from '../mutations/UpdateTaskMutation'
 import convertToTaskContent from '../utils/draftjs/convertToTaskContent'
-import {PokerEstimateHeaderCardParabol_task} from '../__generated__/PokerEstimateHeaderCardParabol_task.graphql'
+import {PokerEstimateHeaderCardParabol_task$key} from '../__generated__/PokerEstimateHeaderCardParabol_task.graphql'
 import CardButton from './CardButton'
 import IconLabel from './IconLabel'
 import TaskEditor from './TaskEditor/TaskEditor'
@@ -65,11 +65,23 @@ const Content = styled('div')({
 })
 
 interface Props {
-  task: PokerEstimateHeaderCardParabol_task
+  task: PokerEstimateHeaderCardParabol_task$key
 }
 
 const PokerEstimateHeaderCardParabol = (props: Props) => {
-  const {task} = props
+  const {task: taskRef} = props
+  const task = useFragment(
+    graphql`
+      fragment PokerEstimateHeaderCardParabol_task on Task {
+        id
+        title
+        plaintextContent
+        content
+        teamId
+      }
+    `,
+    taskRef
+  )
   const {id: taskId, content} = task
   const atmosphere = useAtmosphere()
   const [isExpanded, setIsExpanded] = useState(true)
@@ -135,14 +147,4 @@ const PokerEstimateHeaderCardParabol = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PokerEstimateHeaderCardParabol, {
-  task: graphql`
-    fragment PokerEstimateHeaderCardParabol_task on Task {
-      id
-      title
-      plaintextContent
-      content
-      teamId
-    }
-  `
-})
+export default PokerEstimateHeaderCardParabol

--- a/packages/client/components/PokerEstimatePhase.tsx
+++ b/packages/client/components/PokerEstimatePhase.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import useGotoStageId from '~/hooks/useGotoStageId'
 import useRightDrawer from '~/hooks/useRightDrawer'
 import {Breakpoint, DiscussionThreadEnum} from '~/types/constEnums'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
-import {PokerEstimatePhase_meeting} from '../__generated__/PokerEstimatePhase_meeting.graphql'
+import {PokerEstimatePhase_meeting$key} from '../__generated__/PokerEstimatePhase_meeting.graphql'
 import ErrorBoundary from './ErrorBoundary'
 import EstimatePhaseArea from './EstimatePhaseArea'
 import EstimatePhaseDiscussionDrawer from './EstimatePhaseDiscussionDrawer'
@@ -45,11 +45,35 @@ const EstimateAreaWrapper = styled('div')({
 
 interface Props extends PokerMeetingPhaseProps {
   gotoStageId: ReturnType<typeof useGotoStageId>
-  meeting: PokerEstimatePhase_meeting
+  meeting: PokerEstimatePhase_meeting$key
 }
 
 const PokerEstimatePhase = (props: Props) => {
-  const {avatarGroup, meeting, toggleSidebar, gotoStageId} = props
+  const {avatarGroup, meeting: meetingRef, toggleSidebar, gotoStageId} = props
+  const meeting = useFragment(
+    graphql`
+      fragment PokerEstimatePhase_meeting on PokerMeeting {
+        ...EstimatePhaseArea_meeting
+        id
+        endedAt
+        isCommentUnread
+        isRightDrawerOpen
+        localStage {
+          ...PokerEstimateHeaderCard_stage
+        }
+        phases {
+          ... on EstimatePhase {
+            stages {
+              ...PokerEstimateHeaderCard_stage
+            }
+          }
+        }
+        showSidebar
+        ...EstimatePhaseDiscussionDrawer_meeting
+      }
+    `,
+    meetingRef
+  )
   const {
     id: meetingId,
     localStage,
@@ -101,26 +125,4 @@ const PokerEstimatePhase = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PokerEstimatePhase, {
-  meeting: graphql`
-    fragment PokerEstimatePhase_meeting on PokerMeeting {
-      ...EstimatePhaseArea_meeting
-      id
-      endedAt
-      isCommentUnread
-      isRightDrawerOpen
-      localStage {
-        ...PokerEstimateHeaderCard_stage
-      }
-      phases {
-        ... on EstimatePhase {
-          stages {
-            ...PokerEstimateHeaderCard_stage
-          }
-        }
-      }
-      showSidebar
-      ...EstimatePhaseDiscussionDrawer_meeting
-    }
-  `
-})
+export default PokerEstimatePhase

--- a/packages/client/components/PokerSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/PokerSidebarPhaseListItemChildren.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useGotoStageId from '~/hooks/useGotoStageId'
 import {
   NewMeetingPhaseTypeEnum,
-  PokerSidebarPhaseListItemChildren_meeting
+  PokerSidebarPhaseListItemChildren_meeting$key
 } from '~/__generated__/PokerSidebarPhaseListItemChildren_meeting.graphql'
 import MeetingSidebarTeamMemberStageItems from './MeetingSidebarTeamMemberStageItems'
 import PokerSidebarEstimateSection from './PokerSidebarEstimateSection'
@@ -13,11 +13,26 @@ interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
   handleMenuClick: () => void
   phaseType: NewMeetingPhaseTypeEnum
-  meeting: PokerSidebarPhaseListItemChildren_meeting
+  meeting: PokerSidebarPhaseListItemChildren_meeting$key
 }
 
 const PokerSidebarPhaseListItemChildren = (props: Props) => {
-  const {gotoStageId, handleMenuClick, phaseType, meeting} = props
+  const {gotoStageId, handleMenuClick, phaseType, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment PokerSidebarPhaseListItemChildren_meeting on PokerMeeting {
+        ...MeetingSidebarTeamMemberStageItems_meeting
+        ...PokerSidebarEstimateSection_meeting
+        phases {
+          phaseType
+          stages {
+            isComplete
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   if (phaseType === 'checkin') {
     return (
       <MeetingSidebarTeamMemberStageItems
@@ -39,17 +54,4 @@ const PokerSidebarPhaseListItemChildren = (props: Props) => {
   return null
 }
 
-export default createFragmentContainer(PokerSidebarPhaseListItemChildren, {
-  meeting: graphql`
-    fragment PokerSidebarPhaseListItemChildren_meeting on PokerMeeting {
-      ...MeetingSidebarTeamMemberStageItems_meeting
-      ...PokerSidebarEstimateSection_meeting
-      phases {
-        phaseType
-        stages {
-          isComplete
-        }
-      }
-    }
-  `
-})
+export default PokerSidebarPhaseListItemChildren

--- a/packages/client/components/PokerVotingRow.tsx
+++ b/packages/client/components/PokerVotingRow.tsx
@@ -1,19 +1,19 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {PALETTE} from '../styles/paletteV3'
 import {PokerCards} from '../types/constEnums'
-import {PokerVotingRow_scaleValue} from '../__generated__/PokerVotingRow_scaleValue.graphql'
-import {PokerVotingRow_scores} from '../__generated__/PokerVotingRow_scores.graphql'
+import {PokerVotingRow_scaleValue$key} from '../__generated__/PokerVotingRow_scaleValue.graphql'
+import {PokerVotingRow_scores$key} from '../__generated__/PokerVotingRow_scores.graphql'
 import AvatarList from './AvatarList'
 import MiniPokerCard from './MiniPokerCard'
 import PokerVotingNoVotes from './PokerVotingNoVotes'
 import PokerVotingRowBase from './PokerVotingRowBase'
 
 interface Props {
-  scaleValue: PokerVotingRow_scaleValue
-  scores: PokerVotingRow_scores
+  scaleValue: PokerVotingRow_scaleValue$key
+  scores: PokerVotingRow_scores$key
   setFinalScore?: () => void
   isInitialStageRender: boolean
 }
@@ -24,7 +24,26 @@ const MiniCardWrapper = styled('div')({
 })
 
 const PokerVotingRow = (props: Props) => {
-  const {scaleValue, scores, setFinalScore, isInitialStageRender} = props
+  const {scaleValue: scaleValueRef, scores: scoresRef, setFinalScore, isInitialStageRender} = props
+  const scaleValue = useFragment(
+    graphql`
+      fragment PokerVotingRow_scaleValue on TemplateScaleValue {
+        color
+        label
+      }
+    `,
+    scaleValueRef
+  )
+  const scores = useFragment(
+    graphql`
+      fragment PokerVotingRow_scores on EstimateUserScore @relay(plural: true) {
+        user {
+          ...AvatarList_users
+        }
+      }
+    `,
+    scoresRef
+  )
   const {label, color} = scaleValue
   const users = scores.map(({user}) => user)
   return (
@@ -45,18 +64,4 @@ const PokerVotingRow = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PokerVotingRow, {
-  scaleValue: graphql`
-    fragment PokerVotingRow_scaleValue on TemplateScaleValue {
-      color
-      label
-    }
-  `,
-  scores: graphql`
-    fragment PokerVotingRow_scores on EstimateUserScore @relay(plural: true) {
-      user {
-        ...AvatarList_users
-      }
-    }
-  `
-})
+export default PokerVotingRow

--- a/packages/client/components/PromoteToBillingLeader.tsx
+++ b/packages/client/components/PromoteToBillingLeader.tsx
@@ -1,17 +1,31 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useRouter from '~/hooks/useRouter'
 import defaultOrgAvatar from '~/styles/theme/images/avatar-organization.svg'
-import {PromoteToBillingLeader_notification} from '~/__generated__/PromoteToBillingLeader_notification.graphql'
+import {PromoteToBillingLeader_notification$key} from '~/__generated__/PromoteToBillingLeader_notification.graphql'
 import NotificationAction from './NotificationAction'
 import NotificationTemplate from './NotificationTemplate'
 interface Props {
-  notification: PromoteToBillingLeader_notification
+  notification: PromoteToBillingLeader_notification$key
 }
 
 const PromoteToBillingLeader = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment PromoteToBillingLeader_notification on NotifyPromoteToOrgLeader {
+        ...NotificationTemplate_notification
+        id
+        organization {
+          id
+          name
+          picture
+        }
+      }
+    `,
+    notificationRef
+  )
   const {history} = useRouter()
   const {organization} = notification
   const {name: orgName, id: orgId, picture: orgPicture} = organization
@@ -30,16 +44,4 @@ const PromoteToBillingLeader = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(PromoteToBillingLeader, {
-  notification: graphql`
-    fragment PromoteToBillingLeader_notification on NotifyPromoteToOrgLeader {
-      ...NotificationTemplate_notification
-      id
-      organization {
-        id
-        name
-        picture
-      }
-    }
-  `
-})
+export default PromoteToBillingLeader

--- a/packages/client/components/ReflectionCard/ColorBadge.tsx
+++ b/packages/client/components/ReflectionCard/ColorBadge.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {MenuPosition} from '~/hooks/useCoords'
 import useTooltip from '~/hooks/useTooltip'
 import {NewMeetingPhaseTypeEnum} from '~/__generated__/ActionMeeting_meeting.graphql'
-import {ColorBadge_reflection} from '~/__generated__/ColorBadge_reflection.graphql'
+import {ColorBadge_reflection$key} from '~/__generated__/ColorBadge_reflection.graphql'
 
 const DROP_SIZE = 32
 const DROP_SIZE_HALF = DROP_SIZE / 2
@@ -33,11 +33,22 @@ const BadgeWrapper = styled('div')({
 
 interface Props {
   phaseType: NewMeetingPhaseTypeEnum
-  reflection: ColorBadge_reflection
+  reflection: ColorBadge_reflection$key
 }
 
 const ColorBadge = (props: Props) => {
-  const {reflection, phaseType} = props
+  const {reflection: reflectionRef, phaseType} = props
+  const reflection = useFragment(
+    graphql`
+      fragment ColorBadge_reflection on RetroReflection {
+        prompt {
+          question
+          groupColor
+        }
+      }
+    `,
+    reflectionRef
+  )
   const {prompt} = reflection
   const {question, groupColor} = prompt
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
@@ -57,13 +68,4 @@ const ColorBadge = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ColorBadge, {
-  reflection: graphql`
-    fragment ColorBadge_reflection on RetroReflection {
-      prompt {
-        question
-        groupColor
-      }
-    }
-  `
-})
+export default ColorBadge

--- a/packages/client/components/ReflectionCard/ReactjiSection.tsx
+++ b/packages/client/components/ReflectionCard/ReactjiSection.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useInitialRender from '~/hooks/useInitialRender'
 import useTransition, {TransitionStatus} from '~/hooks/useTransition'
 import {Threshold} from '~/types/constEnums'
-import {ReactjiSection_reactjis} from '~/__generated__/ReactjiSection_reactjis.graphql'
+import {ReactjiSection_reactjis$key} from '~/__generated__/ReactjiSection_reactjis.graphql'
 import AddReactjiButton from './AddReactjiButton'
 import ReactjiCount from './ReactjiCount'
 
@@ -20,11 +20,22 @@ const Wrapper = styled('div')({
 interface Props {
   className?: string
   onToggle: (emojiId: string) => void
-  reactjis: ReactjiSection_reactjis
+  reactjis: ReactjiSection_reactjis$key
 }
 
 const ReactjiSection = (props: Props) => {
-  const {className, onToggle, reactjis} = props
+  const {className, onToggle, reactjis: reactjisRef} = props
+  const reactjis = useFragment(
+    graphql`
+      fragment ReactjiSection_reactjis on Reactji @relay(plural: true) {
+        ...ReactjiCount_reactji
+        id
+        count
+        isViewerReactji
+      }
+    `,
+    reactjisRef
+  )
   const animatedReactjis = reactjis.map((reactji) => ({...reactji, key: reactji.id}))
   const tranChildren = useTransition(animatedReactjis)
   const isInit = useInitialRender()
@@ -48,13 +59,4 @@ const ReactjiSection = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ReactjiSection, {
-  reactjis: graphql`
-    fragment ReactjiSection_reactjis on Reactji @relay(plural: true) {
-      ...ReactjiCount_reactji
-      id
-      count
-      isViewerReactji
-    }
-  `
-})
+export default ReactjiSection

--- a/packages/client/components/ReflectionGroup/ReflectionGroupTitleEditor.tsx
+++ b/packages/client/components/ReflectionGroup/ReflectionGroupTitleEditor.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {RefObject, useRef} from 'react'
-import {commitLocalUpdate, createFragmentContainer} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
 import UpdateReflectionGroupTitleMutation from '../../mutations/UpdateReflectionGroupTitleMutation'
@@ -9,15 +9,15 @@ import {PALETTE} from '../../styles/paletteV3'
 import ui from '../../styles/ui'
 import {Card} from '../../types/constEnums'
 import {RETRO_TOPIC_LABEL} from '../../utils/constants'
-import {ReflectionGroupTitleEditor_meeting} from '../../__generated__/ReflectionGroupTitleEditor_meeting.graphql'
-import {ReflectionGroupTitleEditor_reflectionGroup} from '../../__generated__/ReflectionGroupTitleEditor_reflectionGroup.graphql'
+import {ReflectionGroupTitleEditor_meeting$key} from '../../__generated__/ReflectionGroupTitleEditor_meeting.graphql'
+import {ReflectionGroupTitleEditor_reflectionGroup$key} from '../../__generated__/ReflectionGroupTitleEditor_reflectionGroup.graphql'
 import StyledError from '../StyledError'
 
 interface Props {
   isExpanded: boolean
-  reflectionGroup: ReflectionGroupTitleEditor_reflectionGroup
+  reflectionGroup: ReflectionGroupTitleEditor_reflectionGroup$key
   readOnly: boolean
-  meeting: ReflectionGroupTitleEditor_meeting
+  meeting: ReflectionGroupTitleEditor_meeting$key
   titleInputRef: RefObject<HTMLInputElement>
 }
 
@@ -95,7 +95,33 @@ const getValidationError = (
 const ReflectionGroupTitleEditor = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {submitMutation, submitting, onCompleted, onError, error} = useMutationProps()
-  const {meeting, reflectionGroup, titleInputRef, isExpanded, readOnly} = props
+  const {
+    meeting: meetingRef,
+    reflectionGroup: reflectionGroupRef,
+    titleInputRef,
+    isExpanded,
+    readOnly
+  } = props
+  const reflectionGroup = useFragment(
+    graphql`
+      fragment ReflectionGroupTitleEditor_reflectionGroup on RetroReflectionGroup {
+        id
+        title
+      }
+    `,
+    reflectionGroupRef
+  )
+  const meeting = useFragment(
+    graphql`
+      fragment ReflectionGroupTitleEditor_meeting on RetrospectiveMeeting {
+        reflectionGroups {
+          id
+          title
+        }
+      }
+    `,
+    meetingRef
+  )
   const {reflectionGroups} = meeting
   const {id: reflectionGroupId, title} = reflectionGroup
   const dirtyRef = useRef(false)
@@ -171,19 +197,4 @@ const ReflectionGroupTitleEditor = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ReflectionGroupTitleEditor, {
-  reflectionGroup: graphql`
-    fragment ReflectionGroupTitleEditor_reflectionGroup on RetroReflectionGroup {
-      id
-      title
-    }
-  `,
-  meeting: graphql`
-    fragment ReflectionGroupTitleEditor_meeting on RetrospectiveMeeting {
-      reflectionGroups {
-        id
-        title
-      }
-    }
-  `
-})
+export default ReflectionGroupTitleEditor

--- a/packages/client/components/ReflectionGroupHeader.tsx
+++ b/packages/client/components/ReflectionGroupHeader.tsx
@@ -2,21 +2,21 @@ import styled from '@emotion/styled'
 import {Edit} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {forwardRef, Ref, RefObject} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {PortalStatus} from '../hooks/usePortal'
 import {PALETTE} from '../styles/paletteV3'
 import {ElementWidth, Gutters} from '../types/constEnums'
 import {GROUP, VOTE} from '../utils/constants'
 import plural from '../utils/plural'
-import {ReflectionGroupHeader_meeting} from '../__generated__/ReflectionGroupHeader_meeting.graphql'
-import {ReflectionGroupHeader_reflectionGroup} from '../__generated__/ReflectionGroupHeader_reflectionGroup.graphql'
+import {ReflectionGroupHeader_meeting$key} from '../__generated__/ReflectionGroupHeader_meeting.graphql'
+import {ReflectionGroupHeader_reflectionGroup$key} from '../__generated__/ReflectionGroupHeader_reflectionGroup.graphql'
 import ReflectionGroupTitleEditor from './ReflectionGroup/ReflectionGroupTitleEditor'
 import ReflectionGroupVoting from './ReflectionGroupVoting'
 import BaseTag from './Tag/BaseTag'
 
 interface Props {
-  meeting: ReflectionGroupHeader_meeting
-  reflectionGroup: ReflectionGroupHeader_reflectionGroup
+  meeting: ReflectionGroupHeader_meeting$key
+  reflectionGroup: ReflectionGroupHeader_reflectionGroup$key
   isExpanded?: boolean
   portalStatus: PortalStatus
   titleInputRef: RefObject<HTMLInputElement>
@@ -67,7 +67,40 @@ const StyledTag = styled(BaseTag)<{dialogClosed: boolean}>(({dialogClosed}) => (
 }))
 
 const ReflectionGroupHeader = forwardRef((props: Props, ref: Ref<HTMLDivElement>) => {
-  const {meeting, reflectionGroup, titleInputRef, portalStatus, dataCy} = props
+  const {
+    meeting: meetingRef,
+    reflectionGroup: reflectionGroupRef,
+    titleInputRef,
+    portalStatus,
+    dataCy
+  } = props
+  const meeting = useFragment(
+    graphql`
+      fragment ReflectionGroupHeader_meeting on RetrospectiveMeeting {
+        localStage {
+          isComplete
+        }
+        localPhase {
+          phaseType
+        }
+        ...ReflectionGroupTitleEditor_meeting
+        ...ReflectionGroupVoting_meeting
+      }
+    `,
+    meetingRef
+  )
+  const reflectionGroup = useFragment(
+    graphql`
+      fragment ReflectionGroupHeader_reflectionGroup on RetroReflectionGroup {
+        ...ReflectionGroupTitleEditor_reflectionGroup
+        ...ReflectionGroupVoting_reflectionGroup
+        reflections {
+          id
+        }
+      }
+    `,
+    reflectionGroupRef
+  )
   const isExpanded = !!props.isExpanded
   const {
     localStage,
@@ -109,26 +142,4 @@ const ReflectionGroupHeader = forwardRef((props: Props, ref: Ref<HTMLDivElement>
   )
 })
 
-export default createFragmentContainer(ReflectionGroupHeader, {
-  meeting: graphql`
-    fragment ReflectionGroupHeader_meeting on RetrospectiveMeeting {
-      localStage {
-        isComplete
-      }
-      localPhase {
-        phaseType
-      }
-      ...ReflectionGroupTitleEditor_meeting
-      ...ReflectionGroupVoting_meeting
-    }
-  `,
-  reflectionGroup: graphql`
-    fragment ReflectionGroupHeader_reflectionGroup on RetroReflectionGroup {
-      ...ReflectionGroupTitleEditor_reflectionGroup
-      ...ReflectionGroupVoting_reflectionGroup
-      reflections {
-        id
-      }
-    }
-  `
-})
+export default ReflectionGroupHeader

--- a/packages/client/components/RetroGroupPhase.tsx
+++ b/packages/client/components/RetroGroupPhase.tsx
@@ -4,9 +4,9 @@ import graphql from 'babel-plugin-relay/macro'
  *
  */
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useCallbackRef from '~/hooks/useCallbackRef'
-import {RetroGroupPhase_meeting} from '~/__generated__/RetroGroupPhase_meeting.graphql'
+import {RetroGroupPhase_meeting$key} from '~/__generated__/RetroGroupPhase_meeting.graphql'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import GroupingKanban from './GroupingKanban'
 import MeetingContent from './MeetingContent'
@@ -20,11 +20,23 @@ import {RetroMeetingPhaseProps} from './RetroMeeting'
 import StageTimerDisplay from './StageTimerDisplay'
 
 interface Props extends RetroMeetingPhaseProps {
-  meeting: RetroGroupPhase_meeting
+  meeting: RetroGroupPhase_meeting$key
 }
 
 const RetroGroupPhase = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment RetroGroupPhase_meeting on RetrospectiveMeeting {
+        ...StageTimerControl_meeting
+        ...StageTimerDisplay_meeting
+        ...GroupingKanban_meeting
+        endedAt
+        showSidebar
+      }
+    `,
+    meetingRef
+  )
   const [callbackRef, phaseRef] = useCallbackRef()
   const {endedAt, showSidebar} = meeting
 
@@ -50,14 +62,4 @@ const RetroGroupPhase = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(RetroGroupPhase, {
-  meeting: graphql`
-    fragment RetroGroupPhase_meeting on RetrospectiveMeeting {
-      ...StageTimerControl_meeting
-      ...StageTimerDisplay_meeting
-      ...GroupingKanban_meeting
-      endedAt
-      showSidebar
-    }
-  `
-})
+export default RetroGroupPhase

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {Fragment, useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useRouter from '~/hooks/useRouter'
 import isDemoRoute from '~/utils/isDemoRoute'
 import {
   NewMeetingPhaseTypeEnum,
-  RetroMeetingSidebar_meeting
+  RetroMeetingSidebar_meeting$key
 } from '~/__generated__/RetroMeetingSidebar_meeting.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useGotoStageId from '../hooks/useGotoStageId'
@@ -21,7 +21,7 @@ interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
   handleMenuClick: () => void
   toggleSidebar: () => void
-  meeting: RetroMeetingSidebar_meeting
+  meeting: RetroMeetingSidebar_meeting$key
 }
 
 const collapsiblePhases: NewMeetingPhaseTypeEnum[] = ['checkin', 'discuss']
@@ -30,7 +30,43 @@ const RetroMeetingSidebar = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   const {viewerId} = atmosphere
-  const {gotoStageId, handleMenuClick, toggleSidebar, meeting} = props
+  const {gotoStageId, handleMenuClick, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment RetroMeetingSidebar_meeting on RetrospectiveMeeting {
+        ...RetroSidebarPhaseListItemChildren_meeting
+        ...NewMeetingSidebar_meeting
+        showSidebar
+        settings {
+          phaseTypes
+        }
+        id
+        endedAt
+        facilitatorUserId
+        facilitatorStageId
+        localPhase {
+          phaseType
+        }
+        localStage {
+          id
+        }
+        meetingMembers {
+          id
+        }
+        phases {
+          phaseType
+          stages {
+            id
+            isComplete
+            isNavigable
+            isNavigableByFacilitator
+            readyCount
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {
     id: meetingId,
     endedAt,
@@ -142,38 +178,4 @@ const RetroMeetingSidebar = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(RetroMeetingSidebar, {
-  meeting: graphql`
-    fragment RetroMeetingSidebar_meeting on RetrospectiveMeeting {
-      ...RetroSidebarPhaseListItemChildren_meeting
-      ...NewMeetingSidebar_meeting
-      showSidebar
-      settings {
-        phaseTypes
-      }
-      id
-      endedAt
-      facilitatorUserId
-      facilitatorStageId
-      localPhase {
-        phaseType
-      }
-      localStage {
-        id
-      }
-      meetingMembers {
-        id
-      }
-      phases {
-        phaseType
-        stages {
-          id
-          isComplete
-          isNavigable
-          isNavigableByFacilitator
-          readyCount
-        }
-      }
-    }
-  `
-})
+export default RetroMeetingSidebar

--- a/packages/client/components/RetroReflectPhase/ReflectionStack.tsx
+++ b/packages/client/components/RetroReflectPhase/ReflectionStack.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {RefObject, useRef} from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {ReflectionStack_meeting} from '~/__generated__/ReflectionStack_meeting.graphql'
+import {useFragment} from 'react-relay'
+import {ReflectionStack_meeting$key} from '~/__generated__/ReflectionStack_meeting.graphql'
 import useExpandedReflections from '../../hooks/useExpandedReflections'
 import {
   Breakpoint,
@@ -17,7 +17,7 @@ import ReflectionStackPlaceholder from './ReflectionStackPlaceholder'
 
 interface Props {
   idx: number
-  meeting: ReflectionStack_meeting
+  meeting: ReflectionStack_meeting$key
   phaseEditorRef: React.RefObject<HTMLDivElement>
   phaseRef: RefObject<HTMLDivElement>
   dataCy: string
@@ -59,7 +59,17 @@ const ReflectionWrapper = styled('div')<{idx: number}>(({idx}): any => {
 })
 
 const ReflectionStack = (props: Props) => {
-  const {phaseRef, idx, meeting, reflectionStack, stackTopRef, dataCy} = props
+  const {phaseRef, idx, meeting: meetingRef, reflectionStack, stackTopRef, dataCy} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ReflectionStack_meeting on RetrospectiveMeeting {
+        ...DraggableReflectionCard_meeting
+        ...ReflectionCard_meeting
+        id
+      }
+    `,
+    meetingRef
+  )
   const stackRef = useRef<HTMLDivElement>(null)
   const {setItemsRef, scrollRef, bgRef, portal, collapse, expand} = useExpandedReflections(
     stackRef,
@@ -111,12 +121,4 @@ const ReflectionStack = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ReflectionStack, {
-  meeting: graphql`
-    fragment ReflectionStack_meeting on RetrospectiveMeeting {
-      ...DraggableReflectionCard_meeting
-      ...ReflectionCard_meeting
-      id
-    }
-  `
-})
+export default ReflectionStack

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useCallbackRef from '~/hooks/useCallbackRef'
-import {RetroReflectPhase_meeting} from '~/__generated__/RetroReflectPhase_meeting.graphql'
+import {RetroReflectPhase_meeting$key} from '~/__generated__/RetroReflectPhase_meeting.graphql'
 import useBreakpoint from '../../hooks/useBreakpoint'
 import {Breakpoint} from '../../types/constEnums'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
@@ -19,11 +19,35 @@ import ReflectWrapperMobile from './ReflectionWrapperMobile'
 import ReflectWrapperDesktop from './ReflectWrapperDesktop'
 
 interface Props extends RetroMeetingPhaseProps {
-  meeting: RetroReflectPhase_meeting
+  meeting: RetroReflectPhase_meeting$key
 }
 
 const RetroReflectPhase = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment RetroReflectPhase_meeting on RetrospectiveMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
+        ...PhaseItemColumn_meeting
+        endedAt
+        localPhase {
+          ...RetroReflectPhase_phase @relay(mask: false)
+        }
+        localStage {
+          isComplete
+        }
+        phases {
+          ...RetroReflectPhase_phase @relay(mask: false)
+        }
+        showSidebar
+        settings {
+          disableAnonymity
+        }
+      }
+    `,
+    meetingRef
+  )
   const [callbackRef, phaseRef] = useCallbackRef()
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
@@ -81,26 +105,4 @@ graphql`
   }
 `
 
-export default createFragmentContainer(RetroReflectPhase, {
-  meeting: graphql`
-    fragment RetroReflectPhase_meeting on RetrospectiveMeeting {
-      ...StageTimerDisplay_meeting
-      ...StageTimerControl_meeting
-      ...PhaseItemColumn_meeting
-      endedAt
-      localPhase {
-        ...RetroReflectPhase_phase @relay(mask: false)
-      }
-      localStage {
-        isComplete
-      }
-      phases {
-        ...RetroReflectPhase_phase @relay(mask: false)
-      }
-      showSidebar
-      settings {
-        disableAnonymity
-      }
-    }
-  `
-})
+export default RetroReflectPhase

--- a/packages/client/components/RetroSidebarPhaseListItemChildren.tsx
+++ b/packages/client/components/RetroSidebarPhaseListItemChildren.tsx
@@ -1,10 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useGotoStageId from '~/hooks/useGotoStageId'
 import {
   NewMeetingPhaseTypeEnum,
-  RetroSidebarPhaseListItemChildren_meeting
+  RetroSidebarPhaseListItemChildren_meeting$key
 } from '~/__generated__/RetroSidebarPhaseListItemChildren_meeting.graphql'
 import isPhaseComplete from '../utils/meetings/isPhaseComplete'
 import MeetingSidebarTeamMemberStageItems from './MeetingSidebarTeamMemberStageItems'
@@ -14,11 +14,26 @@ interface Props {
   gotoStageId: ReturnType<typeof useGotoStageId>
   handleMenuClick: () => void
   phaseType: NewMeetingPhaseTypeEnum
-  meeting: RetroSidebarPhaseListItemChildren_meeting
+  meeting: RetroSidebarPhaseListItemChildren_meeting$key
 }
 
 const RetroSidebarPhaseListItemChildren = (props: Props) => {
-  const {gotoStageId, handleMenuClick, phaseType, meeting} = props
+  const {gotoStageId, handleMenuClick, phaseType, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment RetroSidebarPhaseListItemChildren_meeting on RetrospectiveMeeting {
+        ...MeetingSidebarTeamMemberStageItems_meeting
+        ...RetroSidebarDiscussSection_meeting
+        phases {
+          phaseType
+          stages {
+            isComplete
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const {phases} = meeting
   const showDiscussSection = phases && isPhaseComplete('vote', phases)
   if (phaseType === 'checkin') {
@@ -42,17 +57,4 @@ const RetroSidebarPhaseListItemChildren = (props: Props) => {
   return null
 }
 
-export default createFragmentContainer(RetroSidebarPhaseListItemChildren, {
-  meeting: graphql`
-    fragment RetroSidebarPhaseListItemChildren_meeting on RetrospectiveMeeting {
-      ...MeetingSidebarTeamMemberStageItems_meeting
-      ...RetroSidebarDiscussSection_meeting
-      phases {
-        phaseType
-        stages {
-          isComplete
-        }
-      }
-    }
-  `
-})
+export default RetroSidebarPhaseListItemChildren

--- a/packages/client/components/RetroVoteMetaHeader.tsx
+++ b/packages/client/components/RetroVoteMetaHeader.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled'
 import {ExpandMore} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import lazyPreload from '~/utils/lazyPreload'
-import {RetroVoteMetaHeader_meeting} from '~/__generated__/RetroVoteMetaHeader_meeting.graphql'
+import {RetroVoteMetaHeader_meeting$key} from '~/__generated__/RetroVoteMetaHeader_meeting.graphql'
 import {PALETTE} from '../styles/paletteV3'
 import {FONT_FAMILY} from '../styles/typographyV2'
 import {Breakpoint} from '../types/constEnums'
@@ -91,11 +91,25 @@ const TeamVotesCountLabel = styled(VoteCountLabel)({
 })
 
 interface Props {
-  meeting: RetroVoteMetaHeader_meeting
+  meeting: RetroVoteMetaHeader_meeting$key
 }
 
 const RetroVoteMetaHeader = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment RetroVoteMetaHeader_meeting on RetrospectiveMeeting {
+        ...VoteSettingsMenu_meeting
+        endedAt
+        facilitatorUserId
+        viewerMeetingMember {
+          votesRemaining
+        }
+        votesRemaining
+      }
+    `,
+    meetingRef
+  )
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
   const {viewerMeetingMember, endedAt, facilitatorUserId} = meeting
@@ -134,16 +148,4 @@ const RetroVoteMetaHeader = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(RetroVoteMetaHeader, {
-  meeting: graphql`
-    fragment RetroVoteMetaHeader_meeting on RetrospectiveMeeting {
-      ...VoteSettingsMenu_meeting
-      endedAt
-      facilitatorUserId
-      viewerMeetingMember {
-        votesRemaining
-      }
-      votesRemaining
-    }
-  `
-})
+export default RetroVoteMetaHeader

--- a/packages/client/components/RetroVotePhase.tsx
+++ b/packages/client/components/RetroVotePhase.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {RetroVotePhase_meeting} from '~/__generated__/RetroVotePhase_meeting.graphql'
+import {useFragment} from 'react-relay'
+import {RetroVotePhase_meeting$key} from '~/__generated__/RetroVotePhase_meeting.graphql'
 import useCallbackRef from '../hooks/useCallbackRef'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import GroupingKanban from './GroupingKanban'
@@ -17,11 +17,24 @@ import RetroVoteMetaHeader from './RetroVoteMetaHeader'
 import StageTimerDisplay from './StageTimerDisplay'
 
 interface Props extends RetroMeetingPhaseProps {
-  meeting: RetroVotePhase_meeting
+  meeting: RetroVotePhase_meeting$key
 }
 
 const RetroVotePhase = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment RetroVotePhase_meeting on RetrospectiveMeeting {
+        ...StageTimerControl_meeting
+        ...StageTimerDisplay_meeting
+        ...GroupingKanban_meeting
+        ...RetroVoteMetaHeader_meeting
+        endedAt
+        showSidebar
+      }
+    `,
+    meetingRef
+  )
   const [callbackRef, phaseRef] = useCallbackRef()
   const {endedAt, showSidebar} = meeting
 
@@ -50,15 +63,4 @@ const RetroVotePhase = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(RetroVotePhase, {
-  meeting: graphql`
-    fragment RetroVotePhase_meeting on RetrospectiveMeeting {
-      ...StageTimerControl_meeting
-      ...StageTimerDisplay_meeting
-      ...GroupingKanban_meeting
-      ...RetroVoteMetaHeader_meeting
-      endedAt
-      showSidebar
-    }
-  `
-})
+export default RetroVotePhase


### PR DESCRIPTION
# Description

Partially Fixes https://github.com/ParabolInc/parabol/issues/6283

Converted using the process described in https://www.notion.so/parabol/How-to-Migrate-createFragmentContainer-useFragment-with-codeshift-d534e7d0b8674089a2075f2835544558 🔒

## Testing scenarios
- [ ] Smoke test the app

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
