### PR TITLE
feat(summaries): Bulk task export button

### DIFF
--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -23,7 +23,8 @@ interface Props {
   label?: string
   onPushToIntegration: (
     integrationRepoId: string,
-    integrationProviderService: IntegrationProviderServiceEnum
+    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationLabel?: string
   ) => void
 }
 
@@ -146,7 +147,7 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
               key={integrationRepoId}
               query={query}
               label={repoIntegration.name}
-              onClick={() => onPushToIntegration(integrationRepoId, 'jira')}
+              onClick={() => onPushToIntegration(integrationRepoId, 'jira', repoIntegration.name)}
               service='jira'
             />
           )
@@ -157,7 +158,9 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
               key={integrationRepoId}
               query={query}
               label={repoIntegration.name}
-              onClick={() => onPushToIntegration(integrationRepoId, 'jiraServer')}
+              onClick={() =>
+                onPushToIntegration(integrationRepoId, 'jiraServer', repoIntegration.name)
+              }
               service='jiraServer'
             />
           )
@@ -169,7 +172,9 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
               key={integrationRepoId}
               query={query}
               label={repoIntegration.nameWithOwner}
-              onClick={() => onPushToIntegration(nameWithOwner, 'github')}
+              onClick={() =>
+                onPushToIntegration(nameWithOwner, 'github', repoIntegration.nameWithOwner)
+              }
               service='github'
             />
           )
@@ -181,7 +186,7 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
               key={integrationRepoId}
               query={query}
               label={fullPath}
-              onClick={() => onPushToIntegration(fullPath, 'gitlab')}
+              onClick={() => onPushToIntegration(fullPath, 'gitlab', fullPath)}
               service='gitlab'
             />
           )
@@ -198,7 +203,7 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
               key={integrationRepoId}
               query={query}
               label={name}
-              onClick={() => onPushToIntegration(integrationRepoId, 'azureDevOps')}
+              onClick={() => onPushToIntegration(integrationRepoId, 'azureDevOps', name)}
               service='azureDevOps'
             />
           )

--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -6,15 +6,13 @@ import useSearchFilter from '~/hooks/useSearchFilter'
 import IntegrationRepoId from '~/shared/gqlIds/IntegrationRepoId'
 import {MenuProps} from '../hooks/useMenu'
 import {PALETTE} from '../styles/paletteV3'
-import {
-  IntegrationProviderServiceEnum,
-  TaskFooterIntegrateMenuListLocalQuery
-} from '../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
+import {TaskFooterIntegrateMenuListLocalQuery} from '../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
 import {EmptyDropdownMenuItemLabel} from './EmptyDropdownMenuItemLabel'
 import Menu from './Menu'
 import MenuItemHR from './MenuItemHR'
 import {SearchMenuItem} from './SearchMenuItem'
 import TaskIntegrationMenuItem from './TaskIntegrationMenuItem'
