### PR TITLE
chore(relay): createFragmentContainer -> useFragment 5/N

### DIFF
--- a/packages/client/components/ScopePhase.tsx
+++ b/packages/client/components/ScopePhase.tsx
@@ -1,8 +1,8 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useGotoStageId from '~/hooks/useGotoStageId'
-import {ScopePhase_meeting} from '~/__generated__/ScopePhase_meeting.graphql'
+import {ScopePhase_meeting$key} from '~/__generated__/ScopePhase_meeting.graphql'
 import {phaseLabelLookup} from '../utils/meetings/lookups'
 import MeetingContent from './MeetingContent'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
@@ -14,12 +14,32 @@ import {PokerMeetingPhaseProps} from './PokerMeeting'
 import ScopePhaseArea from './ScopePhaseArea'
 import StageTimerDisplay from './StageTimerDisplay'
 interface Props extends PokerMeetingPhaseProps {
-  meeting: ScopePhase_meeting
+  meeting: ScopePhase_meeting$key
   gotoStageId?: ReturnType<typeof useGotoStageId>
 }
 
 const ScopePhase = (props: Props) => {
-  const {avatarGroup, toggleSidebar, meeting} = props
+  const {avatarGroup, toggleSidebar, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ScopePhase_meeting on PokerMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
+        ...ScopePhaseArea_meeting
+        endedAt
+        localStage {
+          isComplete
+        }
+        phases {
+          stages {
+            isComplete
+          }
+        }
+        showSidebar
+      }
+    `,
+    meetingRef
+  )
   const {endedAt, showSidebar} = meeting
   return (
     <MeetingContent>
@@ -51,22 +71,4 @@ graphql`
   }
 `
 
-export default createFragmentContainer(ScopePhase, {
-  meeting: graphql`
-    fragment ScopePhase_meeting on PokerMeeting {
-      ...StageTimerDisplay_meeting
-      ...StageTimerControl_meeting
-      ...ScopePhaseArea_meeting
-      endedAt
-      localStage {
-        isComplete
-      }
-      phases {
-        stages {
-          isComplete
-        }
-      }
-      showSidebar
-    }
-  `
-})
+export default ScopePhase

--- a/packages/client/components/ScopePhaseArea.tsx
+++ b/packages/client/components/ScopePhaseArea.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import SwipeableViews from 'react-swipeable-views'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import {Breakpoint} from '~/types/constEnums'
-import {ScopePhaseArea_meeting} from '~/__generated__/ScopePhaseArea_meeting.graphql'
+import {ScopePhaseArea_meeting$key} from '~/__generated__/ScopePhaseArea_meeting.graphql'
 import {Elevation} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
 import AzureDevOpsSVG from './AzureDevOpsSVG'
@@ -24,7 +24,7 @@ import Tab from './Tab/Tab'
 import Tabs from './Tabs/Tabs'
 
 interface Props {
-  meeting: ScopePhaseArea_meeting
+  meeting: ScopePhaseArea_meeting$key
 }
 
 const ScopingArea = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
@@ -81,7 +81,65 @@ const containerStyle = {height: '100%'}
 const innerStyle = {width: '100%', height: '100%'}
 
 const ScopePhaseArea = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ScopePhaseArea_meeting on PokerMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
+        ...ScopePhaseAreaGitHub_meeting
+        ...ScopePhaseAreaGitLab_meeting
+        ...ScopePhaseAreaJira_meeting
+        ...ScopePhaseAreaJiraServer_meeting
+        ...ScopePhaseAreaParabolScoping_meeting
+        ...ScopePhaseAreaAzureDevOps_meeting
+        endedAt
+        localPhase {
+          ...ScopePhaseArea_phase @relay(mask: false)
+        }
+        localStage {
+          isComplete
+        }
+        phases {
+          ...ScopePhaseArea_phase @relay(mask: false)
+        }
+        showSidebar
+        viewerMeetingMember {
+          teamMember {
+            integrations {
+              gitlab {
+                cloudProvider {
+                  clientId
+                }
+                sharedProviders {
+                  clientId
+                }
+              }
+              jiraServer {
+                sharedProviders {
+                  id
+                }
+              }
+              azureDevOps {
+                cloudProvider {
+                  id
+                }
+                sharedProviders {
+                  id
+                }
+              }
+            }
+          }
+          user {
+            featureFlags {
+              azureDevOps
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const {viewerMeetingMember} = meeting
   const featureFlags = viewerMeetingMember?.user.featureFlags
@@ -197,60 +255,4 @@ graphql`
   }
 `
 
-export default createFragmentContainer(ScopePhaseArea, {
-  meeting: graphql`
-    fragment ScopePhaseArea_meeting on PokerMeeting {
-      ...StageTimerDisplay_meeting
-      ...StageTimerControl_meeting
-      ...ScopePhaseAreaGitHub_meeting
-      ...ScopePhaseAreaGitLab_meeting
-      ...ScopePhaseAreaJira_meeting
-      ...ScopePhaseAreaJiraServer_meeting
-      ...ScopePhaseAreaParabolScoping_meeting
-      ...ScopePhaseAreaAzureDevOps_meeting
-      endedAt
-      localPhase {
-        ...ScopePhaseArea_phase @relay(mask: false)
-      }
-      localStage {
-        isComplete
-      }
-      phases {
-        ...ScopePhaseArea_phase @relay(mask: false)
-      }
-      showSidebar
-      viewerMeetingMember {
-        teamMember {
-          integrations {
-            gitlab {
-              cloudProvider {
-                clientId
-              }
-              sharedProviders {
-                clientId
-              }
-            }
-            jiraServer {
-              sharedProviders {
-                id
-              }
-            }
-            azureDevOps {
-              cloudProvider {
-                id
-              }
-              sharedProviders {
-                id
-              }
-            }
-          }
-        }
-        user {
-          featureFlags {
-            azureDevOps
-          }
-        }
-      }
-    }
-  `
-})
+export default ScopePhaseArea

--- a/packages/client/components/SelectMeetingDropdown.tsx
+++ b/packages/client/components/SelectMeetingDropdown.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled'
 import {Forum} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useRouter from '~/hooks/useRouter'
 import {PALETTE} from '~/styles/paletteV3'
 import getTeamIdFromPathname from '~/utils/getTeamIdFromPathname'
 import plural from '~/utils/plural'
-import {SelectMeetingDropdown_meetings} from '~/__generated__/SelectMeetingDropdown_meetings.graphql'
+import {SelectMeetingDropdown_meetings$key} from '~/__generated__/SelectMeetingDropdown_meetings.graphql'
 import {MenuProps} from '../hooks/useMenu'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
@@ -15,7 +15,7 @@ import SelectMeetingDropdownItem from './SelectMeetingDropdownItem'
 
 interface Props {
   menuProps: MenuProps
-  meetings: SelectMeetingDropdown_meetings
+  meetings: SelectMeetingDropdown_meetings$key
 }
 
 const HeaderLabel = styled('div')({
@@ -51,7 +51,16 @@ const NoMeetingItem = () => (
 )
 
 const SelectMeetingDropdown = (props: Props) => {
-  const {meetings, menuProps} = props
+  const {meetings: meetingsRef, menuProps} = props
+  const meetings = useFragment(
+    graphql`
+      fragment SelectMeetingDropdown_meetings on NewMeeting @relay(plural: true) {
+        ...SelectMeetingDropdownItem_meeting
+        id
+      }
+    `,
+    meetingsRef
+  )
   const {history} = useRouter()
   const meetingCount = meetings.length
   const label = `${meetingCount} Active ${plural(meetingCount, 'Meeting')}`
@@ -79,11 +88,4 @@ const SelectMeetingDropdown = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(SelectMeetingDropdown, {
-  meetings: graphql`
-    fragment SelectMeetingDropdown_meetings on NewMeeting @relay(plural: true) {
-      ...SelectMeetingDropdownItem_meeting
-      id
-    }
-  `
-})
+export default SelectMeetingDropdown

--- a/packages/client/components/SelectMeetingDropdownItem.tsx
+++ b/packages/client/components/SelectMeetingDropdownItem.tsx
@@ -8,12 +8,12 @@ import {
 import * as Sentry from '@sentry/browser'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useRouter from '~/hooks/useRouter'
 import {PALETTE} from '~/styles/paletteV3'
 import getMeetingPhase from '~/utils/getMeetingPhase'
 import {meetingTypeToIcon, phaseLabelLookup} from '~/utils/meetings/lookups'
-import {SelectMeetingDropdownItem_meeting} from '~/__generated__/SelectMeetingDropdownItem_meeting.graphql'
+import {SelectMeetingDropdownItem_meeting$key} from '~/__generated__/SelectMeetingDropdownItem_meeting.graphql'
 
 const Wrapper = styled('div')({
   alignItems: 'center',
@@ -60,11 +60,30 @@ const Action = styled('div')({
 })
 
 interface Props {
-  meeting: SelectMeetingDropdownItem_meeting
+  meeting: SelectMeetingDropdownItem_meeting$key
 }
 
 const SelectMeetingDropdownItem = (props: Props) => {
-  const {meeting} = props
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment SelectMeetingDropdownItem_meeting on NewMeeting {
+        id
+        name
+        meetingType
+        phases {
+          phaseType
+          stages {
+            isComplete
+          }
+        }
+        team {
+          name
+        }
+      }
+    `,
+    meetingRef
+  )
   const {history} = useRouter()
   const {name, team, id: meetingId, meetingType, phases} = meeting
   if (!team) {
@@ -115,21 +134,4 @@ const SelectMeetingDropdownItem = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(SelectMeetingDropdownItem, {
-  meeting: graphql`
-    fragment SelectMeetingDropdownItem_meeting on NewMeeting {
-      id
-      name
-      meetingType
-      phases {
-        phaseType
-        stages {
-          isComplete
-        }
-      }
-      team {
-        name
-      }
-    }
-  `
-})
+export default SelectMeetingDropdownItem

--- a/packages/client/components/SelectSharingScopeDropdown.tsx
+++ b/packages/client/components/SelectSharingScopeDropdown.tsx
@@ -1,23 +1,39 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import useMutationProps from '../hooks/useMutationProps'
 import UpdatePokerTemplateScopeMutation from '../mutations/UpdatePokerTemplateScopeMutation'
 import UpdateReflectTemplateScopeMutation from '../mutations/UpdateReflectTemplateScopeMutation'
-import {SelectSharingScopeDropdown_template} from '../__generated__/SelectSharingScopeDropdown_template.graphql'
+import {SelectSharingScopeDropdown_template$key} from '../__generated__/SelectSharingScopeDropdown_template.graphql'
 import DropdownMenuIconItemLabel from './DropdownMenuIconItemLabel'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
 
 interface Props {
   menuProps: MenuProps
-  template: SelectSharingScopeDropdown_template
+  template: SelectSharingScopeDropdown_template$key
 }
 
 const SelectSharingScopeDropdown = (props: Props) => {
-  const {menuProps, template} = props
+  const {menuProps, template: templateRef} = props
+  const template = useFragment(
+    graphql`
+      fragment SelectSharingScopeDropdown_template on MeetingTemplate {
+        id
+        scope
+        type
+        team {
+          name
+          organization {
+            name
+          }
+        }
+      }
+    `,
+    templateRef
+  )
   const atmosphere = useAtmosphere()
   const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
   const {id: templateId, scope, team, type} = template
@@ -66,18 +82,4 @@ const SelectSharingScopeDropdown = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(SelectSharingScopeDropdown, {
-  template: graphql`
-    fragment SelectSharingScopeDropdown_template on MeetingTemplate {
-      id
-      scope
-      type
-      team {
-        name
-        organization {
-          name
-        }
-      }
-    }
-  `
-})
+export default SelectSharingScopeDropdown

--- a/packages/client/components/SelectTeamDropdown.tsx
+++ b/packages/client/components/SelectTeamDropdown.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {SelectTeamDropdown_teams} from '~/__generated__/SelectTeamDropdown_teams.graphql'
+import {useFragment} from 'react-relay'
+import {SelectTeamDropdown_teams$key} from '~/__generated__/SelectTeamDropdown_teams.graphql'
 import {MenuProps} from '../hooks/useMenu'
 import DropdownMenuItemLabel from './DropdownMenuItemLabel'
 import DropdownMenuLabel from './DropdownMenuLabel'
@@ -12,7 +12,7 @@ import MenuItem from './MenuItem'
 interface Props {
   menuProps: MenuProps
   teamHandleClick: (teamId: string, e: React.MouseEvent) => void
-  teams: SelectTeamDropdown_teams
+  teams: SelectTeamDropdown_teams$key
 }
 
 const TeamMenu = styled(Menu)({
@@ -20,7 +20,16 @@ const TeamMenu = styled(Menu)({
 })
 
 const SelectTeamDropdown = (props: Props) => {
-  const {teams, menuProps, teamHandleClick} = props
+  const {teams: teamsRef, menuProps, teamHandleClick} = props
+  const teams = useFragment(
+    graphql`
+      fragment SelectTeamDropdown_teams on Team @relay(plural: true) {
+        id
+        name
+      }
+    `,
+    teamsRef
+  )
   return (
     <TeamMenu ariaLabel={'Select the team associated with the new task'} {...menuProps}>
       <DropdownMenuLabel>Select Team:</DropdownMenuLabel>
@@ -37,11 +46,4 @@ const SelectTeamDropdown = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(SelectTeamDropdown, {
-  teams: graphql`
-    fragment SelectTeamDropdown_teams on Team @relay(plural: true) {
-      id
-      name
-    }
-  `
-})
+export default SelectTeamDropdown

--- a/packages/client/components/StageTimerModal.tsx
+++ b/packages/client/components/StageTimerModal.tsx
@@ -2,12 +2,12 @@ import styled from '@emotion/styled'
 import {Event as EventIcon, Timer as TimerIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import SwipeableViews from 'react-swipeable-views'
 import {MenuProps} from '../hooks/useMenu'
 import {PALETTE} from '../styles/paletteV3'
-import {StageTimerModal_facilitator} from '../__generated__/StageTimerModal_facilitator.graphql'
-import {StageTimerModal_stage} from '../__generated__/StageTimerModal_stage.graphql'
+import {StageTimerModal_facilitator$key} from '../__generated__/StageTimerModal_facilitator.graphql'
+import {StageTimerModal_stage$key} from '../__generated__/StageTimerModal_stage.graphql'
 import StageTimerModalEditTimeEnd from './StageTimerModalEditTimeEnd'
 import StageTimerModalEditTimeLimit from './StageTimerModalEditTimeLimit'
 import StageTimerModalEndTime from './StageTimerModalEndTime'
@@ -21,9 +21,9 @@ interface Props {
   defaultTimeLimit: number
   defaultToAsync: boolean
   meetingId: string
-  stage: StageTimerModal_stage
+  stage: StageTimerModal_stage$key
   menuProps: MenuProps
-  facilitator: StageTimerModal_facilitator
+  facilitator: StageTimerModal_facilitator$key
 }
 
 const FullTab = styled(Tab)({
@@ -51,7 +51,36 @@ const StyledTabsBar = styled(Tabs)({
 })
 
 const StageTimerModal = (props: Props) => {
-  const {defaultTimeLimit, defaultToAsync, meetingId, menuProps, stage, facilitator} = props
+  const {
+    defaultTimeLimit,
+    defaultToAsync,
+    meetingId,
+    menuProps,
+    stage: stageRef,
+    facilitator: facilitatorRef
+  } = props
+  const facilitator = useFragment(
+    graphql`
+      fragment StageTimerModal_facilitator on TeamMember {
+        ...StageTimerModalEndTime_facilitator
+        ...StageTimerModalEditTimeEnd_facilitator
+      }
+    `,
+    facilitatorRef
+  )
+  const stage = useFragment(
+    graphql`
+      fragment StageTimerModal_stage on NewMeetingStage {
+        ...StageTimerModalTimeLimit_stage
+        ...StageTimerModalEditTimeLimit_stage
+        ...StageTimerModalEndTime_stage
+        ...StageTimerModalEditTimeEnd_stage
+        isAsync
+        suggestedTimeLimit
+      }
+    `,
+    stageRef
+  )
   const {isAsync} = stage
   const [activeIdx, setActiveIdx] = useState(defaultToAsync ? 1 : 0)
   const {closePortal} = menuProps
@@ -102,21 +131,4 @@ const StageTimerModal = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(StageTimerModal, {
-  facilitator: graphql`
-    fragment StageTimerModal_facilitator on TeamMember {
-      ...StageTimerModalEndTime_facilitator
-      ...StageTimerModalEditTimeEnd_facilitator
-    }
-  `,
-  stage: graphql`
-    fragment StageTimerModal_stage on NewMeetingStage {
-      ...StageTimerModalTimeLimit_stage
-      ...StageTimerModalEditTimeLimit_stage
-      ...StageTimerModalEndTime_stage
-      ...StageTimerModalEditTimeEnd_stage
-      isAsync
-      suggestedTimeLimit
-    }
-  `
-})
+export default StageTimerModal

--- a/packages/client/components/StageTimerModalEditTimeEnd.tsx
+++ b/packages/client/components/StageTimerModalEditTimeEnd.tsx
@@ -2,23 +2,23 @@ import styled from '@emotion/styled'
 import {Stop} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import SetStageTimerMutation from '../mutations/SetStageTimerMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {MeetingLabels} from '../types/constEnums'
-import {StageTimerModalEditTimeEnd_facilitator} from '../__generated__/StageTimerModalEditTimeEnd_facilitator.graphql'
-import {StageTimerModalEditTimeEnd_stage} from '../__generated__/StageTimerModalEditTimeEnd_stage.graphql'
+import {StageTimerModalEditTimeEnd_facilitator$key} from '../__generated__/StageTimerModalEditTimeEnd_facilitator.graphql'
+import {StageTimerModalEditTimeEnd_stage$key} from '../__generated__/StageTimerModalEditTimeEnd_stage.graphql'
 import MenuItemHR from './MenuItemHR'
 import PlainButton from './PlainButton/PlainButton'
 import StageTimerModalEndTime from './StageTimerModalEndTime'
 
 interface Props {
   closePortal: () => void
-  facilitator: StageTimerModalEditTimeEnd_facilitator
+  facilitator: StageTimerModalEditTimeEnd_facilitator$key
   meetingId: string
-  stage: StageTimerModalEditTimeEnd_stage
+  stage: StageTimerModalEditTimeEnd_stage$key
 }
 
 const Modal = styled('div')({
@@ -50,7 +50,23 @@ const StyledIcon = styled(Stop)({
 })
 
 const StageTimerModalEditTimeEnd = (props: Props) => {
-  const {meetingId, closePortal, facilitator, stage} = props
+  const {meetingId, closePortal, facilitator: facilitatorRef, stage: stageRef} = props
+  const facilitator = useFragment(
+    graphql`
+      fragment StageTimerModalEditTimeEnd_facilitator on TeamMember {
+        ...StageTimerModalEndTime_facilitator
+      }
+    `,
+    facilitatorRef
+  )
+  const stage = useFragment(
+    graphql`
+      fragment StageTimerModalEditTimeEnd_stage on NewMeetingStage {
+        ...StageTimerModalEndTime_stage
+      }
+    `,
+    stageRef
+  )
   const atmosphere = useAtmosphere()
   const {submitMutation, onCompleted, onError, submitting} = useMutationProps()
   const endTimer = () => {
@@ -76,15 +92,4 @@ const StageTimerModalEditTimeEnd = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(StageTimerModalEditTimeEnd, {
-  facilitator: graphql`
-    fragment StageTimerModalEditTimeEnd_facilitator on TeamMember {
-      ...StageTimerModalEndTime_facilitator
-    }
-  `,
-  stage: graphql`
-    fragment StageTimerModalEditTimeEnd_stage on NewMeetingStage {
-      ...StageTimerModalEndTime_stage
-    }
-  `
-})
+export default StageTimerModalEditTimeEnd

--- a/packages/client/components/StageTimerModalEditTimeLimit.tsx
+++ b/packages/client/components/StageTimerModalEditTimeLimit.tsx
@@ -2,20 +2,20 @@ import styled from '@emotion/styled'
 import {TimerOff} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import SetStageTimerMutation from '../mutations/SetStageTimerMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {MeetingLabels} from '../types/constEnums'
-import {StageTimerModalEditTimeLimit_stage} from '../__generated__/StageTimerModalEditTimeLimit_stage.graphql'
+import {StageTimerModalEditTimeLimit_stage$key} from '../__generated__/StageTimerModalEditTimeLimit_stage.graphql'
 import MenuItemHR from './MenuItemHR'
 import PlainButton from './PlainButton/PlainButton'
 import StageTimerModalTimeLimit from './StageTimerModalTimeLimit'
 
 interface Props {
   meetingId: string
-  stage: StageTimerModalEditTimeLimit_stage
+  stage: StageTimerModalEditTimeLimit_stage$key
   closePortal: () => void
 }
 
@@ -48,7 +48,15 @@ const StyledIcon = styled(TimerOff)({
 })
 
 const StageTimerModalEditTimeLimit = (props: Props) => {
-  const {meetingId, closePortal, stage} = props
+  const {meetingId, closePortal, stage: stageRef} = props
+  const stage = useFragment(
+    graphql`
+      fragment StageTimerModalEditTimeLimit_stage on NewMeetingStage {
+        ...StageTimerModalTimeLimit_stage
+      }
+    `,
+    stageRef
+  )
   const atmosphere = useAtmosphere()
   const {submitMutation, onCompleted, onError, submitting} = useMutationProps()
   const endTimer = () => {
@@ -74,10 +82,4 @@ const StageTimerModalEditTimeLimit = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(StageTimerModalEditTimeLimit, {
-  stage: graphql`
-    fragment StageTimerModalEditTimeLimit_stage on NewMeetingStage {
-      ...StageTimerModalTimeLimit_stage
-    }
-  `
-})
+export default StageTimerModalEditTimeLimit

--- a/packages/client/components/StageTimerModalEndTimeSlackToggle.tsx
+++ b/packages/client/components/StageTimerModalEndTimeSlackToggle.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import NotificationErrorMessage from '../modules/notifications/components/NotificationErrorMessage'
@@ -9,12 +9,12 @@ import SetSlackNotificationMutation from '../mutations/SetSlackNotificationMutat
 import {ICON_SIZE} from '../styles/typographyV2'
 import SlackClientManager from '../utils/SlackClientManager'
 import {SetSlackNotificationMutationVariables} from '../__generated__/SetSlackNotificationMutation.graphql'
-import {StageTimerModalEndTimeSlackToggle_facilitator} from '../__generated__/StageTimerModalEndTimeSlackToggle_facilitator.graphql'
+import {StageTimerModalEndTimeSlackToggle_facilitator$key} from '../__generated__/StageTimerModalEndTimeSlackToggle_facilitator.graphql'
 import Checkbox from './Checkbox'
 import PlainButton from './PlainButton/PlainButton'
 
 interface Props {
-  facilitator: StageTimerModalEndTimeSlackToggle_facilitator
+  facilitator: StageTimerModalEndTimeSlackToggle_facilitator$key
 }
 
 const ButtonRow = styled(PlainButton)({
@@ -59,7 +59,35 @@ const StyledNotificationErrorMessage = styled(NotificationErrorMessage)({
 })
 
 const StageTimerModalEndTimeSlackToggle = (props: Props) => {
-  const {facilitator} = props
+  const {facilitator: facilitatorRef} = props
+  const facilitator = useFragment(
+    graphql`
+      fragment StageTimerModalEndTimeSlackToggle_facilitator on TeamMember {
+        teamId
+        integrations {
+          mattermost {
+            auth {
+              isActive
+            }
+          }
+          msTeams {
+            auth {
+              isActive
+            }
+          }
+          slack {
+            isActive
+            defaultTeamChannelId
+            notifications {
+              channelId
+              event
+            }
+          }
+        }
+      }
+    `,
+    facilitatorRef
+  )
   const {integrations, teamId} = facilitator
   const {mattermost, slack, msTeams} = integrations
   const notifications = slack?.notifications ?? []
@@ -104,30 +132,4 @@ const StageTimerModalEndTimeSlackToggle = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(StageTimerModalEndTimeSlackToggle, {
-  facilitator: graphql`
-    fragment StageTimerModalEndTimeSlackToggle_facilitator on TeamMember {
-      teamId
-      integrations {
-        mattermost {
-          auth {
-            isActive
-          }
-        }
-        msTeams {
-          auth {
-            isActive
-          }
-        }
-        slack {
-          isActive
-          defaultTeamChannelId
-          notifications {
-            channelId
-            event
-          }
-        }
-      }
-    }
-  `
-})
+export default StageTimerModalEndTimeSlackToggle

--- a/packages/client/components/StageTimerModalTimeLimit.tsx
+++ b/packages/client/components/StageTimerModalTimeLimit.tsx
@@ -3,7 +3,7 @@ import {Timer} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import ms from 'ms'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
@@ -12,7 +12,7 @@ import SetStageTimerMutation from '../mutations/SetStageTimerMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {MeetingLabels} from '../types/constEnums'
 import plural from '../utils/plural'
-import {StageTimerModalTimeLimit_stage} from '../__generated__/StageTimerModalTimeLimit_stage.graphql'
+import {StageTimerModalTimeLimit_stage$key} from '../__generated__/StageTimerModalTimeLimit_stage.graphql'
 import DropdownMenuToggle from './DropdownMenuToggle'
 import SecondaryButton from './SecondaryButton'
 import StageTimerMinutePicker from './StageTimerMinutePicker'
@@ -22,7 +22,7 @@ interface Props {
   closePortal: () => void
   defaultTimeLimit: number
   meetingId: string
-  stage: StageTimerModalTimeLimit_stage
+  stage: StageTimerModalTimeLimit_stage$key
 }
 
 const Toggle = styled(DropdownMenuToggle)({
@@ -53,7 +53,16 @@ const StyledButton = styled(SecondaryButton)({
 })
 
 const StageTimerModalTimeLimit = (props: Props) => {
-  const {closePortal, defaultTimeLimit, meetingId, stage} = props
+  const {closePortal, defaultTimeLimit, meetingId, stage: stageRef} = props
+  const stage = useFragment(
+    graphql`
+      fragment StageTimerModalTimeLimit_stage on NewMeetingStage {
+        suggestedTimeLimit
+        scheduledEndTime
+      }
+    `,
+    stageRef
+  )
   const {suggestedTimeLimit, scheduledEndTime} = stage
   const initialTimeLimit =
     scheduledEndTime || !suggestedTimeLimit
@@ -115,11 +124,4 @@ const StageTimerModalTimeLimit = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(StageTimerModalTimeLimit, {
-  stage: graphql`
-    fragment StageTimerModalTimeLimit_stage on NewMeetingStage {
-      suggestedTimeLimit
-      scheduledEndTime
-    }
-  `
-})
+export default StageTimerModalTimeLimit

--- a/packages/client/components/SuggestedActionInviteYourTeam.tsx
+++ b/packages/client/components/SuggestedActionInviteYourTeam.tsx
@@ -1,16 +1,16 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {lazy} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useModal from '../hooks/useModal'
 import {PALETTE} from '../styles/paletteV3'
-import {SuggestedActionInviteYourTeam_suggestedAction} from '../__generated__/SuggestedActionInviteYourTeam_suggestedAction.graphql'
+import {SuggestedActionInviteYourTeam_suggestedAction$key} from '../__generated__/SuggestedActionInviteYourTeam_suggestedAction.graphql'
 import SuggestedActionButton from './SuggestedActionButton'
 import SuggestedActionCard from './SuggestedActionCard'
 import SuggestedActionCopy from './SuggestedActionCopy'
 
 interface Props {
-  suggestedAction: SuggestedActionInviteYourTeam_suggestedAction
+  suggestedAction: SuggestedActionInviteYourTeam_suggestedAction$key
 }
 
 const AddTeamMemberModal = lazy(
@@ -22,7 +22,22 @@ const TeamName = styled('span')({
 })
 
 const SuggestedActionInviteYourTeam = (props: Props) => {
-  const {suggestedAction} = props
+  const {suggestedAction: suggestedActionRef} = props
+  const suggestedAction = useFragment(
+    graphql`
+      fragment SuggestedActionInviteYourTeam_suggestedAction on SuggestedActionInviteYourTeam {
+        id
+        team {
+          id
+          name
+          teamMembers {
+            ...AddTeamMemberModal_teamMembers
+          }
+        }
+      }
+    `,
+    suggestedActionRef
+  )
   const {id: suggestedActionId, team} = suggestedAction
   const {id: teamId, name: teamName, teamMembers} = team
   const {togglePortal, modalPortal, closePortal} = useModal()
@@ -44,17 +59,4 @@ const SuggestedActionInviteYourTeam = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(SuggestedActionInviteYourTeam, {
-  suggestedAction: graphql`
-    fragment SuggestedActionInviteYourTeam_suggestedAction on SuggestedActionInviteYourTeam {
-      id
-      team {
-        id
-        name
-        teamMembers {
-          ...AddTeamMemberModal_teamMembers
-        }
-      }
-    }
-  `
-})
+export default SuggestedActionInviteYourTeam

--- a/packages/client/components/TaskInvolves.tsx
+++ b/packages/client/components/TaskInvolves.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {Editor} from 'draft-js'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import NotificationAction from '~/components/NotificationAction'
 import OutcomeCardStatusIndicator from '~/modules/outcomeCard/components/OutcomeCardStatusIndicator/OutcomeCardStatusIndicator'
 import {cardShadow} from '~/styles/elevation'
@@ -13,7 +13,7 @@ import useMutationProps from '../hooks/useMutationProps'
 import useRouter from '../hooks/useRouter'
 import SetNotificationStatusMutation from '../mutations/SetNotificationStatusMutation'
 import {ASSIGNEE, MENTIONEE} from '../utils/constants'
-import {TaskInvolves_notification} from '../__generated__/TaskInvolves_notification.graphql'
+import {TaskInvolves_notification$key} from '../__generated__/TaskInvolves_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
 
 const involvementWord = {
@@ -55,7 +55,7 @@ const OwnerAvatar = styled('img')({
 })
 
 interface Props {
-  notification: TaskInvolves_notification
+  notification: TaskInvolves_notification$key
 }
 
 const deletedTask = {
@@ -69,7 +69,36 @@ const deletedTask = {
 } as const
 
 const TaskInvolves = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment TaskInvolves_notification on NotifyTaskInvolves {
+        ...NotificationTemplate_notification
+        id
+        changeAuthor {
+          picture
+          preferredName
+        }
+        involvement
+        status
+        team {
+          id
+          name
+        }
+        task {
+          id
+          content
+          status
+          tags
+          user {
+            picture
+            preferredName
+          }
+        }
+      }
+    `,
+    notificationRef
+  )
   const {id: notificationId, task, team, involvement, changeAuthor} = notification
   const {content, status, tags, user} = task || deletedTask
   const {picture: changeAuthorPicture, preferredName: changeAuthorName} = changeAuthor
@@ -121,31 +150,4 @@ const TaskInvolves = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TaskInvolves, {
-  notification: graphql`
-    fragment TaskInvolves_notification on NotifyTaskInvolves {
-      ...NotificationTemplate_notification
-      id
-      changeAuthor {
-        picture
-        preferredName
-      }
-      involvement
-      status
-      team {
-        id
-        name
-      }
-      task {
-        id
-        content
-        status
-        tags
-        user {
-          picture
-          preferredName
-        }
-      }
-    }
-  `
-})
+export default TaskInvolves

--- a/packages/client/components/TeamArchived.tsx
+++ b/packages/client/components/TeamArchived.tsx
@@ -1,15 +1,31 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {TeamArchived_notification} from '../__generated__/TeamArchived_notification.graphql'
+import {useFragment} from 'react-relay'
+import {TeamArchived_notification$key} from '../__generated__/TeamArchived_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
-  notification: TeamArchived_notification
+  notification: TeamArchived_notification$key
 }
 
 const TeamArchived = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment TeamArchived_notification on NotifyTeamArchived {
+        ...NotificationTemplate_notification
+        id
+        archivor {
+          picture
+          preferredName
+        }
+        team {
+          name
+        }
+      }
+    `,
+    notificationRef
+  )
   const {archivor, team} = notification
   const {name: teamName} = team
   const {preferredName: archivorName, picture: archivorPicture} = archivor
@@ -22,18 +38,4 @@ const TeamArchived = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamArchived, {
-  notification: graphql`
-    fragment TeamArchived_notification on NotifyTeamArchived {
-      ...NotificationTemplate_notification
-      id
-      archivor {
-        picture
-        preferredName
-      }
-      team {
-        name
-      }
-    }
-  `
-})
+export default TeamArchived

--- a/packages/client/components/TeamDashTeamMemberMenu.tsx
+++ b/packages/client/components/TeamDashTeamMemberMenu.tsx
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import filterTeamMember from '../utils/relay/filterTeamMember'
-import {TeamDashTeamMemberMenu_team} from '../__generated__/TeamDashTeamMemberMenu_team.graphql'
+import {TeamDashTeamMemberMenu_team$key} from '../__generated__/TeamDashTeamMemberMenu_team.graphql'
 import DropdownMenuLabel from './DropdownMenuLabel'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
@@ -14,12 +14,27 @@ import {SearchMenuItem} from './SearchMenuItem'
 
 interface Props {
   menuProps: MenuProps
-  team: TeamDashTeamMemberMenu_team
+  team: TeamDashTeamMemberMenu_team$key
 }
 
 const TeamDashTeamMemberMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {menuProps, team} = props
+  const {menuProps, team: teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment TeamDashTeamMemberMenu_team on Team {
+        id
+        teamMemberFilter {
+          id
+        }
+        teamMembers(sortBy: "preferredName") {
+          id
+          preferredName
+        }
+      }
+    `,
+    teamRef
+  )
   const {id: teamId, teamMembers, teamMemberFilter} = team
   const teamMemberFilterId = teamMemberFilter && teamMemberFilter.id
   const defaultActiveIdx =
@@ -65,17 +80,4 @@ const TeamDashTeamMemberMenu = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamDashTeamMemberMenu, {
-  team: graphql`
-    fragment TeamDashTeamMemberMenu_team on Team {
-      id
-      teamMemberFilter {
-        id
-      }
-      teamMembers(sortBy: "preferredName") {
-        id
-        preferredName
-      }
-    }
-  `
-})
+export default TeamDashTeamMemberMenu

--- a/packages/client/components/TeamInvitationEmailCreateAccount.tsx
+++ b/packages/client/components/TeamInvitationEmailCreateAccount.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
-import {TeamInvitationEmailCreateAccount_verifiedInvitation} from '../__generated__/TeamInvitationEmailCreateAccount_verifiedInvitation.graphql'
+import {TeamInvitationEmailCreateAccount_verifiedInvitation$key} from '../__generated__/TeamInvitationEmailCreateAccount_verifiedInvitation.graphql'
 import AuthPrivacyFooter from './AuthPrivacyFooter'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
@@ -13,7 +13,7 @@ import InvitationDialogCopy from './InvitationDialogCopy'
 import InviteDialog from './InviteDialog'
 
 interface Props {
-  verifiedInvitation: TeamInvitationEmailCreateAccount_verifiedInvitation
+  verifiedInvitation: TeamInvitationEmailCreateAccount_verifiedInvitation$key
   invitationToken: string
 }
 
@@ -27,7 +27,19 @@ const TeamName = styled('span')({
 })
 
 const TeamInvitationEmailCreateAccount = (props: Props) => {
-  const {invitationToken, verifiedInvitation} = props
+  const {invitationToken, verifiedInvitation: verifiedInvitationRef} = props
+  const verifiedInvitation = useFragment(
+    graphql`
+      fragment TeamInvitationEmailCreateAccount_verifiedInvitation on VerifiedInvitationPayload {
+        meetingName
+        teamInvitation {
+          email
+        }
+        teamName
+      }
+    `,
+    verifiedInvitationRef
+  )
   const {meetingName, teamName, teamInvitation} = verifiedInvitation
   useDocumentTitle(`Sign up | Team Invitation`, 'Sign Up')
   if (!teamInvitation) return null
@@ -50,14 +62,4 @@ const TeamInvitationEmailCreateAccount = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationEmailCreateAccount, {
-  verifiedInvitation: graphql`
-    fragment TeamInvitationEmailCreateAccount_verifiedInvitation on VerifiedInvitationPayload {
-      meetingName
-      teamInvitation {
-        email
-      }
-      teamName
-    }
-  `
-})
+export default TeamInvitationEmailCreateAccount

--- a/packages/client/components/TeamInvitationEmailSignin.tsx
+++ b/packages/client/components/TeamInvitationEmailSignin.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
-import {TeamInvitationEmailSignin_verifiedInvitation} from '../__generated__/TeamInvitationEmailSignin_verifiedInvitation.graphql'
+import {TeamInvitationEmailSignin_verifiedInvitation$key} from '../__generated__/TeamInvitationEmailSignin_verifiedInvitation.graphql'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import EmailPasswordAuthForm from './EmailPasswordAuthForm'
@@ -14,7 +14,7 @@ import InviteDialog from './InviteDialog'
 
 interface Props {
   invitationToken: string
-  verifiedInvitation: TeamInvitationEmailSignin_verifiedInvitation
+  verifiedInvitation: TeamInvitationEmailSignin_verifiedInvitation$key
 }
 
 const StyledDialog = styled(InviteDialog)({
@@ -27,7 +27,22 @@ const TeamName = styled('span')({
 })
 
 const TeamInvitationEmailSignin = (props: Props) => {
-  const {invitationToken, verifiedInvitation} = props
+  const {invitationToken, verifiedInvitation: verifiedInvitationRef} = props
+  const verifiedInvitation = useFragment(
+    graphql`
+      fragment TeamInvitationEmailSignin_verifiedInvitation on VerifiedInvitationPayload {
+        meetingName
+        user {
+          preferredName
+        }
+        teamInvitation {
+          email
+        }
+        teamName
+      }
+    `,
+    verifiedInvitationRef
+  )
   const {meetingName, user, teamInvitation, teamName} = verifiedInvitation
   useDocumentTitle(`Sign in | Team Invitation`, 'Sign in')
   if (!user || !teamInvitation) return null
@@ -56,17 +71,4 @@ const TeamInvitationEmailSignin = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationEmailSignin, {
-  verifiedInvitation: graphql`
-    fragment TeamInvitationEmailSignin_verifiedInvitation on VerifiedInvitationPayload {
-      meetingName
-      user {
-        preferredName
-      }
-      teamInvitation {
-        email
-      }
-      teamName
-    }
-  `
-})
+export default TeamInvitationEmailSignin

--- a/packages/client/components/TeamInvitationErrorAccepted.tsx
+++ b/packages/client/components/TeamInvitationErrorAccepted.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
-import {TeamInvitationErrorAccepted_verifiedInvitation} from '../__generated__/TeamInvitationErrorAccepted_verifiedInvitation.graphql'
+import {TeamInvitationErrorAccepted_verifiedInvitation$key} from '../__generated__/TeamInvitationErrorAccepted_verifiedInvitation.graphql'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import InvitationDialogCopy from './InvitationDialogCopy'
@@ -11,7 +11,7 @@ import InviteDialog from './InviteDialog'
 import StyledLink from './StyledLink'
 
 interface Props {
-  verifiedInvitation: TeamInvitationErrorAccepted_verifiedInvitation
+  verifiedInvitation: TeamInvitationErrorAccepted_verifiedInvitation$key
 }
 
 const InlineCopy = styled(InvitationDialogCopy)({
@@ -19,7 +19,20 @@ const InlineCopy = styled(InvitationDialogCopy)({
 })
 
 const TeamInvitationErrorAccepted = (props: Props) => {
-  const {verifiedInvitation} = props
+  const {verifiedInvitation: verifiedInvitationRef} = props
+  const verifiedInvitation = useFragment(
+    graphql`
+      fragment TeamInvitationErrorAccepted_verifiedInvitation on VerifiedInvitationPayload {
+        meetingId
+        meetingName
+        teamName
+        teamInvitation {
+          teamId
+        }
+      }
+    `,
+    verifiedInvitationRef
+  )
   const {meetingId, meetingName, teamInvitation, teamName} = verifiedInvitation
   useDocumentTitle(`Token already accepted | Team Invitation`, 'Team Invitation')
   if (!teamInvitation || teamName === null) return null
@@ -51,15 +64,4 @@ const TeamInvitationErrorAccepted = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationErrorAccepted, {
-  verifiedInvitation: graphql`
-    fragment TeamInvitationErrorAccepted_verifiedInvitation on VerifiedInvitationPayload {
-      meetingId
-      meetingName
-      teamName
-      teamInvitation {
-        teamId
-      }
-    }
-  `
-})
+export default TeamInvitationErrorAccepted

--- a/packages/client/components/TeamInvitationErrorExpired.tsx
+++ b/packages/client/components/TeamInvitationErrorExpired.tsx
@@ -1,17 +1,17 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import {PALETTE} from '../styles/paletteV3'
-import {TeamInvitationErrorExpired_verifiedInvitation} from '../__generated__/TeamInvitationErrorExpired_verifiedInvitation.graphql'
+import {TeamInvitationErrorExpired_verifiedInvitation$key} from '../__generated__/TeamInvitationErrorExpired_verifiedInvitation.graphql'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import InvitationDialogCopy from './InvitationDialogCopy'
 import InviteDialog from './InviteDialog'
 
 interface Props {
-  verifiedInvitation: TeamInvitationErrorExpired_verifiedInvitation
+  verifiedInvitation: TeamInvitationErrorExpired_verifiedInvitation$key
 }
 
 const StyledEmailLink = styled('a')({
@@ -24,7 +24,17 @@ const TeamName = styled('span')({
 })
 
 const TeamInvitationErrorExpired = (props: Props) => {
-  const {verifiedInvitation} = props
+  const {verifiedInvitation: verifiedInvitationRef} = props
+  const verifiedInvitation = useFragment(
+    graphql`
+      fragment TeamInvitationErrorExpired_verifiedInvitation on VerifiedInvitationPayload {
+        teamName
+        inviterName
+        inviterEmail
+      }
+    `,
+    verifiedInvitationRef
+  )
   const {teamName, inviterName, inviterEmail} = verifiedInvitation
   useDocumentTitle(`Token Expired | Team Invitation`, 'Team Invitation')
   return (
@@ -46,12 +56,4 @@ const TeamInvitationErrorExpired = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationErrorExpired, {
-  verifiedInvitation: graphql`
-    fragment TeamInvitationErrorExpired_verifiedInvitation on VerifiedInvitationPayload {
-      teamName
-      inviterName
-      inviterEmail
-    }
-  `
-})
+export default TeamInvitationErrorExpired

--- a/packages/client/components/TeamInvitationGoogleCreateAccount.tsx
+++ b/packages/client/components/TeamInvitationGoogleCreateAccount.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useRouter from '../hooks/useRouter'
 import {PALETTE} from '../styles/paletteV3'
-import {TeamInvitationGoogleCreateAccount_verifiedInvitation} from '../__generated__/TeamInvitationGoogleCreateAccount_verifiedInvitation.graphql'
+import {TeamInvitationGoogleCreateAccount_verifiedInvitation$key} from '../__generated__/TeamInvitationGoogleCreateAccount_verifiedInvitation.graphql'
 import AuthPrivacyFooter from './AuthPrivacyFooter'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
@@ -19,7 +19,7 @@ import PlainButton from './PlainButton/PlainButton'
 
 interface Props {
   invitationToken: string
-  verifiedInvitation: TeamInvitationGoogleCreateAccount_verifiedInvitation
+  verifiedInvitation: TeamInvitationGoogleCreateAccount_verifiedInvitation$key
 }
 
 const StyledDialog = styled(InviteDialog)({
@@ -50,7 +50,19 @@ const TeamInvitationGoogleCreateAccount = (props: Props) => {
   const {match} = useRouter<{token: string}>()
   const {params} = match
   const {token: invitationToken} = params
-  const {verifiedInvitation} = props
+  const {verifiedInvitation: verifiedInvitationRef} = props
+  const verifiedInvitation = useFragment(
+    graphql`
+      fragment TeamInvitationGoogleCreateAccount_verifiedInvitation on VerifiedInvitationPayload {
+        meetingName
+        teamInvitation {
+          email
+        }
+        teamName
+      }
+    `,
+    verifiedInvitationRef
+  )
   const {meetingName, teamInvitation, teamName} = verifiedInvitation
 
   const useEmail = () => {
@@ -89,14 +101,4 @@ const TeamInvitationGoogleCreateAccount = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationGoogleCreateAccount, {
-  verifiedInvitation: graphql`
-    fragment TeamInvitationGoogleCreateAccount_verifiedInvitation on VerifiedInvitationPayload {
-      meetingName
-      teamInvitation {
-        email
-      }
-      teamName
-    }
-  `
-})
+export default TeamInvitationGoogleCreateAccount

--- a/packages/client/components/TeamInvitationGoogleSignin.tsx
+++ b/packages/client/components/TeamInvitationGoogleSignin.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useDocumentTitle from '../hooks/useDocumentTitle'
 import useRouter from '../hooks/useRouter'
-import {TeamInvitationGoogleSignin_verifiedInvitation} from '../__generated__/TeamInvitationGoogleSignin_verifiedInvitation.graphql'
+import {TeamInvitationGoogleSignin_verifiedInvitation$key} from '../__generated__/TeamInvitationGoogleSignin_verifiedInvitation.graphql'
 import DialogContent from './DialogContent'
 import DialogTitle from './DialogTitle'
 import GoogleOAuthButtonBlock from './GoogleOAuthButtonBlock'
@@ -13,7 +13,7 @@ import InvitationDialogCopy from './InvitationDialogCopy'
 import InviteDialog from './InviteDialog'
 
 interface Props {
-  verifiedInvitation: TeamInvitationGoogleSignin_verifiedInvitation
+  verifiedInvitation: TeamInvitationGoogleSignin_verifiedInvitation$key
 }
 
 const TeamName = styled('span')({
@@ -25,7 +25,20 @@ const TeamInvitationGoogleSignin = (props: Props) => {
   const {match} = useRouter<{token: string}>()
   const {params} = match
   const {token: invitationToken} = params
-  const {verifiedInvitation} = props
+  const {verifiedInvitation: verifiedInvitationRef} = props
+  const verifiedInvitation = useFragment(
+    graphql`
+      fragment TeamInvitationGoogleSignin_verifiedInvitation on VerifiedInvitationPayload {
+        meetingName
+        user {
+          email
+          preferredName
+        }
+        teamName
+      }
+    `,
+    verifiedInvitationRef
+  )
   const {meetingName, user, teamName} = verifiedInvitation
   useDocumentTitle(`Sign in with Google | Team Invitation`, 'Sign in')
 
@@ -49,15 +62,4 @@ const TeamInvitationGoogleSignin = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationGoogleSignin, {
-  verifiedInvitation: graphql`
-    fragment TeamInvitationGoogleSignin_verifiedInvitation on VerifiedInvitationPayload {
-      meetingName
-      user {
-        email
-        preferredName
-      }
-      teamName
-    }
-  `
-})
+export default TeamInvitationGoogleSignin

--- a/packages/client/components/TeamInvitationNotification.tsx
+++ b/packages/client/components/TeamInvitationNotification.tsx
@@ -1,20 +1,39 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import NotificationAction from '~/components/NotificationAction'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import useRouter from '~/hooks/useRouter'
-import {TeamInvitationNotification_notification} from '~/__generated__/TeamInvitationNotification_notification.graphql'
+import {TeamInvitationNotification_notification$key} from '~/__generated__/TeamInvitationNotification_notification.graphql'
 import AcceptTeamInvitationMutation from '../mutations/AcceptTeamInvitationMutation'
 import NotificationTemplate from './NotificationTemplate'
 
 interface Props {
-  notification: TeamInvitationNotification_notification
+  notification: TeamInvitationNotification_notification$key
 }
 
 const TeamInvitationNotification = (props: Props) => {
-  const {notification} = props
+  const {notification: notificationRef} = props
+  const notification = useFragment(
+    graphql`
+      fragment TeamInvitationNotification_notification on NotificationTeamInvitation {
+        ...NotificationTemplate_notification
+        id
+        invitation {
+          token
+          inviter {
+            picture
+            preferredName
+          }
+        }
+        team {
+          name
+        }
+      }
+    `,
+    notificationRef
+  )
   const {submitMutation, onError, onCompleted} = useMutationProps()
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
@@ -41,21 +60,4 @@ const TeamInvitationNotification = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TeamInvitationNotification, {
-  notification: graphql`
-    fragment TeamInvitationNotification_notification on NotificationTeamInvitation {
-      ...NotificationTemplate_notification
-      id
-      invitation {
-        token
-        inviter {
-          picture
-          preferredName
-        }
-      }
-      team {
-        name
-      }
-    }
-  `
-})
+export default TeamInvitationNotification

--- a/packages/client/components/ThreadedCommentFooter.tsx
+++ b/packages/client/components/ThreadedCommentFooter.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {PALETTE} from '~/styles/paletteV3'
-import {ThreadedCommentFooter_reactjis} from '~/__generated__/ThreadedCommentFooter_reactjis.graphql'
+import {ThreadedCommentFooter_reactjis$key} from '~/__generated__/ThreadedCommentFooter_reactjis.graphql'
 import ReactjiSection from './ReflectionCard/ReactjiSection'
 import ThreadedReplyButton from './ThreadedReplyButton'
 
@@ -23,11 +23,20 @@ const StyledReactjis = styled(ReactjiSection)({
 interface Props {
   onReply: () => void
   onToggleReactji: (emojiId: string) => void
-  reactjis: ThreadedCommentFooter_reactjis
+  reactjis: ThreadedCommentFooter_reactjis$key
 }
 
 const ThreadedCommentFooter = (props: Props) => {
-  const {onReply, onToggleReactji, reactjis} = props
+  const {onReply, onToggleReactji, reactjis: reactjisRef} = props
+  const reactjis = useFragment(
+    graphql`
+      fragment ThreadedCommentFooter_reactjis on Reactji @relay(plural: true) {
+        ...ReactjiSection_reactjis
+        id
+      }
+    `,
+    reactjisRef
+  )
   const hasReactjis = reactjis.length > 0
   if (!hasReactjis) return null
   return (
@@ -38,11 +47,4 @@ const ThreadedCommentFooter = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ThreadedCommentFooter, {
-  reactjis: graphql`
-    fragment ThreadedCommentFooter_reactjis on Reactji @relay(plural: true) {
-      ...ReactjiSection_reactjis
-      id
-    }
-  `
-})
+export default ThreadedCommentFooter

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {PALETTE} from '~/styles/paletteV3'
 import relativeDate from '~/utils/date/relativeDate'
-import {ThreadedCommentHeader_comment} from '~/__generated__/ThreadedCommentHeader_comment.graphql'
+import {
+  ThreadedCommentHeader_comment$key,
+  ThreadedCommentHeader_comment
+} from '~/__generated__/ThreadedCommentHeader_comment.graphql'
 import CommentAuthorOptionsButton from './CommentAuthorOptionsButton'
 import AddReactjiButton from './ReflectionCard/AddReactjiButton'
 import ThreadedItemHeaderDescription from './ThreadedItemHeaderDescription'
@@ -23,7 +26,7 @@ const AddReactji = styled(AddReactjiButton)({
 })
 
 interface Props {
-  comment: ThreadedCommentHeader_comment
+  comment: ThreadedCommentHeader_comment$key
   editComment: () => void
   onToggleReactji: (emojiId: string) => void
   onReply: () => void
@@ -39,7 +42,24 @@ const getName = (comment: ThreadedCommentHeader_comment) => {
 }
 
 const ThreadedCommentHeader = (props: Props) => {
-  const {comment, onReply, editComment, onToggleReactji, dataCy, meetingId} = props
+  const {comment: commentRef, onReply, editComment, onToggleReactji, dataCy, meetingId} = props
+  const comment = useFragment(
+    graphql`
+      fragment ThreadedCommentHeader_comment on Comment {
+        id
+        createdByUserNullable: createdByUser {
+          preferredName
+        }
+        isActive
+        isViewerComment
+        reactjis {
+          id
+        }
+        updatedAt
+      }
+    `,
+    commentRef
+  )
   const {id: commentId, isActive, isViewerComment, reactjis, updatedAt} = comment
   const name = getName(comment)
   const hasReactjis = reactjis.length > 0
@@ -67,19 +87,4 @@ const ThreadedCommentHeader = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ThreadedCommentHeader, {
-  comment: graphql`
-    fragment ThreadedCommentHeader_comment on Comment {
-      id
-      createdByUserNullable: createdByUser {
-        preferredName
-      }
-      isActive
-      isViewerComment
-      reactjis {
-        id
-      }
-      updatedAt
-    }
-  `
-})
+export default ThreadedCommentHeader

--- a/packages/client/components/ThreadedItem.tsx
+++ b/packages/client/components/ThreadedItem.tsx
@@ -1,9 +1,9 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {ThreadedItem_discussion} from '~/__generated__/ThreadedItem_discussion.graphql'
-import {ThreadedItem_threadable} from '~/__generated__/ThreadedItem_threadable.graphql'
-import {ThreadedItem_viewer} from '~/__generated__/ThreadedItem_viewer.graphql'
+import {useFragment} from 'react-relay'
+import {ThreadedItem_discussion$key} from '~/__generated__/ThreadedItem_discussion.graphql'
+import {ThreadedItem_threadable$key} from '~/__generated__/ThreadedItem_threadable.graphql'
+import {ThreadedItem_viewer$key} from '~/__generated__/ThreadedItem_viewer.graphql'
 import {DiscussionThreadables} from './DiscussionThreadList'
 import ThreadedCommentBase from './ThreadedCommentBase'
 import ThreadedPollBase from './ThreadedPollBase'
@@ -12,9 +12,9 @@ import ThreadedTaskBase from './ThreadedTaskBase'
 
 interface Props {
   allowedThreadables: DiscussionThreadables[]
-  threadable: ThreadedItem_threadable
-  discussion: ThreadedItem_discussion
-  viewer: ThreadedItem_viewer
+  threadable: ThreadedItem_threadable$key
+  discussion: ThreadedItem_discussion$key
+  viewer: ThreadedItem_viewer$key
 }
 
 export type ReplyMention = {
@@ -25,7 +25,47 @@ export type ReplyMention = {
 export type SetReplyMention = (replyMention: ReplyMention) => void
 
 export const ThreadedItem = (props: Props) => {
-  const {allowedThreadables, threadable, discussion, viewer} = props
+  const {
+    allowedThreadables,
+    threadable: threadableRef,
+    discussion: discussionRef,
+    viewer: viewerRef
+  } = props
+  const viewer = useFragment(
+    graphql`
+      fragment ThreadedItem_viewer on User {
+        ...ThreadedTaskBase_viewer
+        ...ThreadedCommentBase_viewer
+        ...ThreadedRepliesList_viewer
+      }
+    `,
+    viewerRef
+  )
+  const discussion = useFragment(
+    graphql`
+      fragment ThreadedItem_discussion on Discussion {
+        ...ThreadedCommentBase_discussion
+        ...ThreadedTaskBase_discussion
+        ...ThreadedPollBase_discussion
+        ...ThreadedRepliesList_discussion
+      }
+    `,
+    discussionRef
+  )
+  const threadable = useFragment(
+    graphql`
+      fragment ThreadedItem_threadable on Threadable {
+        ...ThreadedCommentBase_comment
+        ...ThreadedTaskBase_task
+        ...ThreadedPollBase_poll
+        __typename
+        replies {
+          ...ThreadedRepliesList_replies
+        }
+      }
+    `,
+    threadableRef
+  )
   const {__typename, replies} = threadable
   const [replyMention, setReplyMention] = useState<ReplyMention>(null)
   const child = (
@@ -77,31 +117,4 @@ export const ThreadedItem = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ThreadedItem, {
-  viewer: graphql`
-    fragment ThreadedItem_viewer on User {
-      ...ThreadedTaskBase_viewer
-      ...ThreadedCommentBase_viewer
-      ...ThreadedRepliesList_viewer
-    }
-  `,
-  discussion: graphql`
-    fragment ThreadedItem_discussion on Discussion {
-      ...ThreadedCommentBase_discussion
-      ...ThreadedTaskBase_discussion
-      ...ThreadedPollBase_discussion
-      ...ThreadedRepliesList_discussion
-    }
-  `,
-  threadable: graphql`
-    fragment ThreadedItem_threadable on Threadable {
-      ...ThreadedCommentBase_comment
-      ...ThreadedTaskBase_task
-      ...ThreadedPollBase_poll
-      __typename
-      replies {
-        ...ThreadedRepliesList_replies
-      }
-    }
-  `
-})
+export default ThreadedItem

--- a/packages/client/components/ThreadedRepliesList.tsx
+++ b/packages/client/components/ThreadedRepliesList.tsx
@@ -1,9 +1,9 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {ThreadedRepliesList_discussion} from '~/__generated__/ThreadedRepliesList_discussion.graphql'
-import {ThreadedRepliesList_replies} from '~/__generated__/ThreadedRepliesList_replies.graphql'
-import {ThreadedRepliesList_viewer} from '~/__generated__/ThreadedRepliesList_viewer.graphql'
+import {useFragment} from 'react-relay'
+import {ThreadedRepliesList_discussion$key} from '~/__generated__/ThreadedRepliesList_discussion.graphql'
+import {ThreadedRepliesList_replies$key} from '~/__generated__/ThreadedRepliesList_replies.graphql'
+import {ThreadedRepliesList_viewer$key} from '~/__generated__/ThreadedRepliesList_viewer.graphql'
 import {DiscussionThreadables} from './DiscussionThreadList'
 import ThreadedCommentBase from './ThreadedCommentBase'
 import {SetReplyMention} from './ThreadedItem'
@@ -11,15 +11,51 @@ import ThreadedTaskBase from './ThreadedTaskBase'
 
 interface Props {
   allowedThreadables: DiscussionThreadables[]
-  discussion: ThreadedRepliesList_discussion
-  replies: ThreadedRepliesList_replies
+  discussion: ThreadedRepliesList_discussion$key
+  replies: ThreadedRepliesList_replies$key
   setReplyMention: SetReplyMention
   dataCy: string
-  viewer: ThreadedRepliesList_viewer
+  viewer: ThreadedRepliesList_viewer$key
 }
 
 const ThreadedRepliesList = (props: Props) => {
-  const {allowedThreadables, replies, setReplyMention, discussion, dataCy, viewer} = props
+  const {
+    allowedThreadables,
+    replies: repliesRef,
+    setReplyMention,
+    discussion: discussionRef,
+    dataCy,
+    viewer: viewerRef
+  } = props
+  const viewer = useFragment(
+    graphql`
+      fragment ThreadedRepliesList_viewer on User {
+        ...ThreadedCommentBase_viewer
+        ...ThreadedTaskBase_viewer
+      }
+    `,
+    viewerRef
+  )
+  const discussion = useFragment(
+    graphql`
+      fragment ThreadedRepliesList_discussion on Discussion {
+        ...ThreadedCommentBase_discussion
+        ...ThreadedTaskBase_discussion
+      }
+    `,
+    discussionRef
+  )
+  const replies = useFragment(
+    graphql`
+      fragment ThreadedRepliesList_replies on Threadable @relay(plural: true) {
+        ...ThreadedTaskBase_task
+        ...ThreadedCommentBase_comment
+        __typename
+        id
+      }
+    `,
+    repliesRef
+  )
   // https://sentry.io/organizations/parabol/issues/1569570376/?project=107196&query=is%3Aunresolved
   // not sure why this is required addComment and createTask but request replies
   if (!replies) return null
@@ -55,25 +91,4 @@ const ThreadedRepliesList = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(ThreadedRepliesList, {
-  viewer: graphql`
-    fragment ThreadedRepliesList_viewer on User {
-      ...ThreadedCommentBase_viewer
-      ...ThreadedTaskBase_viewer
-    }
-  `,
-  discussion: graphql`
-    fragment ThreadedRepliesList_discussion on Discussion {
-      ...ThreadedCommentBase_discussion
-      ...ThreadedTaskBase_discussion
-    }
-  `,
-  replies: graphql`
-    fragment ThreadedRepliesList_replies on Threadable @relay(plural: true) {
-      ...ThreadedTaskBase_task
-      ...ThreadedCommentBase_comment
-      __typename
-      id
-    }
-  `
-})
+export default ThreadedRepliesList

--- a/packages/client/components/TimelineEventCard.tsx
+++ b/packages/client/components/TimelineEventCard.tsx
@@ -2,10 +2,10 @@ import styled from '@emotion/styled'
 import {AccountCircle, ChangeHistory, GroupAdd, GroupWork, History, Lock} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {ReactNode} from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import {cardShadow} from '../styles/elevation'
 import {PALETTE} from '../styles/paletteV3'
-import {TimelineEventCard_timelineEvent} from '../__generated__/TimelineEventCard_timelineEvent.graphql'
+import {TimelineEventCard_timelineEvent$key} from '../__generated__/TimelineEventCard_timelineEvent.graphql'
 import TimelineEventDate from './TimelineEventDate'
 import TimelineEventHeaderMenuToggle from './TimelineEventHeaderMenuToggle'
 
@@ -15,7 +15,7 @@ interface Props {
   iconName?: string
   IconSVG?: ReactNode
   title: ReactNode
-  timelineEvent: TimelineEventCard_timelineEvent
+  timelineEvent: TimelineEventCard_timelineEvent$key
 }
 
 const Surface = styled('div')({
@@ -66,7 +66,17 @@ const GrapeLock = styled(Lock)({
 })
 
 const TimelineEventCard = (props: Props) => {
-  const {children, iconName, IconSVG, title, timelineEvent} = props
+  const {children, iconName, IconSVG, title, timelineEvent: timelineEventRef} = props
+  const timelineEvent = useFragment(
+    graphql`
+      fragment TimelineEventCard_timelineEvent on TimelineEvent {
+        id
+        createdAt
+        type
+      }
+    `,
+    timelineEventRef
+  )
   const {id: timelineEventId, createdAt, type} = timelineEvent
   return (
     <Surface>
@@ -104,12 +114,4 @@ const TimelineEventCard = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineEventCard, {
-  timelineEvent: graphql`
-    fragment TimelineEventCard_timelineEvent on TimelineEvent {
-      id
-      createdAt
-      type
-    }
-  `
-})
+export default TimelineEventCard

--- a/packages/client/components/TimelineEventCompletedActionMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedActionMeeting.tsx
@@ -1,19 +1,19 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import relativeDate from '../utils/date/relativeDate'
 import plural from '../utils/plural'
-import {TimelineEventCompletedActionMeeting_timelineEvent} from '../__generated__/TimelineEventCompletedActionMeeting_timelineEvent.graphql'
+import {TimelineEventCompletedActionMeeting_timelineEvent$key} from '../__generated__/TimelineEventCompletedActionMeeting_timelineEvent.graphql'
 import StyledLink from './StyledLink'
 import TimelineEventBody from './TimelineEventBody'
 import TimelineEventCard from './TimelineEventCard'
 import TimelineEventTitle from './TImelineEventTitle'
 
 interface Props {
-  timelineEvent: TimelineEventCompletedActionMeeting_timelineEvent
+  timelineEvent: TimelineEventCompletedActionMeeting_timelineEvent$key
 }
 
 const Link = styled(StyledLink)({
@@ -25,7 +25,37 @@ const CountItem = styled('span')({
 })
 
 const TimelineEventCompletedActionMeeting = (props: Props) => {
-  const {timelineEvent} = props
+  const {timelineEvent: timelineEventRef} = props
+  const timelineEvent = useFragment(
+    graphql`
+      fragment TimelineEventCompletedActionMeeting_timelineEvent on TimelineEventCompletedActionMeeting {
+        ...TimelineEventCard_timelineEvent
+        id
+        type
+        meeting {
+          id
+          agendaItemCount
+          commentCount
+          createdAt
+          endedAt
+          name
+          taskCount
+          locked
+          organization {
+            id
+            viewerOrganizationUser {
+              id
+            }
+          }
+        }
+        team {
+          id
+          name
+        }
+      }
+    `,
+    timelineEventRef
+  )
   const {meeting, team} = timelineEvent
   const {
     id: meetingId,
@@ -92,32 +122,4 @@ const TimelineEventCompletedActionMeeting = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineEventCompletedActionMeeting, {
-  timelineEvent: graphql`
-    fragment TimelineEventCompletedActionMeeting_timelineEvent on TimelineEventCompletedActionMeeting {
-      ...TimelineEventCard_timelineEvent
-      id
-      type
-      meeting {
-        id
-        agendaItemCount
-        commentCount
-        createdAt
-        endedAt
-        name
-        taskCount
-        locked
-        organization {
-          id
-          viewerOrganizationUser {
-            id
-          }
-        }
-      }
-      team {
-        id
-        name
-      }
-    }
-  `
-})
+export default TimelineEventCompletedActionMeeting

--- a/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
+++ b/packages/client/components/TimelineEventCompletedRetroMeeting.tsx
@@ -1,18 +1,18 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import plural from '../utils/plural'
-import {TimelineEventCompletedRetroMeeting_timelineEvent} from '../__generated__/TimelineEventCompletedRetroMeeting_timelineEvent.graphql'
+import {TimelineEventCompletedRetroMeeting_timelineEvent$key} from '../__generated__/TimelineEventCompletedRetroMeeting_timelineEvent.graphql'
 import StyledLink from './StyledLink'
 import TimelineEventBody from './TimelineEventBody'
 import TimelineEventCard from './TimelineEventCard'
 import TimelineEventTitle from './TImelineEventTitle'
 
 interface Props {
-  timelineEvent: TimelineEventCompletedRetroMeeting_timelineEvent
+  timelineEvent: TimelineEventCompletedRetroMeeting_timelineEvent$key
 }
 
 const CountItem = styled('span')({
@@ -24,7 +24,35 @@ const Link = styled(StyledLink)({
 })
 
 const TimelineEventCompletedRetroMeeting = (props: Props) => {
-  const {timelineEvent} = props
+  const {timelineEvent: timelineEventRef} = props
+  const timelineEvent = useFragment(
+    graphql`
+      fragment TimelineEventCompletedRetroMeeting_timelineEvent on TimelineEventCompletedRetroMeeting {
+        ...TimelineEventCard_timelineEvent
+        id
+        meeting {
+          id
+          commentCount
+          name
+          reflectionCount
+          taskCount
+          topicCount
+          locked
+          organization {
+            id
+            viewerOrganizationUser {
+              id
+            }
+          }
+        }
+        team {
+          id
+          name
+        }
+      }
+    `,
+    timelineEventRef
+  )
   const {meeting, team} = timelineEvent
   const {
     id: meetingId,
@@ -97,30 +125,4 @@ const TimelineEventCompletedRetroMeeting = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineEventCompletedRetroMeeting, {
-  timelineEvent: graphql`
-    fragment TimelineEventCompletedRetroMeeting_timelineEvent on TimelineEventCompletedRetroMeeting {
-      ...TimelineEventCard_timelineEvent
-      id
-      meeting {
-        id
-        commentCount
-        name
-        reflectionCount
-        taskCount
-        topicCount
-        locked
-        organization {
-          id
-          viewerOrganizationUser {
-            id
-          }
-        }
-      }
-      team {
-        id
-        name
-      }
-    }
-  `
-})
+export default TimelineEventCompletedRetroMeeting

--- a/packages/client/components/TimelineEventJoinedParabol.tsx
+++ b/packages/client/components/TimelineEventJoinedParabol.tsx
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {TimelineEventJoinedParabol_timelineEvent} from '../__generated__/TimelineEventJoinedParabol_timelineEvent.graphql'
+import {useFragment} from 'react-relay'
+import {TimelineEventJoinedParabol_timelineEvent$key} from '../__generated__/TimelineEventJoinedParabol_timelineEvent.graphql'
 import StyledLink from './StyledLink'
 import TimelineEventBody from './TimelineEventBody'
 import TimelineEventCard from './TimelineEventCard'
 import TimelineEventTitle from './TImelineEventTitle'
 
 interface Props {
-  timelineEvent: TimelineEventJoinedParabol_timelineEvent
+  timelineEvent: TimelineEventJoinedParabol_timelineEvent$key
 }
 
 const Link = styled(StyledLink)({
@@ -17,7 +17,16 @@ const Link = styled(StyledLink)({
 })
 
 const TimelineEventJoinedParabol = (props: Props) => {
-  const {timelineEvent} = props
+  const {timelineEvent: timelineEventRef} = props
+  const timelineEvent = useFragment(
+    graphql`
+      fragment TimelineEventJoinedParabol_timelineEvent on TimelineEventJoinedParabol {
+        ...TimelineEventCard_timelineEvent
+        id
+      }
+    `,
+    timelineEventRef
+  )
   return (
     <TimelineEventCard
       iconName='account_circle'
@@ -32,11 +41,4 @@ const TimelineEventJoinedParabol = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineEventJoinedParabol, {
-  timelineEvent: graphql`
-    fragment TimelineEventJoinedParabol_timelineEvent on TimelineEventJoinedParabol {
-      ...TimelineEventCard_timelineEvent
-      id
-    }
-  `
-})
+export default TimelineEventJoinedParabol

--- a/packages/client/components/TimelineEventPokerComplete.tsx
+++ b/packages/client/components/TimelineEventPokerComplete.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import plural from '../utils/plural'
-import {TimelineEventPokerComplete_timelineEvent} from '../__generated__/TimelineEventPokerComplete_timelineEvent.graphql'
+import {TimelineEventPokerComplete_timelineEvent$key} from '../__generated__/TimelineEventPokerComplete_timelineEvent.graphql'
 import CardsSVG from './CardsSVG'
 import StyledLink from './StyledLink'
 import TimelineEventBody from './TimelineEventBody'
@@ -13,7 +13,7 @@ import TimelineEventCard from './TimelineEventCard'
 import TimelineEventTitle from './TImelineEventTitle'
 
 interface Props {
-  timelineEvent: TimelineEventPokerComplete_timelineEvent
+  timelineEvent: TimelineEventPokerComplete_timelineEvent$key
 }
 
 const CountItem = styled('span')({
@@ -25,7 +25,42 @@ const Link = styled(StyledLink)({
 })
 
 const TimelineEventPokerComplete = (props: Props) => {
-  const {timelineEvent} = props
+  const {timelineEvent: timelineEventRef} = props
+  const timelineEvent = useFragment(
+    graphql`
+      fragment TimelineEventPokerComplete_timelineEvent on TimelineEventPokerComplete {
+        ...TimelineEventCard_timelineEvent
+        id
+        meeting {
+          id
+          commentCount
+          storyCount
+          name
+          phases {
+            phaseType
+            ... on EstimatePhase {
+              stages {
+                id
+              }
+            }
+          }
+          locked
+          organization {
+            id
+            viewerOrganizationUser {
+              id
+            }
+          }
+        }
+        team {
+          id
+          name
+          orgId
+        }
+      }
+    `,
+    timelineEventRef
+  )
   const {meeting, team} = timelineEvent
   const {id: meetingId, name: meetingName, commentCount, storyCount, locked, organization} = meeting
   const {name: teamName} = team
@@ -80,37 +115,4 @@ const TimelineEventPokerComplete = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineEventPokerComplete, {
-  timelineEvent: graphql`
-    fragment TimelineEventPokerComplete_timelineEvent on TimelineEventPokerComplete {
-      ...TimelineEventCard_timelineEvent
-      id
-      meeting {
-        id
-        commentCount
-        storyCount
-        name
-        phases {
-          phaseType
-          ... on EstimatePhase {
-            stages {
-              id
-            }
-          }
-        }
-        locked
-        organization {
-          id
-          viewerOrganizationUser {
-            id
-          }
-        }
-      }
-      team {
-        id
-        name
-        orgId
-      }
-    }
-  `
-})
+export default TimelineEventPokerComplete

--- a/packages/client/components/TimelineEventTeamCreated.tsx
+++ b/packages/client/components/TimelineEventTeamCreated.tsx
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
-import {TimelineEventTeamCreated_timelineEvent} from '../__generated__/TimelineEventTeamCreated_timelineEvent.graphql'
+import {useFragment} from 'react-relay'
+import {TimelineEventTeamCreated_timelineEvent$key} from '../__generated__/TimelineEventTeamCreated_timelineEvent.graphql'
 import StyledLink from './StyledLink'
 import TimelineEventBody from './TimelineEventBody'
 import TimelineEventCard from './TimelineEventCard'
 import TimelineEventTitle from './TImelineEventTitle'
 
 interface Props {
-  timelineEvent: TimelineEventTeamCreated_timelineEvent
+  timelineEvent: TimelineEventTeamCreated_timelineEvent$key
 }
 
 const Link = styled(StyledLink)({
@@ -17,7 +17,21 @@ const Link = styled(StyledLink)({
 })
 
 const TimelineEventTeamCreated = (props: Props) => {
-  const {timelineEvent} = props
+  const {timelineEvent: timelineEventRef} = props
+  const timelineEvent = useFragment(
+    graphql`
+      fragment TimelineEventTeamCreated_timelineEvent on TimelineEventTeamCreated {
+        ...TimelineEventCard_timelineEvent
+        id
+        team {
+          id
+          isArchived
+          name
+        }
+      }
+    `,
+    timelineEventRef
+  )
   const {team} = timelineEvent
   const {id: teamId, name: teamName, isArchived} = team
   return (
@@ -40,16 +54,4 @@ const TimelineEventTeamCreated = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineEventTeamCreated, {
-  timelineEvent: graphql`
-    fragment TimelineEventTeamCreated_timelineEvent on TimelineEventTeamCreated {
-      ...TimelineEventCard_timelineEvent
-      id
-      team {
-        id
-        isArchived
-        name
-      }
-    }
-  `
-})
+export default TimelineEventTeamCreated

--- a/packages/client/components/TimelineRightDrawer.tsx
+++ b/packages/client/components/TimelineRightDrawer.tsx
@@ -1,16 +1,16 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
 import {PALETTE} from '../styles/paletteV3'
 import {DashTimeline, NavSidebar} from '../types/constEnums'
-import {TimelineRightDrawer_viewer} from '../__generated__/TimelineRightDrawer_viewer.graphql'
+import {TimelineRightDrawer_viewer$key} from '../__generated__/TimelineRightDrawer_viewer.graphql'
 import ErrorBoundary from './ErrorBoundary'
 import TimelinePriorityTasks from './TimelinePriorityTasks'
 
 interface Props {
-  viewer: TimelineRightDrawer_viewer
+  viewer: TimelineRightDrawer_viewer$key
 }
 
 const MIN_WIDTH =
@@ -32,7 +32,15 @@ export const RightDrawer = styled('div')({
 })
 
 const TimelineRightDrawer = (props: Props) => {
-  const {viewer} = props
+  const {viewer: viewerRef} = props
+  const viewer = useFragment(
+    graphql`
+      fragment TimelineRightDrawer_viewer on User {
+        ...TimelinePriorityTasks_viewer
+      }
+    `,
+    viewerRef
+  )
   return (
     <RightDrawer>
       <ErrorBoundary>
@@ -42,10 +50,4 @@ const TimelineRightDrawer = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(TimelineRightDrawer, {
-  viewer: graphql`
-    fragment TimelineRightDrawer_viewer on User {
-      ...TimelinePriorityTasks_viewer
-    }
-  `
-})
+export default TimelineRightDrawer

--- a/packages/client/components/VoteSettingsMenu.tsx
+++ b/packages/client/components/VoteSettingsMenu.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
-import {createFragmentContainer} from 'react-relay'
+import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import UpdateRetroMaxVotesMutation from '~/mutations/UpdateRetroMaxVotesMutation'
 import {PALETTE} from '~/styles/paletteV3'
 import {MeetingSettingsThreshold} from '~/types/constEnums'
-import {VoteSettingsMenu_meeting} from '~/__generated__/VoteSettingsMenu_meeting.graphql'
+import {VoteSettingsMenu_meeting$key} from '~/__generated__/VoteSettingsMenu_meeting.graphql'
 import {MenuProps} from '../hooks/useMenu'
 import Menu from './Menu'
 import StyledError from './StyledError'
@@ -15,7 +15,7 @@ import VoteStepper from './VoteSettingsStepper'
 
 interface Props {
   menuProps: MenuProps
-  meeting: VoteSettingsMenu_meeting
+  meeting: VoteSettingsMenu_meeting$key
 }
 
 const VoteOption = styled('div')({
@@ -35,7 +35,17 @@ const Error = styled(StyledError)({
 })
 
 const VoteSettingsMenu = (props: Props) => {
-  const {menuProps, meeting} = props
+  const {menuProps, meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment VoteSettingsMenu_meeting on RetrospectiveMeeting {
+        id
+        totalVotes
+        maxVotesPerGroup
+      }
+    `,
+    meetingRef
+  )
   const {id: meetingId, totalVotes, maxVotesPerGroup} = meeting
   const {error, onError, onCompleted, submitMutation} = useMutationProps()
   const atmosphere = useAtmosphere()
@@ -95,12 +105,4 @@ const VoteSettingsMenu = (props: Props) => {
   )
 }
 
-export default createFragmentContainer(VoteSettingsMenu, {
-  meeting: graphql`
-    fragment VoteSettingsMenu_meeting on RetrospectiveMeeting {
-      id
-      totalVotes
-      maxVotesPerGroup
-    }
-  `
-})
+export default VoteSettingsMenu


### PR DESCRIPTION
# Description
refs https://github.com/ParabolInc/parabol/issues/6283

Converted using the process described in https://www.notion.so/parabol/How-to-Migrate-createFragmentContainer-useFragment-with-codeshift-d534e7d0b8674089a2075f2835544558 🔒 

## Testing scenarios
- [ ] Smoke test the app

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
