### PR TITLE
chore(upgradeRelay): refactor response and variables from relay mutation types

### DIFF
--- a/packages/client/components/GitHubScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitHubScopingSearchFilterMenu.tsx
@@ -8,10 +8,7 @@ import useGetRepoContributions from '../hooks/useGetRepoContributions'
 import {MenuProps} from '../hooks/useMenu'
 import SearchQueryId from '../shared/gqlIds/SearchQueryId'
 import getReposFromQueryStr from '../utils/getReposFromQueryStr'
-import {
-  GitHubScopingSearchFilterMenuQuery,
-  GitHubScopingSearchFilterMenuQueryResponse
-} from '../__generated__/GitHubScopingSearchFilterMenuQuery.graphql'
+import {GitHubScopingSearchFilterMenuQuery} from '../__generated__/GitHubScopingSearchFilterMenuQuery.graphql'
 import Checkbox from './Checkbox'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
@@ -36,7 +33,9 @@ interface Props {
 }
 
 type GitHubSearchQuery = NonNullable<
-  NonNullable<GitHubScopingSearchFilterMenuQueryResponse['viewer']['meeting']>['githubSearchQuery']
+  NonNullable<
+    GitHubScopingSearchFilterMenuQuery['response']['viewer']['meeting']
+  >['githubSearchQuery']
 >
 
 const MAX_REPOS = 10

--- a/packages/client/components/GitLabScopingSearchFilterMenu.tsx
+++ b/packages/client/components/GitLabScopingSearchFilterMenu.tsx
@@ -8,10 +8,7 @@ import getNonNullEdges from '~/utils/getNonNullEdges'
 import useAtmosphere from '../hooks/useAtmosphere'
 import {MenuProps} from '../hooks/useMenu'
 import SearchQueryId from '../shared/gqlIds/SearchQueryId'
-import {
-  GitLabScopingSearchFilterMenuQuery,
-  GitLabScopingSearchFilterMenuQueryResponse
-} from '../__generated__/GitLabScopingSearchFilterMenuQuery.graphql'
+import {GitLabScopingSearchFilterMenuQuery} from '../__generated__/GitLabScopingSearchFilterMenuQuery.graphql'
 import Checkbox from './Checkbox'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
@@ -36,7 +33,9 @@ interface Props {
 }
 
 type GitLabSearchQuery = NonNullable<
-  NonNullable<GitLabScopingSearchFilterMenuQueryResponse['viewer']['meeting']>['gitlabSearchQuery']
+  NonNullable<
+    GitLabScopingSearchFilterMenuQuery['response']['viewer']['meeting']
+  >['gitlabSearchQuery']
 >
 
 const MAX_PROJECTS = 10

--- a/packages/client/components/NewAzureIssueInput.tsx
+++ b/packages/client/components/NewAzureIssueInput.tsx
@@ -17,7 +17,7 @@ import UpdatePokerScopeMutation from '../mutations/UpdatePokerScopeMutation'
 import {CompletedHandler} from '../types/relayMutations'
 import convertToTaskContent from '../utils/draftjs/convertToTaskContent'
 import Legitity from '../validation/Legitity'
-import {CreateTaskMutationResponse} from '../__generated__/CreateTaskMutation.graphql'
+import {CreateTaskMutation as TCreateTaskMutation} from '../__generated__/CreateTaskMutation.graphql'
 import Checkbox from './Checkbox'
 import NewAzureIssueMenu from './NewAzureIssueMenu'
 import PlainButton from './PlainButton/PlainButton'
@@ -188,7 +188,7 @@ const NewAzureIssueInput = (props: Props) => {
         serviceProjectHash
       }
     }
