### PR TITLE
feat(checkout-flow): add teams limit warning

### DIFF
--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -8,8 +8,6 @@ import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMu
 import useModal from '../hooks/useModal'
 import CreditCardModal from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
 import {PALETTE} from '../styles/paletteV3'
-import {Threshold} from '../types/constEnums'
-import relativeDate from '../utils/date/relativeDate'
 import {InsightsDomainNudge_domain$key} from '../__generated__/InsightsDomainNudge_domain.graphql'
 import PrimaryButton from './PrimaryButton'
 import LimitExceededWarning from './LimitExceededWarning'
@@ -21,30 +19,6 @@ const NudgeBlock = styled('div')({
   borderTop: `1px solid ${PALETTE.SLATE_400}`,
   padding: 16,
   width: '100%'
-})
-
-const WarningMsg = styled('div')({
-  background: PALETTE.GOLD_100,
-  padding: '16px',
-  fontSize: 16,
-  borderRadius: 2,
-  lineHeight: '26px',
-  fontWeight: 500
-})
-
-const BoldText = styled('span')({
-  fontWeight: 600
-})
-
-const OverLimitBlock = styled('div')({
-  backgroundColor: PALETTE.GOLD_100,
-  borderRadius: 2,
-  color: PALETTE.SLATE_900,
-  fontSize: 16,
-  lineHeight: '24px',
-  width: '100%',
-  display: 'flex',
-  flexWrap: 'wrap'
 })
 
 const CTA = styled(PrimaryButton)({
@@ -85,51 +59,47 @@ const InsightsDomainNudge = (props: Props) => {
   )
   const atmosphere = useAtmosphere()
   const history = useHistory()
+  const {togglePortal, closePortal, modalPortal} = useModal()
   const {id: domainId, suggestedTier, tier, viewerOrganizations} = domain
   const starterOrganizations = viewerOrganizations
     .filter((org) => org.tier === 'starter')
     .sort((a, b) => (a.orgUserCount > b.orgUserCount ? -1 : 1))
   const [biggestOrganization] = starterOrganizations
-  const organizationName = biggestOrganization?.name ?? ''
+  if (!biggestOrganization) return null
+  const {id: biggestOrganizationId, name: organizationName, orgUserCount} = biggestOrganization
   const suggestTeam = suggestedTier === 'team' && tier === 'starter'
   const suggestEnterprise = suggestedTier === 'enterprise' && tier !== 'enterprise'
   const toBeLockedOrg = viewerOrganizations.find(({scheduledLockAt}) => scheduledLockAt)
   const showNudge = suggestTeam || suggestEnterprise || toBeLockedOrg
   const CTACopy = suggestTeam || toBeLockedOrg ? `Upgrade ${organizationName}` : 'Contact Us'
   const CTAType = suggestTeam ? 'team' : 'enterprise'
+
   const onClickCTA = () => {
     const event = toBeLockedOrg ? 'Upgrade CTA Clicked' : 'Clicked Domain Stats CTA'
     const variables = toBeLockedOrg
       ? ({
           upgradeCTALocation: 'usageStats',
-          orgId: biggestOrganization?.id,
+          orgId: biggestOrganizationId,
           upgradeTier: 'team'
         } as const)
       : ({CTAType, domainId} as const)
     SendClientSegmentEventMutation(atmosphere, event, variables)
     if (toBeLockedOrg) {
-      history.push(`/me/organizations/${biggestOrganization?.id}/billing`)
+      history.push(`/me/organizations/${biggestOrganizationId}/billing`)
     } else if (suggestTeam) {
       togglePortal()
     } else if (suggestEnterprise) {
       window.open('mailto:love@parabol.co?subject=Increase Usage Limits')
     }
   }
-  const {togglePortal, closePortal, modalPortal} = useModal()
-
-  const scheduledLockAt = toBeLockedOrg?.scheduledLockAt
-
-  const isLocked = scheduledLockAt
-    ? new Date(scheduledLockAt).getTime() <= new Date().getTime()
-    : false
 
   return (
     <>
       {modalPortal(
         <CreditCardModal
           // will be null if they successfully upgraded their last free org
-          activeUserCount={biggestOrganization?.orgUserCount?.activeUserCount ?? 0}
-          orgId={biggestOrganization?.id ?? ''}
+          activeUserCount={orgUserCount.activeUserCount}
+          orgId={biggestOrganizationId}
           actionType={'upgrade'}
           closePortal={closePortal}
         />
@@ -137,20 +107,6 @@ const InsightsDomainNudge = (props: Props) => {
       {showNudge && (
         <NudgeBlock>
           <LimitExceededWarning organizationRef={biggestOrganization} domainId={domainId} />
-          {/* <OverLimitBlock>
-            <WarningMsg>
-              <BoldText>{domainId}</BoldText>
-              {` is over the limit of `}
-              <BoldText>{`${Threshold.MAX_STARTER_TIER_TEAMS} free teams`}</BoldText>
-              {scheduledLockAt && !isLocked && (
-                <>
-                  {`. Your free access will end in `}
-                  <BoldText>{`${relativeDate(scheduledLockAt)}.`}</BoldText>
-                </>
-              )}
-              {isLocked && `. Please upgrade to continue using Parabol.`}
-            </WarningMsg>
-          </OverLimitBlock> */}
           <ButtonBlock>
             <CTA size={'large'} onClick={onClickCTA}>
               {CTACopy}

--- a/packages/client/components/InsightsDomainNudge.tsx
+++ b/packages/client/components/InsightsDomainNudge.tsx
@@ -12,6 +12,7 @@ import {Threshold} from '../types/constEnums'
 import relativeDate from '../utils/date/relativeDate'
 import {InsightsDomainNudge_domain$key} from '../__generated__/InsightsDomainNudge_domain.graphql'
 import PrimaryButton from './PrimaryButton'
+import LimitExceededWarning from './LimitExceededWarning'
 
 const NudgeBlock = styled('div')({
   display: 'flex',
@@ -69,6 +70,7 @@ const InsightsDomainNudge = (props: Props) => {
         suggestedTier
         tier
         viewerOrganizations {
+          ...LimitExceededWarning_organization
           id
           name
           scheduledLockAt
@@ -134,7 +136,8 @@ const InsightsDomainNudge = (props: Props) => {
       )}
       {showNudge && (
         <NudgeBlock>
-          <OverLimitBlock>
+          <LimitExceededWarning organizationRef={biggestOrganization} domainId={domainId} />
+          {/* <OverLimitBlock>
             <WarningMsg>
               <BoldText>{domainId}</BoldText>
               {` is over the limit of `}
@@ -147,7 +150,7 @@ const InsightsDomainNudge = (props: Props) => {
               )}
               {isLocked && `. Please upgrade to continue using Parabol.`}
             </WarningMsg>
-          </OverLimitBlock>
+          </OverLimitBlock> */}
           <ButtonBlock>
             <CTA size={'large'} onClick={onClickCTA}>
               {CTACopy}

--- a/packages/client/components/LimitExceededWarning.tsx
+++ b/packages/client/components/LimitExceededWarning.tsx
@@ -1,0 +1,98 @@
+import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {useHistory} from 'react-router'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
+import useModal from '../hooks/useModal'
+import CreditCardModal from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
+import {PALETTE} from '../styles/paletteV3'
+import {Threshold} from '../types/constEnums'
+import relativeDate from '../utils/date/relativeDate'
+import {InsightsDomainNudge_domain$key} from '../__generated__/InsightsDomainNudge_domain.graphql'
+import PrimaryButton from './PrimaryButton'
+
+const NudgeBlock = styled('div')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  flexDirection: 'column',
+  borderTop: `1px solid ${PALETTE.SLATE_400}`,
+  padding: 16,
+  width: '100%'
+})
+
+const WarningMsg = styled('div')({
+  background: PALETTE.GOLD_100,
+  padding: '16px',
+  fontSize: 16,
+  borderRadius: 2,
+  lineHeight: '26px',
+  fontWeight: 500
+})
+
+const BoldText = styled('span')({
+  fontWeight: 600
+})
+
+const OverLimitBlock = styled('div')({
+  backgroundColor: PALETTE.GOLD_100,
+  borderRadius: 2,
+  color: PALETTE.SLATE_900,
+  fontSize: 16,
+  lineHeight: '24px',
+  width: '100%',
+  display: 'flex',
+  flexWrap: 'wrap'
+})
+
+const CTA = styled(PrimaryButton)({
+  lineHeight: '24px',
+  padding: '8px 32px',
+  width: 'fit-content'
+})
+
+const ButtonBlock = styled('div')({
+  paddingTop: 16
+})
+
+interface Props {
+  organizationRef: any // InsightsDomainNudge_domain$key
+  domainId?: string
+}
+
+const LimitExceededWarning = (props: Props) => {
+  const {organizationRef, domainId} = props
+  const organization = useFragment(
+    graphql`
+      fragment LimitExceededWarning_organization on Organization {
+        name
+        scheduledLockAt
+      }
+    `,
+    organizationRef
+  )
+  const {scheduledLockAt, name: orgName} = organization
+  const isLocked = scheduledLockAt
+    ? new Date(scheduledLockAt).getTime() <= new Date().getTime()
+    : false
+
+  return (
+    <OverLimitBlock>
+      <WarningMsg>
+        <BoldText>{domainId ?? orgName}</BoldText>
+        {` is over the limit of `}
+        <BoldText>{`${Threshold.MAX_STARTER_TIER_TEAMS} free teams`}</BoldText>
+        {scheduledLockAt && !isLocked && (
+          <>
+            {`. Your free access will end in `}
+            <BoldText>{`${relativeDate(scheduledLockAt)}.`}</BoldText>
+          </>
+        )}
+        {isLocked && `. Please upgrade to continue using Parabol.`}
+      </WarningMsg>
+    </OverLimitBlock>
+  )
+}
+
+export default LimitExceededWarning

--- a/packages/client/components/LimitExceededWarning.tsx
+++ b/packages/client/components/LimitExceededWarning.tsx
@@ -2,25 +2,10 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
-import {useHistory} from 'react-router'
-import useAtmosphere from '~/hooks/useAtmosphere'
-import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
-import useModal from '../hooks/useModal'
-import CreditCardModal from '../modules/userDashboard/components/CreditCardModal/CreditCardModal'
 import {PALETTE} from '../styles/paletteV3'
 import {Threshold} from '../types/constEnums'
 import relativeDate from '../utils/date/relativeDate'
-import {InsightsDomainNudge_domain$key} from '../__generated__/InsightsDomainNudge_domain.graphql'
-import PrimaryButton from './PrimaryButton'
-
-const NudgeBlock = styled('div')({
-  display: 'flex',
-  flexWrap: 'wrap',
-  flexDirection: 'column',
-  borderTop: `1px solid ${PALETTE.SLATE_400}`,
-  padding: 16,
-  width: '100%'
-})
+import {LimitExceededWarning_organization$key} from '../__generated__/LimitExceededWarning_organization.graphql'
 
 const WarningMsg = styled('div')({
   background: PALETTE.GOLD_100,
@@ -46,18 +31,8 @@ const OverLimitBlock = styled('div')({
   flexWrap: 'wrap'
 })
 
-const CTA = styled(PrimaryButton)({
-  lineHeight: '24px',
-  padding: '8px 32px',
-  width: 'fit-content'
-})
-
-const ButtonBlock = styled('div')({
-  paddingTop: 16
-})
-
 interface Props {
-  organizationRef: any // InsightsDomainNudge_domain$key
+  organizationRef: LimitExceededWarning_organization$key
   domainId?: string
 }
 

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -14,6 +14,7 @@ import {OrgPlans_organization$key} from '../../../../__generated__/OrgPlans_orga
 import {ElementWidth, Threshold} from '../../../../types/constEnums'
 import {TierEnum} from '../../../../__generated__/SendClientSegmentEventMutation.graphql'
 import OrgStats from './OrgStats'
+import LimitExceededWarning from '../../../../components/LimitExceededWarning'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH,
@@ -189,6 +190,7 @@ const OrgPlans = (props: Props) => {
     graphql`
       fragment OrgPlans_organization on Organization {
         ...OrgStats_organization
+        ...LimitExceededWarning_organization
         tier
       }
     `,
@@ -245,6 +247,7 @@ const OrgPlans = (props: Props) => {
   return (
     <StyledPanel label='Plans'>
       <StyledRow>
+        <LimitExceededWarning organizationRef={organization} />
         <OrgStats organizationRef={organization} />
       </StyledRow>
       <StyledRow>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -192,6 +192,8 @@ const OrgPlans = (props: Props) => {
         ...OrgStats_organization
         ...LimitExceededWarning_organization
         tier
+        scheduledLockAt
+        lockedAt
       }
     `,
     organizationRef
@@ -199,7 +201,8 @@ const OrgPlans = (props: Props) => {
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.LOWER_CENTER
   )
-  const {tier} = organization
+  const {tier, scheduledLockAt, lockedAt} = organization
+  const showNudge = scheduledLockAt || lockedAt
 
   const plans = [
     {
@@ -247,7 +250,7 @@ const OrgPlans = (props: Props) => {
   return (
     <StyledPanel label='Plans'>
       <StyledRow>
-        <LimitExceededWarning organizationRef={organization} />
+        {showNudge && <LimitExceededWarning organizationRef={organization} />}
         <OrgStats organizationRef={organization} />
       </StyledRow>
       <StyledRow>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7692

In this PR, I'm using the UI that we have in Insights as I think we should be consistent with the UI & messaging.

Org with the `scheduledToLock`:
![warning-1](https://user-images.githubusercontent.com/39854876/223540606-21f0672f-8b40-4dd6-b22a-0781110ddf43.png)

Org with the `lockedAt`:
![warning-2](https://user-images.githubusercontent.com/39854876/223540633-4df586c3-a745-4036-afbf-a724c71b9dd5.png)

### To test

- [ ] View the billing page for an org that has the `scheduledToLock` field and see that the warning UI is the same as Insight
- [ ] View the billing page for an org that has the `lockedAt` field and see that the warning UI is the same as Insight
- [ ] Usage Stats page still works as it did previously
- [ ] The warning message UI looks good