### PR TITLE
fix(templates): Fix 'Create new template' button error for retros

### DIFF
--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -108,20 +108,20 @@ const ReflectTemplateList = (props: Props) => {
     graphql`
       fragment ReflectTemplateList_settings on RetrospectiveMeetingSettings {
         ...ReflectTemplateSearchBar_settings
-        ...ReflectTemplateListTeam_settings
         id
+        templateSearchQuery
         team {
           ...AddNewReflectTemplate_team
+          ...ReflectTemplateListTeam_team
           id
         }
         activeTemplate {
           ...getTemplateList_template
           id
-          teamId
-          orgId
         }
         teamTemplates {
           ...AddNewReflectTemplate_reflectTemplates
+          ...ReflectTemplateListTeam_teamTemplates
           id
         }
       }
@@ -137,7 +137,7 @@ const ReflectTemplateList = (props: Props) => {
     `,
     viewerRef
   )
-  const {id: settingsId, team, teamTemplates} = settings
+  const {id: settingsId, team, teamTemplates, templateSearchQuery} = settings
   const {id: teamId} = team
   const activeTemplateId = settings.activeTemplate?.id ?? '-tmp'
   const readyToScrollSmooth = useReadyToSmoothScroll(activeTemplateId)
@@ -231,8 +231,9 @@ const ReflectTemplateList = (props: Props) => {
           <ReflectTemplateListTeam
             activeTemplateId={activeTemplateId}
             showPublicTemplates={() => goToTab('PUBLIC')}
-            settingsRef={settings}
-            teamId={teamId}
+            templateSearchQuery={templateSearchQuery ?? ''}
+            teamRef={team}
+            teamTemplatesRef={teamTemplates}
             isActive={activeIdx === 0}
             viewerRef={viewer}
           />


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7900

See [slack](https://parabol.slack.com/archives/C4JAUUZ9P/p1678371595957819) 🔒 
Attempting to click "create new template" for retros currently throws an error due to weirdness manifesting as a result of the `createFragmentContainer` -> `useFragment` migration in `ReflectTemplateItem`.

Fix this by changing the fragments to the same structure that Poker uses, which doesn't contain this bug.

## Demo
N/A

## Testing scenarios
- [ ] Click "create new template" in the retro template modal and confirm now error is thrown

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
