### PR TITLE
feat(standups): Persist draft responses to localstorage

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -181,7 +181,7 @@ const TeamPromptResponseCard = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
 
-  const {teamMember, meetingId, meeting, discussion, response, teamId} = responseStage
+  const {id: stageId, teamMember, meetingId, meeting, discussion, response, teamId} = responseStage
   const {picture, preferredName, userId} = teamMember
 
   const contentJSON: JSONContent | null = useMemo(
@@ -265,6 +265,7 @@ const TeamPromptResponseCard = (props: Props) => {
               content={contentJSON}
               readOnly={!isViewerResponse || isMeetingEnded}
               placeholder={viewerEmptyResponsePlaceholder}
+              draftStorageKey={`draftResponse:${stageId}`}
             />
             {!!plaintextContent && (
               <ResponseCardFooter>


### PR DESCRIPTION
# Description
Fixes https://github.com/ParabolInc/parabol/issues/6871

[miniRFC](https://www.notion.so/parabol/miniRFC-Persist-draft-standup-responses-ee2d82b79055447992aea5e3601c4c90)

Currently, if a user drafts a response in a standup meeting, then navigates away or refreshes the page without submitting, their entire draft response will be lost. This has led to things like "WIP" notes at the top of responses as individuals draft a response that they don't want to lose.

To solve this, persist draft responses to localstorage upon an update to the edited response. Then, when the editor loads, check localstorage for the presence of draft content that differs from the content provided by the GQL layer.

Note that almost the entire diff is included as part of `PromptResponseEditor` - I considered doing the localstorage setting+fetching in the response card, but the resulting behavior is so coupled with `PromptResponseEditor` that it made more sense to keep most of the logic within that component.

## Demo
https://www.loom.com/share/97f8e43275074bcda9ed93d83cea3acf

## Testing scenarios
From a fresh standup response:
- [ ] Draft a response, then refresh, and confirm the draft persisted, and "submit" button is shown
- [ ] Submit the draft, and confirm the UI is correct before and after refresh
- [ ] change the submitted response without updating, then refresh and confirm the draft persists, and shows "cancel" and "update" buttons
- [ ] click cancel, and confirm that the state reverts to a submitted response before and after refresh, and the "cancel" and "update" buttons are no longer present
- [ ] make changes to the submitted response, then update, and confirm the response is submitted correctly and the UI is correct before + after refresh
- [ ] Change the response only via bubble menu, and confirm it persists correctly.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
