### PR TITLE
fix(sentiment-analysis): Fix error payload from Google Language API

### DIFF
--- a/packages/server/GoogleLanguageManager.ts
+++ b/packages/server/GoogleLanguageManager.ts
@@ -73,11 +73,14 @@ interface CloudKey {
   privateKey: string
 }
 
-export type GoogleErrorResponse = [
-  {
-    error: GoogleError
-  }
-]
+export type GoogleErrorResponse = {
+  error: GoogleError
+}
+
+export type GoogleLanguageResponse =
+  | GoogleAnalyzedSyntax
+  | GoogleAnalyzedEntities
+  | GoogleAnalyzedSentiment
 
 const MAX_REQUEST_TIME = 10000
 
@@ -112,15 +115,13 @@ export default class GoogleLanguageManager {
 
   async post<T>(endpoint: string, content: string): Promise<T> {
     if (!this.jwt) {
-      return [
-        {
-          error: {
-            code: 500,
-            message: 'No JWT provided',
-            status: 'GOOGLE_CLOUD_PRIVATE_KEY is invalid in the .env'
-          }
+      return {
+        error: {
+          code: 500,
+          message: 'No JWT provided',
+          status: 'GOOGLE_CLOUD_PRIVATE_KEY is invalid in the .env'
         }
-      ] as any
+      } as any
     }
     const controller = new AbortController()
     const {signal} = controller as any
@@ -149,15 +150,13 @@ export default class GoogleLanguageManager {
       const error = e instanceof Error ? e : new Error('Failed to fetch google language apis')
       sendToSentry(error)
       clearTimeout(timeout)
-      return [
-        {
-          error: {
-            code: 500,
-            message: error.message,
-            status: 'Google is down'
-          }
+      return {
+        error: {
+          code: 500,
+          message: error.message,
+          status: 'Google is down'
         }
-      ] as any
+      } as any
     }
   }
 

--- a/packages/server/graphql/mutations/helpers/manageGoogleNLPErrorResponse.ts
+++ b/packages/server/graphql/mutations/helpers/manageGoogleNLPErrorResponse.ts
@@ -1,19 +1,15 @@
-import {GoogleErrorResponse} from '../../../GoogleLanguageManager'
+import {GoogleErrorResponse, GoogleLanguageResponse} from '../../../GoogleLanguageManager'
 import sendToSentry from '../../../utils/sendToSentry'
 
-const manageGoogleNLPErrorResponse = <T>(res: T) => {
-  if (Array.isArray(res)) {
-    const [firstError] = res
-    if (firstError) {
-      const {error} = firstError
-      if (error) {
-        const {message} = error
-        if (message !== 'No JWT provided') {
-          const re = /language \S+ is not supported/
-          if (!re.test(message)) {
-            sendToSentry(new Error(`Grouping Error: Google NLP: ${message}`))
-          }
-        }
+const manageGoogleNLPErrorResponse = <T extends GoogleLanguageResponse | GoogleErrorResponse>(
+  res: T
+) => {
+  if ('error' in res) {
+    const {message} = res.error
+    if (message !== 'No JWT provided') {
+      const re = /language \S+ is not supported/
+      if (!re.test(message)) {
+        sendToSentry(new Error(`Unhandled error from Google NLP: ${message}`))
       }
     }
     return null


### PR DESCRIPTION
# Description

Fixes #7987 

## Demo

Tested Russian & Arabic and verified the reflections can be added:

<img width="1160" alt="Screenshot 2023-04-03 at 09 27 28" src="https://user-images.githubusercontent.com/1879975/229570664-c9d74161-3acc-48ea-85ee-d653d9443c36.png">

## Testing scenarios

Try a few language options from the supported & unsupported [list](https://cloud.google.com/natural-language/docs/languages#entity_analysis) and make sure reflections can be properly added

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
