### PR TITLE
chore(metrics): emit `is_patient_0` as user properties for GA4

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -20,7 +20,7 @@ const query = graphql`
       id
       segmentId
       email
-      isWatched
+      isPatient0
     }
   }
 `
@@ -111,10 +111,13 @@ const AnalyticsPage = () => {
         const res = await atmosphere.fetchQuery<AnalyticsPageQuery>(query)
         if (!res) return
         const {viewer} = res
-        const {id, segmentId} = viewer
+        const {id, segmentId, isPatient0} = viewer
         ReactGA.set({
           userId: id,
-          clientId: segmentId ?? getAnonymousId()
+          clientId: segmentId ?? getAnonymousId(),
+          user_properties: {
+            is_patient_0: !!isPatient0
+          }
         })
       } else {
         ReactGA.set({

--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -17,9 +17,8 @@ const SAMLRedirect = () => {
     const token = params.get('token')
     const error = params.get('error')
     const isNewUser = params.get('isNewUser') === 'true'
-    const isPatient0 = params.get('isPatient0') === 'true'
     if (isNewUser && !error) {
-      ReactGA.event('sign_up', {isPatient0})
+      ReactGA.event('sign_up')
     }
     let isSameOriginPopup = false
     if (window.opener) {

--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -19,7 +19,11 @@ const SAMLRedirect = () => {
     const isNewUser = params.get('isNewUser') === 'true'
     const isPatient0 = params.get('isPatient0') === 'true'
     if (isNewUser && !error) {
-      ReactGA.event('sign_up', {isPatient0})
+      ReactGA.event('sign_up', {
+        user_properties: {
+          is_patient0: isPatient0
+        }
+      })
     }
     let isSameOriginPopup = false
     if (window.opener) {

--- a/packages/client/components/SAMLRedirect.tsx
+++ b/packages/client/components/SAMLRedirect.tsx
@@ -17,8 +17,9 @@ const SAMLRedirect = () => {
     const token = params.get('token')
     const error = params.get('error')
     const isNewUser = params.get('isNewUser') === 'true'
+    const isPatient0 = params.get('isPatient0') === 'true'
     if (isNewUser && !error) {
-      ReactGA.event('sign_up')
+      ReactGA.event('sign_up', {isPatient0})
     }
     let isSameOriginPopup = false
     if (window.opener) {

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -49,7 +49,11 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
         if (isNewUser) {
-          ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
+          ReactGA.event('sign_up', {
+            user_properties: {
+              is_patient_0: user!.isPatient0
+            }
+          })
         }
         handleSuccessfulLogin(loginWithGoogle)
         const authToken = acceptTeamInvitation?.authToken ?? loginWithGoogle.authToken

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -45,11 +45,11 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, loginWithGoogle} = res
       onCompleted({loginWithGoogle}, errors)
-      const {error: uiError, isNewUser, user} = loginWithGoogle
+      const {error: uiError, isNewUser} = loginWithGoogle
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
         if (isNewUser) {
-          ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
+          ReactGA.event('sign_up')
         }
         handleSuccessfulLogin(loginWithGoogle)
         const authToken = acceptTeamInvitation?.authToken ?? loginWithGoogle.authToken

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -45,11 +45,11 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, loginWithGoogle} = res
       onCompleted({loginWithGoogle}, errors)
-      const {error: uiError, isNewUser} = loginWithGoogle
+      const {error: uiError, isNewUser, user} = loginWithGoogle
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
         if (isNewUser) {
-          ReactGA.event('sign_up')
+          ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
         }
         handleSuccessfulLogin(loginWithGoogle)
         const authToken = acceptTeamInvitation?.authToken ?? loginWithGoogle.authToken

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -50,7 +50,11 @@ const SignUpWithPasswordMutation: StandardMutation<
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
-        ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
+        ReactGA.event('sign_up', {
+          user_properties: {
+            is_patient_0: user!.isPatient0
+          }
+        })
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken
         atmosphere.setAuthToken(authToken)

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -46,11 +46,11 @@ const SignUpWithPasswordMutation: StandardMutation<
     onError,
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, signUpWithPassword} = res
-      const {error: uiError} = signUpWithPassword
+      const {error: uiError, user} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
-        ReactGA.event('sign_up')
+        ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken
         atmosphere.setAuthToken(authToken)

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -46,11 +46,11 @@ const SignUpWithPasswordMutation: StandardMutation<
     onError,
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, signUpWithPassword} = res
-      const {error: uiError, user} = signUpWithPassword
+      const {error: uiError} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
-        ReactGA.event('sign_up', {isPatient0: user!.isPatient0})
+        ReactGA.event('sign_up')
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken ?? signUpWithPassword.authToken
         atmosphere.setAuthToken(authToken)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol-data-sanctum/issues/564
TLDR: previously we emit `isPatient0` as event-scoped dimension. We should make it user-scoped dimension.

## Demo
* Page view:

<img width="1557" alt="Screenshot 2023-03-07 at 10 41 20" src="https://user-images.githubusercontent.com/1879975/223521065-91e47921-0814-4ead-898e-92170fc5c73c.png">

* Sign up:

<img width="1554" alt="Screenshot 2023-03-07 at 10 46 46" src="https://user-images.githubusercontent.com/1879975/223521148-4e220c2d-df94-48b4-bd3b-5e4c7284c8ec.png">


## Testing scenarios

- [ ] Page view
  - Sign in as a user
  - View a couple of pages
  - Verify in Analytics Debugger that `page_view` events have user properties with `is_patient_0` set up

- [ ] Sign up
  - From `/create-account`, sign up 
  - Verify in Analytics Debugger that `sign_up` events have user properties with `is_patient_0` set up

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
