### PR TITLE
fix: slack stats

### DIFF
--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -55,6 +55,7 @@ const finishRetroMeeting = async (meeting: MeetingRetrospective, context: GQLCon
       })
     }
   }
+
   await Promise.allSettled([
     generateWholeMeetingSummary(discussionIds, meetingId, teamId, facilitatorUserId, dataLoader),
     r

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -55,8 +55,7 @@ const finishRetroMeeting = async (meeting: MeetingRetrospective, context: GQLCon
       })
     }
   }
-
-  await Promise.all([
+  await Promise.allSettled([
     generateWholeMeetingSummary(discussionIds, meetingId, teamId, facilitatorUserId, dataLoader),
     r
       .table('NewMeeting')


### PR DESCRIPTION
Related to: https://github.com/ParabolInc/parabol/issues/7674

I won't be able to dig into this issue properly before the retreat (I fly tomorrow), but this PR _might_ help.

Previously, we were using `Promise.all` when adding the meeting stats. If `generateWholeMeetingSummary` were to throw an error, the meeting object wouldn't be updated with the commentCount, taskCount, etc.

Perhaps `generateWholeMeetingSummary` could throw an error if OpenAI took a long time to respond, but in the linked issue, the user doesn't have the OpenAI env vars set-up, so it would just return null right away. 

The linked issue also suggests that there aren't any stats in Slack, but the meeting summary does have the correct stats, suggesting the rethinkdb query in the Promise.all has been executed successfully.

I think this is unlikely to solve the issue, but as it's OK for one function to execute and the other to fail, we should use Promise.allSettled instead of Promise.all.
