### PR TITLE
fix(teams-limit): fix locked message in usage stats

### DIFF
--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -114,6 +114,11 @@ const InsightsDomainNudge = (props: Props) => {
     }
   }
   const {togglePortal, closePortal, modalPortal} = useModal()
+
+  const isLocked = toBeLockedOrg?.scheduledLockAt
+    ? new Date(toBeLockedOrg?.scheduledLockAt).getTime() <= new Date().getTime()
+    : false
+
   return (
     <>
       {modalPortal(
@@ -132,12 +137,13 @@ const InsightsDomainNudge = (props: Props) => {
               <BoldText>{domainId}</BoldText>
               {` is over the limit of `}
               <BoldText>{`${Threshold.MAX_STARTER_TIER_TEAMS} free teams`}</BoldText>
-              {toBeLockedOrg?.scheduledLockAt && (
+              {toBeLockedOrg?.scheduledLockAt && !isLocked && (
                 <>
                   {`. Your free access will end in `}
                   <BoldText>{`${relativeDate(toBeLockedOrg?.scheduledLockAt)}.`}</BoldText>
                 </>
               )}
+              {isLocked && `. Please upgrade to continue using Parabol`}
             </WarningMsg>
           </OverLimitBlock>
           <ButtonBlock>

--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -115,8 +115,10 @@ const InsightsDomainNudge = (props: Props) => {
   }
   const {togglePortal, closePortal, modalPortal} = useModal()
 
-  const isLocked = toBeLockedOrg?.scheduledLockAt
-    ? new Date(toBeLockedOrg?.scheduledLockAt).getTime() <= new Date().getTime()
+  const scheduledLockAt = toBeLockedOrg?.scheduledLockAt
+
+  const isLocked = scheduledLockAt
+    ? new Date(scheduledLockAt).getTime() <= new Date().getTime()
     : false
 
   return (
@@ -137,10 +139,10 @@ const InsightsDomainNudge = (props: Props) => {
               <BoldText>{domainId}</BoldText>
               {` is over the limit of `}
               <BoldText>{`${Threshold.MAX_STARTER_TIER_TEAMS} free teams`}</BoldText>
-              {toBeLockedOrg?.scheduledLockAt && !isLocked && (
+              {scheduledLockAt && !isLocked && (
                 <>
                   {`. Your free access will end in `}
-                  <BoldText>{`${relativeDate(toBeLockedOrg?.scheduledLockAt)}.`}</BoldText>
+                  <BoldText>{`${relativeDate(scheduledLockAt)}.`}</BoldText>
                 </>
               )}
               {isLocked && `. Please upgrade to continue using Parabol`}

--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -145,7 +145,7 @@ const InsightsDomainNudge = (props: Props) => {
                   <BoldText>{`${relativeDate(scheduledLockAt)}.`}</BoldText>
                 </>
               )}
-              {isLocked && `. Please upgrade to continue using Parabol`}
+              {isLocked && `. Please upgrade to continue using Parabol.`}
             </WarningMsg>
           </OverLimitBlock>
           <ButtonBlock>


### PR DESCRIPTION
Fixes #7838

When the time is up, instead of the countdown timer show another message

<img width="633" alt="image" src="https://user-images.githubusercontent.com/466991/223024130-8e412b1b-7dbb-417f-a132-4b46f04b905e.png">

**How to test:**

- Set scheduledLockAt on the org = new Date()
- See the message from the screenshot above