### PR TITLE
fix: changing width to max-width in tailwind format

### DIFF
--- a/packages/client/components/ActionMeetingUpdatesPrompt.tsx
+++ b/packages/client/components/ActionMeetingUpdatesPrompt.tsx
@@ -26,8 +26,7 @@ const PromptText = styled('div')({
 
 const StyledHeader = styled(PhaseHeaderTitle)({
   fontSize: 18,
-  overflowWrap: 'break-word',
-  width: '55vw'
+  overflowWrap: 'break-word'
 })
 
 const getQuestion = (isConnected: boolean | null, taskCount: number, preferredName: string) => {
@@ -92,7 +91,7 @@ const ActionMeetingUpdatesPrompt = (props: Props) => {
     <StyledPrompt>
       <Avatar picture={picture || defaultUserAvatar} size={64} />
       <PromptText>
-        <StyledHeader>
+        <StyledHeader className='max-w-full'>
           {prefix}
           <i>{getQuestion(isConnected, taskCount, preferredName)}</i>
         </StyledHeader>


### PR DESCRIPTION
# Description

Fixes #7878 

- Removed width css
- Updating it to max-width (there's a horizontal scroll without)
- Moved the CSS to the HTML, with new Tailwind format

## Demo
https://www.loom.com/share/29ebf1a158d8439a9f127c5c3529997e

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Review with a long name to ensure it wraps correctly

- [ ] Scenario B
  - Review with a large attendee list to make sure it doesn't wrap too soon

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
