### PR TITLE
chore(relay): Remove 'UNSTABLE_renderPolicy: full'

### DIFF
--- a/packages/client/components/AzureDevOpsScopingSearchResults.tsx
+++ b/packages/client/components/AzureDevOpsScopingSearchResults.tsx
@@ -68,8 +68,7 @@ const AzureDevOpsScopingSearchResults = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const meeting = useFragment(

--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -118,8 +118,7 @@ const Dashboard = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   const {teams, featureFlags} = viewer

--- a/packages/client/components/DemoMeetingRoot.tsx
+++ b/packages/client/components/DemoMeetingRoot.tsx
@@ -27,15 +27,9 @@ const DemoMeetingRoot = () => {
   useSubscription('DemoMeetingRoot', TaskSubscription)
   useSubscription('DemoMeetingRoot', TeamSubscription)
   useSubscription('DemoMeetingRoot', MeetingSubscription, {meetingId: RetroDemo.MEETING_ID})
-  const data = useLazyLoadQuery<DemoMeetingRootQuery>(
-    query,
-    {
-      meetingId: RetroDemo.MEETING_ID
-    },
-    {
-      UNSTABLE_renderPolicy: 'full'
-    }
-  )
+  const data = useLazyLoadQuery<DemoMeetingRootQuery>(query, {
+    meetingId: RetroDemo.MEETING_ID
+  })
   if (!data?.viewer?.meeting) return null
   return <RetroMeeting meeting={data.viewer.meeting} />
 }

--- a/packages/client/components/DiscussionThread.tsx
+++ b/packages/client/components/DiscussionThread.tsx
@@ -74,8 +74,7 @@ const DiscussionThread = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   const isExpanded =

--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -65,8 +65,7 @@ const GitHubScopingSearchFilterMenu = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const repoContributions = useGetRepoContributions(query.viewer.teamMember!)

--- a/packages/client/components/GitHubScopingSearchResults.tsx
+++ b/packages/client/components/GitHubScopingSearchResults.tsx
@@ -67,8 +67,7 @@ const GitHubScopingSearchResults = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const paginationRes = usePaginationFragment<

--- a/packages/client/components/GitLabScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitLabScopingSearchFilterMenu.tsx
@@ -91,8 +91,7 @@ const GitLabScopingSearchFilterMenu = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const nullableEdges =

--- a/packages/client/components/GitLabScopingSearchResults.tsx
+++ b/packages/client/components/GitLabScopingSearchResults.tsx
@@ -65,8 +65,7 @@ const GitLabScopingSearchResults = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const paginationRes = usePaginationFragment<

--- a/packages/client/components/Insights.tsx
+++ b/packages/client/components/Insights.tsx
@@ -35,8 +35,7 @@ const Insights = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   const {domains} = viewer

--- a/packages/client/components/InvitationLink.tsx
+++ b/packages/client/components/InvitationLink.tsx
@@ -19,9 +19,7 @@ const query = graphql`
 
 function InvitationLink(props: Props) {
   const {queryRef} = props
-  const data = usePreloadedQuery<InvitationLinkQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<InvitationLinkQuery>(query, queryRef)
   const {massInvitation} = data
   // the meeting background is prettier than the plain one, so let's always use it
   return (

--- a/packages/client/components/JiraScopingSearchFilterMenuRoot.tsx
+++ b/packages/client/components/JiraScopingSearchFilterMenuRoot.tsx
@@ -48,7 +48,6 @@ const JiraScopingSearchFilterMenuRoot = (props: Props) => {
       meetingId
     },
     {
-      UNSTABLE_renderPolicy: 'full',
       fetchPolicy: 'store-or-network'
     }
   )

--- a/packages/client/components/JiraScopingSearchResults.tsx
+++ b/packages/client/components/JiraScopingSearchResults.tsx
@@ -87,9 +87,7 @@ const JiraScopingSearchResults = (props: Props) => {
     `,
     meetingRef
   )
