### PR TITLE
chore(template-limits): add template limit flag to p0 domains

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -28,7 +28,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
   const r = await getRethink()
   const joinEvent = new TimelineEventJoinedParabol({userId})
 
-  // remove the following after templateLimit experiment is complete: https://github.com/ParabolInc/parabol/issues/7712
+  // TODO: remove the following after templateLimit experiment is complete: https://github.com/ParabolInc/parabol/issues/7712
   const hideTemplateLimitsP0Experiment = process.env.hideTemplateLimitsP0Experiment
   const domainUserHasFlag = usersWithDomain.some((user) =>
     user.featureFlags.includes('templateLimit')

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -10,23 +10,37 @@ import insertUser from '../../../postgres/queries/insertUser'
 import IUser from '../../../postgres/types/IUser'
 import {analytics} from '../../../utils/analytics/analytics'
 import segmentIo from '../../../utils/segmentIo'
+import {UserFeatureFlagsResolvers} from '../../private/resolverTypes'
+import {UserFeatureFlags, UserFlagEnum} from '../../public/resolverTypes'
 import addSeedTasks from './addSeedTasks'
 import createNewOrg from './createNewOrg'
 import createTeamAndLeader from './createTeamAndLeader'
 import isPatientZero from './isPatientZero'
+import getUsersbyDomain from '../../../postgres/queries/getUsersByDomain'
 
 const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
   const {id: userId, createdAt, preferredName, email, featureFlags, tier, segmentId} = newUser
   const domain = email.split('@')[1]
-  const isPatient0 = await isPatientZero(domain)
+  const [isPatient0, usersWithDomain] = await Promise.all([
+    isPatientZero(domain),
+    getUsersbyDomain(domain)
+  ])
   const r = await getRethink()
   const joinEvent = new TimelineEventJoinedParabol({userId})
+
+  // remove the following after templateLimit experiment is complete: https://github.com/ParabolInc/parabol/issues/7712
+  const hideTemplateLimitsP0Experiment = process.env.hideTemplateLimitsP0Experiment
+  const domainUserHasFlag = usersWithDomain.some((user) =>
+    user.featureFlags.includes('templateLimit')
+  )
+  const addTemplateFlag = !hideTemplateLimitsP0Experiment && (isPatient0 || domainUserHasFlag)
+  const experimentalFlags = addTemplateFlag ? [...featureFlags, 'templateLimit'] : featureFlags
 
   await Promise.all([
     r({
       event: r.table('TimelineEvent').insert(joinEvent)
     }).run(),
-    insertUser({...newUser, isPatient0})
+    insertUser({...newUser, isPatient0, featureFlags: experimentalFlags})
   ])
 
   // Identify the user so user properties are set before any events are sent
@@ -37,7 +51,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
       email,
       name: preferredName,
       isActive: true,
-      featureFlags,
+      featureFlags: experimentalFlags,
       highestTier: tier,
       isPatient0
     },

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -29,11 +29,11 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
   const joinEvent = new TimelineEventJoinedParabol({userId})
 
   // TODO: remove the following after templateLimit experiment is complete: https://github.com/ParabolInc/parabol/issues/7712
-  const hideTemplateLimitsP0Experiment = process.env.hideTemplateLimitsP0Experiment
+  const stopTemplateLimitsP0Experiment = !!process.env.STOP_TEMPLATE_LIMITS_P0_EXPERIMENT
   const domainUserHasFlag = usersWithDomain.some((user) =>
     user.featureFlags.includes('templateLimit')
   )
-  const addTemplateFlag = !hideTemplateLimitsP0Experiment && (isPatient0 || domainUserHasFlag)
+  const addTemplateFlag = !stopTemplateLimitsP0Experiment && (isPatient0 || domainUserHasFlag)
   const experimentalFlags = addTemplateFlag ? [...featureFlags, 'templateLimit'] : featureFlags
 
   await Promise.all([


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7712

### To test

- [ ] Create a p0 user, i.e. a user that has a domain that doesn't exist in the db. After creating the user, go to pgadmin, search for the user, and see that the `templateLimit` feature flag has been added
- [ ] Create a user with a domain that does exist in the db, but other users with that domain have the `templateLimit` feature flag. Go to pgadmin and see that the new user does have the feature flag
- [ ] Create a user with a domain that does exist in the db and no other users in the domain have the `templateLimit` feature flag. Go to pgadmin and see that the new user does not have the feature flag
- [ ] If the `hideTemplateLimitsP0Experiment` env var is added, the feature flag is never added to p0 users or users that belong to a domain with the feature flag