+import {TaskServiceEnum} from '../__generated__/CreateTaskMutation.graphql'
 
 interface Props {
   menuProps: MenuProps
@@ -23,7 +21,7 @@ interface Props {
   label?: string
   onPushToIntegration: (
     integrationRepoId: string,
-    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationProviderService: Exclude<TaskServiceEnum, 'PARABOL'>,
     integrationLabel?: string
   ) => void
 }

--- a/packages/client/components/TaskIntegrationMenuItem.tsx
+++ b/packages/client/components/TaskIntegrationMenuItem.tsx
@@ -18,26 +18,23 @@ interface Props {
   query: string
 }
 
-const svgLookup: Record<TaskServiceEnum, React.MemoExoticComponent<() => JSX.Element>> = {
-  jiraServer: JiraServerSVG,
-  gitlab: GitLabSVG,
-  azureDevOps: AzureDevOpsSVG,
-  github: GitHubSVG,
-  jira: JiraSVG,
-  PARABOL: ParabolLogoSVG
+export const integrationSvgLookup: Record<TaskServiceEnum, JSX.Element> = {
+  jiraServer: <JiraServerSVG />,
+  gitlab: <GitLabSVG />,
+  azureDevOps: <AzureDevOpsSVG />,
+  github: <GitHubSVG />,
+  jira: <JiraSVG />,
+  PARABOL: <ParabolLogoSVG />
 }
 
 const TaskIntegrationMenuItem = forwardRef((props: Props, ref: any) => {
   const {label, onClick, service, query} = props
-  const Svg = svgLookup[service]
   return (
     <MenuItem
       ref={ref}
       label={
         <MenuItemLabel>
-          <MenuItemAvatar>
-            <Svg />
-          </MenuItemAvatar>
+          <MenuItemAvatar>{integrationSvgLookup[service]}</MenuItemAvatar>
           <TypeAheadLabel query={query} label={label} />
         </MenuItemLabel>
       }

--- a/packages/client/hooks/useIsIntegrated.ts
+++ b/packages/client/hooks/useIsIntegrated.ts
@@ -1,0 +1,97 @@
+import graphql from 'babel-plugin-relay/macro'
+
+import {useIsIntegrated_integrations$key} from '../__generated__/useIsIntegrated_integrations.graphql'
+import {useFragment} from 'react-relay'
+
+type IntegrationLookup = {
+  hasGitHub: boolean
+  hasAtlassian: boolean
+  hasGitLab: boolean
+  hasJiraServer: boolean
+  hasAzureDevOps: boolean
+}
+
+graphql`
+  fragment useIsIntegratedJiraServerIntegration on JiraServerIntegration {
+    auth {
+      isActive
+    }
+  }
+`
+graphql`
+  fragment useIsIntegratedAtlassianIntegration on AtlassianIntegration {
+    isActive
+  }
+`
+graphql`
+  fragment useIsIntegratedGitHubIntegration on GitHubIntegration {
+    isActive
+  }
+`
+graphql`
+  fragment useIsIntegratedGitLabIntegration on GitLabIntegration {
+    auth {
+      isActive
+    }
+  }
+`
+graphql`
+  fragment useIsIntegratedAzureDevOpsIntegration on AzureDevOpsIntegration {
+    auth {
+      isActive
+    }
+  }
+`
+
+export const makePlaceholder = (integrationLookup: IntegrationLookup) => {
+  const {hasGitHub, hasAtlassian, hasGitLab, hasAzureDevOps} = integrationLookup
+  const names = [] as string[]
+  if (hasGitHub) names.push('GitHub')
+  if (hasAtlassian) names.push('Jira')
+  if (hasGitLab) names.push('GitLab')
+  if (hasAzureDevOps) names.push('Azure DevOps')
+  return `Search ${names.join(' & ')}`
+}
+
+export const useIsIntegrated = (integrationsRef?: useIsIntegrated_integrations$key) => {
+  const integrations = useFragment(
+    graphql`
+      fragment useIsIntegrated_integrations on TeamMemberIntegrations {
+        jiraServer {
+          ...useIsIntegratedJiraServerIntegration @relay(mask: false)
+        }
+        atlassian {
+          ...useIsIntegratedAtlassianIntegration @relay(mask: false)
+        }
+        github {
+          ...useIsIntegratedGitHubIntegration @relay(mask: false)
+        }
+        gitlab {
+          ...useIsIntegratedGitLabIntegration @relay(mask: false)
+        }
+        azureDevOps {
+          ...useIsIntegratedAzureDevOpsIntegration @relay(mask: false)
+        }
+      }
+    `,
+    integrationsRef ?? null
+  )
+  if (!integrations) {
+    return null
+  }
+  const {atlassian, github, jiraServer, gitlab, azureDevOps} = integrations
+  const hasAtlassian = atlassian?.isActive ?? false
+  const hasGitHub = github?.isActive ?? false
+  const hasGitLab = gitlab?.auth?.isActive ?? false
+  const hasJiraServer = jiraServer?.auth?.isActive ?? false
+  const hasAzureDevOps = azureDevOps?.auth?.isActive ?? false
+  return hasAtlassian || hasGitHub || hasJiraServer || hasGitLab || hasAzureDevOps
+    ? {
+        hasAtlassian,
+        hasGitHub,
+        hasJiraServer,
+        hasGitLab,
+        hasAzureDevOps
+      }
+    : null
+}

--- a/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
@@ -1,7 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {Parser as JSON2CSVParser} from 'json2csv'
 import Parser from 'json2csv/lib/JSON2CSVParser' // only grab the sync parser
-import {PALETTE} from 'parabol-client/styles/paletteV3'
 import extractTextFromDraftString from 'parabol-client/utils/draftjs/extractTextFromDraftString'
 import withMutationProps, {WithMutationProps} from 'parabol-client/utils/relay/withMutationProps'
 import {ExportToCSVQuery} from 'parabol-client/__generated__/ExportToCSVQuery.graphql'
@@ -10,7 +9,6 @@ import useAtmosphere from '~/hooks/useAtmosphere'
 import {ExternalLinks, PokerCards} from '../../../../types/constEnums'
 import {CorsOptions} from '../../../../types/cors'
 import AnchorIfEmail from './MeetingSummaryEmail/AnchorIfEmail'
-import EmailBorderBottom from './MeetingSummaryEmail/EmailBorderBottom'
 import {MeetingSummaryReferrer} from './MeetingSummaryEmail/MeetingSummaryEmail'
 
 interface Props extends WithMutationProps {
@@ -148,12 +146,6 @@ interface CSVActionRow {
 }
 
 const label = 'Export to CSV'
-
-const iconLinkLabel = {
-  color: PALETTE.SLATE_700,
-  fontSize: '13px',
-  paddingTop: 32
-}
 
 const labelStyle = {
   paddingLeft: 8
@@ -352,22 +344,15 @@ const ExportToCSV = (props: Props) => {
 
   const {emailCSVUrl, referrer, corsOptions} = props
   return (
-    <>
-      <tr>
-        <td align='center' style={iconLinkLabel} width='100%'>
-          <AnchorIfEmail isEmail={referrer === 'email'} href={emailCSVUrl} title={label}>
-            <img
-              alt={label}
-              src={`${ExternalLinks.EMAIL_CDN}cloud_download.png`}
-              style={imageStyle}
-              {...corsOptions}
-            />
-            <span style={labelStyle}>{label}</span>
-          </AnchorIfEmail>
-        </td>
-      </tr>
-      <EmailBorderBottom />
-    </>
+    <AnchorIfEmail isEmail={referrer === 'email'} href={emailCSVUrl} title={label}>
+      <img
+        alt={label}
+        src={`${ExternalLinks.EMAIL_CDN}cloud_download.png`}
+        style={imageStyle}
+        {...corsOptions}
+      />
+      <span style={labelStyle}>{label}</span>
+    </AnchorIfEmail>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
@@ -1,6 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import type {Parser as JSON2CSVParser} from 'json2csv'
 import Parser from 'json2csv/lib/JSON2CSVParser' // only grab the sync parser
+import {PALETTE} from 'parabol-client/styles/paletteV3'
 import extractTextFromDraftString from 'parabol-client/utils/draftjs/extractTextFromDraftString'
 import withMutationProps, {WithMutationProps} from 'parabol-client/utils/relay/withMutationProps'
 import {ExportToCSVQuery} from 'parabol-client/__generated__/ExportToCSVQuery.graphql'
@@ -146,6 +147,12 @@ interface CSVActionRow {
 }
 
 const label = 'Export to CSV'
+
+const iconLinkLabel = {
+  color: PALETTE.SLATE_700,
+  fontSize: '13px',
+  paddingTop: 32
+}
 
 const labelStyle = {
   paddingLeft: 8
@@ -344,15 +351,21 @@ const ExportToCSV = (props: Props) => {
 
   const {emailCSVUrl, referrer, corsOptions} = props
   return (
-    <AnchorIfEmail isEmail={referrer === 'email'} href={emailCSVUrl} title={label}>
-      <img
-        alt={label}
-        src={`${ExternalLinks.EMAIL_CDN}cloud_download.png`}
-        style={imageStyle}
-        {...corsOptions}
-      />
-      <span style={labelStyle}>{label}</span>
-    </AnchorIfEmail>
+    <>
+      <tr>
+        <td align='center' style={iconLinkLabel} width='100%'>
+          <AnchorIfEmail isEmail={referrer === 'email'} href={emailCSVUrl} title={label}>
+            <img
+              alt={label}
+              src={`${ExternalLinks.EMAIL_CDN}cloud_download.png`}
+              style={imageStyle}
+              {...corsOptions}
+            />
+            <span style={labelStyle}>{label}</span>
+          </AnchorIfEmail>
+        </td>
+      </tr>
+    </>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -1,0 +1,122 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {Check} from '@mui/icons-material'
+import {MenuPosition} from '../../../../../hooks/useCoords'
+import useMenu from '../../../../../hooks/useMenu'
+import useMutationProps from '../../../../../hooks/useMutationProps'
+import lazyPreload from '../../../../../utils/lazyPreload'
+import {useFragment} from 'react-relay'
+import {ExportAllTasks_meeting$key} from '../../../../../__generated__/ExportAllTasks_meeting.graphql'
+import styled from '@emotion/styled'
+import BaseButton from '../../../../../components/BaseButton'
+import {PALETTE} from '../../../../../styles/paletteV3'
+import {buttonShadow} from '../../../../../styles/elevation'
+import {emailFontFamily} from '../../../styles'
+
+const ExportAllTasksMenuRoot = lazyPreload(
+  () => import(/* webpackChunkName: 'ExportAllTasksMenuRoot' */ './ExportAllTasksMenuRoot')
+)
+
+interface Props {
+  meetingRef: ExportAllTasks_meeting$key
+}
+
+const ExportButton = styled(BaseButton)({
+  backgroundColor: PALETTE.SKY_500,
+  opacity: 1,
+  outline: 0,
+  marginTop: 12,
+  padding: '9px 20px',
+  borderRadius: '4em',
+  boxShadow: buttonShadow,
+  color: '#FFFFFF',
+  cursor: 'pointer',
+  display: 'block',
+  fontFamily: emailFontFamily,
+  fontSize: 14,
+  fontWeight: 600,
+  margin: '0px auto',
+  textAlign: 'center',
+  textDecoration: 'none'
+})
+
+const ExportAllTasks = (props: Props) => {
+  const {meetingRef} = props
+  const mutationProps = useMutationProps()
+  const {togglePortal, originRef, menuPortal, menuProps, loadingWidth, loadingDelay} = useMenu(
+    MenuPosition.UPPER_RIGHT,
+    {
+      loadingWidth: 200
+    }
+  )
+  const meeting = useFragment(
+    graphql`
+      fragment ExportAllTasks_meeting on NewMeeting {
+        teamId
+        ...ExportAllTasksMenuRoot_meeting
+        ... on RetrospectiveMeeting {
+          tasks {
+            taskService
+            integration {
+              id
+            }
+          }
+        }
+        ... on ActionMeeting {
+          tasks {
+            taskService
+            integration {
+              id
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
+
+  const {tasks} = meeting
+  if (!tasks) {
+    return null
+  }
+
+  const filteredTasks = tasks.filter((task) => !task.integration)
+  const taskServices = Array.from(
+    tasks.reduce(
+      (serviceSet, task) => (task.taskService ? serviceSet.add(task.taskService) : serviceSet),
+      new Set<string>()
+    )
+  )
+
+  return (
+    <>
+      {filteredTasks.length === 0 ? (
+        <span className='flex justify-center text-center'>
+          {taskServices.length === 1
+            ? `All tasks pushed to ${taskServices[0]}`
+            : `All tasks pushed to integration`}
+          <Check className='ml-2' />
+        </span>
+      ) : (
+        <ExportButton
+          onClick={togglePortal}
+          ref={originRef}
+          onMouseEnter={ExportAllTasksMenuRoot.preload}
+        >
+          Export tasks to integration
+        </ExportButton>
+      )}
+      {menuPortal(
+        <ExportAllTasksMenuRoot
+          menuProps={menuProps}
+          loadingDelay={loadingDelay}
+          loadingWidth={loadingWidth}
+          mutationProps={mutationProps}
+          meetingRef={meeting}
+        />
+      )}
+    </>
+  )
+}
+
+export default ExportAllTasks

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -10,12 +10,14 @@ import {
   ExportAllTasks_meeting$key,
   TaskServiceEnum
 } from '../../../../../__generated__/ExportAllTasks_meeting.graphql'
-import {buttonShadow} from '../../../../../styles/elevation'
 import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
 import CreateTaskIntegrationMutation from '../../../../../mutations/CreateTaskIntegrationMutation'
 import useAtmosphere from '../../../../../hooks/useAtmosphere'
 import {integrationSvgLookup} from '../../../../../components/TaskIntegrationMenuItem'
 import {Providers} from '../../../../../types/constEnums'
+import GitHubSVG from '../../../../../components/GitHubSVG'
+import JiraSVG from '../../../../../components/JiraSVG'
+import GitLabSVG from '../../../../../components/GitLabSVG'
 
 const ExportAllTasksMenuRoot = lazyPreload(
   () => import(/* webpackChunkName: 'ExportAllTasksMenuRoot' */ './ExportAllTasksMenuRoot')
@@ -127,53 +129,55 @@ const ExportAllTasks = (props: Props) => {
   }
 
   return (
-    <div className='font-sans text-sm'>
-      {submitting ? (
-        <span className='flex justify-center text-center'>Pushing tasks to integration...</span>
-      ) : filteredTasks.length === 0 ? (
-        <span className='flex justify-center text-center'>
-          {taskServices.length === 1 ? (
-            <>
-              <span>
-                All tasks pushed to{' '}
-                <b>
-                  {pushedIntegrationLabel ??
-                    integrationToServiceName[taskServices[0] as TaskServiceEnum]}
-                </b>
-              </span>
-              {integrationSvgLookup[taskServices[0] as TaskServiceEnum]}
-            </>
-          ) : (
-            <>
-              All tasks pushed to integrations
-              <Check className='ml-2' />
-            </>
-          )}
-        </span>
-      ) : (
-        <button
-          className={
-            'cursor-pointer rounded-full bg-sky-500 px-5 py-2 text-center font-semibold text-white shadow-card-1'
-          }
-          style={{boxShadow: buttonShadow}}
-          onClick={togglePortal}
-          ref={originRef}
-          onMouseEnter={ExportAllTasksMenuRoot.preload}
-        >
-          Export tasks to integration
-        </button>
-      )}
-      {menuPortal(
-        <ExportAllTasksMenuRoot
-          menuProps={menuProps}
-          loadingDelay={loadingDelay}
-          loadingWidth={loadingWidth}
-          mutationProps={mutationProps}
-          meetingRef={meeting}
-          handlePushToIntegration={handlePushToIntegration}
-        />
-      )}
-    </div>
+    <>
+      <div className='font-sans text-sm'>
+        {submitting ? (
+          <span className='flex justify-center text-center'>Pushing tasks to integration...</span>
+        ) : filteredTasks.length === 0 ? (
+          <span className='flex justify-center text-center'>
+            {taskServices.length === 1 ? (
+              <>
+                <span>
+                  All tasks pushed to{' '}
+                  <b>
+                    {pushedIntegrationLabel ??
+                      integrationToServiceName[taskServices[0] as TaskServiceEnum]}
+                  </b>
+                </span>
+                {integrationSvgLookup[taskServices[0] as TaskServiceEnum]}
+              </>
+            ) : (
+              <>
+                All tasks pushed to integrations
+                <Check className='ml-2' />
+              </>
+            )}
+          </span>
+        ) : (
+          <button
+            className={
+              'flex cursor-pointer items-center gap-2 rounded-full border border-solid border-slate-400 bg-white px-5 py-2 text-center font-semibold hover:bg-slate-100'
+            }
+            onClick={togglePortal}
+            ref={originRef}
+            onMouseEnter={ExportAllTasksMenuRoot.preload}
+          >
+            <div>Send Tasks to</div>
+            <JiraSVG /> <GitHubSVG /> <GitLabSVG />
+          </button>
+        )}
+        {menuPortal(
+          <ExportAllTasksMenuRoot
+            menuProps={menuProps}
+            loadingDelay={loadingDelay}
+            loadingWidth={loadingWidth}
+            mutationProps={mutationProps}
+            meetingRef={meeting}
+            handlePushToIntegration={handlePushToIntegration}
+          />
+        )}
+      </div>
+    </>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -118,12 +118,6 @@ const ExportAllTasks = (props: Props) => {
               if (error) {
                 reject(error)
               } else {
-                SendClientSegmentEventMutation(atmosphere, 'Bulk Tasks Published', {
-                  teamId,
-                  meetingId,
-                  meetingType,
-                  service: integrationProviderService
-                })
                 resolve()
               }
             }
@@ -135,6 +129,12 @@ const ExportAllTasks = (props: Props) => {
       if (errors.length > 0) {
         onError(errors[0]!.reason)
       } else {
+        SendClientSegmentEventMutation(atmosphere, 'Bulk Tasks Published', {
+          teamId,
+          meetingId,
+          meetingType,
+          service: integrationProviderService
+        })
         integrationLabel && setPushedIntegrationLabel(integrationLabel)
         onCompleted()
       }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -10,11 +10,7 @@ import {
   ExportAllTasks_meeting$key,
   TaskServiceEnum
 } from '../../../../../__generated__/ExportAllTasks_meeting.graphql'
-import styled from '@emotion/styled'
-import BaseButton from '../../../../../components/BaseButton'
-import {PALETTE} from '../../../../../styles/paletteV3'
 import {buttonShadow} from '../../../../../styles/elevation'
-import {emailFontFamily} from '../../../styles'
 import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
 import CreateTaskIntegrationMutation from '../../../../../mutations/CreateTaskIntegrationMutation'
 import useAtmosphere from '../../../../../hooks/useAtmosphere'
@@ -37,25 +33,6 @@ const integrationToServiceName: Record<TaskServiceEnum, string> = {
 interface Props {
   meetingRef: ExportAllTasks_meeting$key
 }
-
-const ExportButton = styled(BaseButton)({
-  backgroundColor: PALETTE.SKY_500,
-  opacity: 1,
-  outline: 0,
-  marginTop: 12,
-  padding: '9px 20px',
-  borderRadius: '4em',
-  boxShadow: buttonShadow,
-  color: '#FFFFFF',
-  cursor: 'pointer',
-  display: 'block',
-  fontFamily: emailFontFamily,
-  fontSize: 14,
-  fontWeight: 600,
-  margin: '0px auto',
-  textAlign: 'center',
-  textDecoration: 'none'
-})
 
 const ExportAllTasks = (props: Props) => {
   const {meetingRef} = props
@@ -150,7 +127,7 @@ const ExportAllTasks = (props: Props) => {
   }
 
   return (
-    <>
+    <div className='font-sans text-sm'>
       {submitting ? (
         <span className='flex justify-center text-center'>Pushing tasks to integration...</span>
       ) : filteredTasks.length === 0 ? (
@@ -174,13 +151,17 @@ const ExportAllTasks = (props: Props) => {
           )}
         </span>
       ) : (
-        <ExportButton
+        <button
+          className={
+            'cursor-pointer rounded-full bg-sky-500 px-5 py-2 text-center font-semibold text-white shadow-card-1'
+          }
+          style={{boxShadow: buttonShadow}}
           onClick={togglePortal}
           ref={originRef}
           onMouseEnter={ExportAllTasksMenuRoot.preload}
         >
           Export tasks to integration
-        </ExportButton>
+        </button>
       )}
       {menuPortal(
         <ExportAllTasksMenuRoot
@@ -192,7 +173,7 @@ const ExportAllTasks = (props: Props) => {
           handlePushToIntegration={handlePushToIntegration}
         />
       )}
-    </>
+    </div>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -97,13 +97,13 @@ const ExportAllTasks = (props: Props) => {
     )
   )
 
-  const handlePushToIntegration = (
+  const handlePushToIntegration = async (
     integrationRepoId: string,
     integrationProviderService: Exclude<TaskServiceEnum, 'PARABOL'>,
     integrationLabel?: string
   ) => {
     submitMutation()
-    Promise.allSettled(
+    const results = await Promise.allSettled(
       filteredTasks?.map((task) => {
         return new Promise<void>((resolve, reject) => {
           const variables = {
@@ -124,21 +124,21 @@ const ExportAllTasks = (props: Props) => {
           })
         })
       })
-    ).then((results) => {
-      const errors = results.filter((res) => res.status === 'rejected') as PromiseRejectedResult[]
-      if (errors.length > 0) {
-        onError(errors[0]!.reason)
-      } else {
-        SendClientSegmentEventMutation(atmosphere, 'Bulk Tasks Published', {
-          teamId,
-          meetingId,
-          meetingType,
-          service: integrationProviderService
-        })
-        integrationLabel && setPushedIntegrationLabel(integrationLabel)
-        onCompleted()
-      }
-    })
+    )
+
+    const errors = results.filter((res) => res.status === 'rejected') as PromiseRejectedResult[]
+    if (errors.length > 0) {
+      onError(errors[0]!.reason)
+    } else {
+      SendClientSegmentEventMutation(atmosphere, 'Bulk Tasks Published', {
+        teamId,
+        meetingId,
+        meetingType,
+        service: integrationProviderService
+      })
+      integrationLabel && setPushedIntegrationLabel(integrationLabel)
+      onCompleted()
+    }
   }
 
   return (

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
-import {Check} from '@mui/icons-material'
+import {Loop} from '@mui/icons-material'
 import {MenuPosition} from '../../../../../hooks/useCoords'
 import useMenu from '../../../../../hooks/useMenu'
 import useMutationProps, {getOnCompletedError} from '../../../../../hooks/useMutationProps'
@@ -18,10 +18,14 @@ import {Providers} from '../../../../../types/constEnums'
 import GitHubSVG from '../../../../../components/GitHubSVG'
 import JiraSVG from '../../../../../components/JiraSVG'
 import GitLabSVG from '../../../../../components/GitLabSVG'
+import clsx from 'clsx'
 
 const ExportAllTasksMenuRoot = lazyPreload(
   () => import(/* webpackChunkName: 'ExportAllTasksMenuRoot' */ './ExportAllTasksMenuRoot')
 )
+
+const BUTTON_CLASSES =
+  'flex items-center gap-2 rounded-full border border-solid border-slate-400 px-5 py-2 text-center font-sans text-sm font-semibold'
 
 const integrationToServiceName: Record<TaskServiceEnum, string> = {
   PARABOL: 'Parabol',
@@ -130,53 +134,44 @@ const ExportAllTasks = (props: Props) => {
 
   return (
     <>
-      <div className='font-sans text-sm'>
-        {submitting ? (
-          <span className='flex justify-center text-center'>Pushing tasks to integration...</span>
-        ) : filteredTasks.length === 0 ? (
-          <span className='flex justify-center text-center'>
-            {taskServices.length === 1 ? (
-              <>
-                <span>
-                  All tasks pushed to{' '}
-                  <b>
-                    {pushedIntegrationLabel ??
-                      integrationToServiceName[taskServices[0] as TaskServiceEnum]}
-                  </b>
-                </span>
-                {integrationSvgLookup[taskServices[0] as TaskServiceEnum]}
-              </>
-            ) : (
-              <>
-                All tasks pushed to integrations
-                <Check className='ml-2' />
-              </>
-            )}
-          </span>
-        ) : (
-          <button
-            className={
-              'flex cursor-pointer items-center gap-2 rounded-full border border-solid border-slate-400 bg-white px-5 py-2 text-center font-semibold hover:bg-slate-100'
-            }
-            onClick={togglePortal}
-            ref={originRef}
-            onMouseEnter={ExportAllTasksMenuRoot.preload}
-          >
-            <div>Send Tasks to</div>
-            <JiraSVG /> <GitHubSVG /> <GitLabSVG />
-          </button>
-        )}
-        {menuPortal(
-          <ExportAllTasksMenuRoot
-            menuProps={menuProps}
-            loadingDelay={loadingDelay}
-            loadingWidth={loadingWidth}
-            mutationProps={mutationProps}
-            meetingRef={meeting}
-            handlePushToIntegration={handlePushToIntegration}
-          />
-        )}
-      </div>
+      {submitting ? (
+        <button className={clsx(BUTTON_CLASSES, 'cursor-wait bg-slate-300')}>
+          <Loop style={{width: '14px', height: '14px'}} /> Syncing in Progress...
+        </button>
+      ) : filteredTasks.length === 0 ? (
+        <button className={clsx(BUTTON_CLASSES, 'bg-slate-200')}>
+          {taskServices.length === 1 ? (
+            <>
+              {integrationSvgLookup[taskServices[0] as TaskServiceEnum]}
+              Tasks synced to{' '}
+              {pushedIntegrationLabel ??
+                integrationToServiceName[taskServices[0] as TaskServiceEnum]}
+            </>
+          ) : (
+            'Tasks synced'
+          )}
+        </button>
+      ) : (
+        <button
+          className={clsx(BUTTON_CLASSES, 'cursor-pointer bg-white hover:bg-slate-100')}
+          onClick={togglePortal}
+          ref={originRef}
+          onMouseEnter={ExportAllTasksMenuRoot.preload}
+        >
+          <div>Send Tasks to</div>
+          <JiraSVG /> <GitHubSVG /> <GitLabSVG />
+        </button>
+      )}
+      {menuPortal(
+        <ExportAllTasksMenuRoot
+          menuProps={menuProps}
+          loadingDelay={loadingDelay}
+          loadingWidth={loadingWidth}
+          mutationProps={mutationProps}
+          meetingRef={meeting}
+          handlePushToIntegration={handlePushToIntegration}
+        />
+      )}
     </>
   )
 }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -79,6 +79,7 @@ const ExportAllTasks = (props: Props) => {
     meetingRef
   )
 
+  // :TODO: (jmtaber129): Get this information from the tasks integration.
   const [pushedIntegrationLabel, setPushedIntegrationLabel] = useState<string | null>(null)
 
   const {tasks} = meeting

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -40,6 +40,16 @@ interface Props {
   meetingRef: ExportAllTasks_meeting$key
 }
 
+graphql`
+  fragment ExportAllTasks_meetingTasks on Task {
+    id
+    taskService
+    integration {
+      id
+    }
+  }
+`
+
 const ExportAllTasks = (props: Props) => {
   const {meetingRef} = props
   const mutationProps = useMutationProps()
@@ -60,20 +70,17 @@ const ExportAllTasks = (props: Props) => {
         ...ExportAllTasksMenuRoot_meeting
         ... on RetrospectiveMeeting {
           tasks {
-            id
-            taskService
-            integration {
-              id
-            }
+            ...ExportAllTasks_meetingTasks @relay(mask: false)
           }
         }
         ... on ActionMeeting {
           tasks {
-            id
-            taskService
-            integration {
-              id
-            }
+            ...ExportAllTasks_meetingTasks @relay(mask: false)
+          }
+        }
+        ... on TeamPromptMeeting {
+          tasks {
+            ...ExportAllTasks_meetingTasks @relay(mask: false)
           }
         }
       }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -128,6 +128,11 @@ const ExportAllTasks = (props: Props) => {
 
     const errors = results.filter((res) => res.status === 'rejected') as PromiseRejectedResult[]
     if (errors.length > 0) {
+      atmosphere.eventEmitter.emit('addSnackbar', {
+        key: 'bulkExportError',
+        message: 'Could not sync all tasks. Please try again',
+        autoDismiss: 10
+      })
       onError(errors[0]!.reason)
     } else {
       SendClientSegmentEventMutation(atmosphere, 'Bulk Tasks Published', {

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -1,21 +1,38 @@
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useState} from 'react'
 import {Check} from '@mui/icons-material'
 import {MenuPosition} from '../../../../../hooks/useCoords'
 import useMenu from '../../../../../hooks/useMenu'
-import useMutationProps from '../../../../../hooks/useMutationProps'
+import useMutationProps, {getOnCompletedError} from '../../../../../hooks/useMutationProps'
 import lazyPreload from '../../../../../utils/lazyPreload'
 import {useFragment} from 'react-relay'
-import {ExportAllTasks_meeting$key} from '../../../../../__generated__/ExportAllTasks_meeting.graphql'
+import {
+  ExportAllTasks_meeting$key,
+  TaskServiceEnum
+} from '../../../../../__generated__/ExportAllTasks_meeting.graphql'
 import styled from '@emotion/styled'
 import BaseButton from '../../../../../components/BaseButton'
 import {PALETTE} from '../../../../../styles/paletteV3'
 import {buttonShadow} from '../../../../../styles/elevation'
 import {emailFontFamily} from '../../../styles'
+import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
+import CreateTaskIntegrationMutation from '../../../../../mutations/CreateTaskIntegrationMutation'
+import useAtmosphere from '../../../../../hooks/useAtmosphere'
+import {integrationSvgLookup} from '../../../../../components/TaskIntegrationMenuItem'
+import {Providers} from '../../../../../types/constEnums'
 
 const ExportAllTasksMenuRoot = lazyPreload(
   () => import(/* webpackChunkName: 'ExportAllTasksMenuRoot' */ './ExportAllTasksMenuRoot')
 )
+
+const integrationToServiceName: Record<TaskServiceEnum, string> = {
+  PARABOL: 'Parabol',
+  github: Providers.GITHUB_NAME,
+  jira: 'Jira',
+  jiraServer: Providers.JIRA_SERVER_NAME,
+  azureDevOps: Providers.AZUREDEVOPS_NAME,
+  gitlab: Providers.GITHUB_NAME
+}
 
 interface Props {
   meetingRef: ExportAllTasks_meeting$key
@@ -43,6 +60,8 @@ const ExportButton = styled(BaseButton)({
 const ExportAllTasks = (props: Props) => {
   const {meetingRef} = props
   const mutationProps = useMutationProps()
+  const atmosphere = useAtmosphere()
+  const {onCompleted, onError, submitMutation, submitting} = mutationProps
   const {togglePortal, originRef, menuPortal, menuProps, loadingWidth, loadingDelay} = useMenu(
     MenuPosition.UPPER_RIGHT,
     {
@@ -56,6 +75,7 @@ const ExportAllTasks = (props: Props) => {
         ...ExportAllTasksMenuRoot_meeting
         ... on RetrospectiveMeeting {
           tasks {
+            id
             taskService
             integration {
               id
@@ -64,6 +84,7 @@ const ExportAllTasks = (props: Props) => {
         }
         ... on ActionMeeting {
           tasks {
+            id
             taskService
             integration {
               id
@@ -74,6 +95,8 @@ const ExportAllTasks = (props: Props) => {
     `,
     meetingRef
   )
+
+  const [pushedIntegrationLabel, setPushedIntegrationLabel] = useState<string | null>(null)
 
   const {tasks} = meeting
   if (!tasks) {
@@ -88,14 +111,67 @@ const ExportAllTasks = (props: Props) => {
     )
   )
 
+  const handlePushToIntegration = (
+    integrationRepoId: string,
+    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationLabel?: string
+  ) => {
+    submitMutation()
+    Promise.allSettled(
+      filteredTasks?.map((task) => {
+        return new Promise<void>((resolve, reject) => {
+          const variables = {
+            integrationRepoId,
+            taskId: task.id,
+            integrationProviderService: integrationProviderService
+          }
+          CreateTaskIntegrationMutation(atmosphere, variables, {
+            onError: reject,
+            onCompleted: (res, errors) => {
+              const error = getOnCompletedError(res, errors)
+              if (error) {
+                reject(error)
+              } else {
+                resolve()
+              }
+            }
+          })
+        })
+      })
+    ).then((results) => {
+      const errors = results.filter((res) => res.status === 'rejected') as PromiseRejectedResult[]
+      if (errors.length > 0) {
+        onError(errors[0]!.reason)
+      } else {
+        integrationLabel && setPushedIntegrationLabel(integrationLabel)
+        onCompleted()
+      }
+    })
+  }
+
   return (
     <>
-      {filteredTasks.length === 0 ? (
+      {submitting ? (
+        <span className='flex justify-center text-center'>Pushing tasks to integration...</span>
+      ) : filteredTasks.length === 0 ? (
         <span className='flex justify-center text-center'>
-          {taskServices.length === 1
-            ? `All tasks pushed to ${taskServices[0]}`
-            : `All tasks pushed to integration`}
-          <Check className='ml-2' />
+          {taskServices.length === 1 ? (
+            <>
+              <span>
+                All tasks pushed to{' '}
+                <b>
+                  {pushedIntegrationLabel ??
+                    integrationToServiceName[taskServices[0] as TaskServiceEnum]}
+                </b>
+              </span>
+              {integrationSvgLookup[taskServices[0] as TaskServiceEnum]}
+            </>
+          ) : (
+            <>
+              All tasks pushed to integrations
+              <Check className='ml-2' />
+            </>
+          )}
         </span>
       ) : (
         <ExportButton
@@ -113,6 +189,7 @@ const ExportAllTasks = (props: Props) => {
           loadingWidth={loadingWidth}
           mutationProps={mutationProps}
           meetingRef={meeting}
+          handlePushToIntegration={handlePushToIntegration}
         />
       )}
     </>

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
@@ -7,8 +7,8 @@ import {ExportAllTasksMenuQuery} from '../../../../../__generated__/ExportAllTas
 import {ExportAllTasksMenu_meeting$key} from '../../../../../__generated__/ExportAllTasksMenu_meeting.graphql'
 import TaskFooterIntegrateMenuList from '../../../../../components/TaskFooterIntegrateMenuList'
 import TaskFooterIntegrateMenuSignup from '../../../../../components/TaskFooterIntegrateMenuSignup'
-import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
 import {useIsIntegrated, makePlaceholder} from '../../../../../hooks/useIsIntegrated'
+import {TaskServiceEnum} from '../../../../../__generated__/CreateTaskMutation.graphql'
 
 interface Props {
   menuProps: MenuProps
@@ -17,7 +17,7 @@ interface Props {
   queryRef: PreloadedQuery<ExportAllTasksMenuQuery>
   handlePushToIntegration: (
     integrationRepoId: string,
-    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationProviderService: Exclude<TaskServiceEnum, 'PARABOL'>,
     integrationLabel?: string
   ) => void
 }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
@@ -36,6 +36,15 @@ const query = graphql`
   }
 `
 
+graphql`
+  fragment ExportAllTasksMenu_meetingTasks on Task {
+    id
+    integration {
+      id
+    }
+  }
+`
+
 const ExportAllTasksMenu = (props: Props) => {
   const {menuProps, mutationProps, meetingRef, queryRef, handlePushToIntegration} = props
   const data = usePreloadedQuery<ExportAllTasksMenuQuery>(query, queryRef)
@@ -46,18 +55,17 @@ const ExportAllTasksMenu = (props: Props) => {
         teamId
         ... on RetrospectiveMeeting {
           tasks {
-            id
-            integration {
-              id
-            }
+            ...ExportAllTasksMenu_meetingTasks @relay(mask: false)
           }
         }
         ... on ActionMeeting {
           tasks {
-            id
-            integration {
-              id
-            }
+            ...ExportAllTasksMenu_meetingTasks @relay(mask: false)
+          }
+        }
+        ... on TeamPromptMeeting {
+          tasks {
+            ...ExportAllTasksMenu_meetingTasks @relay(mask: false)
           }
         }
       }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
@@ -1,0 +1,160 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {PreloadedQuery, useFragment, usePreloadedQuery} from 'react-relay'
+import {MenuProps} from '../../../../../hooks/useMenu'
+import {MenuMutationProps} from '../../../../../hooks/useMutationProps'
+import {
+  ExportAllTasksMenuQuery,
+  ExportAllTasksMenuQuery$data
+} from '../../../../../__generated__/ExportAllTasksMenuQuery.graphql'
+import {ExportAllTasksMenu_meeting$key} from '../../../../../__generated__/ExportAllTasksMenu_meeting.graphql'
+import TaskFooterIntegrateMenuList from '../../../../../components/TaskFooterIntegrateMenuList'
+import TaskFooterIntegrateMenuSignup from '../../../../../components/TaskFooterIntegrateMenuSignup'
+import useAtmosphere from '../../../../../hooks/useAtmosphere'
+import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
+import CreateTaskIntegrationMutation from '../../../../../mutations/CreateTaskIntegrationMutation'
+
+interface Props {
+  menuProps: MenuProps
+  mutationProps: MenuMutationProps
+  meetingRef: ExportAllTasksMenu_meeting$key
+  queryRef: PreloadedQuery<ExportAllTasksMenuQuery>
+}
+
+type IntegrationLookup = {
+  hasGitHub: boolean
+  hasAtlassian: boolean
+  hasGitLab: boolean
+  hasJiraServer: boolean
+  hasAzureDevOps: boolean
+}
+
+const makePlaceholder = (integrationLookup: IntegrationLookup) => {
+  const {hasGitHub, hasAtlassian, hasGitLab, hasAzureDevOps} = integrationLookup
+  const names = [] as string[]
+  if (hasGitHub) names.push('GitHub')
+  if (hasAtlassian) names.push('Jira')
+  if (hasGitLab) names.push('GitLab')
+  if (hasAzureDevOps) names.push('Azure DevOps')
+  return `Search ${names.join(' & ')}`
+}
+
+type Integrations = NonNullable<
+  ExportAllTasksMenuQuery$data['viewer']['viewerTeamMember']
+>['integrations']
+
+const isIntegrated = (integrations: Integrations) => {
+  const {atlassian, github, jiraServer, gitlab, azureDevOps} = integrations
+  const hasAtlassian = atlassian?.isActive ?? false
+  const hasGitHub = github?.isActive ?? false
+  const hasGitLab = gitlab?.auth?.isActive ?? false
+  const hasJiraServer = jiraServer?.auth?.isActive ?? false
+  const hasAzureDevOps = azureDevOps?.auth?.isActive ?? false
+  return hasAtlassian || hasGitHub || hasJiraServer || hasGitLab || hasAzureDevOps
+    ? {
+        hasAtlassian,
+        hasGitHub,
+        hasJiraServer,
+        hasGitLab,
+        hasAzureDevOps
+      }
+    : null
+}
+
+const query = graphql`
+  query ExportAllTasksMenuQuery($teamId: ID!) {
+    viewer {
+      id
+      viewerTeamMember: teamMember(userId: null, teamId: $teamId) {
+        ...TaskFooterIntegrateMenuTeamMemberIntegrations @relay(mask: false)
+      }
+    }
+  }
+`
+
+const ExportAllTasksMenu = (props: Props) => {
+  const {menuProps, mutationProps, meetingRef, queryRef} = props
+  const data = usePreloadedQuery<ExportAllTasksMenuQuery>(query, queryRef)
+  const {viewer} = data
+  const meeting = useFragment(
+    graphql`
+      fragment ExportAllTasksMenu_meeting on NewMeeting {
+        teamId
+        ... on RetrospectiveMeeting {
+          tasks {
+            id
+            integration {
+              id
+            }
+          }
+        }
+        ... on ActionMeeting {
+          tasks {
+            id
+            integration {
+              id
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
+  const atmosphere = useAtmosphere()
+
+  const {viewerTeamMember} = viewer
+  const {teamId, tasks} = meeting
+  if (!viewerTeamMember) return null
+  const {integrations: viewerIntegrations} = viewerTeamMember
+  const isViewerIntegrated = isIntegrated(viewerIntegrations)
+
+  const {onError, onCompleted} = mutationProps
+
+  const filteredTasks = tasks?.filter((task) => !task.integration)
+
+  if (!filteredTasks || filteredTasks.length === 0) {
+    return null
+  }
+
+  const handlePushToIntegration = (
+    integrationRepoId: string,
+    integrationProviderService: IntegrationProviderServiceEnum
+  ) => {
+    filteredTasks?.forEach((task) => {
+      const variables = {
+        integrationRepoId,
+        taskId: task.id,
+        integrationProviderService: integrationProviderService
+      }
+      CreateTaskIntegrationMutation(atmosphere, variables, {onError, onCompleted})
+    })
+  }
+
+  if (isViewerIntegrated) {
+    const placeholder = makePlaceholder(isViewerIntegrated)
+    const label = 'Push with your credentials'
+    return (
+      <TaskFooterIntegrateMenuList
+        menuProps={menuProps}
+        placeholder={placeholder}
+        teamId={teamId}
+        onPushToIntegration={handlePushToIntegration}
+        label={label}
+      />
+    )
+  }
+
+  const label = "You don't have any integrations for this team yet."
+
+  return (
+    <TaskFooterIntegrateMenuSignup
+      menuProps={menuProps}
+      mutationProps={mutationProps}
+      teamId={teamId}
+      label={label}
+      integrationsRef={viewerIntegrations}
+    />
+  )
+}
+
+export default ExportAllTasksMenu

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenu.tsx
@@ -7,9 +7,7 @@ import {ExportAllTasksMenuQuery} from '../../../../../__generated__/ExportAllTas
 import {ExportAllTasksMenu_meeting$key} from '../../../../../__generated__/ExportAllTasksMenu_meeting.graphql'
 import TaskFooterIntegrateMenuList from '../../../../../components/TaskFooterIntegrateMenuList'
 import TaskFooterIntegrateMenuSignup from '../../../../../components/TaskFooterIntegrateMenuSignup'
-import useAtmosphere from '../../../../../hooks/useAtmosphere'
 import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
-import CreateTaskIntegrationMutation from '../../../../../mutations/CreateTaskIntegrationMutation'
 import {useIsIntegrated, makePlaceholder} from '../../../../../hooks/useIsIntegrated'
 
 interface Props {
@@ -17,6 +15,11 @@ interface Props {
   mutationProps: MenuMutationProps
   meetingRef: ExportAllTasksMenu_meeting$key
   queryRef: PreloadedQuery<ExportAllTasksMenuQuery>
+  handlePushToIntegration: (
+    integrationRepoId: string,
+    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationLabel?: string
+  ) => void
 }
 
 const query = graphql`
@@ -34,7 +37,7 @@ const query = graphql`
 `
 
 const ExportAllTasksMenu = (props: Props) => {
-  const {menuProps, mutationProps, meetingRef, queryRef} = props
+  const {menuProps, mutationProps, meetingRef, queryRef, handlePushToIntegration} = props
   const data = usePreloadedQuery<ExportAllTasksMenuQuery>(query, queryRef)
   const {viewer} = data
   const meeting = useFragment(
@@ -61,7 +64,6 @@ const ExportAllTasksMenu = (props: Props) => {
     `,
     meetingRef
   )
-  const atmosphere = useAtmosphere()
 
   const {viewerTeamMember} = viewer
   const {teamId, tasks} = meeting
@@ -70,26 +72,10 @@ const ExportAllTasksMenu = (props: Props) => {
   if (!viewerTeamMember) return null
   const {integrations: viewerIntegrations} = viewerTeamMember
 
-  const {onError, onCompleted} = mutationProps
-
   const filteredTasks = tasks?.filter((task) => !task.integration)
 
   if (!filteredTasks || filteredTasks.length === 0) {
     return null
-  }
-
-  const handlePushToIntegration = (
-    integrationRepoId: string,
-    integrationProviderService: IntegrationProviderServiceEnum
-  ) => {
-    filteredTasks?.forEach((task) => {
-      const variables = {
-        integrationRepoId,
-        taskId: task.id,
-        integrationProviderService: integrationProviderService
-      }
-      CreateTaskIntegrationMutation(atmosphere, variables, {onError, onCompleted})
-    })
   }
 
   if (isViewerIntegrated) {

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenuRoot.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenuRoot.tsx
@@ -1,0 +1,62 @@
+import graphql from 'babel-plugin-relay/macro'
+import React, {Suspense} from 'react'
+import {useFragment} from 'react-relay'
+import useQueryLoaderNow from '../../../../../hooks/useQueryLoaderNow'
+import {LoaderSize} from '../../../../../types/constEnums'
+import exportAllTasksMenuQuery, {
+  ExportAllTasksMenuQuery
+} from '../../../../../__generated__/ExportAllTasksMenuQuery.graphql'
+import {ExportAllTasksMenuRoot_meeting$key} from '../../../../../__generated__/ExportAllTasksMenuRoot_meeting.graphql'
+import LoadingComponent from '../../../../../components/LoadingComponent/LoadingComponent'
+import ExportAllTasksMenu from './ExportAllTasksMenu'
+import {MenuProps} from '../../../../../hooks/useMenu'
+import {MenuMutationProps} from '../../../../../hooks/useMutationProps'
+
+interface Props {
+  menuProps: MenuProps
+  loadingDelay: number
+  loadingWidth: number
+  mutationProps: MenuMutationProps
+  meetingRef: ExportAllTasksMenuRoot_meeting$key
+}
+
+const ExportAllTasksMenuRoot = (props: Props) => {
+  const {menuProps, loadingDelay, loadingWidth, mutationProps, meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment ExportAllTasksMenuRoot_meeting on NewMeeting {
+        teamId
+        ...ExportAllTasksMenu_meeting
+      }
+    `,
+    meetingRef
+  )
+  const {teamId} = meeting
+  const queryRef = useQueryLoaderNow<ExportAllTasksMenuQuery>(exportAllTasksMenuQuery, {
+    teamId
+  })
+  return (
+    <Suspense
+      fallback={
+        <LoadingComponent
+          delay={loadingDelay}
+          spinnerSize={LoaderSize.MENU}
+          height={loadingWidth ? LoaderSize.MENU : undefined}
+          width={loadingWidth}
+          showAfter={loadingWidth ? 0 : undefined}
+        />
+      }
+    >
+      {queryRef && (
+        <ExportAllTasksMenu
+          queryRef={queryRef}
+          menuProps={menuProps}
+          mutationProps={mutationProps}
+          meetingRef={meeting}
+        />
+      )}
+    </Suspense>
+  )
+}
+
+export default ExportAllTasksMenuRoot

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenuRoot.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenuRoot.tsx
@@ -11,7 +11,7 @@ import LoadingComponent from '../../../../../components/LoadingComponent/Loading
 import ExportAllTasksMenu from './ExportAllTasksMenu'
 import {MenuProps} from '../../../../../hooks/useMenu'
 import {MenuMutationProps} from '../../../../../hooks/useMutationProps'
-import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
+import {TaskServiceEnum} from '../../../../../__generated__/CreateTaskMutation.graphql'
 
 interface Props {
   menuProps: MenuProps
@@ -21,7 +21,7 @@ interface Props {
   meetingRef: ExportAllTasksMenuRoot_meeting$key
   handlePushToIntegration: (
     integrationRepoId: string,
-    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationProviderService: Exclude<TaskServiceEnum, 'PARABOL'>,
     integrationLabel?: string
   ) => void
 }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenuRoot.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasksMenuRoot.tsx
@@ -11,6 +11,7 @@ import LoadingComponent from '../../../../../components/LoadingComponent/Loading
 import ExportAllTasksMenu from './ExportAllTasksMenu'
 import {MenuProps} from '../../../../../hooks/useMenu'
 import {MenuMutationProps} from '../../../../../hooks/useMutationProps'
+import {IntegrationProviderServiceEnum} from '../../../../../__generated__/TaskFooterIntegrateMenuListLocalQuery.graphql'
 
 interface Props {
   menuProps: MenuProps
@@ -18,10 +19,22 @@ interface Props {
   loadingWidth: number
   mutationProps: MenuMutationProps
   meetingRef: ExportAllTasksMenuRoot_meeting$key
+  handlePushToIntegration: (
+    integrationRepoId: string,
+    integrationProviderService: IntegrationProviderServiceEnum,
+    integrationLabel?: string
+  ) => void
 }
 
 const ExportAllTasksMenuRoot = (props: Props) => {
-  const {menuProps, loadingDelay, loadingWidth, mutationProps, meetingRef} = props
+  const {
+    menuProps,
+    loadingDelay,
+    loadingWidth,
+    mutationProps,
+    meetingRef,
+    handlePushToIntegration
+  } = props
   const meeting = useFragment(
     graphql`
       fragment ExportAllTasksMenuRoot_meeting on NewMeeting {
@@ -53,6 +66,7 @@ const ExportAllTasksMenuRoot = (props: Props) => {
           menuProps={menuProps}
           mutationProps={mutationProps}
           meetingRef={meeting}
+          handlePushToIntegration={handlePushToIntegration}
         />
       )}
     </Suspense>

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -19,6 +19,7 @@ import SummaryPokerStories from './SummaryPokerStories'
 import SummarySheetCTA from './SummarySheetCTA'
 import TeamPromptResponseSummary from './TeamPromptResponseSummary'
 import WholeMeetingSummary from './WholeMeetingSummary'
+import ExportAllTasks from './ExportAllTasks'
 
 interface Props {
   emailCSVUrl: string
@@ -51,6 +52,15 @@ const SummarySheet = (props: Props) => {
     graphql`
       fragment SummarySheet_meeting on NewMeeting {
         id
+        ... on RetrospectiveMeeting {
+          taskCount
+        }
+        ... on ActionMeeting {
+          taskCount
+        }
+        ... on TeamPromptMeeting {
+          taskCount
+        }
         ...WholeMeetingSummary_meeting
         ...SummaryHeader_meeting
         ...QuickStats_meeting
@@ -59,13 +69,14 @@ const SummarySheet = (props: Props) => {
         ...RetroTopics_meeting
         ...SummaryPokerStories_meeting
         ...TeamPromptResponseSummary_meeting
+        ...ExportAllTasks_meeting
         meetingType
         name
       }
     `,
     meetingRef
   )
-  const {id: meetingId, meetingType} = meeting
+  const {id: meetingId, meetingType, taskCount} = meeting
   const isDemo = !!props.isDemo
 
   return (
@@ -78,6 +89,19 @@ const SummarySheet = (props: Props) => {
           </td>
         </tr>
         <SummarySheetCTA referrer={referrer} isDemo={isDemo} teamDashUrl={teamDashUrl} />
+        {referrer === 'meeting' && taskCount && taskCount > 0 && (
+          <tr>
+            <td
+              style={{
+                paddingTop: 44
+              }}
+              align='center'
+              width='100%'
+            >
+              <ExportAllTasks meetingRef={meeting} />
+            </td>
+          </tr>
+        )}
         <ExportToCSV
           emailCSVUrl={emailCSVUrl}
           meetingId={meetingId}

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -20,6 +20,9 @@ import SummarySheetCTA from './SummarySheetCTA'
 import TeamPromptResponseSummary from './TeamPromptResponseSummary'
 import WholeMeetingSummary from './WholeMeetingSummary'
 import lazyPreload from '../../../../../utils/lazyPreload'
+import EmailBorderBottom from '../MeetingSummaryEmail/EmailBorderBottom'
+import {PALETTE} from '../../../../../styles/paletteV3'
+import {TableChart} from '@mui/icons-material'
 
 const ExportAllTasks = lazyPreload(() => import('./ExportAllTasks'))
 
@@ -38,6 +41,11 @@ interface Props {
 const sheetStyle = {
   borderSpacing: 0,
   boxShadow: sheetShadow
+}
+
+const iconLinkLabel = {
+  color: PALETTE.SLATE_700,
+  fontSize: '13px'
 }
 
 const SummarySheet = (props: Props) => {
@@ -91,26 +99,59 @@ const SummarySheet = (props: Props) => {
           </td>
         </tr>
         <SummarySheetCTA referrer={referrer} isDemo={isDemo} teamDashUrl={teamDashUrl} />
-        {referrer === 'meeting' && !!taskCount && taskCount > 0 && (
+        {referrer === 'meeting' && !!taskCount && taskCount > 0 ? (
+          <>
+            <tr>
+              <td>
+                <table width='90%' align='center' className='mt-8 rounded-lg bg-slate-200 py-4'>
+                  <tbody>
+                    <tr>
+                      <td align='center' width='100%'>
+                        <div className='flex justify-center gap-4'>
+                          <ExportAllTasks meetingRef={meeting} />
+                          <button
+                            className={
+                              'flex cursor-pointer items-center gap-2 rounded-full border border-solid border-slate-400 bg-white px-5 py-2 text-center font-sans text-sm font-semibold hover:bg-slate-100'
+                            }
+                          >
+                            <TableChart
+                              style={{width: '14px', height: '14px', color: PALETTE.SLATE_600}}
+                            />
+                            Export to CSV
+                          </button>
+                        </div>
+                      </td>
+                      <td style={iconLinkLabel} align='center' width='0%'>
+                        <div className='hidden'>
+                          <ExportToCSV
+                            emailCSVUrl={emailCSVUrl}
+                            meetingId={meetingId}
+                            urlAction={urlAction}
+                            referrer={referrer}
+                            corsOptions={corsOptions}
+                          />
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </>
+        ) : (
           <tr>
-            <td
-              style={{
-                paddingTop: 44
-              }}
-              align='center'
-              width='100%'
-            >
-              <ExportAllTasks meetingRef={meeting} />
+            <td align='center' style={iconLinkLabel} width='100%'>
+              <ExportToCSV
+                emailCSVUrl={emailCSVUrl}
+                meetingId={meetingId}
+                urlAction={urlAction}
+                referrer={referrer}
+                corsOptions={corsOptions}
+              />
             </td>
           </tr>
         )}
-        <ExportToCSV
-          emailCSVUrl={emailCSVUrl}
-          meetingId={meetingId}
-          urlAction={urlAction}
-          referrer={referrer}
-          corsOptions={corsOptions}
-        />
+        <EmailBorderBottom />
         <CreateAccountSection dataCy='create-account-section' isDemo={isDemo} />
         {meetingType === 'teamPrompt' ? (
           <TeamPromptResponseSummary meetingRef={meeting} />

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -23,6 +23,7 @@ import lazyPreload from '../../../../../utils/lazyPreload'
 import EmailBorderBottom from '../MeetingSummaryEmail/EmailBorderBottom'
 import {PALETTE} from '../../../../../styles/paletteV3'
 import {TableChart} from '@mui/icons-material'
+import {Link} from 'react-router-dom'
 
 const ExportAllTasks = lazyPreload(() => import('./ExportAllTasks'))
 
@@ -109,7 +110,8 @@ const SummarySheet = (props: Props) => {
                       <td align='center' width='100%'>
                         <div className='flex justify-center gap-4'>
                           <ExportAllTasks meetingRef={meeting} />
-                          <button
+                          <Link
+                            to={emailCSVUrl}
                             className={
                               'flex cursor-pointer items-center gap-2 rounded-full border border-solid border-slate-400 bg-white px-5 py-2 text-center font-sans text-sm font-semibold hover:bg-slate-100'
                             }
@@ -118,7 +120,7 @@ const SummarySheet = (props: Props) => {
                               style={{width: '14px', height: '14px', color: PALETTE.SLATE_600}}
                             />
                             Export to CSV
-                          </button>
+                          </Link>
                         </div>
                       </td>
                       <td style={iconLinkLabel} align='center' width='0%'>
@@ -139,17 +141,13 @@ const SummarySheet = (props: Props) => {
             </tr>
           </>
         ) : (
-          <tr>
-            <td align='center' style={iconLinkLabel} width='100%'>
-              <ExportToCSV
-                emailCSVUrl={emailCSVUrl}
-                meetingId={meetingId}
-                urlAction={urlAction}
-                referrer={referrer}
-                corsOptions={corsOptions}
-              />
-            </td>
-          </tr>
+          <ExportToCSV
+            emailCSVUrl={emailCSVUrl}
+            meetingId={meetingId}
+            urlAction={urlAction}
+            referrer={referrer}
+            corsOptions={corsOptions}
+          />
         )}
         <EmailBorderBottom />
         <CreateAccountSection dataCy='create-account-section' isDemo={isDemo} />

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -44,11 +44,6 @@ const sheetStyle = {
   boxShadow: sheetShadow
 }
 
-const iconLinkLabel = {
-  color: PALETTE.SLATE_700,
-  fontSize: '13px'
-}
-
 const SummarySheet = (props: Props) => {
   const {
     emailCSVUrl,
@@ -100,7 +95,7 @@ const SummarySheet = (props: Props) => {
           </td>
         </tr>
         <SummarySheetCTA referrer={referrer} isDemo={isDemo} teamDashUrl={teamDashUrl} />
-        {referrer === 'meeting' && !!taskCount && taskCount > 0 ? (
+        {referrer === 'meeting' ? (
           <>
             <tr>
               <td>
@@ -109,7 +104,7 @@ const SummarySheet = (props: Props) => {
                     <tr>
                       <td align='center' width='100%'>
                         <div className='flex justify-center gap-4'>
-                          <ExportAllTasks meetingRef={meeting} />
+                          {!!taskCount && taskCount > 0 && <ExportAllTasks meetingRef={meeting} />}
                           <Link
                             to={emailCSVUrl}
                             className={
@@ -123,22 +118,25 @@ const SummarySheet = (props: Props) => {
                           </Link>
                         </div>
                       </td>
-                      <td style={iconLinkLabel} align='center' width='0%'>
-                        <div className='hidden'>
-                          <ExportToCSV
-                            emailCSVUrl={emailCSVUrl}
-                            meetingId={meetingId}
-                            urlAction={urlAction}
-                            referrer={referrer}
-                            corsOptions={corsOptions}
-                          />
-                        </div>
-                      </td>
                     </tr>
                   </tbody>
                 </table>
               </td>
             </tr>
+            {/* :HACK: The 'ExportToCSV' component both downloads the CSV if 'urlAction' is 'csv'
+                and shows the 'Export to CSV' button. We need the download functionality, but we
+                don't want to show the button as-is, so hide it in the DOM */}
+            <div className='hidden'>
+              {/* :TODO: (jmtaber129): Decouple the download and button functionality of this
+                  component. */}
+              <ExportToCSV
+                emailCSVUrl={emailCSVUrl}
+                meetingId={meetingId}
+                urlAction={urlAction}
+                referrer={referrer}
+                corsOptions={corsOptions}
+              />
+            </div>
           </>
         ) : (
           <ExportToCSV

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -19,7 +19,9 @@ import SummaryPokerStories from './SummaryPokerStories'
 import SummarySheetCTA from './SummarySheetCTA'
 import TeamPromptResponseSummary from './TeamPromptResponseSummary'
 import WholeMeetingSummary from './WholeMeetingSummary'
-import ExportAllTasks from './ExportAllTasks'
+import lazyPreload from '../../../../../utils/lazyPreload'
+
+const ExportAllTasks = lazyPreload(() => import('./ExportAllTasks'))
 
 interface Props {
   emailCSVUrl: string
@@ -89,7 +91,7 @@ const SummarySheet = (props: Props) => {
           </td>
         </tr>
         <SummarySheetCTA referrer={referrer} isDemo={isDemo} teamDashUrl={teamDashUrl} />
-        {referrer === 'meeting' && taskCount && taskCount > 0 && (
+        {referrer === 'meeting' && !!taskCount && taskCount > 0 && (
           <tr>
             <td
               style={{

--- a/packages/client/mutations/AddAtlassianAuthMutation.ts
+++ b/packages/client/mutations/AddAtlassianAuthMutation.ts
@@ -9,7 +9,7 @@ graphql`
       integrations {
         atlassian {
           ...AtlassianProviderRowAtlassianIntegration
-          ...TaskFooterIntegrateMenuViewerAtlassianIntegration
+          ...useIsIntegratedAtlassianIntegration
         }
       }
     }

--- a/packages/client/mutations/AddGitHubAuthMutation.ts
+++ b/packages/client/mutations/AddGitHubAuthMutation.ts
@@ -9,7 +9,7 @@ graphql`
       ...ScopePhaseAreaGitHub_teamMember
       integrations {
         github {
-          ...TaskFooterIntegrateMenuViewerGitHubIntegration
+          ...useIsIntegratedGitHubIntegration
           ...GitHubProviderRowGitHubIntegration
           ...GitHubScopingSearchBarGitHubIntegration
         }

--- a/packages/server/__tests__/processRecurrence.test.ts
+++ b/packages/server/__tests__/processRecurrence.test.ts
@@ -178,7 +178,7 @@ test('Should end meetings that are scheduled to end in the past', async () => {
 
   const actualMeeting = await r.table('NewMeeting').get(meetingId).run()
   expect(actualMeeting.endedAt).toBeTruthy()
-})
+}, 10000)
 
 test('Should end the current meeting and start a new meeting', async () => {
   const r = await getRethink()
@@ -316,7 +316,7 @@ test('Should only start a new meeting if it would still be active', async () => 
 
   const actualMeeting = await r.table('NewMeeting').get(meetingId).run()
   expect(actualMeeting.endedAt).toBeTruthy()
-})
+}, 10000)
 
 test('Should not start a new meeting if the rrule has not started', async () => {
   const r = await getRethink()

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -6118,6 +6118,11 @@ type TeamPromptMeeting implements NewMeeting {
   summarySentAt: DateTime
 
   """
+  The tasks created within the meeting
+  """
+  tasks: [Task!]!
+
+  """
   foreign key for team
   """
   teamId: ID!

--- a/packages/server/graphql/public/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/public/types/TeamPromptMeeting.ts
@@ -2,6 +2,8 @@ import MeetingSeriesId from 'parabol-client/shared/gqlIds/MeetingSeriesId'
 import {TeamPromptMeetingResolvers} from '../resolverTypes'
 import getRethink from '../../../database/rethinkDriver'
 import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
+import {getUserId} from '../../../utils/authorization'
+import filterTasksByMeeting from '../../../utils/filterTasksByMeeting'
 
 const TeamPromptMeeting: TeamPromptMeetingResolvers = {
   meetingSeriesId: ({meetingSeriesId}, _args, _context) => {
@@ -60,6 +62,13 @@ const TeamPromptMeeting: TeamPromptMeetingResolvers = {
       .run()
 
     return meetings[0] as MeetingTeamPrompt
+  },
+  tasks: async ({id: meetingId}, _args: unknown, {authToken, dataLoader}) => {
+    const viewerId = getUserId(authToken)
+    const meeting = await dataLoader.get('newMeetings').load(meetingId)
+    const {teamId} = meeting
+    const teamTasks = await dataLoader.get('tasksByTeamId').load(teamId)
+    return filterTasksByMeeting(teamTasks, meetingId, viewerId)
   }
 }
 


### PR DESCRIPTION
# Description
Add a bulk task export button to meeting summaries where tasks may have been created. This would:
* Enhance integration discoverability
* Reduce friction for moving meeting action items into a backlog (e.g. GitHub, Jira, etc.)

For simplicity, I'm calling the existing `createTaskIntegration` mutation multiple times in parallel instead of creating a new mutation or modifying the existing mutation to handle multiple tasks. We could refactor this approach into one of those two options, but it's best to use this simpler approach for now and pay down that tech debt sometime in the future.

## Demo
https://www.loom.com/share/349595bcea0646f19b5202bb4a6e5a1e

## Testing scenarios
- [ ] Smoke test pushing task to integration from task card
- [ ] Smoke test meeting summary with no tasks
- [ ] Smoke test email summary with + without tasks
- [ ] Test bulk export for one task
- [ ] Test bulk export for multiple tasks

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
