### PR TITLE
feat(rid): Activity categories

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -56,6 +56,10 @@ const CATEGORY_ID_TO_NAME = {
   strategy: 'Strategy'
 }
 
+type CategoryID = keyof typeof CATEGORY_ID_TO_NAME
+
+// :TODO: (jmtaber129): Fold this into the 'MeetingThemes' to be added in
+// https://github.com/ParabolInc/parabol/pull/7908.
 const CATEGORY_ID_TO_COLOR_CLASS = {
   recommended: 'bg-grape-700',
   retro: 'bg-grape-500',
@@ -101,23 +105,26 @@ export const ActivityLibrary = (props: Props) => {
     resetQuery
   } = useSearchFilter(templates, getTemplateValue)
 
-  const [selectedCategory, setSelectedCategory] =
-    useState<keyof typeof CATEGORY_ID_TO_NAME>('recommended')
+  const [selectedCategory, setSelectedCategory] = useState<CategoryID>('recommended')
 
-  const templatesToRender =
-    searchQuery.length > 0
-      ? filteredTemplates
-      : filteredTemplates.filter((template) =>
-          selectedCategory === 'recommended'
-            ? template.isRecommended
-            : template.category === selectedCategory
-        )
+  const templatesToRender = useMemo(() => {
+    if (searchQuery.length > 0) {
+      // If there's a search query, just use the search filter results
+      return filteredTemplates
+    }
+
+    return filteredTemplates.filter((template) =>
+      selectedCategory === 'recommended'
+        ? template.isRecommended
+        : template.category === selectedCategory
+    )
+  }, [searchQuery, filteredTemplates, selectedCategory])
 
   if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />
   }
 
