### PR TITLE
fix(relay): Revert to createFragmentContainer for ReflectTemplateItem

### DIFF
--- a/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useEffect, useRef} from 'react'
-import {useFragment} from 'react-relay'
+import {createFragmentContainer} from 'react-relay'
 import TypeAheadLabel from '~/components/TypeAheadLabel'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useScrollIntoView from '../../../hooks/useScrollIntoVIew'
@@ -11,8 +11,8 @@ import textOverflow from '../../../styles/helpers/textOverflow'
 import {PALETTE} from '../../../styles/paletteV3'
 import makeTemplateDescription from '../../../utils/makeTemplateDescription'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
-import {ReflectTemplateItem_template$key} from '../../../__generated__/ReflectTemplateItem_template.graphql'
-import {ReflectTemplateItem_viewer$key} from '../../../__generated__/ReflectTemplateItem_viewer.graphql'
+import {ReflectTemplateItem_template} from '../../../__generated__/ReflectTemplateItem_template.graphql'
+import {ReflectTemplateItem_viewer} from '../../../__generated__/ReflectTemplateItem_viewer.graphql'
 import {TierEnum} from '../../../__generated__/SendClientSegmentEventMutation.graphql'
 
 const TemplateItem = styled('li')<{isActive: boolean}>(({isActive}) => ({
@@ -56,46 +56,15 @@ const TemplateItemAction = styled('div')({})
 interface Props {
   isActive: boolean
   teamId: string
-  template: ReflectTemplateItem_template$key
+  template: ReflectTemplateItem_template
   lowestScope: 'TEAM' | 'ORGANIZATION' | 'PUBLIC'
   templateSearchQuery: string
   tier?: TierEnum
-  viewer?: ReflectTemplateItem_viewer$key
+  viewer?: ReflectTemplateItem_viewer
 }
 
 const ReflectTemplateItem = (props: Props) => {
-  const {
-    lowestScope,
-    isActive,
-    teamId,
-    template: templateRef,
-    templateSearchQuery,
-    tier,
-    viewer: viewerRef
-  } = props
-  const template = useFragment(
-    graphql`
-      fragment ReflectTemplateItem_template on ReflectTemplate {
-        #get the details here so we can show them in the details view
-        ...ReflectTemplateDetailsTemplate
-        ...makeTemplateDescription_template
-        id
-        name
-        lastUsedAt
-        scope
-        isFree
-      }
-    `,
-    templateRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment ReflectTemplateItem_viewer on User {
-        ...makeTemplateDescription_viewer
-      }
-    `,
-    viewerRef ?? null
-  )
+  const {lowestScope, isActive, teamId, template, templateSearchQuery, tier, viewer} = props
   const {id: templateId, name: templateName, scope, isFree} = template
   const description = makeTemplateDescription(lowestScope, template, viewer, tier)
   const atmosphere = useAtmosphere()
@@ -126,4 +95,22 @@ const ReflectTemplateItem = (props: Props) => {
   )
 }
 
-export default ReflectTemplateItem
+export default createFragmentContainer(ReflectTemplateItem, {
+  template: graphql`
+    fragment ReflectTemplateItem_template on ReflectTemplate {
+      #get the details here so we can show them in the details view
+      ...ReflectTemplateDetailsTemplate
+      ...makeTemplateDescription_template
+      id
+      name
+      lastUsedAt
+      scope
+      isFree
+    }
+  `,
+  viewer: graphql`
+    fragment ReflectTemplateItem_viewer on User {
+      ...makeTemplateDescription_viewer
+    }
+  `
+})


### PR DESCRIPTION
# Description
See [slack](https://parabol.slack.com/archives/C4JAUUZ9P/p1678371595957819) 🔒 
Attempting to click "create new template" for retros currently throws an error due to weirdness manifesting as a result of the `createFragmentContainer` -> `useFragment` migration in `ReflectTemplateItem`.

As a hotfix, just revert the migration

## Demo
N/A

## Testing scenarios
- [ ] Click "create new template" in the retro template modal and confirm now error is thrown

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
