### PR TITLE
chore(teams-limit): change first warning notification text

### DIFF
--- a/packages/client/components/TeamsLimitExceededNotification.tsx
+++ b/packages/client/components/TeamsLimitExceededNotification.tsx
@@ -6,6 +6,7 @@ import defaultOrgAvatar from '~/styles/theme/images/avatar-organization.svg'
 import {TeamsLimitExceededNotification_notification$key} from '~/__generated__/TeamsLimitExceededNotification_notification.graphql'
 import NotificationAction from './NotificationAction'
 import NotificationTemplate from './NotificationTemplate'
+import {Threshold} from '../types/constEnums'
 
 interface Props {
   notification: TeamsLimitExceededNotification_notification$key
@@ -34,7 +35,7 @@ const TeamsLimitExceededNotification = (props: Props) => {
   return (
     <NotificationTemplate
       avatar={orgPicture || defaultOrgAvatar}
-      message={`Your account is on a roll! Check out "${orgName}"'s usage`}
+      message={`"${orgName}" is over the limit of ${Threshold.MAX_STARTER_TIER_TEAMS} free teams. Action is needed.`}
       action={<NotificationAction label={'See Usage'} onClick={onActionClick} />}
       notification={notification}
     />

--- a/packages/client/mutations/toasts/mapTeamsLimitExceededToToast.ts
+++ b/packages/client/mutations/toasts/mapTeamsLimitExceededToToast.ts
@@ -4,6 +4,7 @@ import {OnNextHistoryContext} from '../../types/relayMutations'
 import {mapTeamsLimitExceededToToast_notification} from '../../__generated__/mapTeamsLimitExceededToToast_notification.graphql'
 import SendClientSegmentEventMutation from '../SendClientSegmentEventMutation'
 import makeNotificationToastKey from './makeNotificationToastKey'
+import {Threshold} from '../../types/constEnums'
 
 graphql`
   fragment mapTeamsLimitExceededToToast_notification on NotifyTeamsLimitExceeded {
@@ -20,8 +21,9 @@ const mapTeamsLimitExceededToToast = (
 
   return {
     autoDismiss: 0,
+    showDismissButton: true,
     key: makeNotificationToastKey(notificationId),
-    message: `Your account is on a roll! Check out "${orgName}"'s usage`,
+    message: `"${orgName}" is over the limit of ${Threshold.MAX_STARTER_TIER_TEAMS} free teams. Action is needed.`,
     onManualDismiss: () => {
       SendClientSegmentEventMutation(atmosphere, 'Snackbar Clicked', {
         snackbarType: 'teamsLimitExceeded'

--- a/packages/client/mutations/toasts/mapTeamsLimitReminderToToast.ts
+++ b/packages/client/mutations/toasts/mapTeamsLimitReminderToToast.ts
@@ -24,6 +24,7 @@ const mapTeamsLimitReminderToToast = (
 
   return {
     autoDismiss: 0,
+    showDismissButton: true,
     key: makeNotificationToastKey(notificationId),
     message: `"${orgName}" is over the limit of ${
       Threshold.MAX_STARTER_TIER_TEAMS


### PR DESCRIPTION
Fixes #7856

- Added a close button to each teams limit snackbar
- Changed "Your account is on roll" message. Made it similar to the second warning message. See the bottom snackbar:

<img width="708" alt="image" src="https://user-images.githubusercontent.com/466991/223039449-52b9fd8f-9fa8-48e8-9d49-285bbe8d562f.png">

<img width="465" alt="image" src="https://user-images.githubusercontent.com/466991/223039653-3bd077e3-c375-47c5-8c4a-2c2c66df4838.png">


**How to test**

- Trigger teams limit
- Run `runScheduledJobs` to see the second snackbar too