### PR TITLE
feat(ai-summary): replace GPT-3 with ChatGPT

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -123,7 +123,7 @@
     "node-pg-migrate": "^5.9.0",
     "nodemailer": "^6.4.6",
     "oauth-1.0a": "^2.2.6",
-    "openai": "^3.1.0",
+    "openai": "^3.2.0",
     "oy-vey": "^0.11.0",
     "parabol-client": "^6.96.0",
     "pg": "^8.5.1",

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -20,20 +20,25 @@ class OpenAIServerManager {
     if (!this.openAIApi) return null
     try {
       const location = summaryLocation ?? 'retro meeting'
-      const response = await this.openAIApi.createCompletion({
-        model: 'text-davinci-003',
-        prompt: `Below is a comma-separated list of text from a ${location}. Summarize the text for a second-grade student in one or two sentences.
+      const response = await this.openAIApi.createChatCompletion({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: `Below is a comma-separated list of text from a ${location}. Summarize the text for a second-grade student in one or two sentences.
 
-        Text: """
-        ${text}
-        """`,
+          Text: """
+          ${text}
+          """`
+          }
+        ],
         temperature: 0.7,
         max_tokens: 256,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      return (response.data.choices[0]?.text?.trim() as string) ?? null
+      return (response.data.choices[0]?.message?.content?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -20,19 +20,18 @@ class OpenAIServerManager {
     if (!this.openAIApi) return null
     try {
       const location = summaryLocation ?? 'retro meeting'
-      const prompt = `Below is a comma-separated list of text from a ${location}.
-      Summarize the text for a second-grade student in one or two sentences.
-      If you can't provide a summary, simply say the word "No".
-
-      Text: """
-      ${text}
-      """`
       const response = await this.openAIApi.createChatCompletion({
         model: 'gpt-3.5-turbo',
         messages: [
           {
             role: 'user',
-            content: prompt
+            content: `Below is a comma-separated list of text from a ${location}.
+            Summarize the text for a second-grade student in one or two sentences.
+            If you can't provide a summary, simply say the word "No".
+
+            Text: """
+            ${text}
+            """`
           }
         ],
         temperature: 0.7,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14466,10 +14466,10 @@ open@^8.0.9, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openai@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-3.1.0.tgz#13bfb228cf777155b882c2deb3a03bc5094cb7b3"
-  integrity sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==
+openai@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-3.2.1.tgz#1fa35bdf979cbde8453b43f2dd3a7d401ee40866"
+  integrity sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==
   dependencies:
     axios "^0.26.0"
     form-data "^4.0.0"


### PR DESCRIPTION
# Description
ChatGPT or GPT-3.5 performs at a similar capacity to GPT-3 but at only 10% of the price. This PR upgrades our OpenAI models to GPT-3.5. See the [official documentation](https://platform.openai.com/docs/guides/chat/chat-vs-completions) from OpenAI on this.

I would also like to make our prompts better, using all I've learnt from ["prompt engineering" course](https://learnprompting.org/docs/intro) but let's keep this one small and simple for now.

## Demo
This is from production:

<img width="878" alt="Screenshot 2023-03-28 at 18 28 19" src="https://user-images.githubusercontent.com/1879975/228322309-49a2691e-6cdc-4104-b7df-644dfd48a120.png">

This is from my local test, using same set of reflection text:
<img width="1108" alt="Screenshot 2023-03-28 at 18 28 28" src="https://user-images.githubusercontent.com/1879975/228322372-695c8c7b-34de-462f-accf-4e90bc0a3462.png">


## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Topic summary
  - Start a retro meeting and advance to discussion phase with more than 1 reflection for the topic
  - Observe the topic summary

- [ ] Meeting summary
  - End a retro meeting
  - Observer the meeting summary

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
