### PR TITLE
chore(tailwind): Fix rename warning

### DIFF
--- a/packages/client/tailwindTheme.ts
+++ b/packages/client/tailwindTheme.ts
@@ -6,7 +6,10 @@ const defaultColors = require('tailwindcss/colors')
 export default {
   theme: {
     colors: {
-      ...defaultColors,
+      transparent: 'transparent',
+      current: 'currentColor',
+      black: defaultColors.black,
+      white: defaultColors.white,
       primary: '#493272',
       tomato: {
         '100': '#FFE2E0',


### PR DESCRIPTION
# Description
Currently, there are a lot of warnings in local dev that look like:
```
warn - As of Tailwind CSS v2.2, `lightBlue` has been renamed to `sky`
warn - Update your configuration file to silence this warning.
```

This is because we're currently pulling in all default colors in `tailwindcss/colors`, which includes a few colors that have been renamed.

To fix this, just pull in the colors we're actually using.

## Demo
N/A 

## Testing scenarios
- [ ] Warnings no longer appear

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
