### PR TITLE
fix: org members panel UI

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -70,7 +70,8 @@ const OrgMembers = (props: Props) => {
   )
   const {data} = paginationRes
   const {viewer} = data
-  const {organization, checkoutFlow} = viewer
+  const {organization, featureFlags} = viewer
+  const {checkoutFlow} = featureFlags
   if (!organization) return null
   const {organizationUsers, name: orgName, isBillingLeader} = organization
   const billingLeaderCount = organizationUsers.edges.reduce(

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -14,7 +14,7 @@ import {APP_CORS_OPTIONS} from '../../../../types/cors'
 import OrgMemberRow from '../OrgUserRow/OrgMemberRow'
 
 const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
-  width: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
+  maxWidth: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
 }))
 
 interface Props {
@@ -108,7 +108,7 @@ const OrgMembers = (props: Props) => {
 
   return (
     <StyledPanel
-      isWide={!!checkoutFlow}
+      isWide={checkoutFlow}
       label='Organization Members'
       controls={
         isBillingLeader && (

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -13,9 +13,9 @@ import {ElementWidth} from '../../../../types/constEnums'
 import {APP_CORS_OPTIONS} from '../../../../types/cors'
 import OrgMemberRow from '../OrgUserRow/OrgMemberRow'
 
-const StyledPanel = styled(Panel)({
-  width: ElementWidth.PANEL_WIDTH
-})
+const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
+  width: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
+}))
 
 interface Props {
   queryRef: PreloadedQuery<OrgMembersQuery>
@@ -35,6 +35,9 @@ const OrgMembers = (props: Props) => {
     graphql`
       fragment OrgMembers_viewer on Query @refetchable(queryName: "OrgMembersPaginationQuery") {
         viewer {
+          featureFlags {
+            checkoutFlow
+          }
           organization(orgId: $orgId) {
             ...OrgMemberRow_organization
             name
@@ -67,7 +70,7 @@ const OrgMembers = (props: Props) => {
   )
   const {data} = paginationRes
   const {viewer} = data
-  const {organization} = viewer
+  const {organization, checkoutFlow} = viewer
   if (!organization) return null
   const {organizationUsers, name: orgName, isBillingLeader} = organization
   const billingLeaderCount = organizationUsers.edges.reduce(
@@ -104,6 +107,7 @@ const OrgMembers = (props: Props) => {
 
   return (
     <StyledPanel
+      isWide={!!checkoutFlow}
       label='Organization Members'
       controls={
         isBillingLeader && (


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7976

### To test

- [ ] Check the org members page with the checkoutFlow feature flag and see that the UI looks as expected
- [ ] Check the org members page without the checkoutFlow feature flag and see that the panel no longer stretches out to the right