### PR TITLE
chore(upgradeRelay): add $data suffix to relay data fragments

### DIFF
--- a/packages/client/components/AzureDevOpsScopingSearchFilterMenu.tsx
+++ b/packages/client/components/AzureDevOpsScopingSearchFilterMenu.tsx
@@ -5,8 +5,8 @@ import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import {
-  AzureDevOpsScopingSearchFilterMenu_meeting$key,
-  AzureDevOpsScopingSearchFilterMenu_meeting
+  AzureDevOpsScopingSearchFilterMenu_meeting$data,
+  AzureDevOpsScopingSearchFilterMenu_meeting$key
 } from '../__generated__/AzureDevOpsScopingSearchFilterMenu_meeting.graphql'
 import Checkbox from './Checkbox'
 import DropdownMenuLabel from './DropdownMenuLabel'
@@ -37,7 +37,7 @@ interface Props {
 }
 
 type AzureDevOpsSearchQuery = NonNullable<
-  NonNullable<AzureDevOpsScopingSearchFilterMenu_meeting>['azureDevOpsSearchQuery']
+  NonNullable<AzureDevOpsScopingSearchFilterMenu_meeting$data>['azureDevOpsSearchQuery']
 >
 
 const AzureDevOpsScopingSearchFilterMenu = (props: Props) => {

--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -7,7 +7,7 @@ import {Breakpoint} from '~/types/constEnums'
 import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
 import {
   DashNavList_viewer$key,
-  DashNavList_viewer
+  DashNavList_viewer$data
 } from '../../__generated__/DashNavList_viewer.graphql'
 import LeftDashNavItem from '../Dashboard/LeftDashNavItem'
 
@@ -46,7 +46,7 @@ interface Props {
   onClick?: () => void
 }
 
-type Team = DashNavList_viewer['teams'][0]
+type Team = DashNavList_viewer$data['teams'][0]
 
 const DashNavList = (props: Props) => {
   const {className, onClick, viewer: viewerRef} = props

--- a/packages/client/components/DashboardAvatars/DashboardAvatars.tsx
+++ b/packages/client/components/DashboardAvatars/DashboardAvatars.tsx
@@ -11,7 +11,7 @@ import ToggleTeamDrawerMutation from '../../mutations/ToggleTeamDrawerMutation'
 import {PALETTE} from '../../styles/paletteV3'
 import {
   DashboardAvatars_team$key,
-  DashboardAvatars_team
+  DashboardAvatars_team$data
 } from '../../__generated__/DashboardAvatars_team.graphql'
 import ErrorBoundary from '../ErrorBoundary'
 import PlainButton from '../PlainButton/PlainButton'
@@ -74,7 +74,7 @@ interface Props {
   team: DashboardAvatars_team$key
 }
 
-type Avatar = DashboardAvatars_team['teamMembers'][0]
+type Avatar = DashboardAvatars_team$data['teamMembers'][0]
 
 const DashboardAvatars = (props: Props) => {
   const {team: teamRef} = props

--- a/packages/client/components/NewAzureIssueMenu.tsx
+++ b/packages/client/components/NewAzureIssueMenu.tsx
@@ -4,7 +4,7 @@ import {useFragment} from 'react-relay'
 import {MenuProps} from '~/hooks/useMenu'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {
-  NewAzureIssueMenu_AzureDevOpsRemoteProjects,
+  NewAzureIssueMenu_AzureDevOpsRemoteProjects$data,
   NewAzureIssueMenu_AzureDevOpsRemoteProjects$key
 } from '../__generated__/NewAzureIssueMenu_AzureDevOpsRemoteProjects.graphql'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
@@ -18,7 +18,7 @@ interface Props {
   projectsRef: NewAzureIssueMenu_AzureDevOpsRemoteProjects$key
 }
 
-const getValue = (project: NewAzureIssueMenu_AzureDevOpsRemoteProjects[0]) => project.name
+const getValue = (project: NewAzureIssueMenu_AzureDevOpsRemoteProjects$data[0]) => project.name
 
 const NewAzureIssueMenu = (props: Props) => {
   const {setSelectedProjectName, menuProps, projectsRef} = props

--- a/packages/client/components/NewJiraIssueMenu.tsx
+++ b/packages/client/components/NewJiraIssueMenu.tsx
@@ -4,7 +4,7 @@ import {useFragment} from 'react-relay'
 import {MenuProps} from '~/hooks/useMenu'
 import useSearchFilter from '~/hooks/useSearchFilter'
 import {
-  NewJiraIssueMenu_JiraRemoteProjects,
+  NewJiraIssueMenu_JiraRemoteProjects$data,
   NewJiraIssueMenu_JiraRemoteProjects$key
 } from '../__generated__/NewJiraIssueMenu_JiraRemoteProjects.graphql'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
@@ -18,7 +18,7 @@ interface Props {
   projectsRef: NewJiraIssueMenu_JiraRemoteProjects$key
 }
 
-const getValue = (project: NewJiraIssueMenu_JiraRemoteProjects[0]) => project.name
+const getValue = (project: NewJiraIssueMenu_JiraRemoteProjects$data[0]) => project.name
 
 const NewJiraIssueMenu = (props: Props) => {
   const {handleSelectProjectKey, menuProps, projectsRef} = props

--- a/packages/client/components/NotificationDropdown.tsx
+++ b/packages/client/components/NotificationDropdown.tsx
@@ -6,7 +6,7 @@ import useAtmosphere from '~/hooks/useAtmosphere'
 import useTimeout from '~/hooks/useTimeout'
 import SetNotificationStatusMutation from '~/mutations/SetNotificationStatusMutation'
 import {
-  NotificationDropdown_query,
+  NotificationDropdown_query$data,
   NotificationDropdown_query$key
 } from '~/__generated__/NotificationDropdown_query.graphql'
 import useLoadNextOnScrollBottom from '../hooks/useLoadNextOnScrollBottom'
@@ -35,7 +35,7 @@ const NoNotifications = styled('div')({
   width: '100%'
 })
 
-const defaultViewer = {notifications: {edges: []}} as unknown as NotificationDropdown_query
+const defaultViewer = {notifications: {edges: []}} as unknown as NotificationDropdown_query$data
 
 const NotificationDropdown = (props: Props) => {
   const {queryRef, menuProps, parentRef} = props

--- a/packages/client/components/PokerDiscussVoting.tsx
+++ b/packages/client/components/PokerDiscussVoting.tsx
@@ -9,7 +9,7 @@ import isSpecialPokerLabel from '../utils/isSpecialPokerLabel'
 import {PokerDiscussVoting_meeting$key} from '../__generated__/PokerDiscussVoting_meeting.graphql'
 import {
   PokerDiscussVoting_stage$key,
-  PokerDiscussVoting_stage
+  PokerDiscussVoting_stage$data
 } from '../__generated__/PokerDiscussVoting_stage.graphql'
 import PokerDimensionValueControl from './PokerDimensionValueControl'
 import PokerVotingRow from './PokerVotingRow'
@@ -87,7 +87,7 @@ const PokerDiscussVoting = (props: Props) => {
   }
 
   const {rows, topLabel} = useMemo(() => {
-    const scoreObj = {} as {[label: string]: PokerDiscussVoting_stage['scores'][0][]}
+    const scoreObj = {} as {[label: string]: PokerDiscussVoting_stage$data['scores'][0][]}
     let highScore = 0
     let topLabel = ''
     scores.forEach((score) => {

--- a/packages/client/components/PokerEstimateHeaderCard.tsx
+++ b/packages/client/components/PokerEstimateHeaderCard.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {
   PokerEstimateHeaderCard_stage$key,
-  PokerEstimateHeaderCard_stage
+  PokerEstimateHeaderCard_stage$data
 } from '../__generated__/PokerEstimateHeaderCard_stage.graphql'
 import PokerEstimateHeaderCardContent, {
   PokerEstimateHeaderCardContentProps
@@ -15,7 +15,7 @@ interface Props {
   stage: PokerEstimateHeaderCard_stage$key
 }
 
-type Integration = NonNullable<PokerEstimateHeaderCard_stage['task']>['integration']
+type Integration = NonNullable<PokerEstimateHeaderCard_stage$data['task']>['integration']
 
 const getHeaderFields = (
   integration: Integration | null

--- a/packages/client/components/ReflectionGroup/RemoteReflection.tsx
+++ b/packages/client/components/ReflectionGroup/RemoteReflection.tsx
@@ -14,7 +14,7 @@ import {getMinTop} from '../../utils/retroGroup/updateClonePosition'
 import {RemoteReflection_meeting$key} from '../../__generated__/RemoteReflection_meeting.graphql'
 import {
   RemoteReflection_reflection$key,
-  RemoteReflection_reflection
+  RemoteReflection_reflection$data
 } from '../../__generated__/RemoteReflection_reflection.graphql'
 import ReflectionCardAuthor from '../ReflectionCard/ReflectionCardAuthor'
 import ReflectionCardRoot from '../ReflectionCard/ReflectionCardRoot'
@@ -80,7 +80,7 @@ const windowDims = {
 
 const OFFSCREEN_PADDING = 16
 const getCoords = (
-  remoteDrag: DeepNonNullable<NonNullable<RemoteReflection_reflection['remoteDrag']>>
+  remoteDrag: DeepNonNullable<NonNullable<RemoteReflection_reflection$data['remoteDrag']>>
 ) => {
   const {targetId, clientHeight, clientWidth, clientX, clientY, targetOffsetX, targetOffsetY} =
     remoteDrag
@@ -134,7 +134,7 @@ const getHeaderTransform = (ref: RefObject<HTMLDivElement>, topPadding = 18) => 
   and in the styled component depending on situation
 */
 const getStyle = (
-  remoteDrag: RemoteReflection_reflection['remoteDrag'],
+  remoteDrag: RemoteReflection_reflection$data['remoteDrag'],
   isDropping: boolean | null,
   isSpotlight: boolean,
   style: React.CSSProperties
@@ -209,7 +209,7 @@ const RemoteReflection = (props: Props) => {
   const {id: reflectionId, content, isDropping, reflectionGroupId, creator} = reflection
   const {meetingMembers, localPhase, disableAnonymity} = meeting
   const remoteDrag = reflection.remoteDrag as DeepNonNullable<
-    RemoteReflection_reflection['remoteDrag']
+    RemoteReflection_reflection$data['remoteDrag']
   >
   const ref = useRef<HTMLDivElement>(null)
   const [editorState] = useEditorState(content)

--- a/packages/client/components/ReflectionGroup/useSpotlightReflectionGroup.ts
+++ b/packages/client/components/ReflectionGroup/useSpotlightReflectionGroup.ts
@@ -1,12 +1,12 @@
 import {useMemo} from 'react'
 import useSpotlightResults from '~/hooks/useSpotlightResults'
-import {ReflectionGroup_meeting} from '~/__generated__/ReflectionGroup_meeting.graphql'
-import {ReflectionGroup_reflectionGroup} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
+import {ReflectionGroup_meeting$data} from '~/__generated__/ReflectionGroup_meeting.graphql'
+import {ReflectionGroup_reflectionGroup$data} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
 import useSpotlightVisibleReflections from './useSpotlightVisibleReflections'
 
 const useSpotlightReflectionGroup = (
-  meeting: ReflectionGroup_meeting,
-  reflectionGroup: ReflectionGroup_reflectionGroup,
+  meeting: ReflectionGroup_meeting$data,
+  reflectionGroup: ReflectionGroup_reflectionGroup$data,
   isBehindSpotlight: boolean,
   reflectionIdsToHide?: string[] | null
 ) => {

--- a/packages/client/components/ReflectionGroup/useSpotlightVisibleReflections.ts
+++ b/packages/client/components/ReflectionGroup/useSpotlightVisibleReflections.ts
@@ -1,8 +1,8 @@
 import {useMemo} from 'react'
-import {ReflectionGroup_reflectionGroup} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
+import {ReflectionGroup_reflectionGroup$data} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
 
 const useSpotlightVisibleReflections = (
-  reflections: ReflectionGroup_reflectionGroup['reflections'],
+  reflections: ReflectionGroup_reflectionGroup$data['reflections'],
   spotlightSearchQuery?: string | null,
   reflectionIdsToHide?: string[] | null
 ) => {

--- a/packages/client/components/RetroReflectPhase/ReflectionStack.tsx
+++ b/packages/client/components/RetroReflectPhase/ReflectionStack.tsx
@@ -10,7 +10,7 @@ import {
   ElementWidth,
   ReflectionStackPerspective
 } from '../../types/constEnums'
-import {PhaseItemColumn_meeting} from '../../__generated__/PhaseItemColumn_meeting.graphql'
+import {PhaseItemColumn_meeting$data} from '../../__generated__/PhaseItemColumn_meeting.graphql'
 import ReflectionCard from '../ReflectionCard/ReflectionCard'
 import ExpandedReflectionStack from './ExpandedReflectionStack'
 import ReflectionStackPlaceholder from './ReflectionStackPlaceholder'
@@ -21,7 +21,7 @@ interface Props {
   phaseEditorRef: React.RefObject<HTMLDivElement>
   phaseRef: RefObject<HTMLDivElement>
   dataCy: string
-  reflectionStack: readonly PhaseItemColumn_meeting['reflectionGroups'][0]['reflections'][0][]
+  reflectionStack: readonly PhaseItemColumn_meeting$data['reflectionGroups'][0]['reflections'][0][]
   stackTopRef: RefObject<HTMLDivElement>
 }
 

--- a/packages/client/components/RetroSidebarDiscussSection.tsx
+++ b/packages/client/components/RetroSidebarDiscussSection.tsx
@@ -9,7 +9,7 @@ import useGotoStageId from '~/hooks/useGotoStageId'
 import {DeepNonNullable} from '~/types/generics'
 import {
   RetroSidebarDiscussSection_meeting$key,
-  RetroSidebarDiscussSection_meeting
+  RetroSidebarDiscussSection_meeting$data
 } from '~/__generated__/RetroSidebarDiscussSection_meeting.graphql'
 import DragDiscussionTopicMutation from '../mutations/DragDiscussionTopicMutation'
 import {navItemRaised} from '../styles/elevation'
@@ -59,7 +59,7 @@ const ScrollWrapper = styled('div')({
   height: '100%'
 })
 
-type NonNullPhase = DeepNonNullable<RetroSidebarDiscussSection_meeting['phases'][0]>
+type NonNullPhase = DeepNonNullable<RetroSidebarDiscussSection_meeting$data['phases'][0]>
 
 const RetroSidebarDiscussSection = (props: Props) => {
   const atmosphere = useAtmosphere()

--- a/packages/client/components/ThreadedCommentHeader.tsx
+++ b/packages/client/components/ThreadedCommentHeader.tsx
@@ -6,7 +6,7 @@ import {PALETTE} from '~/styles/paletteV3'
 import relativeDate from '~/utils/date/relativeDate'
 import {
   ThreadedCommentHeader_comment$key,
-  ThreadedCommentHeader_comment
+  ThreadedCommentHeader_comment$data
 } from '~/__generated__/ThreadedCommentHeader_comment.graphql'
 import CommentAuthorOptionsButton from './CommentAuthorOptionsButton'
 import AddReactjiButton from './ReflectionCard/AddReactjiButton'
@@ -34,7 +34,7 @@ interface Props {
   meetingId: string
 }
 
-const getName = (comment: ThreadedCommentHeader_comment) => {
+const getName = (comment: ThreadedCommentHeader_comment$data) => {
   const {isActive, createdByUserNullable, isViewerComment} = comment
   if (!isActive) return 'Message Deleted'
   if (createdByUserNullable?.preferredName) return createdByUserNullable.preferredName

--- a/packages/client/components/UserDashTeamMemberMenu.tsx
+++ b/packages/client/components/UserDashTeamMemberMenu.tsx
@@ -10,7 +10,7 @@ import {useUserTaskFilters} from '~/utils/useUserTaskFilters'
 import {MenuProps} from '../hooks/useMenu'
 import {
   UserDashTeamMemberMenu_viewer$key,
-  UserDashTeamMemberMenu_viewer
+  UserDashTeamMemberMenu_viewer$data
 } from '../__generated__/UserDashTeamMemberMenu_viewer.graphql'
 import DropdownMenuLabel from './DropdownMenuLabel'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
@@ -47,7 +47,7 @@ const UserDashTeamMemberMenu = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {userIds, teamIds, showArchived} = useUserTaskFilters(atmosphere.viewerId)
 
-  const oldTeamsRef = useRef<UserDashTeamMemberMenu_viewer['teams']>([])
+  const oldTeamsRef = useRef<UserDashTeamMemberMenu_viewer$data['teams']>([])
   const nextTeams = viewer?.teams ?? oldTeamsRef.current
   if (nextTeams) {
     oldTeamsRef.current = nextTeams

--- a/packages/client/components/UserDashTeamMenu.tsx
+++ b/packages/client/components/UserDashTeamMenu.tsx
@@ -8,8 +8,8 @@ import {UserTaskViewFilterLabels} from '~/types/constEnums'
 import constructUserTaskFilterQueryParamURL from '~/utils/constructUserTaskFilterQueryParamURL'
 import {useUserTaskFilters} from '~/utils/useUserTaskFilters'
 import {
-  UserDashTeamMenu_viewer$key,
-  UserDashTeamMenu_viewer
+  UserDashTeamMenu_viewer$data,
+  UserDashTeamMenu_viewer$key
 } from '~/__generated__/UserDashTeamMenu_viewer.graphql'
 import {MenuProps} from '../hooks/useMenu'
 import DropdownMenuLabel from './DropdownMenuLabel'
@@ -42,7 +42,7 @@ const UserDashTeamMenu = (props: Props) => {
     `,
     viewerRef
   )
-  const oldTeamsRef = useRef<UserDashTeamMenu_viewer['teams']>([])
+  const oldTeamsRef = useRef<UserDashTeamMenu_viewer$data['teams']>([])
   const nextTeams = viewer?.teams ?? oldTeamsRef.current
   if (nextTeams) {
     oldTeamsRef.current = nextTeams

--- a/packages/client/hooks/useDraggableReflectionCard.tsx
+++ b/packages/client/hooks/useDraggableReflectionCard.tsx
@@ -23,7 +23,7 @@ import updateClonePosition, {
   getDroppingStyles,
   getSpotlightAnimation
 } from '../utils/retroGroup/updateClonePosition'
-import {DraggableReflectionCard_reflection} from '../__generated__/DraggableReflectionCard_reflection.graphql'
+import {DraggableReflectionCard_reflection$data} from '../__generated__/DraggableReflectionCard_reflection.graphql'
 import useAtmosphere from './useAtmosphere'
 import useEventCallback from './useEventCallback'
 import useSpotlightResults from './useSpotlightResults'
@@ -36,7 +36,7 @@ const windowDims = {
 // Adds the remotely dragged card substitute, does not hide the local card or collapse anything
 const useRemotelyDraggedCard = (
   meeting: DraggableReflectionCard_meeting,
-  reflection: DraggableReflectionCard_reflection,
+  reflection: DraggableReflectionCard_reflection$data,
   drag: ReflectionDragState,
   staticIdx: number
 ) => {
@@ -138,7 +138,7 @@ const useRemotelyDraggedCard = (
 }
 
 const useLocalDrag = (
-  reflection: DraggableReflectionCard_reflection,
+  reflection: DraggableReflectionCard_reflection$data,
   drag: ReflectionDragState,
   staticIdx: number,
   onMouseMove: any,
@@ -193,7 +193,7 @@ const removeClone = (reflectionId: string, setPortal: SetPortal) => {
 
 const useDroppingDrag = (
   drag: ReflectionDragState,
-  reflection: DraggableReflectionCard_reflection
+  reflection: DraggableReflectionCard_reflection$data
 ) => {
   const setPortal = useContext(PortalContext)
   const {remoteDrag, id: reflectionId, isDropping} = reflection
@@ -230,7 +230,7 @@ const useDroppingDrag = (
 
 const useDragAndDrop = (
   drag: ReflectionDragState,
-  reflection: DraggableReflectionCard_reflection,
+  reflection: DraggableReflectionCard_reflection$data,
   staticIdx: number,
   meeting: DraggableReflectionCard_meeting,
   teamId: string,
@@ -394,7 +394,7 @@ const useDragAndDrop = (
 
 // Collapse the position of the card in the list if necessary
 const useCollapsePlaceholder = (
-  reflection: DraggableReflectionCard_reflection,
+  reflection: DraggableReflectionCard_reflection$data,
   drag: ReflectionDragState,
   staticIdx: number,
   staticReflectionCount: number
@@ -438,7 +438,7 @@ const useCollapsePlaceholder = (
 
 const useDraggableReflectionCard = (
   meeting: DraggableReflectionCard_meeting,
-  reflection: DraggableReflectionCard_reflection,
+  reflection: DraggableReflectionCard_reflection$data,
   drag: ReflectionDragState,
   staticIdx: number,
   teamId: string,

--- a/packages/client/hooks/useSortNewReflectionGroup.ts
+++ b/packages/client/hooks/useSortNewReflectionGroup.ts
@@ -1,6 +1,6 @@
 import {useEffect} from 'react'
 import {commitLocalUpdate} from 'react-relay'
-import {GroupingKanbanColumn_reflectionGroups} from '~/__generated__/GroupingKanbanColumn_reflectionGroups.graphql'
+import {GroupingKanbanColumn_reflectionGroups$data} from '~/__generated__/GroupingKanbanColumn_reflectionGroups.graphql'
 import useAtmosphere from './useAtmosphere'
 
 interface SubColumnIdxs {
@@ -10,7 +10,7 @@ interface SubColumnIdxs {
 const useSortNewReflectionGroup = (
   subColumnCount: number,
   subColumnIndexes: number[],
-  reflectionGroups: GroupingKanbanColumn_reflectionGroups
+  reflectionGroups: GroupingKanbanColumn_reflectionGroups$data
 ) => {
   const atmosphere = useAtmosphere()
 

--- a/packages/client/hooks/useSpotlightSimulatedDrag.tsx
+++ b/packages/client/hooks/useSpotlightSimulatedDrag.tsx
@@ -2,12 +2,12 @@ import {MutableRefObject, useCallback, useEffect, useMemo, useRef} from 'react'
 import {commitLocalUpdate} from 'react-relay'
 import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
 import {Times} from '~/types/constEnums'
-import {GroupingKanban_meeting} from '~/__generated__/GroupingKanban_meeting.graphql'
+import {GroupingKanban_meeting$data} from '~/__generated__/GroupingKanban_meeting.graphql'
 import EndDraggingReflectionMutation from '../mutations/EndDraggingReflectionMutation'
 import useAtmosphere from './useAtmosphere'
 
 const useSpotlightSimulatedDrag = (
-  meeting: GroupingKanban_meeting,
+  meeting: GroupingKanban_meeting$data,
   dragIdRef: MutableRefObject<string | undefined>
 ) => {
   const atmosphere = useAtmosphere()

--- a/packages/client/hooks/useSubColumns.ts
+++ b/packages/client/hooks/useSubColumns.ts
@@ -2,7 +2,7 @@ import {RefObject, useMemo, useState} from 'react'
 import {commitLocalUpdate} from 'react-relay'
 import getBBox from '~/components/RetroReflectPhase/getBBox'
 import {Breakpoint, ElementHeight, ElementWidth} from '~/types/constEnums'
-import {GroupingKanbanColumn_reflectionGroups} from '~/__generated__/GroupingKanbanColumn_reflectionGroups.graphql'
+import {GroupingKanbanColumn_reflectionGroups$data} from '~/__generated__/GroupingKanbanColumn_reflectionGroups.graphql'
 import useAtmosphere from './useAtmosphere'
 import useBreakpoint from './useBreakpoint'
 import useResizeObserver from './useResizeObserver'
@@ -17,7 +17,7 @@ const useSubColumns = (
   columnBodyRef: RefObject<HTMLDivElement>,
   phaseRef: RefObject<HTMLDivElement>,
   reflectPromptsCount: number,
-  reflectionGroups: GroupingKanbanColumn_reflectionGroups,
+  reflectionGroups: GroupingKanbanColumn_reflectionGroups$data,
   columnsRef: RefObject<HTMLDivElement>
 ) => {
   const atmosphere = useAtmosphere()

--- a/packages/client/modules/invoice/components/InvoiceLineItem/InvoiceLineItemDetails.tsx
+++ b/packages/client/modules/invoice/components/InvoiceLineItem/InvoiceLineItemDetails.tsx
@@ -4,7 +4,7 @@ import React, {useState} from 'react'
 import {useFragment} from 'react-relay'
 import {
   InvoiceLineItemDetails_details$key,
-  InvoiceLineItemDetails_details
+  InvoiceLineItemDetails_details$data
 } from '~/__generated__/InvoiceLineItemDetails_details.graphql'
 import {InvoiceLineItemEnum} from '~/__generated__/InvoiceLineItem_item.graphql'
 import {PALETTE} from '../../../../styles/paletteV3'
@@ -13,11 +13,11 @@ import makeDateString from '../../../../utils/makeDateString'
 import invoiceLineFormat from '../../helpers/invoiceLineFormat'
 
 const detailDescriptionMaker = {
-  ADDED_USERS: (detail: InvoiceLineItemDetails_details[0]) =>
+  ADDED_USERS: (detail: InvoiceLineItemDetails_details$data[0]) =>
     `${detail.email} joined ${makeDateString(detail.startAt)}`,
-  REMOVED_USERS: (detail: InvoiceLineItemDetails_details[0]) =>
+  REMOVED_USERS: (detail: InvoiceLineItemDetails_details$data[0]) =>
     `${detail.email} left ${makeDateString(detail.startAt)}`,
-  INACTIVITY_ADJUSTMENTS: (detail: InvoiceLineItemDetails_details[0]) => {
+  INACTIVITY_ADJUSTMENTS: (detail: InvoiceLineItemDetails_details$data[0]) => {
     if (!detail.endAt) {
       return `${detail.email} has been paused since ${makeDateString(detail.startAt)}`
     } else if (!detail.startAt) {

--- a/packages/client/modules/meeting/components/NewTemplateScaleValueLabelInput.tsx
+++ b/packages/client/modules/meeting/components/NewTemplateScaleValueLabelInput.tsx
@@ -13,7 +13,7 @@ import isSpecialPokerLabel from '../../../utils/isSpecialPokerLabel'
 import Legitity from '../../../validation/Legitity'
 import {
   NewTemplateScaleValueLabelInput_scale$key,
-  NewTemplateScaleValueLabelInput_scale
+  NewTemplateScaleValueLabelInput_scale$data
 } from '../../../__generated__/NewTemplateScaleValueLabelInput_scale.graphql'
 import EditableTemplateScaleValueColor from './EditableTemplateScaleValueColor'
 
@@ -67,7 +67,7 @@ const RemoveScaleValueIcon = styled('div')({
   padding: 0
 })
 
-const predictNextLabel = (values: NewTemplateScaleValueLabelInput_scale['values']) => {
+const predictNextLabel = (values: NewTemplateScaleValueLabelInput_scale$data['values']) => {
   const existingLabels = values
     .map(({label}) => label)
     .filter((label) => !isSpecialPokerLabel(label))

--- a/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
@@ -11,7 +11,7 @@ import {PALETTE} from '../../../styles/paletteV3'
 import {ReflectTemplateListTeam_viewer$key} from '../../../__generated__/ReflectTemplateListTeam_viewer.graphql'
 import {
   ReflectTemplateListTeam_teamTemplates$key,
-  ReflectTemplateListTeam_teamTemplates
+  ReflectTemplateListTeam_teamTemplates$data
 } from '../../../__generated__/ReflectTemplateListTeam_teamTemplates.graphql'
 import {ReflectTemplateListTeam_team$key} from '../../../__generated__/ReflectTemplateListTeam_team.graphql'
 import ReflectTemplateItem from './ReflectTemplateItem'
@@ -52,7 +52,7 @@ interface Props {
   templateSearchQuery: string
 }
 
-const getValue = (item: ReflectTemplateListTeam_teamTemplates[0]) => {
+const getValue = (item: ReflectTemplateListTeam_teamTemplates$data[0]) => {
   return item.name.toLowerCase()
 }
 

--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useRef, useState} from 'react'
 import {useFragment} from 'react-relay'
 import {
   AgendaItem_meeting$key,
-  AgendaItem_meeting
+  AgendaItem_meeting$data
 } from '~/__generated__/AgendaItem_meeting.graphql'
 import Avatar from '../../../../components/Avatar/Avatar'
 import IconButton from '../../../../components/IconButton'
@@ -63,7 +63,7 @@ const getItemProps = (
   agendaItemId: string,
   viewerId: string,
   gotoStageId: ReturnType<typeof useGotoStageId> | undefined,
-  meeting: AgendaItem_meeting | null
+  meeting: AgendaItem_meeting$data | null
 ) => {
   const fallback = {
     isDisabled: false,

--- a/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaListAndInput/AgendaListAndInput.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {
   AgendaListAndInput_meeting$key,
-  AgendaListAndInput_meeting
+  AgendaListAndInput_meeting$data
 } from '~/__generated__/AgendaListAndInput_meeting.graphql'
 import useGotoStageId from '../../../../hooks/useGotoStageId'
 import {AgendaListAndInput_team$key} from '../../../../__generated__/AgendaListAndInput_team.graphql'
@@ -39,7 +39,7 @@ interface Props {
   team: AgendaListAndInput_team$key
 }
 
-const getAgendaItems = (meeting: AgendaListAndInput_meeting | null) => {
+const getAgendaItems = (meeting: AgendaListAndInput_meeting$data | null) => {
   if (!meeting) return null
   const agendaItemsPhase = meeting.phases!.find((phase) => phase.phaseType === 'agendaitems')
   if (!agendaItemsPhase?.stages) return null

--- a/packages/client/modules/userDashboard/components/UserTasksHeader/UserTasksHeader.tsx
+++ b/packages/client/modules/userDashboard/components/UserTasksHeader/UserTasksHeader.tsx
@@ -12,7 +12,7 @@ import constructUserTaskFilterQueryParamURL from '~/utils/constructUserTaskFilte
 import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
 import {useUserTaskFilters} from '~/utils/useUserTaskFilters'
 import {
-  UserTasksHeader_viewer,
+  UserTasksHeader_viewer$data,
   UserTasksHeader_viewer$key
 } from '~/__generated__/UserTasksHeader_viewer.graphql'
 import DashSectionControls from '../../../../components/Dashboard/DashSectionControls'
@@ -122,7 +122,7 @@ const UserTasksHeader = (props: Props) => {
   } = useMenu(MenuPosition.UPPER_RIGHT, {
     isDropdown: true
   })
-  const oldTeamsRef = useRef<UserTasksHeader_viewer['teams']>([])
+  const oldTeamsRef = useRef<UserTasksHeader_viewer$data['teams']>([])
   const nextTeams = viewer?.teams ?? oldTeamsRef.current
   if (nextTeams) {
     oldTeamsRef.current = nextTeams

--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {InvitationTokenError, LOCKED_MESSAGE} from '~/types/constEnums'
-import {AcceptTeamInvitationMutation_notification} from '~/__generated__/AcceptTeamInvitationMutation_notification.graphql'
+import {AcceptTeamInvitationMutation_notification$data} from '~/__generated__/AcceptTeamInvitationMutation_notification.graphql'
 import Atmosphere from '../Atmosphere'
 import {
   HistoryMaybeLocalHandler,
@@ -12,7 +12,7 @@ import {
 import fromTeamMemberId from '../utils/relay/fromTeamMemberId'
 import getGraphQLError from '../utils/relay/getGraphQLError'
 import {AcceptTeamInvitationMutation as TAcceptTeamInvitationMutation} from '../__generated__/AcceptTeamInvitationMutation.graphql'
-import {AcceptTeamInvitationMutation_team} from '../__generated__/AcceptTeamInvitationMutation_team.graphql'
+import {AcceptTeamInvitationMutation_team$data} from '../__generated__/AcceptTeamInvitationMutation_team.graphql'
 import handleAddOrganization from './handlers/handleAddOrganization'
 import handleAddTeamMembers from './handlers/handleAddTeamMembers'
 import handleAddTeams from './handlers/handleAddTeams'
@@ -105,7 +105,7 @@ const mutation = graphql`
 `
 
 export const acceptTeamInvitationNotificationUpdater: SharedUpdater<
-  AcceptTeamInvitationMutation_notification
+  AcceptTeamInvitationMutation_notification$data
 > = (payload, {store}) => {
   const team = payload.getLinkedRecord('team')
   if (!team) return
@@ -127,10 +127,9 @@ export const acceptTeamInvitationNotificationUpdater: SharedUpdater<
   }
 }
 
-export const acceptTeamInvitationTeamUpdater: SharedUpdater<AcceptTeamInvitationMutation_team> = (
-  payload,
-  {store}
-) => {
+export const acceptTeamInvitationTeamUpdater: SharedUpdater<
+  AcceptTeamInvitationMutation_team$data
+> = (payload, {store}) => {
   const teamMember = payload.getLinkedRecord('teamMember')
   handleAddTeamMembers(teamMember, store)
   const team = payload.getLinkedRecord('team')
@@ -139,10 +138,9 @@ export const acceptTeamInvitationTeamUpdater: SharedUpdater<AcceptTeamInvitation
   handleAddTeams(team, store)
 }
 
-export const acceptTeamInvitationTeamOnNext: OnNextHandler<AcceptTeamInvitationMutation_team> = (
-  payload,
-  {atmosphere}
-) => {
+export const acceptTeamInvitationTeamOnNext: OnNextHandler<
+  AcceptTeamInvitationMutation_team$data
+> = (payload, {atmosphere}) => {
   const {team, teamMember} = payload
   const {viewerId} = atmosphere
   if (!team || !teamMember) return

--- a/packages/client/mutations/AddAgendaItemMutation.ts
+++ b/packages/client/mutations/AddAgendaItemMutation.ts
@@ -4,7 +4,7 @@ import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import clientTempId from '../utils/relay/clientTempId'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {AddAgendaItemMutation as TAddAgendaItemMutation} from '../__generated__/AddAgendaItemMutation.graphql'
-import {AddAgendaItemMutation_team} from '../__generated__/AddAgendaItemMutation_team.graphql'
+import {AddAgendaItemMutation_team$data} from '../__generated__/AddAgendaItemMutation_team.graphql'
 import handleAddAgendaItems from './handlers/handleAddAgendaItems'
 graphql`
   fragment AddAgendaItemMutation_team on AddAgendaItemPayload {
@@ -44,7 +44,7 @@ const mutation = graphql`
   }
 `
 
-export const addAgendaItemUpdater: SharedUpdater<AddAgendaItemMutation_team> = (
+export const addAgendaItemUpdater: SharedUpdater<AddAgendaItemMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/AddCommentMutation.ts
+++ b/packages/client/mutations/AddCommentMutation.ts
@@ -3,7 +3,7 @@ import {commitMutation} from 'react-relay'
 import makeEmptyStr from '~/utils/draftjs/makeEmptyStr'
 import addNodeToArray from '~/utils/relay/addNodeToArray'
 import createProxyRecord from '~/utils/relay/createProxyRecord'
-import {AddCommentMutation_meeting} from '~/__generated__/AddCommentMutation_meeting.graphql'
+import {AddCommentMutation_meeting$data} from '~/__generated__/AddCommentMutation_meeting.graphql'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {AddCommentMutation as TAddCommentMutation} from '../__generated__/AddCommentMutation.graphql'
 import getDiscussionThreadConn from './connections/getDiscussionThreadConn'
@@ -34,7 +34,7 @@ const mutation = graphql`
   }
 `
 
-export const addCommentMeetingUpdater: SharedUpdater<AddCommentMutation_meeting> = (
+export const addCommentMeetingUpdater: SharedUpdater<AddCommentMutation_meeting$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/AddOrgMutation.ts
+++ b/packages/client/mutations/AddOrgMutation.ts
@@ -8,8 +8,8 @@ import {
 } from '../types/relayMutations'
 import getGraphQLError from '../utils/relay/getGraphQLError'
 import {AddOrgMutation as TAddOrgMutation} from '../__generated__/AddOrgMutation.graphql'
-import {AddOrgMutation_notification} from '../__generated__/AddOrgMutation_notification.graphql'
-import {AddOrgMutation_organization} from '../__generated__/AddOrgMutation_organization.graphql'
+import {AddOrgMutation_notification$data} from '../__generated__/AddOrgMutation_notification.graphql'
+import {AddOrgMutation_organization$data} from '../__generated__/AddOrgMutation_organization.graphql'
 import handleAddOrganization from './handlers/handleAddOrganization'
 import handleAddTeams from './handlers/handleAddTeams'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
@@ -54,7 +54,7 @@ const mutation = graphql`
   }
 `
 
-const popOrganizationCreatedToast: OnNextHandler<AddOrgMutation_organization> = (
+const popOrganizationCreatedToast: OnNextHandler<AddOrgMutation_organization$data> = (
   payload,
   {atmosphere}
 ) => {
@@ -68,7 +68,7 @@ const popOrganizationCreatedToast: OnNextHandler<AddOrgMutation_organization> = 
   })
 }
 
-export const addOrgMutationOrganizationUpdater: SharedUpdater<AddOrgMutation_organization> = (
+export const addOrgMutationOrganizationUpdater: SharedUpdater<AddOrgMutation_organization$data> = (
   payload,
   {store}
 ) => {
@@ -79,7 +79,7 @@ export const addOrgMutationOrganizationUpdater: SharedUpdater<AddOrgMutation_org
   handleAddTeams(team, store)
 }
 
-export const addOrgMutationNotificationUpdater: SharedUpdater<AddOrgMutation_notification> = (
+export const addOrgMutationNotificationUpdater: SharedUpdater<AddOrgMutation_notification$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/AddPokerTemplateDimensionMutation.ts
+++ b/packages/client/mutations/AddPokerTemplateDimensionMutation.ts
@@ -4,7 +4,7 @@ import {SprintPokerDefaults} from '~/types/constEnums'
 import {BaseLocalHandlers, SharedUpdater, StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {AddPokerTemplateDimensionMutation as TAddPokerTemplateDimensionMutation} from '../__generated__/AddPokerTemplateDimensionMutation.graphql'
-import {AddPokerTemplateDimensionMutation_dimension} from '../__generated__/AddPokerTemplateDimensionMutation_dimension.graphql'
+import {AddPokerTemplateDimensionMutation_dimension$data} from '../__generated__/AddPokerTemplateDimensionMutation_dimension.graphql'
 import handleAddPokerTemplateDimension from './handlers/handleAddPokerTemplateDimension'
 
 interface Handlers extends BaseLocalHandlers {
@@ -35,7 +35,7 @@ const mutation = graphql`
 `
 
 export const addPokerTemplateDimensionTeamUpdater: SharedUpdater<
-  AddPokerTemplateDimensionMutation_dimension
+  AddPokerTemplateDimensionMutation_dimension$data
 > = (payload, {store}) => {
   const dimension = payload.getLinkedRecord('dimension')
   if (!dimension) return

--- a/packages/client/mutations/AddPokerTemplateMutation.ts
+++ b/packages/client/mutations/AddPokerTemplateMutation.ts
@@ -5,7 +5,7 @@ import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {setActiveTemplateInRelayStore} from '../utils/relay/setActiveTemplate'
 import {AddPokerTemplateMutation as TAddPokerTemplateMutation} from '../__generated__/AddPokerTemplateMutation.graphql'
-import {AddPokerTemplateMutation_team} from '../__generated__/AddPokerTemplateMutation_team.graphql'
+import {AddPokerTemplateMutation_team$data} from '../__generated__/AddPokerTemplateMutation_team.graphql'
 import handleAddPokerTemplate from './handlers/handleAddPokerTemplate'
 
 graphql`
@@ -27,7 +27,7 @@ const mutation = graphql`
   }
 `
 
-export const addPokerTemplateTeamUpdater: SharedUpdater<AddPokerTemplateMutation_team> = (
+export const addPokerTemplateTeamUpdater: SharedUpdater<AddPokerTemplateMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/AddPokerTemplateScaleMutation.ts
+++ b/packages/client/mutations/AddPokerTemplateScaleMutation.ts
@@ -5,7 +5,7 @@ import {PokerCards} from '../types/constEnums'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {AddPokerTemplateScaleMutation as TAddPokerTemplateScaleMutation} from '../__generated__/AddPokerTemplateScaleMutation.graphql'
-import {AddPokerTemplateScaleMutation_scale} from '../__generated__/AddPokerTemplateScaleMutation_scale.graphql'
+import {AddPokerTemplateScaleMutation_scale$data} from '../__generated__/AddPokerTemplateScaleMutation_scale.graphql'
 import handleAddPokerTemplateScale from './handlers/handleAddPokerTemplateScale'
 
 graphql`
@@ -31,7 +31,7 @@ const mutation = graphql`
 `
 
 export const addPokerTemplateScaleTeamUpdater: SharedUpdater<
-  AddPokerTemplateScaleMutation_scale
+  AddPokerTemplateScaleMutation_scale$data
 > = (payload, {store}) => {
   const scale = payload.getLinkedRecord('scale')
   if (!scale) return

--- a/packages/client/mutations/AddReflectTemplateMutation.ts
+++ b/packages/client/mutations/AddReflectTemplateMutation.ts
@@ -4,7 +4,7 @@ import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {setActiveTemplateInRelayStore} from '../utils/relay/setActiveTemplate'
 import {AddReflectTemplateMutation as TAddReflectTemplateMutation} from '../__generated__/AddReflectTemplateMutation.graphql'
-import {AddReflectTemplateMutation_team} from '../__generated__/AddReflectTemplateMutation_team.graphql'
+import {AddReflectTemplateMutation_team$data} from '../__generated__/AddReflectTemplateMutation_team.graphql'
 import handleAddReflectTemplate from './handlers/handleAddReflectTemplate'
 
 graphql`
@@ -26,7 +26,7 @@ const mutation = graphql`
   }
 `
 
-export const addReflectTemplateTeamUpdater: SharedUpdater<AddReflectTemplateMutation_team> = (
+export const addReflectTemplateTeamUpdater: SharedUpdater<AddReflectTemplateMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/AddReflectTemplatePromptMutation.ts
+++ b/packages/client/mutations/AddReflectTemplatePromptMutation.ts
@@ -3,7 +3,7 @@ import {commitMutation} from 'react-relay'
 import {BaseLocalHandlers, SharedUpdater, StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {AddReflectTemplatePromptMutation as TAddReflectTemplatePromptMutation} from '../__generated__/AddReflectTemplatePromptMutation.graphql'
-import {AddReflectTemplatePromptMutation_team} from '../__generated__/AddReflectTemplatePromptMutation_team.graphql'
+import {AddReflectTemplatePromptMutation_team$data} from '../__generated__/AddReflectTemplatePromptMutation_team.graphql'
 import handleAddReflectTemplatePrompt from './handlers/handleAddReflectTemplatePrompt'
 
 interface Handlers extends BaseLocalHandlers {
@@ -35,7 +35,7 @@ const mutation = graphql`
 `
 
 export const addReflectTemplatePromptTeamUpdater: SharedUpdater<
-  AddReflectTemplatePromptMutation_team
+  AddReflectTemplatePromptMutation_team$data
 > = (payload, {store}) => {
   const prompt = payload.getLinkedRecord('prompt')
   if (!prompt) return

--- a/packages/client/mutations/AddTeamMutation.ts
+++ b/packages/client/mutations/AddTeamMutation.ts
@@ -9,8 +9,8 @@ import {
 } from '../types/relayMutations'
 import getGraphQLError from '../utils/relay/getGraphQLError'
 import {AddTeamMutation as TAddTeamMutation} from '../__generated__/AddTeamMutation.graphql'
-import {AddTeamMutation_notification} from '../__generated__/AddTeamMutation_notification.graphql'
-import {AddTeamMutation_team} from '../__generated__/AddTeamMutation_team.graphql'
+import {AddTeamMutation_notification$data} from '../__generated__/AddTeamMutation_notification.graphql'
+import {AddTeamMutation_team$data} from '../__generated__/AddTeamMutation_team.graphql'
 import handleAddTeams from './handlers/handleAddTeams'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
 
@@ -43,7 +43,7 @@ const mutation = graphql`
   }
 `
 
-const popTeamCreatedToast: OnNextHandler<AddTeamMutation_team, OnNextHistoryContext> = (
+const popTeamCreatedToast: OnNextHandler<AddTeamMutation_team$data, OnNextHistoryContext> = (
   payload,
   {atmosphere, history}
 ) => {
@@ -58,15 +58,14 @@ const popTeamCreatedToast: OnNextHandler<AddTeamMutation_team, OnNextHistoryCont
   history && history.push(`/team/${teamId}`)
 }
 
-export const addTeamTeamUpdater: SharedUpdater<AddTeamMutation_team> = (payload, {store}) => {
+export const addTeamTeamUpdater: SharedUpdater<AddTeamMutation_team$data> = (payload, {store}) => {
   const team = payload.getLinkedRecord('team')
   handleAddTeams(team, store)
 }
 
-export const addTeamMutationNotificationUpdater: SharedUpdater<AddTeamMutation_notification> = (
-  payload,
-  {store}
-) => {
+export const addTeamMutationNotificationUpdater: SharedUpdater<
+  AddTeamMutation_notification$data
+> = (payload, {store}) => {
   const removedSuggestedActionId = payload.getValue('removedSuggestedActionId')
   handleRemoveSuggestedActions(removedSuggestedActionId, store)
 }

--- a/packages/client/mutations/ArchiveOrganizationMutation.ts
+++ b/packages/client/mutations/ArchiveOrganizationMutation.ts
@@ -11,7 +11,7 @@ import onMeetingRoute from '../utils/onMeetingRoute'
 import onTeamRoute from '../utils/onTeamRoute'
 import safeRemoveNodeFromArray from '../utils/relay/safeRemoveNodeFromArray'
 import {ArchiveOrganizationMutation as TArchiveOrganizationMutation} from '../__generated__/ArchiveOrganizationMutation.graphql'
-import {ArchiveOrganizationMutation_organization} from '../__generated__/ArchiveOrganizationMutation_organization.graphql'
+import {ArchiveOrganizationMutation_organization$data} from '../__generated__/ArchiveOrganizationMutation_organization.graphql'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
 
 graphql`
@@ -40,7 +40,7 @@ const mutation = graphql`
 `
 
 const popOrgArchivedToast: OnNextHandler<
-  ArchiveOrganizationMutation_organization,
+  ArchiveOrganizationMutation_organization$data,
   OnNextHistoryContext
 > = (payload, {history, atmosphere}) => {
   if (!payload) return
@@ -64,7 +64,7 @@ const popOrgArchivedToast: OnNextHandler<
 }
 
 export const archiveOrganizationOrganizationUpdater: SharedUpdater<
-  ArchiveOrganizationMutation_organization
+  ArchiveOrganizationMutation_organization$data
 > = (payload, {store}) => {
   const viewer = store.getRoot().getLinkedRecord('viewer')!
   const teams = payload.getLinkedRecords('teams')
@@ -82,7 +82,7 @@ export const archiveOrganizationOrganizationUpdater: SharedUpdater<
 }
 
 export const archiveOrganizationOrganizationOnNext: OnNextHandler<
-  ArchiveOrganizationMutation_organization,
+  ArchiveOrganizationMutation_organization$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   popOrgArchivedToast(payload, {atmosphere, history})

--- a/packages/client/mutations/ArchiveTeamMutation.ts
+++ b/packages/client/mutations/ArchiveTeamMutation.ts
@@ -11,7 +11,7 @@ import onMeetingRoute from '../utils/onMeetingRoute'
 import onTeamRoute from '../utils/onTeamRoute'
 import safeRemoveNodeFromArray from '../utils/relay/safeRemoveNodeFromArray'
 import {ArchiveTeamMutation as TArchiveTeamMutation} from '../__generated__/ArchiveTeamMutation.graphql'
-import {ArchiveTeamMutation_team} from '../__generated__/ArchiveTeamMutation_team.graphql'
+import {ArchiveTeamMutation_team$data} from '../__generated__/ArchiveTeamMutation_team.graphql'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleRemoveReflectTemplate from './handlers/handleRemoveReflectTemplate'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
@@ -47,7 +47,7 @@ const mutation = graphql`
   }
 `
 
-const popTeamArchivedToast: OnNextHandler<ArchiveTeamMutation_team, OnNextHistoryContext> = (
+const popTeamArchivedToast: OnNextHandler<ArchiveTeamMutation_team$data, OnNextHistoryContext> = (
   payload,
   {history, atmosphere}
 ) => {
@@ -87,7 +87,7 @@ const popTeamArchivedToast: OnNextHandler<ArchiveTeamMutation_team, OnNextHistor
   }
 }
 
-export const archiveTeamTeamUpdater: SharedUpdater<ArchiveTeamMutation_team> = (
+export const archiveTeamTeamUpdater: SharedUpdater<ArchiveTeamMutation_team$data> = (
   payload,
   {store}
 ) => {
@@ -105,7 +105,7 @@ export const archiveTeamTeamUpdater: SharedUpdater<ArchiveTeamMutation_team> = (
 }
 
 export const archiveTeamTeamOnNext: OnNextHandler<
-  ArchiveTeamMutation_team,
+  ArchiveTeamMutation_team$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   popTeamArchivedToast(payload, {atmosphere, history})

--- a/packages/client/mutations/ArchiveTimelineEventMutation.ts
+++ b/packages/client/mutations/ArchiveTimelineEventMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordSourceSelectorProxy} from 'relay-runtime'
-import {ArchiveTimelineEventMutation_notification} from '__generated__/ArchiveTimelineEventMutation_notification.graphql'
+import {ArchiveTimelineEventMutation_notification$data} from '__generated__/ArchiveTimelineEventMutation_notification.graphql'
 import safeRemoveNodeFromConn from '~/utils/relay/safeRemoveNodeFromConn'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import {ArchiveTimelineEventMutation as TArchiveTimelineEventMutation} from '../__generated__/ArchiveTimelineEventMutation.graphql'
@@ -30,7 +30,7 @@ const mutation = graphql`
 `
 
 export const archiveTimelineEventNotificationUpdater: SharedUpdater<
-  ArchiveTimelineEventMutation_notification
+  ArchiveTimelineEventMutation_notification$data
 > = (payload, {store}) => {
   const timelineEvent = payload.getLinkedRecord('timelineEvent')
   if (!timelineEvent) return

--- a/packages/client/mutations/ChangeTaskTeamMutation.ts
+++ b/packages/client/mutations/ChangeTaskTeamMutation.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {ChangeTaskTeamMutation_task} from '~/__generated__/ChangeTaskTeamMutation_task.graphql'
+import {ChangeTaskTeamMutation_task$data} from '~/__generated__/ChangeTaskTeamMutation_task.graphql'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import getBaseRecord from '../utils/relay/getBaseRecord'
 import safeRemoveNodeFromUnknownConn from '../utils/relay/safeRemoveNodeFromUnknownConn'
@@ -37,7 +37,7 @@ const mutation = graphql`
 
 type Task = NonNullable<NonNullable<ChangeTaskTeamMutationResponse['changeTaskTeam']>['task']>
 
-export const changeTaskTeamTaskUpdater: SharedUpdater<ChangeTaskTeamMutation_task> = (
+export const changeTaskTeamTaskUpdater: SharedUpdater<ChangeTaskTeamMutation_task$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/CreatePollMutation.ts
+++ b/packages/client/mutations/CreatePollMutation.ts
@@ -1,9 +1,9 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {CreatePollMutation_meeting} from '~/__generated__/CreatePollMutation_meeting.graphql'
+import {CreatePollMutation_meeting$data} from '~/__generated__/CreatePollMutation_meeting.graphql'
 import {LocalHandlers, SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {CreatePollMutation as TCreatePollMutation} from '../__generated__/CreatePollMutation.graphql'
-import {ThreadedPollBase_poll} from '../__generated__/ThreadedPollBase_poll.graphql'
+import {ThreadedPollBase_poll$data} from '../__generated__/ThreadedPollBase_poll.graphql'
 import getDiscussionThreadConn from './connections/getDiscussionThreadConn'
 import safePutNodeInConn from './handlers/safePutNodeInConn'
 
@@ -35,7 +35,7 @@ const mutation = graphql`
   }
 `
 
-export const createPollMeetingUpdater: SharedUpdater<CreatePollMutation_meeting> = (
+export const createPollMeetingUpdater: SharedUpdater<CreatePollMutation_meeting$data> = (
   payload,
   {store}
 ) => {
@@ -52,7 +52,7 @@ export const createPollMeetingUpdater: SharedUpdater<CreatePollMutation_meeting>
 }
 
 interface Handlers extends LocalHandlers {
-  localPoll: ThreadedPollBase_poll
+  localPoll: ThreadedPollBase_poll$data
 }
 
 const CreatePollMutation: StandardMutation<TCreatePollMutation, Handlers> = (

--- a/packages/client/mutations/CreateReflectionMutation.ts
+++ b/packages/client/mutations/CreateReflectionMutation.ts
@@ -4,7 +4,7 @@
  */
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {CreateReflectionMutation_meeting} from '~/__generated__/CreateReflectionMutation_meeting.graphql'
+import {CreateReflectionMutation_meeting$data} from '~/__generated__/CreateReflectionMutation_meeting.graphql'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import makeEmptyStr from '../utils/draftjs/makeEmptyStr'
 import clientTempId from '../utils/relay/clientTempId'
@@ -43,10 +43,9 @@ const mutation = graphql`
   }
 `
 
-export const createReflectionMeetingUpdater: SharedUpdater<CreateReflectionMutation_meeting> = (
-  payload,
-  {store}
-) => {
+export const createReflectionMeetingUpdater: SharedUpdater<
+  CreateReflectionMutation_meeting$data
+> = (payload, {store}) => {
   const reflectionGroup = payload.getLinkedRecord('reflectionGroup')
   handleAddReflectionGroups(reflectionGroup, store)
 }

--- a/packages/client/mutations/CreateTaskMutation.ts
+++ b/packages/client/mutations/CreateTaskMutation.ts
@@ -17,8 +17,8 @@ import clientTempId from '../utils/relay/clientTempId'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import getOptimisticTaskEditor from '../utils/relay/getOptimisticTaskEditor'
 import {CreateTaskMutation as TCreateTaskMutation} from '../__generated__/CreateTaskMutation.graphql'
-import {CreateTaskMutation_notification} from '../__generated__/CreateTaskMutation_notification.graphql'
-import {CreateTaskMutation_task} from '../__generated__/CreateTaskMutation_task.graphql'
+import {CreateTaskMutation_notification$data} from '../__generated__/CreateTaskMutation_notification.graphql'
+import {CreateTaskMutation_task$data} from '../__generated__/CreateTaskMutation_task.graphql'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleAzureCreateIssue from './handlers/handleAzureCreateIssue'
 import handleEditTask from './handlers/handleEditTask'
@@ -100,7 +100,10 @@ const mutation = graphql`
   }
 `
 
-export const createTaskTaskUpdater: SharedUpdater<CreateTaskMutation_task> = (payload, {store}) => {
+export const createTaskTaskUpdater: SharedUpdater<CreateTaskMutation_task$data> = (
+  payload,
+  {store}
+) => {
   const task = payload.getLinkedRecord('task')
   if (!task) return
   const taskId = task.getValue('id')
@@ -118,14 +121,14 @@ export const createTaskTaskUpdater: SharedUpdater<CreateTaskMutation_task> = (pa
 }
 
 export const createTaskNotificationOnNext: OnNextHandler<
-  CreateTaskMutation_notification,
+  CreateTaskMutation_notification$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   if (!payload || !payload.involvementNotification) return
   popInvolvementToast(payload.involvementNotification, {atmosphere, history})
 }
 
-export const createTaskNotificationUpdater: SharedUpdater<CreateTaskMutation_notification> = (
+export const createTaskNotificationUpdater: SharedUpdater<CreateTaskMutation_notification$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/DeleteCommentMutation.ts
+++ b/packages/client/mutations/DeleteCommentMutation.ts
@@ -4,7 +4,7 @@ import {RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
 import convertToTaskContent from '~/utils/draftjs/convertToTaskContent'
 import safeRemoveNodeFromArray from '~/utils/relay/safeRemoveNodeFromArray'
 import safeRemoveNodeFromConn from '~/utils/relay/safeRemoveNodeFromConn'
-import {DeleteCommentMutation_meeting} from '~/__generated__/DeleteCommentMutation_meeting.graphql'
+import {DeleteCommentMutation_meeting$data} from '~/__generated__/DeleteCommentMutation_meeting.graphql'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import {DeleteCommentMutation as TDeleteCommentMutation} from '../__generated__/DeleteCommentMutation.graphql'
 import getDiscussionThreadConn from './connections/getDiscussionThreadConn'
@@ -51,7 +51,7 @@ export const handleRemoveReply = (
 }
 
 const handleDeleteComment = (
-  comment: RecordProxy<DeleteCommentMutation_meeting['comment']>,
+  comment: RecordProxy<DeleteCommentMutation_meeting$data['comment']>,
   store: RecordSourceSelectorProxy
 ) => {
   const commentId = comment.getValue('id')
@@ -78,7 +78,7 @@ const handleDeleteComment = (
   }
 }
 
-export const deleteCommentMeetingUpdater: SharedUpdater<DeleteCommentMutation_meeting> = (
+export const deleteCommentMeetingUpdater: SharedUpdater<DeleteCommentMutation_meeting$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/DeleteTaskMutation.ts
+++ b/packages/client/mutations/DeleteTaskMutation.ts
@@ -3,7 +3,7 @@ import {commitMutation} from 'react-relay'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import isTempId from '../utils/relay/isTempId'
 import {DeleteTaskMutation as TDeleteTaskMutation} from '../__generated__/DeleteTaskMutation.graphql'
-import {DeleteTaskMutation_task} from '../__generated__/DeleteTaskMutation_task.graphql'
+import {DeleteTaskMutation_task$data} from '../__generated__/DeleteTaskMutation_task.graphql'
 import handleRemoveTasks from './handlers/handleRemoveTasks'
 
 graphql`
@@ -25,7 +25,10 @@ const mutation = graphql`
   }
 `
 
-export const deleteTaskTaskUpdater: SharedUpdater<DeleteTaskMutation_task> = (payload, {store}) => {
+export const deleteTaskTaskUpdater: SharedUpdater<DeleteTaskMutation_task$data> = (
+  payload,
+  {store}
+) => {
   const taskId = payload.getLinkedRecord('task').getValue('id')
   handleRemoveTasks(taskId, store)
 }

--- a/packages/client/mutations/DenyPushInvitationMutation.ts
+++ b/packages/client/mutations/DenyPushInvitationMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {OnNextHandler, SimpleMutation} from '../types/relayMutations'
 import {DenyPushInvitationMutation as TDenyPushInvitationMutation} from '../__generated__/DenyPushInvitationMutation.graphql'
-import {DenyPushInvitationMutation_team} from '../__generated__/DenyPushInvitationMutation_team.graphql'
+import {DenyPushInvitationMutation_team$data} from '../__generated__/DenyPushInvitationMutation_team.graphql'
 
 graphql`
   fragment DenyPushInvitationMutation_team on DenyPushInvitationPayload {
@@ -23,7 +23,7 @@ const mutation = graphql`
   }
 `
 
-export const denyPushInvitationTeamOnNext: OnNextHandler<DenyPushInvitationMutation_team> = (
+export const denyPushInvitationTeamOnNext: OnNextHandler<DenyPushInvitationMutation_team$data> = (
   payload,
   {atmosphere}
 ) => {

--- a/packages/client/mutations/DragDiscussionTopicMutation.ts
+++ b/packages/client/mutations/DragDiscussionTopicMutation.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {DragDiscussionTopicMutation_meeting} from '~/__generated__/DragDiscussionTopicMutation_meeting.graphql'
+import {DragDiscussionTopicMutation_meeting$data} from '~/__generated__/DragDiscussionTopicMutation_meeting.graphql'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import {DISCUSS} from '../utils/constants'
 import {DragDiscussionTopicMutation as IDragDiscussionTopicMutation} from '../__generated__/DragDiscussionTopicMutation.graphql'
@@ -27,7 +27,7 @@ const mutation = graphql`
 `
 
 export const dragDiscussionTopicMeetingUpdater: SharedUpdater<
-  DragDiscussionTopicMutation_meeting
+  DragDiscussionTopicMutation_meeting$data
 > = (payload, {store}) => {
   const meetingId = payload.getLinkedRecord('meeting').getValue('id')
   handleUpdateStageSort(store, meetingId, DISCUSS)

--- a/packages/client/mutations/EditReflectionMutation.ts
+++ b/packages/client/mutations/EditReflectionMutation.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {EditReflectionMutation_meeting} from '~/__generated__/EditReflectionMutation_meeting.graphql'
+import {EditReflectionMutation_meeting$data} from '~/__generated__/EditReflectionMutation_meeting.graphql'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import {EditReflectionMutation as TEditReflectionMutation} from '../__generated__/EditReflectionMutation.graphql'
 import handleEditReflection from './handlers/handleEditReflection'
@@ -21,7 +21,7 @@ const mutation = graphql`
   }
 `
 
-export const editReflectionMeetingUpdater: SharedUpdater<EditReflectionMutation_meeting> = (
+export const editReflectionMeetingUpdater: SharedUpdater<EditReflectionMutation_meeting$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/EditTaskMutation.ts
+++ b/packages/client/mutations/EditTaskMutation.ts
@@ -4,7 +4,7 @@ import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import getOptimisticTaskEditor from '../utils/relay/getOptimisticTaskEditor'
 import isTempId from '../utils/relay/isTempId'
 import {EditTaskMutation as TEditTaskMutation} from '../__generated__/EditTaskMutation.graphql'
-import {EditTaskMutation_task} from '../__generated__/EditTaskMutation_task.graphql'
+import {EditTaskMutation_task$data} from '../__generated__/EditTaskMutation_task.graphql'
 import handleEditTask from './handlers/handleEditTask'
 
 graphql`
@@ -31,7 +31,10 @@ const mutation = graphql`
   }
 `
 
-export const editTaskTaskUpdater: SharedUpdater<EditTaskMutation_task> = (payload, {store}) => {
+export const editTaskTaskUpdater: SharedUpdater<EditTaskMutation_task$data> = (
+  payload,
+  {store}
+) => {
   handleEditTask(payload, store)
 }
 

--- a/packages/client/mutations/EndCheckInMutation.ts
+++ b/packages/client/mutations/EndCheckInMutation.ts
@@ -2,8 +2,8 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordProxy} from 'relay-runtime'
 import onMeetingRoute from '~/utils/onMeetingRoute'
-import {EndCheckInMutation_notification} from '~/__generated__/EndCheckInMutation_notification.graphql'
-import {EndCheckInMutation_team} from '~/__generated__/EndCheckInMutation_team.graphql'
+import {EndCheckInMutation_notification$data} from '~/__generated__/EndCheckInMutation_notification.graphql'
+import {EndCheckInMutation_team$data} from '~/__generated__/EndCheckInMutation_team.graphql'
 import {
   HistoryMaybeLocalHandler,
   OnNextHandler,
@@ -79,10 +79,10 @@ const mutation = graphql`
     }
   }
 `
-export const endCheckInTeamOnNext: OnNextHandler<EndCheckInMutation_team, OnNextHistoryContext> = (
-  payload,
-  context
-) => {
+export const endCheckInTeamOnNext: OnNextHandler<
+  EndCheckInMutation_team$data,
+  OnNextHistoryContext
+> = (payload, context) => {
   const {isKill, meeting} = payload
   const {atmosphere, history} = context
   if (!meeting) return
@@ -97,7 +97,7 @@ export const endCheckInTeamOnNext: OnNextHandler<EndCheckInMutation_team, OnNext
   }
 }
 
-export const endCheckInNotificationUpdater: SharedUpdater<EndCheckInMutation_notification> = (
+export const endCheckInNotificationUpdater: SharedUpdater<EndCheckInMutation_notification$data> = (
   payload,
   {store}
 ) => {
@@ -105,7 +105,10 @@ export const endCheckInNotificationUpdater: SharedUpdater<EndCheckInMutation_not
   handleRemoveSuggestedActions(removedSuggestedActionId, store)
 }
 
-export const endCheckInTeamUpdater: SharedUpdater<EndCheckInMutation_team> = (payload, {store}) => {
+export const endCheckInTeamUpdater: SharedUpdater<EndCheckInMutation_team$data> = (
+  payload,
+  {store}
+) => {
   const updatedTasks = payload.getLinkedRecords('updatedTasks')
   const removedTaskIds = payload.getValue('removedTaskIds')
   const meeting = payload.getLinkedRecord('meeting') as RecordProxy

--- a/packages/client/mutations/EndDraggingReflectionMutation.ts
+++ b/packages/client/mutations/EndDraggingReflectionMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitLocalUpdate, commitMutation} from 'react-relay'
 import {RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
 import {EndDraggingReflectionMutation as TEndDraggingReflectionMutation} from '~/__generated__/EndDraggingReflectionMutation.graphql'
-import {EndDraggingReflectionMutation_meeting} from '~/__generated__/EndDraggingReflectionMutation_meeting.graphql'
+import {EndDraggingReflectionMutation_meeting$data} from '~/__generated__/EndDraggingReflectionMutation_meeting.graphql'
 import {OnNextHandler, SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import dndNoise from '../utils/dndNoise'
 import addNodeToArray from '../utils/relay/addNodeToArray'
@@ -108,7 +108,7 @@ export const moveReflectionLocation = (
 }
 
 export const endDraggingReflectionMeetingUpdater: SharedUpdater<
-  EndDraggingReflectionMutation_meeting
+  EndDraggingReflectionMutation_meeting$data
 > = (payload, {store}) => {
   const reflection = payload.getLinkedRecord('reflection')
   if (!reflection) return
@@ -127,7 +127,7 @@ export const endDraggingReflectionMeetingUpdater: SharedUpdater<
 }
 
 export const endDraggingReflectionMeetingOnNext: OnNextHandler<
-  EndDraggingReflectionMutation_meeting
+  EndDraggingReflectionMutation_meeting$data
 > = (payload, context) => {
   const {atmosphere} = context
   const {reflection} = payload

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -2,8 +2,8 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordProxy} from 'relay-runtime'
 import onMeetingRoute from '~/utils/onMeetingRoute'
-import {EndRetrospectiveMutation_notification} from '~/__generated__/EndRetrospectiveMutation_notification.graphql'
-import {EndRetrospectiveMutation_team} from '~/__generated__/EndRetrospectiveMutation_team.graphql'
+import {EndRetrospectiveMutation_notification$data} from '~/__generated__/EndRetrospectiveMutation_notification.graphql'
+import {EndRetrospectiveMutation_team$data} from '~/__generated__/EndRetrospectiveMutation_team.graphql'
 import {RetroDemo} from '../types/constEnums'
 import {
   HistoryMaybeLocalHandler,
@@ -89,7 +89,7 @@ const mutation = graphql`
 `
 
 export const endRetrospectiveTeamOnNext: OnNextHandler<
-  EndRetrospectiveMutation_team,
+  EndRetrospectiveMutation_team$data,
   OnNextHistoryContext
 > = (payload, context) => {
   const {isKill, meeting} = payload
@@ -124,13 +124,13 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
 }
 
 export const endRetrospectiveNotificationUpdater: SharedUpdater<
-  EndRetrospectiveMutation_notification
+  EndRetrospectiveMutation_notification$data
 > = (payload, {store}) => {
   const removedSuggestedActionId = payload.getValue('removedSuggestedActionId')
   handleRemoveSuggestedActions(removedSuggestedActionId, store)
 }
 
-export const endRetrospectiveTeamUpdater: SharedUpdater<EndRetrospectiveMutation_team> = (
+export const endRetrospectiveTeamUpdater: SharedUpdater<EndRetrospectiveMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/EndSprintPokerMutation.ts
+++ b/packages/client/mutations/EndSprintPokerMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import onMeetingRoute from '~/utils/onMeetingRoute'
-import {EndSprintPokerMutation_team} from '~/__generated__/EndSprintPokerMutation_team.graphql'
+import {EndSprintPokerMutation_team$data} from '~/__generated__/EndSprintPokerMutation_team.graphql'
 import {
   HistoryMaybeLocalHandler,
   OnNextHandler,
@@ -45,7 +45,7 @@ const mutation = graphql`
 `
 
 export const endSprintPokerTeamOnNext: OnNextHandler<
-  EndSprintPokerMutation_team,
+  EndSprintPokerMutation_team$data,
   OnNextHistoryContext
 > = (payload, context) => {
   const {isKill, meeting} = payload
@@ -62,7 +62,7 @@ export const endSprintPokerTeamOnNext: OnNextHandler<
   }
 }
 
-export const endSprintPokerTeamUpdater: SharedUpdater<EndSprintPokerMutation_team> = (
+export const endSprintPokerTeamUpdater: SharedUpdater<EndSprintPokerMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordProxy} from 'relay-runtime'
 import onMeetingRoute from '~/utils/onMeetingRoute'
-import {EndTeamPromptMutation_team} from '~/__generated__/EndTeamPromptMutation_team.graphql'
+import {EndTeamPromptMutation_team$data} from '~/__generated__/EndTeamPromptMutation_team.graphql'
 import {
   HistoryMaybeLocalHandler,
   OnNextHandler,
@@ -55,7 +55,7 @@ const mutation = graphql`
 `
 
 export const endTeamPromptTeamOnNext: OnNextHandler<
-  EndTeamPromptMutation_team,
+  EndTeamPromptMutation_team$data,
   OnNextHistoryContext
 > = (payload, context) => {
   const {meeting} = payload
@@ -67,7 +67,7 @@ export const endTeamPromptTeamOnNext: OnNextHandler<
   }
 }
 
-export const endTeamPromptTeamUpdater: SharedUpdater<EndTeamPromptMutation_team> = (
+export const endTeamPromptTeamUpdater: SharedUpdater<EndTeamPromptMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/InviteToTeamMutation.ts
+++ b/packages/client/mutations/InviteToTeamMutation.ts
@@ -9,7 +9,7 @@ import {
   StandardMutation
 } from '../types/relayMutations'
 import {InviteToTeamMutation as TInviteToTeamMutation} from '../__generated__/InviteToTeamMutation.graphql'
-import {InviteToTeamMutation_notification} from '../__generated__/InviteToTeamMutation_notification.graphql'
+import {InviteToTeamMutation_notification$data} from '../__generated__/InviteToTeamMutation_notification.graphql'
 import AcceptTeamInvitationMutation from './AcceptTeamInvitationMutation'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleRemoveSuggestedActions from './handlers/handleRemoveSuggestedActions'
@@ -48,7 +48,7 @@ const mutation = graphql`
 `
 
 const popInvitationReceivedToast = (
-  notification: InviteToTeamMutation_notification['teamInvitationNotification'] | null,
+  notification: InviteToTeamMutation_notification$data['teamInvitationNotification'] | null,
   {atmosphere, history}: OnNextHistoryContext
 ) => {
   if (!notification) return
@@ -73,16 +73,15 @@ const popInvitationReceivedToast = (
   })
 }
 
-export const inviteToTeamNotificationUpdater: SharedUpdater<InviteToTeamMutation_notification> = (
-  payload,
-  {store}
-) => {
+export const inviteToTeamNotificationUpdater: SharedUpdater<
+  InviteToTeamMutation_notification$data
+> = (payload, {store}) => {
   const teamInvitationNotification = payload.getLinkedRecord('teamInvitationNotification')
   handleAddNotifications(teamInvitationNotification, store)
 }
 
 export const inviteToTeamNotificationOnNext: OnNextHandler<
-  InviteToTeamMutation_notification,
+  InviteToTeamMutation_notification$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   const {teamInvitationNotification} = payload

--- a/packages/client/mutations/MovePokerTemplateDimensionMutation.ts
+++ b/packages/client/mutations/MovePokerTemplateDimensionMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {MovePokerTemplateDimensionMutation as TMovePokerTemplateDimensionMutation} from '~/__generated__/MovePokerTemplateDimensionMutation.graphql'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
-import {MovePokerTemplateDimensionMutation_team} from '../__generated__/MovePokerTemplateDimensionMutation_team.graphql'
+import {MovePokerTemplateDimensionMutation_team$data} from '../__generated__/MovePokerTemplateDimensionMutation_team.graphql'
 import handleMovePokerTemplateDimension from './handlers/handleMovePokerTemplateDimension'
 
 graphql`
@@ -26,7 +26,7 @@ const mutation = graphql`
 `
 
 export const movePokerTemplateDimensionTeamUpdater: SharedUpdater<
-  MovePokerTemplateDimensionMutation_team
+  MovePokerTemplateDimensionMutation_team$data
 > = (payload, {store}) => {
   if (!payload) return
   const templateId = payload.getLinkedRecord('dimension').getValue('templateId')

--- a/packages/client/mutations/MoveReflectTemplatePromptMutation.ts
+++ b/packages/client/mutations/MoveReflectTemplatePromptMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {MoveReflectTemplatePromptMutation as TMoveReflectTemplatePromptMutation} from '~/__generated__/MoveReflectTemplatePromptMutation.graphql'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
-import {MoveReflectTemplatePromptMutation_team} from '../__generated__/MoveReflectTemplatePromptMutation_team.graphql'
+import {MoveReflectTemplatePromptMutation_team$data} from '../__generated__/MoveReflectTemplatePromptMutation_team.graphql'
 import handleMoveTemplatePrompt from './handlers/handleMoveTemplatePrompt'
 interface Context {
   templateId: string
@@ -29,7 +29,7 @@ const mutation = graphql`
 `
 
 export const moveReflectTemplatePromptTeamUpdater: SharedUpdater<
-  MoveReflectTemplatePromptMutation_team
+  MoveReflectTemplatePromptMutation_team$data
 > = (payload, {store}) => {
   if (!payload) return
   const templateId = payload.getLinkedRecord('prompt').getValue('templateId')

--- a/packages/client/mutations/NavigateMeetingMutation.ts
+++ b/packages/client/mutations/NavigateMeetingMutation.ts
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {
-  NavigateMeetingMutation_meeting,
+  NavigateMeetingMutation_meeting$data,
   NewMeetingPhaseTypeEnum
 } from '~/__generated__/NavigateMeetingMutation_meeting.graphql'
-import {NavigateMeetingMutation_team} from '~/__generated__/NavigateMeetingMutation_team.graphql'
-import {ReflectionGroup_reflectionGroup} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
+import {NavigateMeetingMutation_team$data} from '~/__generated__/NavigateMeetingMutation_team.graphql'
+import {ReflectionGroup_reflectionGroup$data} from '~/__generated__/ReflectionGroup_reflectionGroup.graphql'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import {REFLECT, VOTE} from '../utils/constants'
 import isInterruptingChickenPhase from '../utils/isInterruptingChickenPhase'
@@ -111,12 +111,12 @@ const mutation = graphql`
   }
 `
 
-export const navigateMeetingTeamUpdater: SharedUpdater<NavigateMeetingMutation_team> = (
+export const navigateMeetingTeamUpdater: SharedUpdater<NavigateMeetingMutation_team$data> = (
   payload,
   {store}
 ) => {
   const meetingId = safeProxy(payload).getLinkedRecord('meeting').getValue('id')!
-  const meeting = store.get<NavigateMeetingMutation_meeting>(meetingId)
+  const meeting = store.get<NavigateMeetingMutation_meeting$data>(meetingId)
   if (!meeting) return
 
   const viewerStageId = safeProxy(meeting).getLinkedRecord('localStage').getValue('id')
@@ -156,14 +156,14 @@ export const navigateMeetingTeamUpdater: SharedUpdater<NavigateMeetingMutation_t
     )
     if (!reflectPhase) return
     const prompts =
-      reflectPhase.getLinkedRecords<ReflectionGroup_reflectionGroup[]>('reflectPrompts')
+      reflectPhase.getLinkedRecords<ReflectionGroup_reflectionGroup$data[]>('reflectPrompts')
     if (!prompts) return
     prompts.forEach((reflectPrompt) => {
       reflectPrompt?.setValue([], 'editorIds')
     })
   }
   const reflectionGroups =
-    meeting.getLinkedRecords<ReflectionGroup_reflectionGroup[]>('reflectionGroups')
+    meeting.getLinkedRecords<ReflectionGroup_reflectionGroup$data[]>('reflectionGroups')
   if (!reflectionGroups) return
   const sortedReflectionGroups = reflectionGroups
     .slice()

--- a/packages/client/mutations/PokerAnnounceDeckHoverMutation.ts
+++ b/packages/client/mutations/PokerAnnounceDeckHoverMutation.ts
@@ -4,8 +4,8 @@ import {RecordProxy} from 'relay-runtime'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {PokerAnnounceDeckHoverMutation as TPokerAnnounceDeckHoverMutation} from '../__generated__/PokerAnnounceDeckHoverMutation.graphql'
-import {PokerAnnounceDeckHoverMutation_meeting} from '../__generated__/PokerAnnounceDeckHoverMutation_meeting.graphql'
-import {PokerMeeting_meeting} from '../__generated__/PokerMeeting_meeting.graphql'
+import {PokerAnnounceDeckHoverMutation_meeting$data} from '../__generated__/PokerAnnounceDeckHoverMutation_meeting.graphql'
+import {PokerMeeting_meeting$data} from '../__generated__/PokerMeeting_meeting.graphql'
 
 // asking for the correct hoveringUsers array would be fine, except we know a user can existing in exactly 1 hoveringUsers array at a time
 // which means we have to iterate over each stage & remove it from all others (because mouseEnter/mouseLeave are not always reliable)
@@ -34,7 +34,7 @@ const mutation = graphql`
     }
   }
 `
-type EstimatePhase = PokerMeeting_meeting['phases'][0]
+type EstimatePhase = PokerMeeting_meeting$data['phases'][0]
 type EstimateStage = EstimatePhase['stages'][0]
 
 const removeHoveringUserFromStage = (stage: RecordProxy<EstimateStage>, userId: string) => {
@@ -50,14 +50,14 @@ const removeHoveringUserFromStage = (stage: RecordProxy<EstimateStage>, userId: 
   stage.setLinkedRecords(nextHoveringUsers, 'hoveringUsers')
 }
 export const pokerAnnounceDeckHoverMeetingUpdater: SharedUpdater<
-  PokerAnnounceDeckHoverMutation_meeting
+  PokerAnnounceDeckHoverMutation_meeting$data
 > = (payload, {store}) => {
   const meetingId = payload.getValue('meetingId')
   const user = payload.getLinkedRecord('user')
   const userId = user.getValue('id')
   const stageId = payload.getValue('stageId')
   const isHover = payload.getValue('isHover')
-  const meeting = store.get<PokerMeeting_meeting>(meetingId)
+  const meeting = store.get<PokerMeeting_meeting$data>(meetingId)
   if (!meeting) return
   if (isHover) {
     const phases = meeting.getLinkedRecords('phases')!

--- a/packages/client/mutations/PromoteNewMeetingFacilitatorMutation.ts
+++ b/packages/client/mutations/PromoteNewMeetingFacilitatorMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {OnNextHandler, SimpleMutation} from '../types/relayMutations'
 import {PromoteNewMeetingFacilitatorMutation as TPromoteNewMeetingFacilitatorMutation} from '../__generated__/PromoteNewMeetingFacilitatorMutation.graphql'
-import {PromoteNewMeetingFacilitatorMutation_meeting} from '../__generated__/PromoteNewMeetingFacilitatorMutation_meeting.graphql'
+import {PromoteNewMeetingFacilitatorMutation_meeting$data} from '../__generated__/PromoteNewMeetingFacilitatorMutation_meeting.graphql'
 
 graphql`
   fragment PromoteNewMeetingFacilitatorMutation_meeting on PromoteNewMeetingFacilitatorPayload {
@@ -38,7 +38,7 @@ const mutation = graphql`
 `
 
 export const promoteNewMeetingFacilitatorMeetingOnNext: OnNextHandler<
-  PromoteNewMeetingFacilitatorMutation_meeting
+  PromoteNewMeetingFacilitatorMutation_meeting$data
 > = (payload, {atmosphere}) => {
   const {viewerId} = atmosphere
   const {oldFacilitator, meeting} = payload

--- a/packages/client/mutations/PushInvitationMutation.ts
+++ b/packages/client/mutations/PushInvitationMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {OnNextHandler, SimpleMutation} from '../types/relayMutations'
 import {PushInvitationMutation as TPushInvitationMutation} from '../__generated__/PushInvitationMutation.graphql'
-import {PushInvitationMutation_team} from '../__generated__/PushInvitationMutation_team.graphql'
+import {PushInvitationMutation_team$data} from '../__generated__/PushInvitationMutation_team.graphql'
 import DenyPushInvitationMutation from './DenyPushInvitationMutation'
 import InviteToTeamMutation from './InviteToTeamMutation'
 
@@ -32,7 +32,7 @@ const mutation = graphql`
   }
 `
 
-export const pushInvitationTeamOnNext: OnNextHandler<PushInvitationMutation_team> = (
+export const pushInvitationTeamOnNext: OnNextHandler<PushInvitationMutation_team$data> = (
   payload,
   {atmosphere}
 ) => {

--- a/packages/client/mutations/RemoveAgendaItemMutation.ts
+++ b/packages/client/mutations/RemoveAgendaItemMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {RemoveAgendaItemMutation as TRemoveAgendaItemMutation} from '../__generated__/RemoveAgendaItemMutation.graphql'
-import {RemoveAgendaItemMutation_team} from '../__generated__/RemoveAgendaItemMutation_team.graphql'
+import {RemoveAgendaItemMutation_team$data} from '../__generated__/RemoveAgendaItemMutation_team.graphql'
 import handleRemoveAgendaItems from './handlers/handleRemoveAgendaItems'
 graphql`
   fragment RemoveAgendaItemMutation_team on RemoveAgendaItemPayload {
@@ -30,7 +30,7 @@ const mutation = graphql`
   }
 `
 
-export const removeAgendaItemUpdater: SharedUpdater<RemoveAgendaItemMutation_team> = (
+export const removeAgendaItemUpdater: SharedUpdater<RemoveAgendaItemMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/RemoveOrgUserMutation.ts
+++ b/packages/client/mutations/RemoveOrgUserMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitLocalUpdate, commitMutation} from 'react-relay'
 import {RemoveOrgUserMutation as TRemoveOrgUserMutation} from '~/__generated__/RemoveOrgUserMutation.graphql'
-import {RemoveOrgUserMutation_team} from '~/__generated__/RemoveOrgUserMutation_team.graphql'
+import {RemoveOrgUserMutation_team$data} from '~/__generated__/RemoveOrgUserMutation_team.graphql'
 import {
   HistoryLocalHandler,
   OnNextHandler,
@@ -14,9 +14,9 @@ import onExOrgRoute from '../utils/onExOrgRoute'
 import onMeetingRoute from '../utils/onMeetingRoute'
 import onTeamRoute from '../utils/onTeamRoute'
 import {setLocalStageAndPhase} from '../utils/relay/updateLocalStage'
-import {RemoveOrgUserMutation_notification} from '../__generated__/RemoveOrgUserMutation_notification.graphql'
-import {RemoveOrgUserMutation_organization} from '../__generated__/RemoveOrgUserMutation_organization.graphql'
-import {RemoveOrgUserMutation_task} from '../__generated__/RemoveOrgUserMutation_task.graphql'
+import {RemoveOrgUserMutation_notification$data} from '../__generated__/RemoveOrgUserMutation_notification.graphql'
+import {RemoveOrgUserMutation_organization$data} from '../__generated__/RemoveOrgUserMutation_organization.graphql'
+import {RemoveOrgUserMutation_task$data} from '../__generated__/RemoveOrgUserMutation_task.graphql'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleRemoveOrganization from './handlers/handleRemoveOrganization'
 import handleRemoveOrgMembers from './handlers/handleRemoveOrgMembers'
@@ -102,10 +102,9 @@ const mutation = graphql`
   }
 `
 
-export const removeOrgUserOrganizationUpdater: SharedUpdater<RemoveOrgUserMutation_organization> = (
-  payload,
-  {atmosphere, store}
-) => {
+export const removeOrgUserOrganizationUpdater: SharedUpdater<
+  RemoveOrgUserMutation_organization$data
+> = (payload, {atmosphere, store}) => {
   const {viewerId} = atmosphere
   const removedUserId = payload.getLinkedRecord('user').getValue('id')
   const removedOrgUserId = payload.getValue('organizationUserId')
@@ -117,15 +116,14 @@ export const removeOrgUserOrganizationUpdater: SharedUpdater<RemoveOrgUserMutati
   }
 }
 
-export const removeOrgUserNotificationUpdater: SharedUpdater<RemoveOrgUserMutation_notification> = (
-  payload,
-  {store}
-) => {
+export const removeOrgUserNotificationUpdater: SharedUpdater<
+  RemoveOrgUserMutation_notification$data
+> = (payload, {store}) => {
   const kickOutNotifications = payload.getLinkedRecords('kickOutNotifications')
   handleAddNotifications(kickOutNotifications, store)
 }
 
-export const removeOrgUserTeamUpdater: SharedUpdater<RemoveOrgUserMutation_team> = (
+export const removeOrgUserTeamUpdater: SharedUpdater<RemoveOrgUserMutation_team$data> = (
   payload,
   {atmosphere, store}
 ) => {
@@ -143,7 +141,7 @@ export const removeOrgUserTeamUpdater: SharedUpdater<RemoveOrgUserMutation_team>
   }
 }
 
-export const removeOrgUserTaskUpdater: SharedUpdater<RemoveOrgUserMutation_task> = (
+export const removeOrgUserTaskUpdater: SharedUpdater<RemoveOrgUserMutation_task$data> = (
   payload,
   {atmosphere, store}
 ) => {
@@ -159,7 +157,7 @@ export const removeOrgUserTaskUpdater: SharedUpdater<RemoveOrgUserMutation_task>
   }
 }
 
-export const removeOrgUserTeamOnNext: OnNextHandler<RemoveOrgUserMutation_team> = (
+export const removeOrgUserTeamOnNext: OnNextHandler<RemoveOrgUserMutation_team$data> = (
   payload,
   context
 ) => {
@@ -187,7 +185,7 @@ export const removeOrgUserTeamOnNext: OnNextHandler<RemoveOrgUserMutation_team> 
 }
 
 export const removeOrgUserOrganizationOnNext: OnNextHandler<
-  RemoveOrgUserMutation_organization,
+  RemoveOrgUserMutation_organization$data,
   OnNextHistoryContext
 > = (payload, context) => {
   // FIXME currently, the server doesn't send this to the user in other tabs, so they don't get redirected in their other tabs
@@ -205,7 +203,7 @@ export const removeOrgUserOrganizationOnNext: OnNextHandler<
 }
 
 export const removeOrgUserNotificationOnNext: OnNextHandler<
-  RemoveOrgUserMutation_notification,
+  RemoveOrgUserMutation_notification$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   if (!payload) return

--- a/packages/client/mutations/RemovePokerTemplateDimensionMutation.ts
+++ b/packages/client/mutations/RemovePokerTemplateDimensionMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {RemovePokerTemplateDimensionMutation as IRemovePokerTemplateDimensionMutation} from '../__generated__/RemovePokerTemplateDimensionMutation.graphql'
-import {RemovePokerTemplateDimensionMutation_team} from '../__generated__/RemovePokerTemplateDimensionMutation_team.graphql'
+import {RemovePokerTemplateDimensionMutation_team$data} from '../__generated__/RemovePokerTemplateDimensionMutation_team.graphql'
 import handleRemovePokerTemplateDimension from './handlers/handleRemovePokerTemplateDimension'
 
 graphql`
@@ -23,7 +23,7 @@ const mutation = graphql`
 `
 
 export const removePokerTemplateDimensionTeamUpdater: SharedUpdater<
-  RemovePokerTemplateDimensionMutation_team
+  RemovePokerTemplateDimensionMutation_team$data
 > = (payload, {store}) => {
   const dimensionId = payload.getLinkedRecord('dimension').getValue('id')
   const teamId = payload.getLinkedRecord('dimension').getValue('teamId')

--- a/packages/client/mutations/RemovePokerTemplateMutation.ts
+++ b/packages/client/mutations/RemovePokerTemplateMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {RemovePokerTemplateMutation as TRemovePokerTemplateMutation} from '../__generated__/RemovePokerTemplateMutation.graphql'
-import {RemovePokerTemplateMutation_team} from '../__generated__/RemovePokerTemplateMutation_team.graphql'
+import {RemovePokerTemplateMutation_team$data} from '../__generated__/RemovePokerTemplateMutation_team.graphql'
 import handleRemovePokerTemplate from './handlers/handleRemovePokerTemplate'
 
 graphql`
@@ -28,16 +28,15 @@ const mutation = graphql`
   }
 `
 
-export const removePokerTemplateTeamUpdater: SharedUpdater<RemovePokerTemplateMutation_team> = (
-  payload,
-  {store}
-) => {
+export const removePokerTemplateTeamUpdater: SharedUpdater<
+  RemovePokerTemplateMutation_team$data
+> = (payload, {store}) => {
   const templateId = payload.getLinkedRecord('pokerTemplate').getValue('id')
   const teamId = payload.getLinkedRecord('pokerTemplate').getValue('teamId')
   handleRemovePokerTemplate(templateId, teamId, store)
 }
 
-type PokerTemplate = NonNullable<RemovePokerTemplateMutation_team['pokerTemplate']>
+type PokerTemplate = NonNullable<RemovePokerTemplateMutation_team$data['pokerTemplate']>
 
 const RemovePokerTemplateMutation: StandardMutation<TRemovePokerTemplateMutation> = (
   atmosphere,

--- a/packages/client/mutations/RemovePokerTemplateScaleMutation.ts
+++ b/packages/client/mutations/RemovePokerTemplateScaleMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {RemovePokerTemplateScaleMutation as IRemovePokerTemplateScaleMutation} from '../__generated__/RemovePokerTemplateScaleMutation.graphql'
-import {RemovePokerTemplateScaleMutation_scale} from '../__generated__/RemovePokerTemplateScaleMutation_scale.graphql'
+import {RemovePokerTemplateScaleMutation_scale$data} from '../__generated__/RemovePokerTemplateScaleMutation_scale.graphql'
 import handleRemovePokerTemplateScale from './handlers/handleRemovePokerTemplateScale'
 
 graphql`
@@ -27,7 +27,7 @@ const mutation = graphql`
 `
 
 export const removePokerTemplateScaleTeamUpdater: SharedUpdater<
-  RemovePokerTemplateScaleMutation_scale
+  RemovePokerTemplateScaleMutation_scale$data
 > = (payload, {store}) => {
   const scaleId = payload.getLinkedRecord('scale').getValue('id')
   const teamId = payload.getLinkedRecord('scale').getValue('teamId')

--- a/packages/client/mutations/RemoveReflectTemplateMutation.ts
+++ b/packages/client/mutations/RemoveReflectTemplateMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {RemoveReflectTemplateMutation as TRemoveReflectTemplateMutation} from '../__generated__/RemoveReflectTemplateMutation.graphql'
-import {RemoveReflectTemplateMutation_team} from '../__generated__/RemoveReflectTemplateMutation_team.graphql'
+import {RemoveReflectTemplateMutation_team$data} from '../__generated__/RemoveReflectTemplateMutation_team.graphql'
 import handleRemoveReflectTemplate from './handlers/handleRemoveReflectTemplate'
 
 graphql`
@@ -28,12 +28,11 @@ const mutation = graphql`
   }
 `
 
-type ReflectTemplate = NonNullable<RemoveReflectTemplateMutation_team['reflectTemplate']>
+type ReflectTemplate = NonNullable<RemoveReflectTemplateMutation_team$data['reflectTemplate']>
 
-export const removeReflectTemplateTeamUpdater: SharedUpdater<RemoveReflectTemplateMutation_team> = (
-  payload,
-  {store}
-) => {
+export const removeReflectTemplateTeamUpdater: SharedUpdater<
+  RemoveReflectTemplateMutation_team$data
+> = (payload, {store}) => {
   const templateId = payload.getLinkedRecord('reflectTemplate').getValue('id')
   const teamId = payload.getLinkedRecord('reflectTemplate').getValue('teamId')
   handleRemoveReflectTemplate(templateId, teamId, store)

--- a/packages/client/mutations/RemoveReflectTemplatePromptMutation.ts
+++ b/packages/client/mutations/RemoveReflectTemplatePromptMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {RemoveReflectTemplatePromptMutation as TRemoveReflectTemplatePromptMutation} from '../__generated__/RemoveReflectTemplatePromptMutation.graphql'
-import {RemoveReflectTemplatePromptMutation_team} from '../__generated__/RemoveReflectTemplatePromptMutation_team.graphql'
+import {RemoveReflectTemplatePromptMutation_team$data} from '../__generated__/RemoveReflectTemplatePromptMutation_team.graphql'
 import handleRemoveReflectTemplatePrompt from './handlers/handleRemoveReflectTemplatePrompt'
 
 graphql`
@@ -23,7 +23,7 @@ const mutation = graphql`
 `
 
 export const removeReflectTemplatePromptTeamUpdater: SharedUpdater<
-  RemoveReflectTemplatePromptMutation_team
+  RemoveReflectTemplatePromptMutation_team$data
 > = (payload, {store}) => {
   const promptId = payload.getLinkedRecord('prompt').getValue('id')
   const teamId = payload.getLinkedRecord('prompt').getValue('teamId')

--- a/packages/client/mutations/RemoveReflectionMutation.ts
+++ b/packages/client/mutations/RemoveReflectionMutation.ts
@@ -5,7 +5,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordSourceSelectorProxy} from 'relay-runtime'
-import {RemoveReflectionMutation_meeting} from '~/__generated__/RemoveReflectionMutation_meeting.graphql'
+import {RemoveReflectionMutation_meeting$data} from '~/__generated__/RemoveReflectionMutation_meeting.graphql'
 import {BaseLocalHandlers, SharedUpdater, StandardMutation} from '../types/relayMutations'
 import safeRemoveNodeFromArray from '../utils/relay/safeRemoveNodeFromArray'
 import {RemoveReflectionMutation as TRemoveReflectionMutation} from '../__generated__/RemoveReflectionMutation.graphql'
@@ -35,7 +35,7 @@ const mutation = graphql`
   }
 `
 
-type Reflection = NonNullable<RemoveReflectionMutation_meeting['reflection']>
+type Reflection = NonNullable<RemoveReflectionMutation_meeting$data['reflection']>
 
 const removeReflectionAndEmptyGroup = (
   reflectionId: string,
@@ -55,10 +55,9 @@ const removeReflectionAndEmptyGroup = (
   }
 }
 
-export const removeReflectionMeetingUpdater: SharedUpdater<RemoveReflectionMutation_meeting> = (
-  payload,
-  {store}
-) => {
+export const removeReflectionMeetingUpdater: SharedUpdater<
+  RemoveReflectionMutation_meeting$data
+> = (payload, {store}) => {
   const meeting = payload.getLinkedRecord('meeting')
   const meetingId = meeting.getValue('id')
   const reflection = payload.getLinkedRecord('reflection')

--- a/packages/client/mutations/RemoveTeamMemberMutation.ts
+++ b/packages/client/mutations/RemoveTeamMemberMutation.ts
@@ -9,8 +9,8 @@ import {
 import onMeetingRoute from '../utils/onMeetingRoute'
 import onTeamRoute from '../utils/onTeamRoute'
 import {RemoveTeamMemberMutation as TRemoveTeamMemberMutation} from '../__generated__/RemoveTeamMemberMutation.graphql'
-import {RemoveTeamMemberMutation_task} from '../__generated__/RemoveTeamMemberMutation_task.graphql'
-import {RemoveTeamMemberMutation_team} from '../__generated__/RemoveTeamMemberMutation_team.graphql'
+import {RemoveTeamMemberMutation_task$data} from '../__generated__/RemoveTeamMemberMutation_task.graphql'
+import {RemoveTeamMemberMutation_team$data} from '../__generated__/RemoveTeamMemberMutation_team.graphql'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleRemoveTasks from './handlers/handleRemoveTasks'
 import handleRemoveTeamMembers from './handlers/handleRemoveTeamMembers'
@@ -92,7 +92,7 @@ const mutation = graphql`
 `
 
 export const removeTeamMemberTeamOnNext: OnNextHandler<
-  RemoveTeamMemberMutation_team,
+  RemoveTeamMemberMutation_team$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   if (!payload) return
@@ -128,7 +128,7 @@ export const removeTeamMemberTeamOnNext: OnNextHandler<
   }
 }
 
-export const removeTeamMemberTasksUpdater: SharedUpdater<RemoveTeamMemberMutation_task> = (
+export const removeTeamMemberTasksUpdater: SharedUpdater<RemoveTeamMemberMutation_task$data> = (
   payload,
   {store}
 ) => {
@@ -137,7 +137,7 @@ export const removeTeamMemberTasksUpdater: SharedUpdater<RemoveTeamMemberMutatio
   handleUpsertTasks(tasks as any, store)
 }
 
-export const removeTeamMemberTeamUpdater: SharedUpdater<RemoveTeamMemberMutation_team> = (
+export const removeTeamMemberTeamUpdater: SharedUpdater<RemoveTeamMemberMutation_team$data> = (
   payload,
   {atmosphere, store}
 ) => {

--- a/packages/client/mutations/SetOrgUserRoleMutation.ts
+++ b/packages/client/mutations/SetOrgUserRoleMutation.ts
@@ -7,7 +7,7 @@ import {
   StandardMutation
 } from '../types/relayMutations'
 import {SetOrgUserRoleMutation as TSetOrgUserRoleMutation} from '../__generated__/SetOrgUserRoleMutation.graphql'
-import {SetOrgUserRoleMutationAdded_organization} from '../__generated__/SetOrgUserRoleMutationAdded_organization.graphql'
+import {SetOrgUserRoleMutationAdded_organization$data} from '../__generated__/SetOrgUserRoleMutationAdded_organization.graphql'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleAddOrganization from './handlers/handleAddOrganization'
 
@@ -58,7 +58,7 @@ const mutation = graphql`
 `
 
 export const setOrgUserRoleAddedOrganizationOnNext: OnNextHandler<
-  SetOrgUserRoleMutationAdded_organization,
+  SetOrgUserRoleMutationAdded_organization$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   if (!payload || !payload.organization) return
@@ -77,7 +77,7 @@ export const setOrgUserRoleAddedOrganizationOnNext: OnNextHandler<
 }
 
 export const setOrgUserRoleAddedOrganizationUpdater: SharedUpdater<
-  SetOrgUserRoleMutationAdded_organization
+  SetOrgUserRoleMutationAdded_organization$data
 > = (payload, {atmosphere, store}) => {
   const {viewerId} = atmosphere
   const promotedUserId = payload

--- a/packages/client/mutations/SetStageTimerMutation.ts
+++ b/packages/client/mutations/SetStageTimerMutation.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {SetStageTimerMutation_meeting} from '~/__generated__/SetStageTimerMutation_meeting.graphql'
+import {SetStageTimerMutation_meeting$data} from '~/__generated__/SetStageTimerMutation_meeting.graphql'
 import {RelayDateHack, SharedUpdater, StandardMutation} from '../types/relayMutations'
 import LocalTimeHandler from '../utils/relay/LocalTimeHandler'
 import {SetStageTimerMutation as _SetStageTimerMutation} from '../__generated__/SetStageTimerMutation.graphql'
@@ -34,7 +34,7 @@ const mutation = graphql`
   }
 `
 
-export const setStageTimerMeetingUpdater: SharedUpdater<SetStageTimerMutation_meeting> = (
+export const setStageTimerMeetingUpdater: SharedUpdater<SetStageTimerMutation_meeting$data> = (
   payload,
   {store}
 ) => {
@@ -50,7 +50,7 @@ export const setStageTimerMeetingUpdater: SharedUpdater<SetStageTimerMutation_me
   })
 }
 
-type Stage = NonNullable<SetStageTimerMutation_meeting['stage']>
+type Stage = NonNullable<SetStageTimerMutation_meeting$data['stage']>
 type TSetStageTimerMutation = RelayDateHack<
   _SetStageTimerMutation,
   {scheduledEndTime?: Date | null}

--- a/packages/client/mutations/StartDraggingReflectionMutation.ts
+++ b/packages/client/mutations/StartDraggingReflectionMutation.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {matchPath} from 'react-router-dom'
 import {Disposable, RecordSourceProxy} from 'relay-runtime'
-import {StartDraggingReflectionMutation_meeting} from '~/__generated__/StartDraggingReflectionMutation_meeting.graphql'
+import {StartDraggingReflectionMutation_meeting$data} from '~/__generated__/StartDraggingReflectionMutation_meeting.graphql'
 import Atmosphere from '../Atmosphere'
 import {ClientRetroReflection} from '../types/clientSchema'
 import {LocalHandlers, SharedUpdater} from '../types/relayMutations'
@@ -48,7 +48,7 @@ interface UpdaterOptions {
 
 // used only by subscription
 export const startDraggingReflectionMeetingUpdater: SharedUpdater<
-  StartDraggingReflectionMutation_meeting
+  StartDraggingReflectionMutation_meeting$data
 > = (payload, {atmosphere, store}: UpdaterOptions) => {
   const meetingId = payload.getValue('meetingId')
   const {pathname} = window.location

--- a/packages/client/mutations/UpdateAgendaItemMutation.ts
+++ b/packages/client/mutations/UpdateAgendaItemMutation.ts
@@ -1,9 +1,9 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
-import {ActionMeeting_meeting} from '~/__generated__/ActionMeeting_meeting.graphql'
-import {AgendaItem_agendaItem} from '~/__generated__/AgendaItem_agendaItem.graphql'
-import {UpdateAgendaItemMutation_team} from '~/__generated__/UpdateAgendaItemMutation_team.graphql'
+import {ActionMeeting_meeting$data} from '~/__generated__/ActionMeeting_meeting.graphql'
+import {AgendaItem_agendaItem$data} from '~/__generated__/AgendaItem_agendaItem.graphql'
+import {UpdateAgendaItemMutation_team$data} from '~/__generated__/UpdateAgendaItemMutation_team.graphql'
 import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import updateProxyRecord from '../utils/relay/updateProxyRecord'
 import {UpdateAgendaItemMutation as TUpdateAgendaItemMutation} from '../__generated__/UpdateAgendaItemMutation.graphql'
@@ -37,7 +37,7 @@ const handleUpdateAgendaPhase = (
   meetingId: string | undefined | null
 ) => {
   if (meetingId) {
-    const meeting = store.get(meetingId) as RecordProxy<ActionMeeting_meeting>
+    const meeting = store.get(meetingId) as RecordProxy<ActionMeeting_meeting$data>
     if (!meeting) return
     const phases = meeting.getLinkedRecords('phases')
     const agendaPhase = phases.find((phase) =>
@@ -45,7 +45,7 @@ const handleUpdateAgendaPhase = (
     )
     if (!agendaPhase) return
     const getSortOrder = (stage: RecordProxy) => {
-      const agendaItem = stage.getLinkedRecord<AgendaItem_agendaItem>('agendaItem')
+      const agendaItem = stage.getLinkedRecord<AgendaItem_agendaItem$data>('agendaItem')
       if (!agendaItem) return 0
       return agendaItem.getValue('sortOrder')
     }
@@ -58,7 +58,7 @@ const handleUpdateAgendaPhase = (
   }
 }
 
-export const updateAgendaItemUpdater: SharedUpdater<UpdateAgendaItemMutation_team> = (
+export const updateAgendaItemUpdater: SharedUpdater<UpdateAgendaItemMutation_team$data> = (
   payload,
   {store}
 ) => {

--- a/packages/client/mutations/UpdateAzureDevOpsDimensionFieldMutation.ts
+++ b/packages/client/mutations/UpdateAzureDevOpsDimensionFieldMutation.ts
@@ -3,8 +3,8 @@ import {commitMutation} from 'react-relay'
 import {DiscriminateProxy} from '../types/generics'
 import {StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {AzureDevOpsFieldMenu_stage} from '../__generated__/AzureDevOpsFieldMenu_stage.graphql'
-import {PokerMeeting_meeting} from '../__generated__/PokerMeeting_meeting.graphql'
+import {AzureDevOpsFieldMenu_stage$data} from '../__generated__/AzureDevOpsFieldMenu_stage.graphql'
+import {PokerMeeting_meeting$data} from '../__generated__/PokerMeeting_meeting.graphql'
 import {UpdateAzureDevOpsDimensionFieldMutation as TUpdateAzureDevOpsDimensionFieldMutation} from '../__generated__/UpdateAzureDevOpsDimensionFieldMutation.graphql'
 
 graphql`
@@ -58,14 +58,14 @@ const UpdateAzureDevOpsDimensionFieldMutation: StandardMutation<
     variables,
     optimisticUpdater: (store) => {
       const {meetingId, instanceId, dimensionName, fieldName} = variables
-      const meeting = store.get<PokerMeeting_meeting>(meetingId)
+      const meeting = store.get<PokerMeeting_meeting$data>(meetingId)
       if (!meeting) {
         return
       }
       // handle meeting records
       const phases = meeting.getLinkedRecords('phases')
       const estimatePhase = phases.find((phase) => phase.getValue('phaseType') === 'ESTIMATE')!
-      const stages = estimatePhase.getLinkedRecords<AzureDevOpsFieldMenu_stage[]>('stages')
+      const stages = estimatePhase.getLinkedRecords<AzureDevOpsFieldMenu_stage$data[]>('stages')
       stages.forEach((stage) => {
         const dimensionRef = stage.getLinkedRecord('dimensionRef')
         const dimensionRefName = dimensionRef.getValue('name')

--- a/packages/client/mutations/UpdateGitHubDimensionFieldMutation.ts
+++ b/packages/client/mutations/UpdateGitHubDimensionFieldMutation.ts
@@ -3,7 +3,7 @@ import {commitMutation} from 'react-relay'
 import {DiscriminateProxy} from '../types/generics'
 import {StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {GitHubFieldMenu_stage} from '../__generated__/GitHubFieldMenu_stage.graphql'
+import {GitHubFieldMenu_stage$data} from '../__generated__/GitHubFieldMenu_stage.graphql'
 import {UpdateGitHubDimensionFieldMutation as TUpdateGitHubDimensionFieldMutation} from '../__generated__/UpdateGitHubDimensionFieldMutation.graphql'
 
 graphql`
@@ -61,7 +61,7 @@ const UpdateGitHubDimensionFieldMutation: StandardMutation<TUpdateGitHubDimensio
       const phases = meeting.getLinkedRecords('phases')
       if (!phases) return
       const estimatePhase = phases.find((phase) => phase.getValue('phaseType') === 'ESTIMATE')!
-      const stages = estimatePhase.getLinkedRecords<GitHubFieldMenu_stage[]>('stages')
+      const stages = estimatePhase.getLinkedRecords<GitHubFieldMenu_stage$data[]>('stages')
       stages.forEach((stage) => {
         const dimensionRef = stage.getLinkedRecord('dimensionRef')
         const dimensionRefName = dimensionRef.getValue('name')

--- a/packages/client/mutations/UpdateGitLabDimensionFieldMutation.ts
+++ b/packages/client/mutations/UpdateGitLabDimensionFieldMutation.ts
@@ -3,7 +3,7 @@ import {commitMutation} from 'react-relay'
 import {DiscriminateProxy} from '../types/generics'
 import {StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {GitLabFieldMenu_stage} from '../__generated__/GitLabFieldMenu_stage.graphql'
+import {GitLabFieldMenu_stage$data} from '../__generated__/GitLabFieldMenu_stage.graphql'
 import {UpdateGitLabDimensionFieldMutation as TUpdateGitLabDimensionFieldMutation} from '../__generated__/UpdateGitLabDimensionFieldMutation.graphql'
 
 graphql`
@@ -61,7 +61,7 @@ const UpdateGitLabDimensionFieldMutation: StandardMutation<TUpdateGitLabDimensio
       const phases = meeting.getLinkedRecords('phases')
       if (!phases) return
       const estimatePhase = phases.find((phase) => phase.getValue('phaseType') === 'ESTIMATE')!
-      const stages = estimatePhase.getLinkedRecords<GitLabFieldMenu_stage[]>('stages')
+      const stages = estimatePhase.getLinkedRecords<GitLabFieldMenu_stage$data[]>('stages')
 
       stages.forEach((stage) => {
         const dimensionRef = stage.getLinkedRecord('dimensionRef')

--- a/packages/client/mutations/UpdateJiraDimensionFieldMutation.ts
+++ b/packages/client/mutations/UpdateJiraDimensionFieldMutation.ts
@@ -3,8 +3,8 @@ import {commitMutation} from 'react-relay'
 import {DiscriminateProxy} from '../types/generics'
 import {StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {JiraFieldMenu_stage} from '../__generated__/JiraFieldMenu_stage.graphql'
-import {PokerMeeting_meeting} from '../__generated__/PokerMeeting_meeting.graphql'
+import {JiraFieldMenu_stage$data} from '../__generated__/JiraFieldMenu_stage.graphql'
+import {PokerMeeting_meeting$data} from '../__generated__/PokerMeeting_meeting.graphql'
 import {UpdateJiraDimensionFieldMutation as TUpdateJiraDimensionFieldMutation} from '../__generated__/UpdateJiraDimensionFieldMutation.graphql'
 
 graphql`
@@ -57,12 +57,12 @@ const UpdateJiraDimensionFieldMutation: StandardMutation<TUpdateJiraDimensionFie
     variables,
     optimisticUpdater: (store) => {
       const {meetingId, dimensionName, fieldId} = variables
-      const meeting = store.get<PokerMeeting_meeting>(meetingId)
+      const meeting = store.get<PokerMeeting_meeting$data>(meetingId)
       if (!meeting) return
       // handle meeting records
       const phases = meeting.getLinkedRecords('phases')
       const estimatePhase = phases.find((phase) => phase.getValue('phaseType') === 'ESTIMATE')!
-      const stages = estimatePhase.getLinkedRecords<JiraFieldMenu_stage[]>('stages')
+      const stages = estimatePhase.getLinkedRecords<JiraFieldMenu_stage$data[]>('stages')
       stages.forEach((stage) => {
         const dimensionRef = stage.getLinkedRecord('dimensionRef')
         const dimensionRefName = dimensionRef.getValue('name')

--- a/packages/client/mutations/UpdatePokerTemplateScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerTemplateScopeMutation.ts
@@ -12,7 +12,7 @@ import safeRemoveNodeFromConn from '../utils/relay/safeRemoveNodeFromConn'
 import {UpdatePokerTemplateScopeMutation as TUpdateTemplateScopeMutation} from '../__generated__/UpdatePokerTemplateScopeMutation.graphql'
 import {
   SharingScopeEnum,
-  UpdatePokerTemplateScopeMutation_organization
+  UpdatePokerTemplateScopeMutation_organization$data
 } from '../__generated__/UpdatePokerTemplateScopeMutation_organization.graphql'
 import getPokerTemplateOrgConn from './connections/getPokerTemplateOrgConn'
 
@@ -130,7 +130,7 @@ const handleUpdateTemplateScope = (
 }
 
 export const updateTemplateScopeOrganizationUpdater: SharedUpdater<
-  UpdatePokerTemplateScopeMutation_organization
+  UpdatePokerTemplateScopeMutation_organization$data
 > = (payload: any, {store}) => {
   const template = payload.getLinkedRecord('template')
   if (!template) return

--- a/packages/client/mutations/UpdateReflectTemplateScopeMutation.ts
+++ b/packages/client/mutations/UpdateReflectTemplateScopeMutation.ts
@@ -12,7 +12,7 @@ import safeRemoveNodeFromConn from '../utils/relay/safeRemoveNodeFromConn'
 import {UpdateReflectTemplateScopeMutation as TUpdateTemplateScopeMutation} from '../__generated__/UpdateReflectTemplateScopeMutation.graphql'
 import {
   SharingScopeEnum,
-  UpdateReflectTemplateScopeMutation_organization
+  UpdateReflectTemplateScopeMutation_organization$data
 } from '../__generated__/UpdateReflectTemplateScopeMutation_organization.graphql'
 import getReflectTemplateOrgConn from './connections/getReflectTemplateOrgConn'
 
@@ -130,7 +130,7 @@ const handleUpdateTemplateScope = (
 }
 
 export const updateTemplateScopeOrganizationUpdater: SharedUpdater<
-  UpdateReflectTemplateScopeMutation_organization
+  UpdateReflectTemplateScopeMutation_organization$data
 > = (payload: any, {store}) => {
   const template = payload.getLinkedRecord('template')
   if (!template) return

--- a/packages/client/mutations/UpdateTaskMutation.ts
+++ b/packages/client/mutations/UpdateTaskMutation.ts
@@ -12,7 +12,7 @@ import extractTextFromDraftString from '../utils/draftjs/extractTextFromDraftStr
 import getTagsFromEntityMap from '../utils/draftjs/getTagsFromEntityMap'
 import updateProxyRecord from '../utils/relay/updateProxyRecord'
 import {UpdateTaskMutation as TUpdateTaskMutation} from '../__generated__/UpdateTaskMutation.graphql'
-import {UpdateTaskMutation_task} from '../__generated__/UpdateTaskMutation_task.graphql'
+import {UpdateTaskMutation_task$data} from '../__generated__/UpdateTaskMutation_task.graphql'
 import handleAddNotifications from './handlers/handleAddNotifications'
 import handleRemoveTasks from './handlers/handleRemoveTasks'
 import handleUpsertTasks from './handlers/handleUpsertTasks'
@@ -54,15 +54,18 @@ const mutation = graphql`
   }
 `
 
-export const updateTaskTaskOnNext: OnNextHandler<UpdateTaskMutation_task, OnNextHistoryContext> = (
-  payload,
-  {atmosphere, history}
-) => {
+export const updateTaskTaskOnNext: OnNextHandler<
+  UpdateTaskMutation_task$data,
+  OnNextHistoryContext
+> = (payload, {atmosphere, history}) => {
   if (!payload || !payload.addedNotification) return
   popInvolvementToast(payload.addedNotification, {atmosphere, history})
 }
 
-export const updateTaskTaskUpdater: SharedUpdater<UpdateTaskMutation_task> = (payload, {store}) => {
+export const updateTaskTaskUpdater: SharedUpdater<UpdateTaskMutation_task$data> = (
+  payload,
+  {store}
+) => {
   const task = payload.getLinkedRecord('task')!
   handleUpsertTasks(task as any, store as any)
 

--- a/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
+++ b/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import clientTempId from '~/utils/relay/clientTempId'
-import {UpsertTeamPromptResponseMutation_meeting} from '~/__generated__/UpsertTeamPromptResponseMutation_meeting.graphql'
+import {UpsertTeamPromptResponseMutation_meeting$data} from '~/__generated__/UpsertTeamPromptResponseMutation_meeting.graphql'
 import {LocalHandlers, SharedUpdater, StandardMutation} from '../types/relayMutations'
 import {UpsertTeamPromptResponseMutation as TUpsertTeamPromptResponseMutation} from '../__generated__/UpsertTeamPromptResponseMutation.graphql'
 
@@ -41,7 +41,7 @@ const mutation = graphql`
 `
 
 export const upsertTeamPromptResponseUpdater: SharedUpdater<
-  UpsertTeamPromptResponseMutation_meeting
+  UpsertTeamPromptResponseMutation_meeting$data
 > = (payload, {store}) => {
   const newResponse = payload.getLinkedRecord('teamPromptResponse')
   const newResponseCreatorId = newResponse.getValue('userId')

--- a/packages/client/mutations/handlers/handleMovePokerTemplateDimension.ts
+++ b/packages/client/mutations/handlers/handleMovePokerTemplateDimension.ts
@@ -1,8 +1,8 @@
 import {RecordSourceProxy} from 'relay-runtime'
-import {PokerTemplateDetailsTemplate} from '~/__generated__/PokerTemplateDetailsTemplate.graphql'
+import {PokerTemplateDetailsTemplate$data} from '~/__generated__/PokerTemplateDetailsTemplate.graphql'
 
 const handleMovePokerTemplateDimension = (store: RecordSourceProxy, templateId: string) => {
-  const template = store.get<PokerTemplateDetailsTemplate>(templateId)
+  const template = store.get<PokerTemplateDetailsTemplate$data>(templateId)
   if (!template) return
   const dimensions = template.getLinkedRecords('dimensions')
   if (!Array.isArray(dimensions)) return

--- a/packages/client/mutations/handlers/handleRemoveAgendaItems.ts
+++ b/packages/client/mutations/handlers/handleRemoveAgendaItems.ts
@@ -1,6 +1,6 @@
 import {RecordSourceSelectorProxy} from 'relay-runtime'
-import {ActionMeeting_meeting} from '~/__generated__/ActionMeeting_meeting.graphql'
-import {AgendaItem_agendaItem} from '~/__generated__/AgendaItem_agendaItem.graphql'
+import {ActionMeeting_meeting$data} from '~/__generated__/ActionMeeting_meeting.graphql'
+import {AgendaItem_agendaItem$data} from '~/__generated__/AgendaItem_agendaItem.graphql'
 import safeRemoveNodeFromArray from '../../utils/relay/safeRemoveNodeFromArray'
 import pluralizeHandler from './pluralizeHandler'
 
@@ -9,14 +9,14 @@ const handleRemoveAgendaItem = (
   store: RecordSourceSelectorProxy,
   meetingId?: string
 ) => {
-  const agendaItem = store.get<AgendaItem_agendaItem>(agendaItemId)
+  const agendaItem = store.get<AgendaItem_agendaItem$data>(agendaItemId)
   if (!agendaItem) return
   const teamId = agendaItem.getValue('id').split('::')[0]
   if (!teamId) return
   const team = store.get(teamId)
   safeRemoveNodeFromArray(agendaItemId, team, 'agendaItems')
   if (meetingId) {
-    const meeting = store.get<ActionMeeting_meeting>(meetingId)
+    const meeting = store.get<ActionMeeting_meeting$data>(meetingId)
     if (!meeting) return
     const phases = meeting.getLinkedRecords('phases')
     if (!phases) return
@@ -26,7 +26,8 @@ const handleRemoveAgendaItem = (
     if (!stages) return
     const stageToRemove = stages.find(
       (stage) =>
-        stage.getLinkedRecord<AgendaItem_agendaItem>('agendaItem')?.getValue('id') === agendaItemId
+        stage.getLinkedRecord<AgendaItem_agendaItem$data>('agendaItem')?.getValue('id') ===
+        agendaItemId
     )
     if (!stageToRemove) return
     const stageId = stageToRemove.getValue('id') as string

--- a/packages/client/mutations/handlers/handleRemovePokerTemplate.ts
+++ b/packages/client/mutations/handlers/handleRemovePokerTemplate.ts
@@ -1,5 +1,5 @@
 import {RecordSourceSelectorProxy} from 'relay-runtime'
-import {PokerTemplateList_settings} from '~/__generated__/PokerTemplateList_settings.graphql'
+import {PokerTemplateList_settings$data} from '~/__generated__/PokerTemplateList_settings.graphql'
 import safeRemoveNodeFromArray from '../../utils/relay/safeRemoveNodeFromArray'
 import safeRemoveNodeFromConn from '../../utils/relay/safeRemoveNodeFromConn'
 import getPokerTemplateOrgConn from '../connections/getPokerTemplateOrgConn'
@@ -12,7 +12,7 @@ const handleRemovePokerTemplate = (
   store: RecordSourceSelectorProxy<any>
 ) => {
   const team = store.get(teamId)!
-  const settings = team.getLinkedRecord<PokerTemplateList_settings>('meetingSettings', {
+  const settings = team.getLinkedRecord<PokerTemplateList_settings$data>('meetingSettings', {
     meetingType: 'poker'
   })
   safeRemoveNodeFromArray(templateId, settings, 'teamTemplates')

--- a/packages/client/mutations/toasts/mapDiscussionMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapDiscussionMentionedToToast.ts
@@ -2,7 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {Snack} from '../../components/Snackbar'
 import {OnNextHistoryContext} from '../../types/relayMutations'
 import fromStageIdToUrl from '../../utils/meetings/fromStageIdToUrl'
-import {mapDiscussionMentionedToToast_notification} from '../../__generated__/mapDiscussionMentionedToToast_notification.graphql'
+import {mapDiscussionMentionedToToast_notification$data} from '../../__generated__/mapDiscussionMentionedToToast_notification.graphql'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
 graphql`
@@ -33,7 +33,7 @@ graphql`
 `
 
 const mapDiscussionMentionedToToast = (
-  notification: mapDiscussionMentionedToToast_notification,
+  notification: mapDiscussionMentionedToToast_notification$data,
   {history}: OnNextHistoryContext
 ): Snack | null => {
   if (!notification) return null

--- a/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseMentionedToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {Snack} from '../../components/Snackbar'
 import {OnNextHistoryContext} from '../../types/relayMutations'
-import {mapResponseMentionedToToast_notification} from '../../__generated__/mapResponseMentionedToToast_notification.graphql'
+import {mapResponseMentionedToToast_notification$data} from '../../__generated__/mapResponseMentionedToToast_notification.graphql'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
 graphql`
@@ -21,7 +21,7 @@ graphql`
 `
 
 const mapResponseMentionedToToast = (
-  notification: mapResponseMentionedToToast_notification,
+  notification: mapResponseMentionedToToast_notification$data,
   {history}: OnNextHistoryContext
 ): Snack | null => {
   if (!notification) return null

--- a/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {Snack} from '../../components/Snackbar'
 import {OnNextHistoryContext} from '../../types/relayMutations'
-import {mapResponseRepliedToToast_notification} from '../../__generated__/mapResponseRepliedToToast_notification.graphql'
+import {mapResponseRepliedToToast_notification$data} from '../../__generated__/mapResponseRepliedToToast_notification.graphql'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
 graphql`
@@ -22,7 +22,7 @@ graphql`
 `
 
 const mapResponseRepliedToToast = (
-  notification: mapResponseRepliedToToast_notification,
+  notification: mapResponseRepliedToToast_notification$data,
   {history}: OnNextHistoryContext
 ): Snack | null => {
   if (!notification) return null

--- a/packages/client/mutations/toasts/mapTeamsLimitExceededToToast.ts
+++ b/packages/client/mutations/toasts/mapTeamsLimitExceededToToast.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {Snack} from '../../components/Snackbar'
 import {OnNextHistoryContext} from '../../types/relayMutations'
-import {mapTeamsLimitExceededToToast_notification} from '../../__generated__/mapTeamsLimitExceededToToast_notification.graphql'
+import {mapTeamsLimitExceededToToast_notification$data} from '../../__generated__/mapTeamsLimitExceededToToast_notification.graphql'
 import SendClientSegmentEventMutation from '../SendClientSegmentEventMutation'
 import makeNotificationToastKey from './makeNotificationToastKey'
 import {Threshold} from '../../types/constEnums'
@@ -14,7 +14,7 @@ graphql`
 `
 
 const mapTeamsLimitExceededToToast = (
-  notification: mapTeamsLimitExceededToToast_notification,
+  notification: mapTeamsLimitExceededToToast_notification$data,
   {history, atmosphere}: OnNextHistoryContext
 ): Snack => {
   const {id: notificationId, orgName} = notification

--- a/packages/client/mutations/toasts/mapTeamsLimitReminderToToast.ts
+++ b/packages/client/mutations/toasts/mapTeamsLimitReminderToToast.ts
@@ -3,7 +3,7 @@ import {Snack} from '../../components/Snackbar'
 import {Threshold} from '../../types/constEnums'
 import {OnNextHistoryContext} from '../../types/relayMutations'
 import makeDateString from '../../utils/makeDateString'
-import {mapTeamsLimitReminderToToast_notification} from '../../__generated__/mapTeamsLimitReminderToToast_notification.graphql'
+import {mapTeamsLimitReminderToToast_notification$data} from '../../__generated__/mapTeamsLimitReminderToToast_notification.graphql'
 import SendClientSegmentEventMutation from '../SendClientSegmentEventMutation'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
@@ -17,7 +17,7 @@ graphql`
 `
 
 const mapTeamsLimitReminderToToast = (
-  notification: mapTeamsLimitReminderToToast_notification,
+  notification: mapTeamsLimitReminderToToast_notification$data,
   {history, atmosphere}: OnNextHistoryContext
 ): Snack => {
   const {id: notificationId, scheduledLockAt, orgId, orgName} = notification

--- a/packages/client/mutations/toasts/popInvolvementToast.ts
+++ b/packages/client/mutations/toasts/popInvolvementToast.ts
@@ -1,9 +1,9 @@
 import {matchPath} from 'react-router-dom'
 import {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
 import {MENTIONEE} from '../../utils/constants'
-import {TaskInvolves_notification} from '../../__generated__/TaskInvolves_notification.graphql'
+import {TaskInvolves_notification$data} from '../../__generated__/TaskInvolves_notification.graphql'
 
-const popInvolvementToast: OnNextHandler<TaskInvolves_notification, OnNextHistoryContext> = (
+const popInvolvementToast: OnNextHandler<TaskInvolves_notification$data, OnNextHistoryContext> = (
   notification,
   {atmosphere, history}
 ) => {

--- a/packages/client/mutations/toasts/popNotificationToast.ts
+++ b/packages/client/mutations/toasts/popNotificationToast.ts
@@ -3,7 +3,7 @@ import {Snack} from '../../components/Snackbar'
 import {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
 import {
   NotificationEnum,
-  popNotificationToast_notification
+  popNotificationToast_notification$data
 } from '../../__generated__/popNotificationToast_notification.graphql'
 import SetNotificationStatusMutation from '../SetNotificationStatusMutation'
 import mapDiscussionMentionedToToast from './mapDiscussionMentionedToToast'
@@ -37,7 +37,7 @@ graphql`
 `
 
 export const popNotificationToastOnNext: OnNextHandler<
-  popNotificationToast_notification,
+  popNotificationToast_notification$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   const {addedNotification} = payload

--- a/packages/client/mutations/toasts/updateNotificationToast.ts
+++ b/packages/client/mutations/toasts/updateNotificationToast.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
-import {updateNotificationToast_notification} from '../../__generated__/updateNotificationToast_notification.graphql'
+import {updateNotificationToast_notification$data} from '../../__generated__/updateNotificationToast_notification.graphql'
 import makeNotificationToastKey from './makeNotificationToastKey'
 
 graphql`
@@ -13,7 +13,7 @@ graphql`
 `
 
 export const updateNotificationToastOnNext: OnNextHandler<
-  updateNotificationToast_notification,
+  updateNotificationToast_notification$data,
   OnNextHistoryContext
 > = (payload, {atmosphere}) => {
   const {updatedNotification} = payload

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -5,9 +5,9 @@ import {RecordSourceSelectorProxy} from 'relay-runtime/lib/store/RelayStoreTypes
 import {archiveTimelineEventNotificationUpdater} from '~/mutations/ArchiveTimelineEventMutation'
 import {endCheckInNotificationUpdater} from '~/mutations/EndCheckInMutation'
 import {endRetrospectiveNotificationUpdater} from '~/mutations/EndRetrospectiveMutation'
-import {InvalidateSessionsMutation_notification} from '~/__generated__/InvalidateSessionsMutation_notification.graphql'
-import {NotificationSubscription_meetingStageTimeLimitEnd} from '~/__generated__/NotificationSubscription_meetingStageTimeLimitEnd.graphql'
-import {NotificationSubscription_paymentRejected} from '~/__generated__/NotificationSubscription_paymentRejected.graphql'
+import {InvalidateSessionsMutation_notification$data} from '~/__generated__/InvalidateSessionsMutation_notification.graphql'
+import {NotificationSubscription_meetingStageTimeLimitEnd$data} from '~/__generated__/NotificationSubscription_meetingStageTimeLimitEnd.graphql'
+import {NotificationSubscription_paymentRejected$data} from '~/__generated__/NotificationSubscription_paymentRejected.graphql'
 import Atmosphere from '../Atmosphere'
 import {acceptTeamInvitationNotificationUpdater} from '../mutations/AcceptTeamInvitationMutation'
 import {addOrgMutationNotificationUpdater} from '../mutations/AddOrgMutation'
@@ -154,7 +154,7 @@ type NextHandler = OnNextHandler<
 >
 
 const stripeFailPaymentNotificationOnNext: OnNextHandler<
-  NotificationSubscription_paymentRejected,
+  NotificationSubscription_paymentRejected$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   if (!payload) return
@@ -177,7 +177,7 @@ const stripeFailPaymentNotificationOnNext: OnNextHandler<
 
 // there's a bug in relay compiler that only shows part of the discriminated union
 const meetingStageTimeLimitOnNext: OnNextHandler<
-  NotificationSubscription_meetingStageTimeLimitEnd,
+  NotificationSubscription_meetingStageTimeLimitEnd$data,
   OnNextHistoryContext
 > = (payload: any, {atmosphere, history}) => {
   if (!payload || payload.__typename !== 'MeetingStageTimeLimitPayload') return
@@ -221,7 +221,7 @@ const authTokenNotificationOnNext: NextHandler = (payload, {atmosphere}) => {
 }
 
 const invalidateSessionsNotificationOnNext: OnNextHandler<
-  InvalidateSessionsMutation_notification,
+  InvalidateSessionsMutation_notification$data,
   OnNextHistoryContext
 > = (_payload, {atmosphere, history}) => {
   window.localStorage.removeItem(LocalStorageKey.APP_TOKEN_KEY)


### PR DESCRIPTION
# Description

Before v12, Relay generated typescript types for data fragments using the fragmentName as the export name.
Relay v12 generates typescript types for data fragments using both the naming convention `fragment` and `fragment$data`. 
Relay v13+ only exports `fragment$data`.

This PR updates all fragment references to use the `$data` suffix.

**There is no impact to runtime in this PR, just types!**

## Demo

 N/A

## Testing scenarios

CI/CD passes