### PR TITLE
chore: simplify org plans button logic

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -160,17 +160,19 @@ const UpgradeButton = styled(FlatPrimaryButton)<{
 }))
 
 const getButtonStyle = (tier: TierEnum, plan: TierEnum) => {
-  if (tier === plan) return 'disabled'
-  else if (tier === 'starter') {
+  if (tier === plan) {
+    return 'disabled'
+  } else if (tier === 'starter') {
     return plan === 'team' ? 'primary' : 'secondary'
   } else {
     return 'secondary'
   }
 }
+
 const getButtonLabel = (tier: TierEnum, plan: TierEnum) => {
   if (tier === plan) {
     return 'Current Plan'
-  } else if (plan === 'enterprise') {
+  } else if (tier === 'enterprise' || plan === 'enterprise') {
     return 'Contact'
   } else if (plan === 'starter') {
     return 'Downgrade'

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -160,22 +160,22 @@ const UpgradeButton = styled(FlatPrimaryButton)<{
 }))
 
 const getButtonStyle = (tier: TierEnum, plan: TierEnum) => {
-  if (tier === 'starter') {
-    return plan === 'starter' ? 'disabled' : plan === 'team' ? 'primary' : 'secondary'
-  } else if (tier === 'team') {
-    return plan === 'team' ? 'disabled' : 'secondary'
+  if (tier === plan) return 'disabled'
+  else if (tier === 'starter') {
+    return plan === 'team' ? 'primary' : 'secondary'
   } else {
-    return plan === 'enterprise' ? 'disabled' : 'secondary'
+    return 'secondary'
   }
 }
-
 const getButtonLabel = (tier: TierEnum, plan: TierEnum) => {
-  if (tier === 'starter') {
-    return plan === 'starter' ? 'Current Plan' : plan === 'team' ? 'Select Plan' : 'Contact'
-  } else if (tier === 'team') {
-    return plan === 'team' ? 'Current Plan' : plan === 'starter' ? 'Downgrade' : 'Contact'
+  if (tier === plan) {
+    return 'Current Plan'
+  } else if (plan === 'enterprise') {
+    return 'Contact'
+  } else if (plan === 'starter') {
+    return 'Downgrade'
   } else {
-    return plan === 'enterprise' ? 'Current Plan' : 'Contact'
+    return 'Select Plan'
   }
 }
 


### PR DESCRIPTION
Inspired by https://github.com/ParabolInc/parabol/pull/7799/files/8a3661137fc2fe70623ca490280625a38f3855cc#r1124136458

I couldn't resist making this cleaner 😅 

### To test

- [ ] Check that the new checkout flow buttons look as they did on the Starter, Team, and Enterprise tiers