### PR TITLE
fix: fix syntax error when adjusting the user tier with empty list

### DIFF
--- a/packages/server/postgres/queries/updateUserTiers.ts
+++ b/packages/server/postgres/queries/updateUserTiers.ts
@@ -1,0 +1,11 @@
+import catchAndLog from '../utils/catchAndLog'
+import getPg from '../getPg'
+import {IUpdateUserTiersQueryParams, updateUserTiersQuery} from './generated/updateUserTiersQuery'
+
+const updateUserTiers = async ({users}: IUpdateUserTiersQueryParams) => {
+  if (users.length) {
+    await catchAndLog(() => updateUserTiersQuery.run({users}, getPg()))
+  }
+}
+
+export default updateUserTiers

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -2,11 +2,9 @@ import getRethink from '../database/rethinkDriver'
 import {RDatum, RValue} from '../database/stricterR'
 import OrganizationUser from '../database/types/OrganizationUser'
 import User from '../database/types/User'
-import {updateUserTiersQuery} from '../postgres//queries/generated/updateUserTiersQuery'
-import getPg from '../postgres/getPg'
 import {TierEnum} from '../postgres/queries/generated/updateUserQuery'
 import {getUsersByIds} from '../postgres/queries/getUsersByIds'
-import catchAndLog from '../postgres/utils/catchAndLog'
+import updateUserTiers from '../postgres//queries/updateUserTiers'
 import segmentIo from './segmentIo'
 
 const setUserTierForUserIds = async (userIds: string[]) => {
@@ -59,7 +57,7 @@ const setUserTierForUserIds = async (userIds: string[]) => {
       )
     }))
     .run()) as {id: string; tier: TierEnum}[]
-  await catchAndLog(() => updateUserTiersQuery.run({users: userTiers}, getPg()))
+  await updateUserTiers({users: userTiers})
 
   const users = await getUsersByIds(userIds)
   users.forEach((user) => {

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -4,7 +4,7 @@ import OrganizationUser from '../database/types/OrganizationUser'
 import User from '../database/types/User'
 import {TierEnum} from '../postgres/queries/generated/updateUserQuery'
 import {getUsersByIds} from '../postgres/queries/getUsersByIds'
-import updateUserTiers from '../postgres//queries/updateUserTiers'
+import updateUserTiers from '../postgres/queries/updateUserTiers'
 import segmentIo from './segmentIo'
 
 const setUserTierForUserIds = async (userIds: string[]) => {
@@ -57,7 +57,14 @@ const setUserTierForUserIds = async (userIds: string[]) => {
       )
     }))
     .run()) as {id: string; tier: TierEnum}[]
-  await updateUserTiers({users: userTiers})
+  const newUserTiers = userIds.map((userId) => {
+    const userTier = userTiers.find((userTier) => userTier.id === userId)
+    return {
+      id: userId,
+      tier: userTier ? userTier.tier : 'starter'
+    }
+  })
+  await updateUserTiers({users: newUserTiers})
 
   const users = await getUsersByIds(userIds)
   users.forEach((user) => {


### PR DESCRIPTION
# Description

Fixes #7934
SQL query expecting a list was called with an empty list which caused a syntax error

## Testing scenarios

- Sign up with a new user and delete the user again from the profile
    - [ ] no error is shown on the server side (as opposed to master)

- Sign up with a user joining a starter and team org
  - leave the team org
  - [ ] verify no error is shown and the User.highestTier is starter

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
