### PR TITLE
feat(rid): Basic activity library search

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -1,10 +1,12 @@
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useMemo} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {Redirect} from 'react-router'
 import {ActivityLibraryQuery} from '~/__generated__/ActivityLibraryQuery.graphql'
 import ActivityLibrarySideBar from './ActivityLibrarySideBar'
 import ActivityLibraryCard from './ActivityLibraryCard'
+import SearchBar from './SearchBar'
+import useSearchFilter from '../../hooks/useSearchFilter'
 
 graphql`
   fragment ActivityLibrary_template on MeetingTemplate {
@@ -39,19 +41,28 @@ interface Props {
   queryRef: PreloadedQuery<ActivityLibraryQuery>
 }
 
+const getTemplateValue = (template: {name: string}) => template.name
+
 export const ActivityLibrary = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<ActivityLibraryQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<ActivityLibraryQuery>(query, queryRef)
   const {viewer} = data
   const {featureFlags, availableTemplates} = viewer
 
-  const templates = [
-    {id: 'action', type: 'action', name: 'Check-in', team: {name: 'Parabol'}},
-    {id: 'teamPrompt', type: 'teamPrompt', name: 'Standup', team: {name: 'Parabol'}},
-    ...availableTemplates.edges.map((edge) => edge.node)
-  ]
+  const templates = useMemo(
+    () => [
+      {id: 'action', type: 'action', name: 'Check-in', team: {name: 'Parabol'}},
+      {id: 'teamPrompt', type: 'teamPrompt', name: 'Standup', team: {name: 'Parabol'}},
+      ...availableTemplates.edges.map((edge) => edge.node)
+    ],
+    [availableTemplates]
+  )
+
+  const {
+    query: searchQuery,
+    filteredItems: filteredTemplates,
+    onQueryChange
+  } = useSearchFilter(templates, getTemplateValue)
 
   if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />
@@ -60,15 +71,18 @@ export const ActivityLibrary = (props: Props) => {
   return (
     <div className='flex'>
       <ActivityLibrarySideBar />
-      <div className='flex flex-wrap'>
-        {templates.map((template) => (
-          <ActivityLibraryCard
-            key={template.id}
-            type={template.type}
-            name={template.name}
-            teamName={template.team.name}
-          />
-        ))}
+      <div>
+        <SearchBar searchQuery={searchQuery} onChange={onQueryChange} />
+        <div className='flex flex-wrap'>
+          {filteredTemplates.map((template) => (
+            <ActivityLibraryCard
+              key={template.id}
+              type={template.type}
+              name={template.name}
+              teamName={template.team.name}
+            />
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -7,6 +7,7 @@ import ActivityLibrarySideBar from './ActivityLibrarySideBar'
 import ActivityLibraryCard from './ActivityLibraryCard'
 import SearchBar from './SearchBar'
 import useSearchFilter from '../../hooks/useSearchFilter'
+import halloweenRetrospectiveTemplate from '../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 
 graphql`
   fragment ActivityLibrary_template on MeetingTemplate {
@@ -69,11 +70,25 @@ export const ActivityLibrary = (props: Props) => {
   }
 
   return (
-    <div className='flex'>
+    <div className='flex h-full bg-white'>
       <ActivityLibrarySideBar />
       <div>
         <SearchBar searchQuery={searchQuery} onChange={onQueryChange} />
         <div className='flex flex-wrap'>
+          {filteredTemplates.length === 0 && (
+            <div className='ml-2 mt-2 flex text-slate-700'>
+              <img className='max-w-[128px]' src={halloweenRetrospectiveTemplate} />
+              <div className='ml-10'>
+                <div className='mb-4 text-xl font-semibold'>No results found!</div>
+                <div className='mb-6 max-w-[360px]'>
+                  Try tapping a category above, using a different search, or creating exactly what
+                  you have in mind.
+                </div>
+                {/* :TODO: (jmtaber129): Add the "create custom activity" card */}
+                <div className='mt-0.5'>TODO: create custom activity</div>
+              </div>
+            </div>
+          )}
           {filteredTemplates.map((template) => (
             <ActivityLibraryCard
               key={template.id}

--- a/packages/client/components/ActivityLibrary/SearchBar.tsx
+++ b/packages/client/components/ActivityLibrary/SearchBar.tsx
@@ -1,5 +1,4 @@
 import React, {ChangeEvent} from 'react'
-
 import {Search as SearchIcon} from '@mui/icons-material'
 
 interface Props {
@@ -14,6 +13,7 @@ const SearchBar = (props: Props) => {
       <SearchIcon className='text-slate-600' />
       <input
         className='ml-2 w-full border-none bg-transparent text-xl text-slate-700 placeholder-slate-600 outline-none'
+        autoFocus
         autoComplete='off'
         name='search'
         placeholder='Search Activities'

--- a/packages/client/components/ActivityLibrary/SearchBar.tsx
+++ b/packages/client/components/ActivityLibrary/SearchBar.tsx
@@ -1,0 +1,28 @@
+import React, {ChangeEvent} from 'react'
+
+import {Search as SearchIcon} from '@mui/icons-material'
+
+interface Props {
+  searchQuery: string
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+}
+
+const SearchBar = (props: Props) => {
+  const {searchQuery, onChange} = props
+  return (
+    <div className='my-4 ml-2 flex items-center'>
+      <SearchIcon className='text-slate-600' />
+      <input
+        className='ml-2 w-full border-none bg-transparent text-xl text-slate-700 placeholder-slate-600 outline-none'
+        autoComplete='off'
+        name='search'
+        placeholder='Search Activities'
+        type='text'
+        onChange={onChange}
+        value={searchQuery}
+      />
+    </div>
+  )
+}
+
+export default SearchBar


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7834

Implement search functionality in activity library:
* Search bar
* Search query filters templates that are rendered by the template name
* Empty state when no templates match the query

Note that the matching is pretty basic - just the basic string match that `useSearchFilter`. Anything more complex is out of scope for RiD v0.

Also note that the "create custom activity" card is excluded from the empty state with a TODO, since we'll likely want to reuse styles+components implemented as part of https://github.com/ParabolInc/parabol/issues/7833. I'll create a new task for that once this PR lands.

## Demo
https://www.loom.com/share/1ae5db6ca2444b289797d8fb7a25c1f6

## Testing scenarios
- [ ] All templates load when query is empty
- [ ] Only matching templates are shown when query is non-empty
- [ ] Empty state is shown when no templates match the query

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