-    const handleCompleted: CompletedHandler<CreateTaskMutationResponse> = (res) => {
+    const handleCompleted: CompletedHandler<TCreateTaskMutation['response']> = (res) => {
       const integrationHash = res.createTask?.task?.integrationHash ?? null
       if (!integrationHash) return
       const pokerScopeVariables = {

--- a/packages/client/components/NewGitHubIssueInput.tsx
+++ b/packages/client/components/NewGitHubIssueInput.tsx
@@ -19,7 +19,7 @@ import GitHubIssueId from '../shared/gqlIds/GitHubIssueId'
 import {CompletedHandler} from '../types/relayMutations'
 import convertToTaskContent from '../utils/draftjs/convertToTaskContent'
 import Legitity from '../validation/Legitity'
-import {CreateTaskMutationResponse} from '../__generated__/CreateTaskMutation.graphql'
+import {CreateTaskMutation as TCreateTaskMutation} from '../__generated__/CreateTaskMutation.graphql'
 import Checkbox from './Checkbox'
 import NewGitHubIssueMenu from './NewGitHubIssueMenu'
 import PlainButton from './PlainButton/PlainButton'
@@ -188,7 +188,7 @@ const NewGitHubIssueInput = (props: Props) => {
         serviceProjectHash: selectedNameWithOwner
       }
     }
-    const handleCompleted: CompletedHandler<CreateTaskMutationResponse> = (res) => {
+    const handleCompleted: CompletedHandler<TCreateTaskMutation['response']> = (res) => {
       const integration = res.createTask?.task?.integration ?? null
       if (!integration) return
       if (integration.__typename !== '_xGitHubIssue') return

--- a/packages/client/components/NewGitLabIssueInput.tsx
+++ b/packages/client/components/NewGitLabIssueInput.tsx
@@ -17,7 +17,7 @@ import UpdatePokerScopeMutation from '../mutations/UpdatePokerScopeMutation'
 import {CompletedHandler} from '../types/relayMutations'
 import convertToTaskContent from '../utils/draftjs/convertToTaskContent'
 import Legitity from '../validation/Legitity'
-import {CreateTaskMutationResponse} from '../__generated__/CreateTaskMutation.graphql'
+import {CreateTaskMutation as TCreateTaskMutation} from '../__generated__/CreateTaskMutation.graphql'
 import Checkbox from './Checkbox'
 import NewGitLabIssueMenu from './NewGitLabIssueMenu'
 import PlainButton from './PlainButton/PlainButton'
@@ -202,7 +202,7 @@ const NewGitLabIssueInput = (props: Props) => {
         serviceProjectHash: selectedFullPath
       }
     }
-    const handleCompleted: CompletedHandler<CreateTaskMutationResponse> = (res) => {
+    const handleCompleted: CompletedHandler<TCreateTaskMutation['response']> = (res) => {
       const integrationHash = res.createTask?.task?.integrationHash ?? null
       if (!integrationHash) return
       const pokerScopeVariables = {

--- a/packages/client/components/ParabolScopingSearchResultItem.tsx
+++ b/packages/client/components/ParabolScopingSearchResultItem.tsx
@@ -16,7 +16,7 @@ import convertToTaskContent from '~/utils/draftjs/convertToTaskContent'
 import isAndroid from '~/utils/draftjs/isAndroid'
 import {Threshold} from '../types/constEnums'
 import {ParabolScopingSearchResultItem_task$key} from '../__generated__/ParabolScopingSearchResultItem_task.graphql'
-import {UpdatePokerScopeMutationVariables} from '../__generated__/UpdatePokerScopeMutation.graphql'
+import {UpdatePokerScopeMutation as TUpdatePokerScopeMutation} from '../__generated__/UpdatePokerScopeMutation.graphql'
 import {AreaEnum} from '../__generated__/UpdateTaskMutation.graphql'
 import Checkbox from './Checkbox'
 import TaskEditor from './TaskEditor/TaskEditor'
@@ -98,7 +98,7 @@ const ParabolScopingSearchResultItem = (props: Props) => {
           action: isSelected ? 'DELETE' : 'ADD'
         }
       ]
-    } as UpdatePokerScopeMutationVariables
+    } as TUpdatePokerScopeMutation['variables']
     UpdatePokerScopeMutation(atmosphere, variables, {
       onError,
       onCompleted,

--- a/packages/client/components/ScopingSearchResultItem.tsx
+++ b/packages/client/components/ScopingSearchResultItem.tsx
@@ -6,7 +6,7 @@ import UpdatePokerScopeMutation from '../mutations/UpdatePokerScopeMutation'
 import {PALETTE} from '../styles/paletteV3'
 import {Threshold} from '../types/constEnums'
 import isTempId from '../utils/relay/isTempId'
-import {UpdatePokerScopeMutationVariables} from '../__generated__/UpdatePokerScopeMutation.graphql'
+import {UpdatePokerScopeMutation as TUpdatePokerScopeMutation} from '../__generated__/UpdatePokerScopeMutation.graphql'
 import Checkbox from './Checkbox'
 import Ellipsis from './Ellipsis/Ellipsis'
 
@@ -78,7 +78,7 @@ const ScopingSearchResultItem = (props: Props) => {
           action: isSelected ? 'DELETE' : 'ADD'
         }
       ]
-    } as UpdatePokerScopeMutationVariables
+    } as TUpdatePokerScopeMutation['variables']
     UpdatePokerScopeMutation(atmosphere, variables, {onError, onCompleted, contents: [summary]})
     if (!isSelected) {
       // if they are adding an item, then their search criteria must be good, so persist it

--- a/packages/client/components/StageTimerModalEndTimeSlackToggle.tsx
+++ b/packages/client/components/StageTimerModalEndTimeSlackToggle.tsx
@@ -8,7 +8,7 @@ import NotificationErrorMessage from '../modules/notifications/components/Notifi
 import SetSlackNotificationMutation from '../mutations/SetSlackNotificationMutation'
 import {ICON_SIZE} from '../styles/typographyV2'
 import SlackClientManager from '../utils/SlackClientManager'
-import {SetSlackNotificationMutationVariables} from '../__generated__/SetSlackNotificationMutation.graphql'
+import {SetSlackNotificationMutation as TSetSlackNotificationMutation} from '../__generated__/SetSlackNotificationMutation.graphql'
 import {StageTimerModalEndTimeSlackToggle_facilitator$key} from '../__generated__/StageTimerModalEndTimeSlackToggle_facilitator.graphql'
 import Checkbox from './Checkbox'
 import PlainButton from './PlainButton/PlainButton'
@@ -111,7 +111,7 @@ const StageTimerModalEndTimeSlackToggle = (props: Props) => {
         slackChannelId: slackToggleActive ? null : defaultTeamChannelId,
         slackNotificationEvents: ['MEETING_STAGE_TIME_LIMIT_START'],
         teamId
-      } as SetSlackNotificationMutationVariables
+      } as TSetSlackNotificationMutation['variables']
       SetSlackNotificationMutation(atmosphere, variables, {onError, onCompleted})
     } else {
       SlackClientManager.openOAuth(atmosphere, teamId, mutationProps)

--- a/packages/client/components/TaskFooterIntegrateMenu.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenu.tsx
@@ -3,10 +3,7 @@ import React from 'react'
 import {PreloadedQuery, useFragment, usePreloadedQuery} from 'react-relay'
 import {MenuProps} from '../hooks/useMenu'
 import {MenuMutationProps} from '../hooks/useMutationProps'
-import {
-  TaskFooterIntegrateMenuQuery,
-  TaskFooterIntegrateMenuQueryResponse
-} from '../__generated__/TaskFooterIntegrateMenuQuery.graphql'
+import {TaskFooterIntegrateMenuQuery} from '../__generated__/TaskFooterIntegrateMenuQuery.graphql'
 import {TaskFooterIntegrateMenu_task$key} from '../__generated__/TaskFooterIntegrateMenu_task.graphql'
 import TaskFooterIntegrateMenuList from './TaskFooterIntegrateMenuList'
 import TaskFooterIntegrateMenuSignup from './TaskFooterIntegrateMenuSignup'
@@ -37,7 +34,7 @@ const makePlaceholder = (integrationLookup: IntegrationLookup) => {
 }
 
 type Integrations = NonNullable<
-  TaskFooterIntegrateMenuQueryResponse['viewer']['viewerTeamMember']
+  TaskFooterIntegrateMenuQuery['response']['viewer']['viewerTeamMember']
 >['integrations']
 
 const isIntegrated = (integrations: Integrations) => {

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -9,10 +9,7 @@ import {MenuProps} from '../hooks/useMenu'
 import {MenuMutationProps} from '../hooks/useMutationProps'
 import CreateTaskIntegrationMutation from '../mutations/CreateTaskIntegrationMutation'
 import {PALETTE} from '../styles/paletteV3'
-import {
-  TaskFooterIntegrateMenuListLocalQuery,
-  TaskFooterIntegrateMenuListLocalQueryResponse
-} from '../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
+import {TaskFooterIntegrateMenuListLocalQuery} from '../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
 import {TaskFooterIntegrateMenuList_task$key} from '../__generated__/TaskFooterIntegrateMenuList_task.graphql'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
@@ -36,7 +33,7 @@ const Label = styled('div')({
 
 type Item = NonNullable<
   NonNullable<
-    TaskFooterIntegrateMenuListLocalQueryResponse['viewer']['teamMember']
+    TaskFooterIntegrateMenuListLocalQuery['response']['viewer']['teamMember']
   >['repoIntegrations']['items']
 >[0]
 

--- a/packages/client/components/useSetTaskEstimate.ts
+++ b/packages/client/components/useSetTaskEstimate.ts
@@ -3,7 +3,7 @@ import useMutationProps from '../hooks/useMutationProps'
 import SetTaskEstimateMutation from '../mutations/SetTaskEstimateMutation'
 import {CompletedHandler} from '../types/relayMutations'
 import {
-  SetTaskEstimateMutationResponse,
+  SetTaskEstimateMutation as TSetTaskEstimateMutation,
   TaskEstimateInput
 } from '../__generated__/SetTaskEstimateMutation.graphql'
 
@@ -16,7 +16,10 @@ const useSetTaskEstimate = () => {
     stageId: string,
     onSuccess?: () => void
   ) => {
-    const handleCompleted: CompletedHandler = (res: SetTaskEstimateMutationResponse, errors) => {
+    const handleCompleted: CompletedHandler = (
+      res: TSetTaskEstimateMutation['response'],
+      errors
+    ) => {
       onCompleted(res as any, errors)
       const {setTaskEstimate} = res
       const {error} = setTaskEstimate

--- a/packages/client/hooks/useDraggableReflectionCard.tsx
+++ b/packages/client/hooks/useDraggableReflectionCard.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useEffect, useRef, useState} from 'react'
 import {commitLocalUpdate} from 'relay-runtime'
 import SendClientSegmentEventMutation from '~/mutations/SendClientSegmentEventMutation'
-import {DraggableReflectionCard_meeting} from '~/__generated__/DraggableReflectionCard_meeting.graphql'
+import {DraggableReflectionCard_meeting$data} from '~/__generated__/DraggableReflectionCard_meeting.graphql'
 import {DragReflectionDropTargetTypeEnum} from '~/__generated__/EndDraggingReflectionMutation_meeting.graphql'
 import {PortalContext, SetPortal} from '../components/AtmosphereProvider/PortalProvider'
 import {SwipeColumn} from '../components/GroupingKanban'
@@ -35,7 +35,7 @@ const windowDims = {
 
 // Adds the remotely dragged card substitute, does not hide the local card or collapse anything
 const useRemotelyDraggedCard = (
-  meeting: DraggableReflectionCard_meeting,
+  meeting: DraggableReflectionCard_meeting$data,
   reflection: DraggableReflectionCard_reflection$data,
   drag: ReflectionDragState,
   staticIdx: number
@@ -232,7 +232,7 @@ const useDragAndDrop = (
   drag: ReflectionDragState,
   reflection: DraggableReflectionCard_reflection$data,
   staticIdx: number,
-  meeting: DraggableReflectionCard_meeting,
+  meeting: DraggableReflectionCard_meeting$data,
   teamId: string,
   reflectionCount: number,
   swipeColumn?: SwipeColumn
@@ -437,7 +437,7 @@ const useCollapsePlaceholder = (
 }
 
 const useDraggableReflectionCard = (
-  meeting: DraggableReflectionCard_meeting,
+  meeting: DraggableReflectionCard_meeting$data,
   reflection: DraggableReflectionCard_reflection$data,
   drag: ReflectionDragState,
   staticIdx: number,

--- a/packages/client/hooks/useGotoStageId.ts
+++ b/packages/client/hooks/useGotoStageId.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useCallback} from 'react'
 import {readInlineData} from 'relay-runtime'
-import {NavigateMeetingMutationVariables} from '~/__generated__/NavigateMeetingMutation.graphql'
+import {NavigateMeetingMutation as TNavigateMeetingMutation} from '~/__generated__/NavigateMeetingMutation.graphql'
 import {useGotoStageId_meeting$key} from '~/__generated__/useGotoStageId_meeting.graphql'
 import {demoTeamId} from '../modules/demo/initDB'
 import LocalAtmosphere from '../modules/demo/LocalAtmosphere'
@@ -66,7 +66,7 @@ const useGotoStageId = (meetingRef: useGotoStageId_meeting$key) => {
         const variables = {
           meetingId,
           facilitatorStageId: stageId
-        } as NavigateMeetingMutationVariables
+        } as TNavigateMeetingMutation['variables']
         if (!isComplete && isForwardProgress(phases, facilitatorStageId, stageId)) {
           variables.completedStageId = facilitatorStageId
         }

--- a/packages/client/hooks/useGroupMatrix.ts
+++ b/packages/client/hooks/useGroupMatrix.ts
@@ -1,11 +1,11 @@
 import {RefObject, useEffect, useState} from 'react'
 import {MAX_SPOTLIGHT_COLUMNS} from '~/utils/constants'
 import {ElementWidth} from '../types/constEnums'
-import {SpotlightResultsQueryResponse} from './../__generated__/SpotlightResultsQuery.graphql'
+import {SpotlightResultsQuery} from './../__generated__/SpotlightResultsQuery.graphql'
 import useInitialRender from './useInitialRender'
 import useResizeObserver from './useResizeObserver'
 
-type Group = SpotlightResultsQueryResponse['viewer']['similarReflectionGroups'][0]
+type Group = SpotlightResultsQuery['response']['viewer']['similarReflectionGroups'][0]
 
 const useGroupMatrix = (
   resultsGroups: readonly Group[],

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsPanel.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsPanel.tsx
@@ -19,7 +19,7 @@ import UpdateIntegrationProviderMutation from '../../../../mutations/UpdateInteg
 import {PALETTE} from '../../../../styles/paletteV3'
 import {Layout} from '../../../../types/constEnums'
 import Legitity from '../../../../validation/Legitity'
-import {AddIntegrationProviderMutationResponse} from '../../../../__generated__/AddIntegrationProviderMutation.graphql'
+import {AddIntegrationProviderMutation as TAddIntegrationProviderMutation} from '../../../../__generated__/AddIntegrationProviderMutation.graphql'
 
 interface Props {
   viewerRef: MSTeamsPanel_viewer$key
@@ -139,7 +139,7 @@ const MSTeamsPanel = (props: Props) => {
         {onError, onCompleted}
       )
     } else {
-      const handleCompleted = (res: AddIntegrationProviderMutationResponse) => {
+      const handleCompleted = (res: TAddIntegrationProviderMutation['response']) => {
         const {addIntegrationProvider} = res
         const {provider} = addIntegrationProvider
         if (!provider) return

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
@@ -20,7 +20,7 @@ import UpdateIntegrationProviderMutation from '../../../../mutations/UpdateInteg
 import {PALETTE} from '../../../../styles/paletteV3'
 import {Layout} from '../../../../types/constEnums'
 import Legitity from '../../../../validation/Legitity'
-import {AddIntegrationProviderMutationResponse} from '../../../../__generated__/AddIntegrationProviderMutation.graphql'
+import {AddIntegrationProviderMutation as TAddIntegrationProviderMutation} from '../../../../__generated__/AddIntegrationProviderMutation.graphql'
 
 interface Props {
   viewerRef: MattermostPanel_viewer$key
@@ -153,7 +153,7 @@ const MattermostPanel = (props: Props) => {
         {onError, onCompleted}
       )
     } else {
-      const handleCompleted = (res: AddIntegrationProviderMutationResponse) => {
+      const handleCompleted = (res: TAddIntegrationProviderMutation['response']) => {
         const {addIntegrationProvider} = res
         const {provider} = addIntegrationProvider
         if (!provider) return

--- a/packages/client/modules/userDashboard/components/OrgBilling/PaymentDetails.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/PaymentDetails.tsx
@@ -1,18 +1,18 @@
 import styled from '@emotion/styled'
 import {Divider} from '@mui/material'
+import {Elements} from '@stripe/react-stripe-js'
+import {loadStripe} from '@stripe/stripe-js'
 import React, {useEffect, useState} from 'react'
-import BillingForm from './BillingForm'
 import Panel from '../../../../components/Panel/Panel'
 import Row from '../../../../components/Row/Row'
-import {PALETTE} from '../../../../styles/paletteV3'
-import {loadStripe} from '@stripe/stripe-js'
-import {Elements} from '@stripe/react-stripe-js'
-import CreatePaymentIntentMutation from '../../../../mutations/CreatePaymentIntentMutation'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
-import {CreatePaymentIntentMutationResponse} from '../../../../__generated__/CreatePaymentIntentMutation.graphql'
-import {CompletedHandler} from '../../../../types/relayMutations'
+import CreatePaymentIntentMutation from '../../../../mutations/CreatePaymentIntentMutation'
+import {PALETTE} from '../../../../styles/paletteV3'
 import {ElementWidth} from '../../../../types/constEnums'
+import {CompletedHandler} from '../../../../types/relayMutations'
+import {CreatePaymentIntentMutation as TCreatePaymentIntentMutation} from '../../../../__generated__/CreatePaymentIntentMutation.graphql'
+import BillingForm from './BillingForm'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH
@@ -131,7 +131,7 @@ const PaymentDetails = () => {
   const {onError} = useMutationProps()
 
   useEffect(() => {
-    const handleCompleted: CompletedHandler<CreatePaymentIntentMutationResponse> = (res) => {
+    const handleCompleted: CompletedHandler<TCreatePaymentIntentMutation['response']> = (res) => {
       const {createPaymentIntent} = res
       const {clientSecret} = createPaymentIntent
       if (clientSecret) {

--- a/packages/client/modules/userDashboard/components/UserSettingsForm/UserSettingsForm.tsx
+++ b/packages/client/modules/userDashboard/components/UserSettingsForm/UserSettingsForm.tsx
@@ -13,7 +13,7 @@ import defaultUserAvatar from '../../../../styles/theme/images/avatar-user.svg'
 import {Breakpoint, Layout} from '../../../../types/constEnums'
 import withForm, {WithFormProps} from '../../../../utils/relay/withForm'
 import Legitity from '../../../../validation/Legitity'
-import {UserProfileQueryResponse} from '../../../../__generated__/UserProfileQuery.graphql'
+import {UserProfileQuery} from '../../../../__generated__/UserProfileQuery.graphql'
 import NotificationErrorMessage from '../../../notifications/components/NotificationErrorMessage'
 
 const SettingsForm = styled('form')({
@@ -62,7 +62,7 @@ const UserAvatarInput = lazy(
 )
 
 interface UserSettingsProps extends WithFormProps<'preferredName'> {
-  viewer: UserProfileQueryResponse['viewer']
+  viewer: UserProfileQuery['response']['viewer']
 }
 
 function UserSettings(props: UserSettingsProps) {

--- a/packages/client/mutations/AddReactjiToReactableMutation.ts
+++ b/packages/client/mutations/AddReactjiToReactableMutation.ts
@@ -2,10 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import createProxyRecord from '~/utils/relay/createProxyRecord'
 import {StandardMutation} from '../types/relayMutations'
-import {
-  AddReactjiToReactableMutation as TAddReactjiToReactableMutation,
-  AddReactjiToReactableMutationResponse
-} from '../__generated__/AddReactjiToReactableMutation.graphql'
+import {AddReactjiToReactableMutation as TAddReactjiToReactableMutation} from '../__generated__/AddReactjiToReactableMutation.graphql'
 
 graphql`
   fragment AddReactjiToReactableMutation_meeting on AddReactjiToReactableSuccess {
@@ -46,7 +43,7 @@ const mutation = graphql`
 `
 
 type Reactable = NonNullable<
-  AddReactjiToReactableMutationResponse['addReactjiToReactable']['reactable']
+  TAddReactjiToReactableMutation['response']['addReactjiToReactable']['reactable']
 >
 
 const AddReactjiToReactableMutation: StandardMutation<TAddReactjiToReactableMutation> = (

--- a/packages/client/mutations/ChangeTaskTeamMutation.ts
+++ b/packages/client/mutations/ChangeTaskTeamMutation.ts
@@ -5,10 +5,7 @@ import {SharedUpdater, StandardMutation} from '../types/relayMutations'
 import getBaseRecord from '../utils/relay/getBaseRecord'
 import safeRemoveNodeFromUnknownConn from '../utils/relay/safeRemoveNodeFromUnknownConn'
 import updateProxyRecord from '../utils/relay/updateProxyRecord'
-import {
-  ChangeTaskTeamMutation as TChangeTaskTeamMutation,
-  ChangeTaskTeamMutationResponse
-} from '../__generated__/ChangeTaskTeamMutation.graphql'
+import {ChangeTaskTeamMutation as TChangeTaskTeamMutation} from '../__generated__/ChangeTaskTeamMutation.graphql'
 import handleUpsertTasks from './handlers/handleUpsertTasks'
 
 graphql`
@@ -35,7 +32,7 @@ const mutation = graphql`
   }
 `
 
-type Task = NonNullable<NonNullable<ChangeTaskTeamMutationResponse['changeTaskTeam']>['task']>
+type Task = NonNullable<NonNullable<TChangeTaskTeamMutation['response']['changeTaskTeam']>['task']>
 
 export const changeTaskTeamTaskUpdater: SharedUpdater<ChangeTaskTeamMutation_task$data> = (
   payload,

--- a/packages/client/mutations/CreateTaskIntegrationMutation.ts
+++ b/packages/client/mutations/CreateTaskIntegrationMutation.ts
@@ -7,10 +7,7 @@ import {StandardMutation} from '../types/relayMutations'
 import splitDraftContent from '../utils/draftjs/splitDraftContent'
 import getMeetingPathParams from '../utils/meetings/getMeetingPathParams'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {
-  CreateTaskIntegrationMutation as TCreateTaskIntegrationMutation,
-  CreateTaskIntegrationMutationVariables
-} from '../__generated__/CreateTaskIntegrationMutation.graphql'
+import {CreateTaskIntegrationMutation as TCreateTaskIntegrationMutation} from '../__generated__/CreateTaskIntegrationMutation.graphql'
 import SendClientSegmentEventMutation from './SendClientSegmentEventMutation'
 
 graphql`
@@ -93,7 +90,7 @@ const mutation = graphql`
 
 const jiraTaskIntegrationOptimisticUpdater = (
   store: RecordSourceSelectorProxy,
-  variables: CreateTaskIntegrationMutationVariables
+  variables: TCreateTaskIntegrationMutation['variables']
 ) => {
   const {integrationRepoId, taskId} = variables
   const {cloudId, projectKey} = JiraProjectId.split(integrationRepoId)
@@ -119,7 +116,7 @@ const jiraTaskIntegrationOptimisticUpdater = (
 
 const githubTaskIntegrationOptimisitcUpdater = (
   store: RecordSourceSelectorProxy,
-  variables: CreateTaskIntegrationMutationVariables
+  variables: TCreateTaskIntegrationMutation['variables']
 ) => {
   const {integrationRepoId, taskId} = variables
   const now = new Date()
@@ -145,7 +142,7 @@ const githubTaskIntegrationOptimisitcUpdater = (
 
 const gitlabTaskIntegrationOptimisitcUpdater = (
   store: RecordSourceSelectorProxy,
-  variables: CreateTaskIntegrationMutationVariables
+  variables: TCreateTaskIntegrationMutation['variables']
 ) => {
   const {integrationRepoId: fullPath, taskId} = variables
   const now = new Date()
@@ -174,7 +171,7 @@ const gitlabTaskIntegrationOptimisitcUpdater = (
 
 const jiraServerTaskIntegrationOptimisticUpdater = (
   store: RecordSourceSelectorProxy,
-  variables: CreateTaskIntegrationMutationVariables
+  variables: TCreateTaskIntegrationMutation['variables']
 ) => {
   const {taskId} = variables
   const now = new Date()
@@ -196,7 +193,7 @@ const jiraServerTaskIntegrationOptimisticUpdater = (
 
 const azureTaskIntegrationOptimisitcUpdater = (
   store: RecordSourceSelectorProxy,
-  variables: CreateTaskIntegrationMutationVariables
+  variables: TCreateTaskIntegrationMutation['variables']
 ) => {
   const {integrationRepoId: teamProject, taskId} = variables
   const now = new Date()

--- a/packages/client/mutations/FlagReadyToAdvanceMutation.ts
+++ b/packages/client/mutations/FlagReadyToAdvanceMutation.ts
@@ -1,10 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SimpleMutation} from '../types/relayMutations'
-import {
-  FlagReadyToAdvanceMutation as TFlagReadyToAdvanceMutation,
-  FlagReadyToAdvanceMutationResponse
-} from '../__generated__/FlagReadyToAdvanceMutation.graphql'
+import {FlagReadyToAdvanceMutation as TFlagReadyToAdvanceMutation} from '../__generated__/FlagReadyToAdvanceMutation.graphql'
 
 graphql`
   fragment FlagReadyToAdvanceMutation_meeting on FlagReadyToAdvanceSuccess {
@@ -29,7 +26,7 @@ const mutation = graphql`
 `
 
 type Stage = NonNullable<
-  NonNullable<FlagReadyToAdvanceMutationResponse['flagReadyToAdvance']>['stage']
+  NonNullable<TFlagReadyToAdvanceMutation['response']['flagReadyToAdvance']>['stage']
 >
 
 const FlagReadyToAdvanceMutation: SimpleMutation<TFlagReadyToAdvanceMutation> = (

--- a/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
+++ b/packages/client/mutations/ResetRetroMeetingToGroupStageMutation.ts
@@ -2,10 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import Atmosphere from '~/Atmosphere'
 import {SharedUpdater, SimpleMutation} from '../types/relayMutations'
-import {
-  ResetRetroMeetingToGroupStageMutation as TResetRetroMeetingToGroupStageMutation,
-  ResetRetroMeetingToGroupStageMutationVariables
-} from '../__generated__/ResetRetroMeetingToGroupStageMutation.graphql'
+import {ResetRetroMeetingToGroupStageMutation as TResetRetroMeetingToGroupStageMutation} from '../__generated__/ResetRetroMeetingToGroupStageMutation.graphql'
 import getDiscussionThreadConn from './connections/getDiscussionThreadConn'
 
 graphql`
@@ -68,7 +65,7 @@ export const resetRetroMeetingToGroupStageUpdater: SharedUpdater<
 
 const ResetRetroMeetingToGroupStageMutation: SimpleMutation<
   TResetRetroMeetingToGroupStageMutation
-> = (atmosphere: Atmosphere, variables: ResetRetroMeetingToGroupStageMutationVariables) => {
+> = (atmosphere: Atmosphere, variables: TResetRetroMeetingToGroupStageMutation['variables']) => {
   return commitMutation<TResetRetroMeetingToGroupStageMutation>(atmosphere, {
     mutation,
     updater: (store) => {

--- a/packages/client/mutations/SelectTemplateMutation.ts
+++ b/packages/client/mutations/SelectTemplateMutation.ts
@@ -1,10 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {SimpleMutation} from '../types/relayMutations'
-import {
-  SelectTemplateMutation as TSelectTemplateMutation,
-  SelectTemplateMutationResponse
-} from '../__generated__/SelectTemplateMutation.graphql'
+import {SelectTemplateMutation as TSelectTemplateMutation} from '../__generated__/SelectTemplateMutation.graphql'
 
 graphql`
   fragment SelectTemplateMutation_team on SelectTemplatePayload {
@@ -33,7 +30,7 @@ const mutation = graphql`
   }
 `
 
-type SelectTemplate = NonNullable<SelectTemplateMutationResponse['selectTemplate']>
+type SelectTemplate = NonNullable<TSelectTemplateMutation['response']['selectTemplate']>
 
 const SelectTemplateMutation: SimpleMutation<TSelectTemplateMutation> = (atmosphere, variables) => {
   return commitMutation(atmosphere, {

--- a/packages/client/mutations/SetMeetingSettingsMutation.ts
+++ b/packages/client/mutations/SetMeetingSettingsMutation.ts
@@ -1,10 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {StandardMutation} from '../types/relayMutations'
-import {
-  SetMeetingSettingsMutation as TSetMeetingSettingsMutation,
-  SetMeetingSettingsMutationResponse
-} from '../__generated__/SetMeetingSettingsMutation.graphql'
+import {SetMeetingSettingsMutation as TSetMeetingSettingsMutation} from '../__generated__/SetMeetingSettingsMutation.graphql'
 
 graphql`
   fragment SetMeetingSettingsMutation_team on SetMeetingSettingsPayload {
@@ -33,7 +30,9 @@ const mutation = graphql`
   }
 `
 
-type Settings = NonNullable<SetMeetingSettingsMutationResponse['setMeetingSettings']['settings']>
+type Settings = NonNullable<
+  TSetMeetingSettingsMutation['response']['setMeetingSettings']['settings']
+>
 
 const SetMeetingSettingsMutation: StandardMutation<TSetMeetingSettingsMutation> = (
   atmosphere,

--- a/packages/client/mutations/SetTaskHighlightMutation.ts
+++ b/packages/client/mutations/SetTaskHighlightMutation.ts
@@ -2,10 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import Atmosphere from '../Atmosphere'
 import {SimpleMutation} from '../types/relayMutations'
-import {
-  SetTaskHighlightMutation as TSetTaskHighlightMutation,
-  SetTaskHighlightMutationVariables
-} from '../__generated__/SetTaskHighlightMutation.graphql'
+import {SetTaskHighlightMutation as TSetTaskHighlightMutation} from '../__generated__/SetTaskHighlightMutation.graphql'
 
 graphql`
   fragment SetTaskHighlightMutation_meeting on SetTaskHighlightSuccess {
@@ -27,7 +24,7 @@ const mutation = graphql`
 
 const SetTaskHighlightMutation: SimpleMutation<TSetTaskHighlightMutation> = (
   atmosphere: Atmosphere,
-  variables: SetTaskHighlightMutationVariables
+  variables: TSetTaskHighlightMutation['variables']
 ) =>
   commitMutation<TSetTaskHighlightMutation>(atmosphere, {
     mutation,

--- a/packages/client/mutations/StartDraggingReflectionMutation.ts
+++ b/packages/client/mutations/StartDraggingReflectionMutation.ts
@@ -6,10 +6,7 @@ import {StartDraggingReflectionMutation_meeting$data} from '~/__generated__/Star
 import Atmosphere from '../Atmosphere'
 import {ClientRetroReflection} from '../types/clientSchema'
 import {LocalHandlers, SharedUpdater} from '../types/relayMutations'
-import {
-  StartDraggingReflectionMutation as TStartDraggingReflectionMutation,
-  StartDraggingReflectionMutationVariables
-} from '../__generated__/StartDraggingReflectionMutation.graphql'
+import {StartDraggingReflectionMutation as TStartDraggingReflectionMutation} from '../__generated__/StartDraggingReflectionMutation.graphql'
 
 graphql`
   fragment StartDraggingReflectionMutation_meeting on StartDraggingReflectionPayload {
@@ -110,7 +107,7 @@ export const startDraggingReflectionMeetingUpdater: SharedUpdater<
 
 const StartDraggingReflectionMutation = (
   atmosphere: Atmosphere,
-  variables: StartDraggingReflectionMutationVariables,
+  variables: TStartDraggingReflectionMutation['variables'],
   {onError, onCompleted}: LocalHandlers = {}
 ): Disposable => {
   return commitMutation<TStartDraggingReflectionMutation>(atmosphere, {

--- a/packages/client/mutations/UpdateCommentContentMutation.ts
+++ b/packages/client/mutations/UpdateCommentContentMutation.ts
@@ -1,10 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {StandardMutation} from '../types/relayMutations'
-import {
-  UpdateCommentContentMutation as TUpdateCommentContentMutation,
-  UpdateCommentContentMutationResponse
-} from '../__generated__/UpdateCommentContentMutation.graphql'
+import {UpdateCommentContentMutation as TUpdateCommentContentMutation} from '../__generated__/UpdateCommentContentMutation.graphql'
 
 graphql`
   fragment UpdateCommentContentMutation_meeting on UpdateCommentContentSuccess {
@@ -29,7 +26,9 @@ const mutation = graphql`
   }
 `
 
-type Comment = NonNullable<UpdateCommentContentMutationResponse['updateCommentContent']>['comment']
+type Comment = NonNullable<
+  TUpdateCommentContentMutation['response']['updateCommentContent']
+>['comment']
 
 const UpdateCommentContentMutation: StandardMutation<TUpdateCommentContentMutation> = (
   atmosphere,

--- a/packages/client/mutations/UpdateDragLocationMutation.ts
+++ b/packages/client/mutations/UpdateDragLocationMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {getRequest} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
-import {UpdateDragLocationMutationVariables} from '../__generated__/UpdateDragLocationMutation.graphql'
+import {UpdateDragLocationMutation} from '../__generated__/UpdateDragLocationMutation.graphql'
 
 graphql`
   fragment UpdateDragLocationMutation_meeting on UpdateDragLocationPayload {
@@ -26,7 +26,7 @@ const mutation = graphql`
 
 const UpdateDragLocationMutation = (
   atmosphere: Atmosphere,
-  variables: UpdateDragLocationMutationVariables
+  variables: UpdateDragLocationMutation['variables']
 ) => {
   const request = getRequest(mutation).params
   atmosphere.handleFetchPromise(request, variables)

--- a/packages/client/mutations/UpdateDragLocationMutation.ts
+++ b/packages/client/mutations/UpdateDragLocationMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {getRequest} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
-import {UpdateDragLocationMutation} from '../__generated__/UpdateDragLocationMutation.graphql'
+import {UpdateDragLocationMutation as TUpdateDragLocationMutation} from '../__generated__/UpdateDragLocationMutation.graphql'
 
 graphql`
   fragment UpdateDragLocationMutation_meeting on UpdateDragLocationPayload {
@@ -26,7 +26,7 @@ const mutation = graphql`
 
 const UpdateDragLocationMutation = (
   atmosphere: Atmosphere,
-  variables: UpdateDragLocationMutation['variables']
+  variables: TUpdateDragLocationMutation['variables']
 ) => {
   const request = getRequest(mutation).params
   atmosphere.handleFetchPromise(request, variables)

--- a/packages/client/mutations/UpdateNewCheckInQuestionMutation.ts
+++ b/packages/client/mutations/UpdateNewCheckInQuestionMutation.ts
@@ -2,10 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {RecordProxy} from 'relay-runtime'
 import {SimpleMutation} from '../types/relayMutations'
-import {
-  UpdateNewCheckInQuestionMutation as TUpdateNewCheckInQuestionMutation,
-  UpdateNewCheckInQuestionMutationResponse
-} from '../__generated__/UpdateNewCheckInQuestionMutation.graphql'
+import {UpdateNewCheckInQuestionMutation as TUpdateNewCheckInQuestionMutation} from '../__generated__/UpdateNewCheckInQuestionMutation.graphql'
 graphql`
   fragment UpdateNewCheckInQuestionMutation_meeting on UpdateNewCheckInQuestionPayload {
     meeting {
@@ -30,7 +27,7 @@ const mutation = graphql`
 `
 
 type CheckInPhase = NonNullable<
-  NonNullable<UpdateNewCheckInQuestionMutationResponse['updateNewCheckInQuestion']>['meeting']
+  NonNullable<TUpdateNewCheckInQuestionMutation['response']['updateNewCheckInQuestion']>['meeting']
 >['phases'][0]
 
 const UpdateNewCheckInQuestionMutation: SimpleMutation<TUpdateNewCheckInQuestionMutation> = (

--- a/packages/client/mutations/UpdateOrgMutation.ts
+++ b/packages/client/mutations/UpdateOrgMutation.ts
@@ -3,10 +3,7 @@ import {commitMutation} from 'react-relay'
 import {Disposable} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
 import {LocalHandlers} from '../types/relayMutations'
-import {
-  UpdateOrgMutation as TUpdateOrgMutation,
-  UpdateOrgMutationVariables
-} from '../__generated__/UpdateOrgMutation.graphql'
+import {UpdateOrgMutation as TUpdateOrgMutation} from '../__generated__/UpdateOrgMutation.graphql'
 graphql`
   fragment UpdateOrgMutation_organization on UpdateOrgPayload {
     organization {
@@ -29,7 +26,7 @@ const mutation = graphql`
 
 const UpdateOrgMutation = (
   atmosphere: Atmosphere,
-  variables: UpdateOrgMutationVariables,
+  variables: TUpdateOrgMutation['variables'],
   {onCompleted, onError}: LocalHandlers
 ): Disposable => {
   return commitMutation<TUpdateOrgMutation>(atmosphere, {

--- a/packages/client/mutations/UpdatePokerScopeMutation.ts
+++ b/packages/client/mutations/UpdatePokerScopeMutation.ts
@@ -12,10 +12,7 @@ import splitDraftContent from '../utils/draftjs/splitDraftContent'
 import getSearchQueryFromMeeting from '../utils/getSearchQueryFromMeeting'
 import clientTempId from '../utils/relay/clientTempId'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {
-  UpdatePokerScopeMutation as TUpdatePokerScopeMutation,
-  UpdatePokerScopeMutationResponse
-} from '../__generated__/UpdatePokerScopeMutation.graphql'
+import {UpdatePokerScopeMutation as TUpdatePokerScopeMutation} from '../__generated__/UpdatePokerScopeMutation.graphql'
 import SendClientSegmentEventMutation from './SendClientSegmentEventMutation'
 
 graphql`
@@ -101,7 +98,7 @@ const mutation = graphql`
 `
 
 export type PokerScopeMeeting = NonNullable<
-  UpdatePokerScopeMutationResponse['updatePokerScope']['meeting']
+  TUpdatePokerScopeMutation['response']['updatePokerScope']['meeting']
 >
 
 interface Handlers extends BaseLocalHandlers {

--- a/packages/client/mutations/UploadOrgImageMutation.ts
+++ b/packages/client/mutations/UploadOrgImageMutation.ts
@@ -3,10 +3,7 @@ import {commitMutation} from 'react-relay'
 import {UploadableMap} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
 import {BaseLocalHandlers} from '../types/relayMutations'
-import {
-  UploadOrgImageMutation as TUploadOrgImageMutation,
-  UploadOrgImageMutationVariables
-} from '../__generated__/UploadOrgImageMutation.graphql'
+import {UploadOrgImageMutation as TUploadOrgImageMutation} from '../__generated__/UploadOrgImageMutation.graphql'
 
 const mutation = graphql`
   mutation UploadOrgImageMutation($file: File!, $orgId: ID!) {
@@ -21,7 +18,7 @@ const mutation = graphql`
 
 const UploadOrgImageMutation = (
   atmosphere: Atmosphere,
-  variables: Omit<UploadOrgImageMutationVariables, 'file'>,
+  variables: Omit<TUploadOrgImageMutation['variables'], 'file'>,
   {onCompleted, onError}: BaseLocalHandlers,
   uploadables?: UploadableMap
 ) => {

--- a/packages/client/mutations/UploadUserImageMutation.ts
+++ b/packages/client/mutations/UploadUserImageMutation.ts
@@ -3,10 +3,7 @@ import {commitMutation} from 'react-relay'
 import {UploadableMap} from 'relay-runtime'
 import Atmosphere from '../Atmosphere'
 import {BaseLocalHandlers} from '../types/relayMutations'
-import {
-  UploadUserImageMutation as TUploadUserImageMutation,
-  UploadUserImageMutationVariables
-} from '../__generated__/UploadUserImageMutation.graphql'
+import {UploadUserImageMutation as TUploadUserImageMutation} from '../__generated__/UploadUserImageMutation.graphql'
 const mutation = graphql`
   mutation UploadUserImageMutation($file: File!) {
     uploadUserImage(file: $file) {
@@ -20,7 +17,7 @@ const mutation = graphql`
 
 const UploadUserImageMutation = (
   atmosphere: Atmosphere,
-  variables: Omit<UploadUserImageMutationVariables, 'file'>,
+  variables: Omit<TUploadUserImageMutation['variables'], 'file'>,
   {onCompleted, onError}: BaseLocalHandlers,
   uploadables?: UploadableMap
 ) => {

--- a/packages/client/mutations/VoteForPokerStoryMutation.ts
+++ b/packages/client/mutations/VoteForPokerStoryMutation.ts
@@ -2,10 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {StandardMutation} from '../types/relayMutations'
 import createProxyRecord from '../utils/relay/createProxyRecord'
-import {
-  VoteForPokerStoryMutation as TVoteForPokerStoryMutation,
-  VoteForPokerStoryMutationResponse
-} from '../__generated__/VoteForPokerStoryMutation.graphql'
+import {VoteForPokerStoryMutation as TVoteForPokerStoryMutation} from '../__generated__/VoteForPokerStoryMutation.graphql'
 
 graphql`
   fragment VoteForPokerStoryMutation_meeting on VoteForPokerStorySuccess {
@@ -33,7 +30,7 @@ const mutation = graphql`
 `
 
 type Stage = NonNullable<
-  NonNullable<VoteForPokerStoryMutationResponse>['voteForPokerStory']['stage']
+  NonNullable<TVoteForPokerStoryMutation['response']>['voteForPokerStory']['stage']
 >
 
 const VoteForPokerStoryMutation: StandardMutation<TVoteForPokerStoryMutation> = (

--- a/packages/client/mutations/VoteForReflectionGroupMutation.ts
+++ b/packages/client/mutations/VoteForReflectionGroupMutation.ts
@@ -2,10 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
 import {BaseLocalHandlers, StandardMutation} from '../types/relayMutations'
 import toTeamMemberId from '../utils/relay/toTeamMemberId'
-import {
-  VoteForReflectionGroupMutation as TVoteForReflectionGroupMutation,
-  VoteForReflectionGroupMutationResponse
-} from '../__generated__/VoteForReflectionGroupMutation.graphql'
+import {VoteForReflectionGroupMutation as TVoteForReflectionGroupMutation} from '../__generated__/VoteForReflectionGroupMutation.graphql'
 
 graphql`
   fragment VoteForReflectionGroupMutation_meeting on VoteForReflectionGroupPayload {
@@ -39,10 +36,14 @@ interface Handlers extends BaseLocalHandlers {
 }
 
 type RetrospectiveMeetingMember = NonNullable<
-  NonNullable<VoteForReflectionGroupMutationResponse['voteForReflectionGroup']>['meetingMember']
+  NonNullable<
+    TVoteForReflectionGroupMutation['response']['voteForReflectionGroup']
+  >['meetingMember']
 >
 type RetroReflectionGroup = NonNullable<
-  NonNullable<VoteForReflectionGroupMutationResponse['voteForReflectionGroup']>['reflectionGroup']
+  NonNullable<
+    TVoteForReflectionGroupMutation['response']['voteForReflectionGroup']
+  >['reflectionGroup']
 >
 
 const VoteForReflectionGroupMutation: StandardMutation<

--- a/packages/client/mutations/handlers/handleAuthenticationRedirect.ts
+++ b/packages/client/mutations/handlers/handleAuthenticationRedirect.ts
@@ -1,4 +1,4 @@
-import {AcceptTeamInvitationMutationReply} from '~/__generated__/AcceptTeamInvitationMutationReply.graphql'
+import {AcceptTeamInvitationMutationReply$data} from '~/__generated__/AcceptTeamInvitationMutationReply.graphql'
 import {OnNextHandler, OnNextHistoryContext} from '../../types/relayMutations'
 import getValidRedirectParam from '../../utils/getValidRedirectParam'
 import SendClientSegmentEventMutation from '../SendClientSegmentEventMutation'
@@ -8,7 +8,7 @@ interface OnNextMeetingId extends OnNextHistoryContext {
 }
 
 const handleAuthenticationRedirect: OnNextHandler<
-  AcceptTeamInvitationMutationReply | undefined,
+  AcceptTeamInvitationMutationReply$data | undefined,
   OnNextMeetingId
 > = (acceptTeamInvitation, {meetingId: locallyRequestedMeetingId, history, atmosphere}) => {
   SendClientSegmentEventMutation(atmosphere, 'User Login')

--- a/packages/client/mutations/handlers/handleAzureCreateIssue.ts
+++ b/packages/client/mutations/handlers/handleAzureCreateIssue.ts
@@ -1,11 +1,11 @@
 import {ConnectionHandler, RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
 import SearchQueryId from '~/shared/gqlIds/SearchQueryId'
 import toTeamMemberId from '../../utils/relay/toTeamMemberId'
-import {CreateTaskMutationResponse} from '../../__generated__/CreateTaskMutation.graphql'
+import {CreateTaskMutation} from '../../__generated__/CreateTaskMutation.graphql'
 import getAzureWorkItemsConn from '../connections/getAzureWorkItemsConn'
 
 const handleAzureCreateIssue = (
-  task: RecordProxy<NonNullable<CreateTaskMutationResponse['createTask']['task']>>,
+  task: RecordProxy<NonNullable<CreateTaskMutation['response']['createTask']['task']>>,
   store: RecordSourceSelectorProxy
 ) => {
   const integration = task.getLinkedRecord('integration')

--- a/packages/client/mutations/handlers/handleGitHubCreateIssue.ts
+++ b/packages/client/mutations/handlers/handleGitHubCreateIssue.ts
@@ -1,11 +1,11 @@
 import {ConnectionHandler, RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
 import SearchQueryId from '../../shared/gqlIds/SearchQueryId'
 import toTeamMemberId from '../../utils/relay/toTeamMemberId'
-import {CreateTaskMutationResponse} from '../../__generated__/CreateTaskMutation.graphql'
+import {CreateTaskMutation} from '../../__generated__/CreateTaskMutation.graphql'
 import getGitHubIssuesConn from '../connections/getGitHubIssuesConn'
 
 const handleGitHubCreateIssue = (
-  task: RecordProxy<NonNullable<CreateTaskMutationResponse['createTask']['task']>>,
+  task: RecordProxy<NonNullable<CreateTaskMutation['response']['createTask']['task']>>,
   store: RecordSourceSelectorProxy
 ) => {
   const integration = task.getLinkedRecord('integration')

--- a/packages/client/mutations/handlers/handleGitLabCreateIssue.ts
+++ b/packages/client/mutations/handlers/handleGitLabCreateIssue.ts
@@ -2,11 +2,11 @@ import {ConnectionHandler, RecordProxy, RecordSourceSelectorProxy} from 'relay-r
 import {gitlabIssueArgs} from '~/components/GitLabScopingSearchResultsRoot'
 import SearchQueryId from '~/shared/gqlIds/SearchQueryId'
 import toTeamMemberId from '../../utils/relay/toTeamMemberId'
-import {CreateTaskMutationResponse} from '../../__generated__/CreateTaskMutation.graphql'
+import {CreateTaskMutation} from '../../__generated__/CreateTaskMutation.graphql'
 import getGitLabProjectsIssuesConn from '../connections/getGitLabProjectsIssuesConn'
 
 const handleGitLabCreateIssue = (
-  task: RecordProxy<NonNullable<CreateTaskMutationResponse['createTask']['task']>>,
+  task: RecordProxy<NonNullable<CreateTaskMutation['response']['createTask']['task']>>,
   store: RecordSourceSelectorProxy
 ) => {
   const integration = task.getLinkedRecord('integration')

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -29,11 +29,7 @@ import {popNotificationToastOnNext} from '../mutations/toasts/popNotificationToa
 import {updateNotificationToastOnNext} from '../mutations/toasts/updateNotificationToast'
 import {LocalStorageKey} from '../types/constEnums'
 import {OnNextHandler, OnNextHistoryContext, SharedUpdater} from '../types/relayMutations'
-import {
-  NotificationSubscription as TNotificationSubscription,
-  NotificationSubscriptionResponse,
-  NotificationSubscriptionVariables
-} from '../__generated__/NotificationSubscription.graphql'
+import {NotificationSubscription as TNotificationSubscription} from '../__generated__/NotificationSubscription.graphql'
 
 graphql`
   fragment NotificationSubscription_paymentRejected on StripeFailPaymentPayload {
@@ -149,7 +145,7 @@ const subscription = graphql`
 `
 
 type NextHandler = OnNextHandler<
-  NotificationSubscriptionResponse['notificationSubscription'],
+  TNotificationSubscription['response']['notificationSubscription'],
   OnNextHistoryContext
 >
 
@@ -250,7 +246,7 @@ const onNextHandlers = {
 
 const NotificationSubscription = (
   atmosphere: Atmosphere,
-  variables: NotificationSubscriptionVariables,
+  variables: TNotificationSubscription['variables'],
   router: {history: RouterProps['history']}
 ) => {
   return requestSubscription<TNotificationSubscription>(atmosphere, {

--- a/packages/client/utils/JiraServerClientManager.ts
+++ b/packages/client/utils/JiraServerClientManager.ts
@@ -1,4 +1,4 @@
-import {CreateOAuth1AuthorizeUrlMutationResponse} from '~/__generated__/CreateOAuth1AuthorizeUrlMutation.graphql'
+import {CreateOAuth1AuthorizeUrlMutation as TCreateOAuth1AuthorizeUrlMutation} from '~/__generated__/CreateOAuth1AuthorizeUrlMutation.graphql'
 import Atmosphere from '../Atmosphere'
 import {MenuMutationProps} from '../hooks/useMutationProps'
 import AddTeamMemberIntegrationAuthMutation from '../mutations/AddTeamMemberIntegrationAuthMutation'
@@ -21,7 +21,7 @@ class JiraServerClientManager {
       getOAuthPopupFeatures({width: 500, height: 750, top: 56})
     )
 
-    const onUrlCompleted = (result: CreateOAuth1AuthorizeUrlMutationResponse) => {
+    const onUrlCompleted = (result: TCreateOAuth1AuthorizeUrlMutation['response']) => {
       if (popup) {
         if (!result.createOAuth1AuthorizeUrl?.url) {
           onError(result.createOAuth1AuthorizeUrl?.error)

--- a/packages/client/utils/getSAMLIdP.ts
+++ b/packages/client/utils/getSAMLIdP.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import Atmosphere from '../Atmosphere'
-import {getSAMLIdPQuery, getSAMLIdPQueryVariables} from '../__generated__/getSAMLIdPQuery.graphql'
+import {getSAMLIdPQuery} from '../__generated__/getSAMLIdPQuery.graphql'
 
 const query = graphql`
   query getSAMLIdPQuery($email: ID!, $isInvited: Boolean) {
@@ -8,7 +8,7 @@ const query = graphql`
   }
 `
 
-const getSAMLIdP = async (atmosphere: Atmosphere, variables: getSAMLIdPQueryVariables) => {
+const getSAMLIdP = async (atmosphere: Atmosphere, variables: getSAMLIdPQuery['variables']) => {
   const res = await atmosphere.fetchQuery<getSAMLIdPQuery>(query, variables)
   return res?.SAMLIdP ?? null
 }


### PR DESCRIPTION
# Description

Let's say there exists a mutation called "AddTask".
Relay v12 generates types for "AddTask" and exports them. they look like this:

```ts
export type AddTaskMutationResponse {};
export type AddTaskMutationVariables {};
export type AddTaskMutation = {
    readonly response: AddTaskMutationResponse;
    readonly variables: AddTaskMutationVariables;
};
```
Relay v13 generates the following types:

```ts
export type AddTaskMutation$response {};
export type AddTaskMutation$variables {};
export type AddTaskMutation = {
    readonly response: AddTaskMutation$response;
    readonly variables: AddTaskMutation$variables;
};
```

Since both v12 & v13 export the same `AddTaskMutation` type, I changed all references from e.g. `AddTaskMutationResponse` to `AddTaskMutation['response']`. 

Why not wait until Relay v13 & rename it to `AddTaskMutation$response`? Because I want to keep that PR as small as possible 🤷 

## Demo

N/A

## Testing scenarios

This PR does not affect runtime, just types! As long as `tsc` on the CI runs, we know it works 😉 