### PR TITLE
fix(teams-limit): add missing billing link to 7 days warning email

### DIFF
--- a/packages/client/modules/email/components/LimitsEmails/SevenDayWarningEmail.tsx
+++ b/packages/client/modules/email/components/LimitsEmails/SevenDayWarningEmail.tsx
@@ -53,9 +53,12 @@ export default function SevenDayWarningEmail(props: LimitsEmailProps) {
         <EmptySpace height={16} />
         <p style={{...copyStyle}}>
           {`You'll need to `}
-          <span style={{fontWeight: 600, textDecoration: 'underline'}}>
+          <a
+            style={{fontWeight: 600, textDecoration: 'underline', color: 'inherit'}}
+            href={billingURL}
+          >
             {`upgrade your account within the next ${Threshold.FINAL_WARNING_DAYS_BEFORE_LOCK} days`}
-          </span>
+          </a>
           {` to avoid losing access to your agile meetings.`}
         </p>
         <Button url={billingURL}>{'Keep Access'}</Button>


### PR DESCRIPTION
<img width="554" alt="image" src="https://user-images.githubusercontent.com/466991/222746361-2fcc3828-da6e-4a64-b72b-9c1d28d3e263.png">

How to test:

- Trigger teams limit and runScheduledJobs
- See that link from the above screenshot is now clickable