### PR TITLE
fix: position of notification bell badge

### DIFF
--- a/packages/client/components/TopBarIcon.tsx
+++ b/packages/client/components/TopBarIcon.tsx
@@ -27,9 +27,9 @@ const Button = styled(PlainButton)({
 
 const Badge = styled('div')({
   borderRadius: 10,
-  top: 15,
+  top: 5,
   position: 'absolute',
-  left: 22,
+  left: 18,
   background: PALETTE.ROSE_500,
   border: `1px solid ${PALETTE.GRAPE_700}`,
   // +1 for borders


### PR DESCRIPTION
# Description

Fixes #7816

## Demo
<img width="212" alt="Captura de pantalla 2023-03-09 a la(s) 5 06 54 p m" src="https://user-images.githubusercontent.com/3276087/224180849-b3a33bc3-0c39-47ef-a8cc-d0aa2c0359fb.png">
<img width="301" alt="Captura de pantalla 2023-03-09 a la(s) 5 07 02 p m" src="https://user-images.githubusercontent.com/3276087/224180852-34ae7cba-2d8b-4866-a6c6-c7e042d759e4.png">
<img width="522" alt="Captura de pantalla 2023-03-09 a la(s) 5 07 16 p m" src="https://user-images.githubusercontent.com/3276087/224181203-035e9fc1-ff97-4e44-8fd8-b41b4b87117a.png">



## Testing scenarios

- [x] Big screen
  - Standby
  - Focus state

- [x] Small screen
  - Standby
  - Focus state
  - 
## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