-  const data = usePreloadedQuery<JiraScopingSearchResultsQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<JiraScopingSearchResultsQuery>(query, queryRef)
   const {viewer} = data
   const atlassian = viewer?.teamMember!.integrations.atlassian ?? null
   const issues = atlassian?.issues ?? null

--- a/packages/client/components/JiraServerScopingSearchFilterMenuRoot.tsx
+++ b/packages/client/components/JiraServerScopingSearchFilterMenuRoot.tsx
@@ -48,7 +48,6 @@ const JiraServerScopingSearchFilterMenuRoot = (props: Props) => {
       meetingId
     },
     {
-      UNSTABLE_renderPolicy: 'full',
       fetchPolicy: 'store-or-network'
     }
   )

--- a/packages/client/components/JiraServerScopingSearchResults.tsx
+++ b/packages/client/components/JiraServerScopingSearchResults.tsx
@@ -63,8 +63,7 @@ const JiraServerScopingSearchResults = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const paginationRes = usePaginationFragment<

--- a/packages/client/components/MassInvitationTokenLink.tsx
+++ b/packages/client/components/MassInvitationTokenLink.tsx
@@ -55,9 +55,7 @@ const query = graphql`
 
 const MassInvitationTokenLink = (props: Props) => {
   const {meetingId, queryRef} = props
-  const data = usePreloadedQuery<MassInvitationTokenLinkQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<MassInvitationTokenLinkQuery>(query, queryRef)
   const {viewer} = data
   const {team} = viewer
   const {id: teamId, massInvitation} = team!

--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -84,9 +84,7 @@ const query = graphql`
 
 const MeetingCardOptionsMenu = (props: Props) => {
   const {menuProps, popTooltip, queryRef} = props
-  const data = usePreloadedQuery<MeetingCardOptionsMenuQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<MeetingCardOptionsMenuQuery>(query, queryRef)
   const {viewer} = data
   const {id: viewerId, team, meeting} = viewer
   const {massInvitation} = team!

--- a/packages/client/components/MeetingSelector.tsx
+++ b/packages/client/components/MeetingSelector.tsx
@@ -41,8 +41,7 @@ const MeetingSelector = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const {viewer} = data

--- a/packages/client/components/MeetingSeriesRedirector.tsx
+++ b/packages/client/components/MeetingSeriesRedirector.tsx
@@ -28,8 +28,7 @@ const MeetingSeriesRedirector = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const {viewer} = data

--- a/packages/client/components/MyDashboardTasksAndHeader.tsx
+++ b/packages/client/components/MyDashboardTasksAndHeader.tsx
@@ -20,8 +20,7 @@ const MyDashboardTasksAndHeader = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   return (

--- a/packages/client/components/MyDashboardTimeline.tsx
+++ b/packages/client/components/MyDashboardTimeline.tsx
@@ -50,10 +50,7 @@ const MyDashboardTimeline = (props: Props) => {
         ...TimelineFeedList_query
       }
     `,
-    queryRef,
-    {
-      UNSTABLE_renderPolicy: 'full'
-    }
+    queryRef
   )
   const {viewer} = data
   useNewFeatureSnackbar(viewer)

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -122,9 +122,7 @@ const query = graphql`
 
 const NewMeeting = (props: Props) => {
   const {teamId, queryRef, onClose} = props
-  const data = usePreloadedQuery<NewMeetingQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<NewMeetingQuery>(query, queryRef)
   const {viewer} = data
   const {teams, featureFlags} = viewer
   const {insights} = featureFlags

--- a/packages/client/components/ParabolScopingSearchResults.tsx
+++ b/packages/client/components/ParabolScopingSearchResults.tsx
@@ -40,10 +40,7 @@ const ParabolScopingSearchResults = (props: Props) => {
         ...ParabolScopingSearchResults_query
       }
     `,
-    queryRef,
-    {
-      UNSTABLE_renderPolicy: 'full'
-    }
+    queryRef
   )
 
   const meeting = useFragment(

--- a/packages/client/components/SpotlightResults.tsx
+++ b/packages/client/components/SpotlightResults.tsx
@@ -82,8 +82,7 @@ const SpotlightResults = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   const {meeting, similarReflectionGroups} = viewer

--- a/packages/client/components/SuggestMentionableUsers.tsx
+++ b/packages/client/components/SuggestMentionableUsers.tsx
@@ -34,9 +34,7 @@ const query = graphql`
 const SuggestMentionableUsers = (props: Props) => {
   const {active, handleSelect, originCoords, suggestions, setSuggestions, triggerWord, queryRef} =
     props
-  const data = usePreloadedQuery<SuggestMentionableUsersQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<SuggestMentionableUsersQuery>(query, queryRef)
   const {viewer} = data
   const {team} = viewer
   const teamMembers = team ? team.teamMembers : null

--- a/packages/client/components/TaskFooterIntegrateMenu.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenu.tsx
@@ -80,9 +80,7 @@ const query = graphql`
 
 const TaskFooterIntegrateMenu = (props: Props) => {
   const {menuProps, mutationProps, task: taskRef, queryRef} = props
-  const data = usePreloadedQuery<TaskFooterIntegrateMenuQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<TaskFooterIntegrateMenuQuery>(query, queryRef)
   const {viewer} = data
   const task = useFragment(
     graphql`

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -111,8 +111,7 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
         }
       }
     `,
-    {teamId, networkOnly, first},
-    {UNSTABLE_renderPolicy: 'full'}
+    {teamId, networkOnly, first}
   )
   const items = viewer?.teamMember?.repoIntegrations.items ?? []
   const {

--- a/packages/client/components/TeamInvitation.tsx
+++ b/packages/client/components/TeamInvitation.tsx
@@ -20,9 +20,7 @@ const query = graphql`
 `
 function TeamInvitation(props: Props) {
   const {queryRef} = props
-  const data = usePreloadedQuery<TeamInvitationQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<TeamInvitationQuery>(query, queryRef)
 
   const {verifiedInvitation} = data
   const {meetingType} = verifiedInvitation

--- a/packages/client/components/ViewerNotOnTeam.tsx
+++ b/packages/client/components/ViewerNotOnTeam.tsx
@@ -36,9 +36,7 @@ const query = graphql`
 
 const ViewerNotOnTeam = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<ViewerNotOnTeamQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<ViewerNotOnTeamQuery>(query, queryRef)
   const {viewer} = data
   const {
     teamInvitation: {teamInvitation, meetingId, teamId}

--- a/packages/client/modules/invoice/components/Invoice/Invoice.tsx
+++ b/packages/client/modules/invoice/components/Invoice/Invoice.tsx
@@ -190,9 +190,7 @@ const query = graphql`
 
 const Invoice = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<InvoiceQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<InvoiceQuery>(query, queryRef)
   const {viewer} = data
   const {invoiceDetails} = viewer
   const endAt = invoiceDetails && invoiceDetails.endAt

--- a/packages/client/modules/meeting/components/PokerTemplateListOrg.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateListOrg.tsx
@@ -72,9 +72,7 @@ const query = graphql`
 `
 const PokerTemplateListOrg = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<PokerTemplateListOrgQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<PokerTemplateListOrgQuery>(query, queryRef)
   const {viewer} = data
   const team = viewer.team!
   const featureFlags = viewer.featureFlags!

--- a/packages/client/modules/meeting/components/PokerTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateListPublic.tsx
@@ -44,9 +44,7 @@ const query = graphql`
 
 const PokerTemplateListPublic = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<PokerTemplateListPublicQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<PokerTemplateListPublicQuery>(query, queryRef)
   const {viewer} = data
   const team = viewer.team!
   const {id: teamId, meetingSettings} = team

--- a/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
@@ -80,9 +80,7 @@ const query = graphql`
 
 const ReflectTemplateListOrg = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<ReflectTemplateListOrgQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<ReflectTemplateListOrgQuery>(query, queryRef)
   const atmosphere = useAtmosphere()
   const history = useHistory()
   const {viewer} = data

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -66,9 +66,7 @@ const query = graphql`
 
 const ReflectTemplateListPublic = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<ReflectTemplateListPublicQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<ReflectTemplateListPublicQuery>(query, queryRef)
   const {viewer} = data
   const team = viewer.team!
   const {id: teamId, meetingSettings, tier} = team

--- a/packages/client/modules/newTeam/NewTeam.tsx
+++ b/packages/client/modules/newTeam/NewTeam.tsx
@@ -80,8 +80,7 @@ const NewTeam = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   const {organizations} = viewer

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -63,9 +63,7 @@ const gqlQuery = graphql`
 
 const TaskFooterTeamAssigneeMenu = (props: Props) => {
   const {menuProps, task: taskRef, queryRef} = props
-  const data = usePreloadedQuery<TaskFooterTeamAssigneeMenuQuery>(gqlQuery, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<TaskFooterTeamAssigneeMenuQuery>(gqlQuery, queryRef)
   const {viewer} = data
 
   const {closePortal: closeTeamAssigneeMenu} = menuProps

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterUserAssigneeMenu.tsx
@@ -60,9 +60,7 @@ const TaskFooterUserAssigneeMenu = (props: Props) => {
     `,
     taskRef
   )
-  const data = usePreloadedQuery<TaskFooterUserAssigneeMenuQuery>(gqlQuery, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<TaskFooterUserAssigneeMenuQuery>(gqlQuery, queryRef)
   const {viewer} = data
 
   const {userId, id: taskId} = task

--- a/packages/client/modules/summary/components/NewMeetingSummary.tsx
+++ b/packages/client/modules/summary/components/NewMeetingSummary.tsx
@@ -37,9 +37,7 @@ const query = graphql`
 
 const NewMeetingSummary = (props: Props) => {
   const {urlAction, queryRef} = props
-  const data = usePreloadedQuery<NewMeetingSummaryQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<NewMeetingSummaryQuery>(query, queryRef)
   const {viewer} = data
   const {newMeeting} = viewer
   const {history} = useRouter()

--- a/packages/client/modules/teamDashboard/components/ProviderList/ProviderList.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderList/ProviderList.tsx
@@ -111,9 +111,7 @@ const query = graphql`
 
 const ProviderList = (props: Props) => {
   const {queryRef, retry, teamId} = props
-  const data = usePreloadedQuery<ProviderListQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<ProviderListQuery>(query, queryRef)
   const {viewer} = data
   const {
     featureFlags: {azureDevOps: allowAzureDevOps, msTeams: allowMSTeams}

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -114,8 +114,7 @@ const TeamArchive = (props: Props) => {
         ...TeamArchive_query
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const {data, hasNext, isLoadingNext, loadNext} = usePaginationFragment<

--- a/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
@@ -62,8 +62,7 @@ const TeamDashMain = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
 
   const {viewer} = data

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
@@ -62,9 +62,7 @@ const query = graphql`
 
 const TeamSettings = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<TeamSettingsQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<TeamSettingsQuery>(query, queryRef)
   const {viewer} = data
   const {history} = useRouter()
   const {team} = viewer

--- a/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
+++ b/packages/client/modules/teamDashboard/components/UnpaidTeamModal/UnpaidTeamModal.tsx
@@ -62,9 +62,7 @@ const query = graphql`
 
 const UnpaidTeamModal = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<UnpaidTeamModalQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<UnpaidTeamModalQuery>(query, queryRef)
   const {viewer} = data
   const atmosphere = useAtmosphere()
   const {history} = useRouter()

--- a/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
@@ -43,8 +43,7 @@ const TeamContainer = (props: Props) => {
         }
       }
     `,
-    queryRef,
-    {UNSTABLE_renderPolicy: 'full'}
+    queryRef
   )
   const {viewer} = data
   const {team} = viewer

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
@@ -23,10 +23,7 @@ const OrgBilling = (props: Props) => {
         ...OrgBilling_query
       }
     `,
-    queryRef,
-    {
-      UNSTABLE_renderPolicy: 'full'
-    }
+    queryRef
   )
   const [queryData, refetch] = useRefetchableFragment<OrgBillingRefetchQuery, OrgBilling_query$key>(
     graphql`

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -29,10 +29,7 @@ const OrgMembers = (props: Props) => {
         ...OrgMembers_viewer
       }
     `,
-    queryRef,
-    {
-      UNSTABLE_renderPolicy: 'full'
-    }
+    queryRef
   )
   const paginationRes = usePaginationFragment<OrgMembersPaginationQuery, OrgMembers_viewer$key>(
     graphql`

--- a/packages/client/modules/userDashboard/components/Organization/Organization.tsx
+++ b/packages/client/modules/userDashboard/components/Organization/Organization.tsx
@@ -100,9 +100,7 @@ const query = graphql`
 
 const Organization = (props: Props) => {
   const {queryRef} = props
-  const data = usePreloadedQuery<OrganizationQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<OrganizationQuery>(query, queryRef)
   const {viewer} = data
   const {organization, featureFlags: userFeatureFlags} = viewer
   const {history} = useRouter()

--- a/packages/client/modules/userDashboard/components/Organizations/Organizations.tsx
+++ b/packages/client/modules/userDashboard/components/Organizations/Organizations.tsx
@@ -36,9 +36,7 @@ const query = graphql`
 const Organizations = (props: Props) => {
   const {history} = useRouter()
   const {queryRef} = props
-  const data = usePreloadedQuery<OrganizationsQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<OrganizationsQuery>(query, queryRef)
   const {viewer} = data
   const {organizations} = viewer
   const gotoNewTeam = () => {

--- a/packages/client/modules/userDashboard/components/UserProfile.tsx
+++ b/packages/client/modules/userDashboard/components/UserProfile.tsx
@@ -43,9 +43,7 @@ const query = graphql`
 `
 
 const UserProfile = ({queryRef}: Props) => {
-  const data = usePreloadedQuery<UserProfileQuery>(query, queryRef, {
-    UNSTABLE_renderPolicy: 'full'
-  })
+  const data = usePreloadedQuery<UserProfileQuery>(query, queryRef)
   const {viewer} = data
   const {identities} = viewer
   const isLocal = identities?.find((identity) => identity?.type === AuthIdentityTypeEnum.LOCAL)

--- a/scripts/codeshift/convertToUseFragment.ts
+++ b/scripts/codeshift/convertToUseFragment.ts
@@ -1,6 +1,10 @@
 /*
  Usage: jscodeshift --extensions=tsx --parser=tsx -t ./scripts/codeshift/convertToUseFragment.ts ./packages/client/components/TeamArchived.tsx
  This codemod converts a component using 'createFragmentContainer' to use 'useFragment'.
+
+ As of March 14, 2023, the migration from 'createFragmentContainer' to use 'useFragment' is
+ complete, so this codemod should no longer be used except as an example for future HOC to hook
+ migrations.
 */
 
 import {Transform} from 'jscodeshift/src/core'


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/6283

Now that all instances of `createFragmentContainer` are removed from the codebase and replaced with `useFragment`, the partial data + suspense issues described in [Matt's blog post](https://www.parabol.co/blog/upgrade-react-to-graphql-relay-hooks/) should no longer be present, so we can remove the `UNSTABLE_renderPolicy: 'full'` workaround that allowed us to migrate to `useFragment` over a longer period of time.

## Demo
N/A

## Testing scenarios
- [ ] Smoke test the app with network throttling (via dev tools), and confirm that components render+suspend appropriately.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