-  const onSelectCategory = (category: keyof typeof CATEGORY_ID_TO_NAME) => {
+  const onSelectCategory = (category: CategoryID) => {
     setSelectedCategory(category)
     resetQuery()
   }
@@ -128,7 +135,7 @@ export const ActivityLibrary = (props: Props) => {
       <div>
         <SearchBar searchQuery={searchQuery} onChange={onQueryChange} />
         <div className='ml-2 flex'>
-          {Object.keys(CATEGORY_ID_TO_NAME).map((category) => (
+          {(Object.keys(CATEGORY_ID_TO_NAME) as Array<CategoryID>).map((category) => (
             <button
               className={clsx(
                 'mr-2 cursor-pointer rounded-full py-2 px-4 text-xs font-semibold text-slate-700',
@@ -136,10 +143,10 @@ export const ActivityLibrary = (props: Props) => {
                   ? [CATEGORY_ID_TO_COLOR_CLASS[category], 'text-white']
                   : 'bg-slate-200'
               )}
-              onClick={() => onSelectCategory(category as keyof typeof CATEGORY_ID_TO_NAME)}
+              onClick={() => onSelectCategory(category)}
               key={category}
             >
-              {CATEGORY_ID_TO_NAME[category as keyof typeof CATEGORY_ID_TO_NAME]}
+              {CATEGORY_ID_TO_NAME[category]}
             </button>
           ))}
         </div>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {useEffect, useMemo} from 'react'
+import React, {useMemo} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {Redirect, useHistory} from 'react-router'
+import {Redirect} from 'react-router'
 import {ActivityLibraryQuery} from '~/__generated__/ActivityLibraryQuery.graphql'
 import ActivityLibrarySideBar from './ActivityLibrarySideBar'
 import ActivityLibraryCard from './ActivityLibraryCard'
@@ -109,16 +109,9 @@ export const ActivityLibrary = (props: Props) => {
     resetQuery
   } = useSearchFilter(templates, getTemplateValue)
 
-  const history = useHistory()
   const {match} = useRouter<{categoryId?: string}>()
   const {params} = match
   const {categoryId: selectedCategory} = params
-
-  useEffect(() => {
-    if (!selectedCategory || !Object.keys(CATEGORY_ID_TO_NAME).includes(selectedCategory)) {
-      history.replace(`/activity-library/category/${QUICK_START_CATEGORY_ID}`)
-    }
-  }, [selectedCategory, history])
 
   const templatesToRender = useMemo(() => {
     if (searchQuery.length > 0) {
@@ -132,6 +125,10 @@ export const ActivityLibrary = (props: Props) => {
         : template.category === selectedCategory
     )
   }, [searchQuery, filteredTemplates, selectedCategory])
+
+  if (!selectedCategory || !Object.keys(CATEGORY_ID_TO_NAME).includes(selectedCategory)) {
+    return <Redirect to={`/activity-library/category/${QUICK_START_CATEGORY_ID}`} />
+  }
 
   if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -10,6 +10,7 @@ import useSearchFilter from '../../hooks/useSearchFilter'
 import halloweenRetrospectiveTemplate from '../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 import clsx from 'clsx'
 import useRouter from '../../hooks/useRouter'
+import {Link} from 'react-router-dom'
 
 graphql`
   fragment ActivityLibrary_template on MeetingTemplate {
@@ -136,11 +137,6 @@ export const ActivityLibrary = (props: Props) => {
     return <Redirect to='/404' />
   }
 
-  const onSelectCategory = (category: CategoryID) => {
-    history.replace(`/activity-library/category/${category}`)
-    resetQuery()
-  }
-
   return (
     <div className='flex h-full bg-white'>
       <ActivityLibrarySideBar />
@@ -148,18 +144,19 @@ export const ActivityLibrary = (props: Props) => {
         <SearchBar searchQuery={searchQuery} onChange={onQueryChange} />
         <div className='ml-2 flex gap-x-2'>
           {(Object.keys(CATEGORY_ID_TO_NAME) as Array<CategoryID>).map((category) => (
-            <button
+            <Link
               className={clsx(
                 'cursor-pointer rounded-full py-2 px-4 text-xs font-semibold text-slate-700',
                 category === selectedCategory && searchQuery.length === 0
-                  ? [CATEGORY_ID_TO_COLOR_CLASS[category], 'text-white']
+                  ? [CATEGORY_ID_TO_COLOR_CLASS[category], 'text-white focus:text-white']
                   : 'bg-slate-200'
               )}
-              onClick={() => onSelectCategory(category)}
+              to={`/activity-library/category/${category}`}
+              onClick={() => resetQuery()}
               key={category}
             >
               {CATEGORY_ID_TO_NAME[category]}
-            </button>
+            </Link>
           ))}
         </div>
         <div className='flex flex-wrap'>

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -47,6 +47,7 @@ const PrivateRoutes = () => {
   return (
     <Switch>
       <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
+      <Route path='/activity-library/category/:categoryId' component={ActivityLibraryRoute} />
       <Route path='/activity-library' component={ActivityLibraryRoute} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />

--- a/packages/client/hooks/useSearchFilter.ts
+++ b/packages/client/hooks/useSearchFilter.ts
@@ -3,16 +3,17 @@ import useForm from '~/hooks/useForm'
 
 // Matches 'items' based on the item's 'getValue' result and the value passed to 'onQueryChange'.
 const useSearchFilter = <T>(items: readonly T[], getValue: (item: T) => string) => {
-  const {fields, onChange} = useForm({
+  const {fields, onChange, setValue} = useForm({
     search: {
       getDefault: () => ''
     }
   })
+  const resetQuery = () => setValue('search', '')
   const {search} = fields
   const {value} = search
   const query = value.toLowerCase()
   const filteredItems = useFilteredItems(query, items, (item) => getValue(item).toLowerCase())
-  return {query: value, filteredItems, onQueryChange: onChange}
+  return {query: value, filteredItems, onQueryChange: onChange, resetQuery}
 }
 
 export default useSearchFilter

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -2450,6 +2450,16 @@ type ReflectTemplate implements MeetingTemplate {
   The prompts that are part of this template
   """
   prompts: [ReflectPrompt!]!
+
+  """
+  The category this template falls under, e.g. retro, feedback, strategy, etc.
+  """
+  category: String!
+
+  """
+  Whether this template should be in the recommended/quick start sections in the UI.
+  """
+  isRecommended: Boolean!
 }
 
 """
@@ -4170,6 +4180,16 @@ type PokerTemplate implements MeetingTemplate {
     """
     dimensionId: ID!
   ): TemplateDimension!
+
+  """
+  The category this template falls under, e.g. retro, feedback, strategy, etc.
+  """
+  category: String!
+
+  """
+  Whether this template should be in the recommended/quick start sections in the UI.
+  """
+  isRecommended: Boolean!
 }
 
 """
@@ -4222,6 +4242,16 @@ interface MeetingTemplate {
   """
   type: MeetingTypeEnum!
   updatedAt: DateTime!
+
+  """
+  The category this template falls under, e.g. retro, feedback, strategy, etc.
+  """
+  category: String!
+
+  """
+  Whether this template should be in the recommended/quick start sections in the UI.
+  """
+  isRecommended: Boolean!
 }
 
 """

--- a/packages/server/graphql/public/types/PokerTemplate.ts
+++ b/packages/server/graphql/public/types/PokerTemplate.ts
@@ -1,0 +1,14 @@
+import {PokerTemplateResolvers} from '../resolverTypes'
+
+const RECOMMENDED_TEMPLATES = ['estimatedEffortTemplate']
+
+const PokerTemplate: PokerTemplateResolvers = {
+  category: (_source, _args, _context) => {
+    return 'estimation'
+  },
+  isRecommended: ({id}, _args, _context) => {
+    return RECOMMENDED_TEMPLATES.includes(id)
+  }
+}
+
+export default PokerTemplate

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -1,0 +1,23 @@
+import {ReflectTemplateResolvers} from '../resolverTypes'
+
+type ReflectCategory = 'retro' | 'strategy' | 'feedback'
+
+const ID_TO_CATEGORY_MAPPING: Record<string, ReflectCategory> = {
+  teamCharterTemplate: 'strategy',
+  sWOTAnalysisTemplate: 'strategy',
+  teamRetreatPlanningTemplate: 'strategy',
+  questionsCommentsConcernsTemplate: 'feedback'
+}
+
+const RECOMMENDED_TEMPLATES = ['teamCharterTemplate', 'startStopContinueTemplate']
+
+const ReflectTemplate: ReflectTemplateResolvers = {
+  category: ({id}, _args, _context): ReflectCategory => {
+    return ID_TO_CATEGORY_MAPPING[id] ?? 'retro'
+  },
+  isRecommended: ({id}, _args, _context) => {
+    return RECOMMENDED_TEMPLATES.includes(id)
+  }
+}
+
+export default ReflectTemplate

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -1,6 +1,6 @@
 import {ReflectTemplateResolvers} from '../resolverTypes'
 
-type ReflectCategory = 'retro' | 'strategy' | 'feedback'
+type ReflectCategory = 'retrospective' | 'strategy' | 'feedback'
 
 const ID_TO_CATEGORY_MAPPING: Record<string, ReflectCategory> = {
   teamCharterTemplate: 'strategy',
@@ -13,7 +13,7 @@ const RECOMMENDED_TEMPLATES = ['teamCharterTemplate', 'startStopContinueTemplate
 
 const ReflectTemplate: ReflectTemplateResolvers = {
   category: ({id}, _args, _context): ReflectCategory => {
-    return ID_TO_CATEGORY_MAPPING[id] ?? 'retro'
+    return ID_TO_CATEGORY_MAPPING[id] ?? 'retrospective'
   },
   isRecommended: ({id}, _args, _context) => {
     return RECOMMENDED_TEMPLATES.includes(id)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7835

Add category filtering to the activity library. Categories are hard-coded for now.

## Demo
https://www.loom.com/share/a06853e17e244a43ad4731ab15eb578f

## Testing scenarios
- [ ] Click a few categories and confirm filtered templates belong to the category according to [the sheet](https://docs.google.com/spreadsheets/d/1yhsu2dWvbgp_Dbftkw_E1Ilwk7iE85iUYHj7m9NxT6I/edit#gid=1843064613) 🔒 
- [ ] Start typing a search query, and confirm activities are only filtered according to the search query and no category is selected
- [ ] Delete the search query, and confirm the most recent category is selected again
- [ ] Start typing a search query, then click a category, and confirm the search query is cleared and templates in the category are shown

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
