### PR TITLE
feat(rid): Activity Details (no sidebar)

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -28,23 +28,9 @@ interface CardTheme {
   secondary: string
 }
 
-export const QUICK_START_CATEGORY_ID = 'recommended'
+export type CategoryID = 'retrospective' | 'estimation' | 'standup' | 'feedback' | 'strategy'
 
-export const CATEGORY_ID_TO_NAME = {
-  [QUICK_START_CATEGORY_ID]: 'Quick Start',
-  retrospective: 'Retrospective',
-  estimation: 'Estimation',
-  standup: 'Standup',
-  feedback: 'Feedback',
-  strategy: 'Strategy'
-}
-
-export type CategoryID = keyof typeof CATEGORY_ID_TO_NAME
-
-export const MeetingThemes: Record<
-  Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>,
-  CardTheme
-> = {
+export const MeetingThemes: Record<CategoryID, CardTheme> = {
   standup: {primary: 'bg-aqua-400', secondary: 'bg-aqua-100'},
   estimation: {primary: 'bg-tomato-500', secondary: 'bg-tomato-100'},
   retrospective: {primary: 'bg-grape-500', secondary: 'bg-[#F2E1F7]'},
@@ -54,7 +40,7 @@ export const MeetingThemes: Record<
 
 export interface ActivityCardProps {
   className?: string
-  category: Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
+  category: CategoryID
   title?: string
   imageSrc: string
   badge: React.ReactNode | null

--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx'
 import React, {ComponentPropsWithoutRef, PropsWithChildren} from 'react'
-import {MeetingTypeEnum} from '../../__generated__/ActivityLibraryQuery.graphql'
 
 const ActivityCardImage = (props: PropsWithChildren<React.ImgHTMLAttributes<HTMLImageElement>>) => {
   const {className, src} = props
@@ -29,28 +28,45 @@ interface CardTheme {
   secondary: string
 }
 
-export const MeetingThemes: Record<MeetingTypeEnum, CardTheme> = {
-  action: {primary: 'bg-aqua-400', secondary: 'bg-aqua-100'},
-  poker: {primary: 'bg-tomato-500', secondary: 'bg-tomato-100'},
+export const QUICK_START_CATEGORY_ID = 'recommended'
+
+export const CATEGORY_ID_TO_NAME = {
+  [QUICK_START_CATEGORY_ID]: 'Quick Start',
+  retrospective: 'Retrospective',
+  estimation: 'Estimation',
+  standup: 'Standup',
+  feedback: 'Feedback',
+  strategy: 'Strategy'
+}
+
+export type CategoryID = keyof typeof CATEGORY_ID_TO_NAME
+
+export const MeetingThemes: Record<
+  Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>,
+  CardTheme
+> = {
+  standup: {primary: 'bg-aqua-400', secondary: 'bg-aqua-100'},
+  estimation: {primary: 'bg-tomato-500', secondary: 'bg-tomato-100'},
   retrospective: {primary: 'bg-grape-500', secondary: 'bg-[#F2E1F7]'},
-  teamPrompt: {primary: 'bg-aqua-400', secondary: 'bg-aqua-100'}
+  feedback: {primary: 'bg-jade-400', secondary: 'bg-jade-100'},
+  strategy: {primary: 'bg-rose-500', secondary: 'bg-rose-100'}
 }
 
 export interface ActivityCardProps {
   className?: string
-  type: MeetingTypeEnum
-  title: string
+  category: Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
+  title?: string
   imageSrc: string
   badge: React.ReactNode | null
 }
 
 export const ActivityCard = (props: ActivityCardProps) => {
-  const {className, type, title, imageSrc, badge} = props
+  const {className, category, title, imageSrc, badge} = props
   return (
     <div
       className={clsx(
         'flex flex-col overflow-hidden rounded-lg',
-        MeetingThemes[type].secondary,
+        MeetingThemes[category].secondary,
         className
       )}
     >
@@ -59,7 +75,7 @@ export const ActivityCard = (props: ActivityCardProps) => {
         <div
           className={clsx(
             'ml-auto h-8 w-8 flex-shrink-0 rounded-bl-full',
-            MeetingThemes[type].primary
+            MeetingThemes[category].primary
           )}
         />
       </div>
@@ -68,7 +84,7 @@ export const ActivityCard = (props: ActivityCardProps) => {
       </div>
       <div className='flex flex-shrink-0'>
         <div
-          className={clsx('h-8 w-8 flex-shrink-0 rounded-tr-full', MeetingThemes[type].primary)}
+          className={clsx('h-8 w-8 flex-shrink-0 rounded-tr-full', MeetingThemes[category].primary)}
         />
         <div className='ml-auto'>{badge}</div>
       </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -1,0 +1,223 @@
+import graphql from 'babel-plugin-relay/macro'
+import React, {useCallback, useEffect} from 'react'
+import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {useHistory} from 'react-router'
+
+import {ActivityDetailsQuery} from '~/__generated__/ActivityDetailsQuery.graphql'
+import {Link} from 'react-router-dom'
+import IconLabel from '../IconLabel'
+import EditableTemplateName from '../../modules/meeting/components/EditableTemplateName'
+import TemplatePromptList from '../../modules/meeting/components/TemplatePromptList'
+import AddTemplatePrompt from '../../modules/meeting/components/AddTemplatePrompt'
+import {
+  ActivityCard,
+  CATEGORY_ID_TO_NAME,
+  CategoryID,
+  MeetingThemes,
+  QUICK_START_CATEGORY_ID
+} from './ActivityCard'
+import {activityIllustrations} from './ActivityIllustrations'
+import customTemplateIllustration from '../../../../static/images/illustrations/customTemplate.png'
+import makeTemplateDescription from '../../utils/makeTemplateDescription'
+import clsx from 'clsx'
+import {UnstyledTemplateSharing} from '../../modules/meeting/components/TemplateSharing'
+import DetailAction from '../DetailAction'
+import RemoveReflectTemplateMutation from '../../mutations/RemoveReflectTemplateMutation'
+import useMutationProps from '../../hooks/useMutationProps'
+import useAtmosphere from '../../hooks/useAtmosphere'
+
+const query = graphql`
+  query ActivityDetailsQuery {
+    viewer {
+      tier
+      availableTemplates(first: 100) @connection(key: "ActivityDetails_availableTemplates") {
+        edges {
+          node {
+            id
+            name
+            type
+            category
+            orgId
+            ...RemoveTemplate_teamTemplates
+            ...EditableTemplateName_teamTemplates
+            ...ReflectTemplateDetailsTemplate @relay(mask: false)
+          }
+        }
+      }
+      teams {
+        id
+      }
+      organizations {
+        id
+      }
+      featureFlags {
+        templateLimit
+        retrosInDisguise
+      }
+
+      ...makeTemplateDescription_viewer
+    }
+  }
+`
+
+interface Props {
+  queryRef: PreloadedQuery<ActivityDetailsQuery>
+  templateId: string
+}
+
+const ActivityDetails = (props: Props) => {
+  const {queryRef, templateId} = props
+  const data = usePreloadedQuery<ActivityDetailsQuery>(query, queryRef)
+  const {viewer} = data
+  const {availableTemplates, teams, organizations, tier} = viewer
+  const selectedTemplate = availableTemplates.edges.find(
+    (edge) => edge.node.id === templateId && edge.node.type === 'retrospective'
+  )?.node
+
+  const history = useHistory()
+
+  useEffect(() => {
+    if (!selectedTemplate) {
+      history.replace('/activity-library')
+    }
+  })
+
+  const atmosphere = useAtmosphere()
+  const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
+
+  const removeTemplate = useCallback(() => {
+    if (submitting) return
+    submitMutation()
+    RemoveReflectTemplateMutation(
+      atmosphere,
+      {templateId},
+      {
+        onError,
+        onCompleted: () => {
+          onCompleted()
+          history.replace('/activity-library')
+        }
+      }
+    )
+  }, [templateId, submitting, submitMutation, onError, onCompleted])
+
+  if (!selectedTemplate) {
+    return null
+  }
+
+  const {name: templateName, prompts} = selectedTemplate
+  const teamIds = teams.map((team) => team.id)
+  const orgIds = organizations.map((org) => org.id)
+
+  const isOwner = teamIds.includes(selectedTemplate.teamId!)
+
+  const teamTemplates = availableTemplates.edges
+    .map((edge) => edge.node)
+    .filter((edge) => edge.teamId === selectedTemplate.teamId)
+
+  const lowestScope = isOwner
+    ? 'TEAM'
+    : orgIds.includes(selectedTemplate.orgId)
+    ? 'ORGANIZATION'
+    : 'PUBLIC'
+  const description = makeTemplateDescription(lowestScope, selectedTemplate, viewer, tier)
+
+  const templateIllustration =
+    activityIllustrations[selectedTemplate.id as keyof typeof activityIllustrations]
+  const activityIllustration = templateIllustration ?? customTemplateIllustration
+
+  return (
+    <div className='flex h-full bg-white'>
+      <div className='ml-4 mt-4'>
+        <div className='flex w-max items-center'>
+          <Link className='mr-4' to='/activity-library'>
+            <IconLabel icon={'arrow_back'} iconLarge />
+          </Link>
+          <div className='w-max text-xl font-semibold'>Start Activity</div>
+        </div>
+      </div>
+      <div className='mt-14 flex w-full justify-center'>
+        <div className='mx-auto flex justify-center'>
+          <ActivityCard
+            className='h-[200px] w-80'
+            category={
+              selectedTemplate.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
+            }
+            imageSrc={activityIllustration}
+            badge={null}
+          />
+          <div className='mx-auto'>
+            <div className='mb-10 pl-14'>
+              <div className='flex h-8 items-center'>
+                <EditableTemplateName
+                  className='mb-2 text-[32px]'
+                  key={templateId}
+                  name={templateName}
+                  templateId={templateId}
+                  teamTemplates={teamTemplates}
+                  isOwner={isOwner}
+                />
+              </div>
+              <div
+                className={clsx(
+                  'mb-4 w-min rounded-full px-3 py-1 text-xs font-semibold text-white',
+                  MeetingThemes[
+                    selectedTemplate.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
+                  ].primary
+                )}
+              >
+                {
+                  CATEGORY_ID_TO_NAME[
+                    selectedTemplate.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
+                  ]
+                }
+              </div>
+              <div className='mb-8'>
+                {isOwner ? (
+                  <div className='flex items-center justify-between'>
+                    <div className='w-max rounded-full border border-solid border-slate-400 pl-3'>
+                      <UnstyledTemplateSharing
+                        noModal={true}
+                        isOwner={isOwner}
+                        template={selectedTemplate}
+                      />
+                    </div>
+                    <div className='rounded-full border border-solid border-slate-400'>
+                      <DetailAction
+                        icon={'delete'}
+                        tooltip={'Delete template'}
+                        onClick={removeTemplate}
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <div className='py-2 text-sm font-semibold text-slate-600'>{description}</div>
+                )}
+              </div>
+
+              <div className='w-[480px]'>
+                <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common themes and
+                vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
+                <b>takeaway tasks</b> that can be integrated with your backlog.
+              </div>
+              {/* {isOwner && (
+                <RemoveTemplate
+                  templateId={templateId}
+                  teamId={selectedTemplate.teamId!}
+                  teamTemplates={teamTemplates}
+                  gotoPublicTemplates={() => history.replace('/activity-library')}
+                  type='retrospective'
+                />
+              )} */}
+              {/* {showClone && <CloneTemplate onClick={onClone} canClone={canClone} />} */}
+            </div>
+            <TemplatePromptList isOwner={isOwner} prompts={prompts!} templateId={templateId} />
+            {isOwner && <AddTemplatePrompt templateId={templateId} prompts={prompts!} />}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ActivityDetails

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {useCallback, useEffect} from 'react'
+import React, {useCallback} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {useHistory} from 'react-router'
+import {Redirect, useHistory} from 'react-router'
 
 import {ActivityDetailsQuery} from '~/__generated__/ActivityDetailsQuery.graphql'
 import {Link} from 'react-router-dom'
@@ -91,12 +91,6 @@ const ActivityDetails = (props: Props) => {
 
   const history = useHistory()
 
-  useEffect(() => {
-    if (!selectedTemplate) {
-      history.replace('/activity-library')
-    }
-  })
-
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
 
@@ -117,7 +111,7 @@ const ActivityDetails = (props: Props) => {
   }, [templateId, submitting, submitMutation, onError, onCompleted])
 
   if (!selectedTemplate) {
-    return null
+    return <Redirect to='/activity-library' />
   }
 
   const {name: templateName, prompts} = selectedTemplate

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -160,7 +160,7 @@ const ActivityDetails = (props: Props) => {
           />
           <div className='mx-auto'>
             <div className='mb-10 pl-14'>
-              <div className='mb-2 flex h-8 items-center'>
+              <div className='mb-2 flex min-h-[40px] items-center'>
                 <EditableTemplateName
                   className='text-[32px]'
                   key={templateId}

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -9,13 +9,7 @@ import IconLabel from '../IconLabel'
 import EditableTemplateName from '../../modules/meeting/components/EditableTemplateName'
 import TemplatePromptList from '../../modules/meeting/components/TemplatePromptList'
 import AddTemplatePrompt from '../../modules/meeting/components/AddTemplatePrompt'
-import {
-  ActivityCard,
-  CATEGORY_ID_TO_NAME,
-  CategoryID,
-  MeetingThemes,
-  QUICK_START_CATEGORY_ID
-} from './ActivityCard'
+import {ActivityCard, CategoryID, MeetingThemes} from './ActivityCard'
 import {activityIllustrations} from './ActivityIllustrations'
 import customTemplateIllustration from '../../../../static/images/illustrations/customTemplate.png'
 import makeTemplateDescription from '../../utils/makeTemplateDescription'
@@ -30,6 +24,7 @@ import JiraSVG from '../JiraSVG'
 import GitLabSVG from '../GitLabSVG'
 import AzureDevOpsSVG from '../AzureDevOpsSVG'
 import JiraServerSVG from '../JiraServerSVG'
+import {CATEGORY_ID_TO_NAME} from './ActivityLibrary'
 
 const query = graphql`
   query ActivityDetailsQuery {
@@ -131,6 +126,8 @@ const ActivityDetails = (props: Props) => {
     activityIllustrations[selectedTemplate.id as keyof typeof activityIllustrations]
   const activityIllustration = templateIllustration ?? customTemplateIllustration
 
+  const category = selectedTemplate.category as CategoryID
+
   return (
     <div className='flex h-full bg-white'>
       <div className='ml-4 mt-4'>
@@ -145,9 +142,7 @@ const ActivityDetails = (props: Props) => {
         <div className='mx-auto flex justify-center'>
           <ActivityCard
             className='h-[200px] w-80'
-            category={
-              selectedTemplate.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
-            }
+            category={category}
             imageSrc={activityIllustration}
             badge={null}
           />
@@ -166,16 +161,10 @@ const ActivityDetails = (props: Props) => {
               <div
                 className={clsx(
                   'mb-4 w-min rounded-full px-3 py-1 text-xs font-semibold text-white',
-                  MeetingThemes[
-                    selectedTemplate.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
-                  ].primary
+                  MeetingThemes[category].primary
                 )}
               >
-                {
-                  CATEGORY_ID_TO_NAME[
-                    selectedTemplate.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
-                  ]
-                }
+                {CATEGORY_ID_TO_NAME[category]}
               </div>
               <div className='mb-8'>
                 {isOwner ? (
@@ -217,16 +206,6 @@ const ActivityDetails = (props: Props) => {
                   <b>Tip:</b> push takeaway tasks to your backlog
                 </div>
               </div>
-              {/* {isOwner && (
-                <RemoveTemplate
-                  templateId={templateId}
-                  teamId={selectedTemplate.teamId!}
-                  teamTemplates={teamTemplates}
-                  gotoPublicTemplates={() => history.replace('/activity-library')}
-                  type='retrospective'
-                />
-              )} */}
-              {/* {showClone && <CloneTemplate onClick={onClone} canClone={canClone} />} */}
             </div>
             <TemplatePromptList isOwner={isOwner} prompts={prompts!} templateId={templateId} />
             {isOwner && <AddTemplatePrompt templateId={templateId} prompts={prompts!} />}

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -38,6 +38,7 @@ const query = graphql`
             type
             category
             orgId
+            isFree
             ...RemoveTemplate_teamTemplates
             ...EditableTemplateName_teamTemplates
             ...ReflectTemplateDetailsTemplate @relay(mask: false)
@@ -59,6 +60,20 @@ const query = graphql`
     }
   }
 `
+
+interface DetailsBadgeProps {
+  className?: string
+  children?: React.ReactNode
+}
+
+const DetailsBadge = (props: DetailsBadgeProps) => {
+  const {className, children} = props
+  return (
+    <div className={clsx('w-min rounded-full px-3 py-1 text-xs font-semibold', className)}>
+      {children}
+    </div>
+  )
+}
 
 interface Props {
   queryRef: PreloadedQuery<ActivityDetailsQuery>
@@ -148,9 +163,9 @@ const ActivityDetails = (props: Props) => {
           />
           <div className='mx-auto'>
             <div className='mb-10 pl-14'>
-              <div className='flex h-8 items-center'>
+              <div className='mb-2 flex h-8 items-center'>
                 <EditableTemplateName
-                  className='mb-2 text-[32px]'
+                  className='text-[32px]'
                   key={templateId}
                   name={templateName}
                   templateId={templateId}
@@ -158,13 +173,16 @@ const ActivityDetails = (props: Props) => {
                   isOwner={isOwner}
                 />
               </div>
-              <div
-                className={clsx(
-                  'mb-4 w-min rounded-full px-3 py-1 text-xs font-semibold text-white',
-                  MeetingThemes[category].primary
-                )}
-              >
-                {CATEGORY_ID_TO_NAME[category]}
+              <div className='mb-4 flex gap-2'>
+                <DetailsBadge className={clsx(MeetingThemes[category].primary, 'text-white')}>
+                  {CATEGORY_ID_TO_NAME[category]}
+                </DetailsBadge>
+                {!selectedTemplate.isFree &&
+                  (lowestScope === 'PUBLIC' ? (
+                    <DetailsBadge className='bg-gold-300 text-grape-700'>Premium</DetailsBadge>
+                  ) : (
+                    <DetailsBadge className='bg-grape-700 text-white'>Custom</DetailsBadge>
+                  ))}
               </div>
               <div className='mb-8'>
                 {isOwner ? (

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -25,6 +25,11 @@ import DetailAction from '../DetailAction'
 import RemoveReflectTemplateMutation from '../../mutations/RemoveReflectTemplateMutation'
 import useMutationProps from '../../hooks/useMutationProps'
 import useAtmosphere from '../../hooks/useAtmosphere'
+import GitHubSVG from '../GitHubSVG'
+import JiraSVG from '../JiraSVG'
+import GitLabSVG from '../GitLabSVG'
+import AzureDevOpsSVG from '../AzureDevOpsSVG'
+import JiraServerSVG from '../JiraServerSVG'
 
 const query = graphql`
   query ActivityDetailsQuery {
@@ -199,6 +204,18 @@ const ActivityDetails = (props: Props) => {
                 <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common themes and
                 vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
                 <b>takeaway tasks</b> that can be integrated with your backlog.
+              </div>
+              <div className='mt-[18px] flex items-center'>
+                <div className='flex items-center gap-3'>
+                  <JiraSVG />
+                  <GitHubSVG />
+                  <JiraServerSVG />
+                  <GitLabSVG />
+                  <AzureDevOpsSVG />
+                </div>
+                <div className='ml-4'>
+                  <b>Tip:</b> push takeaway tasks to your backlog
+                </div>
               </div>
               {/* {isOwner && (
                 <RemoveTemplate

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -89,7 +89,7 @@ const ActivityDetails = (props: Props) => {
     (edge) => edge.node.id === templateId && edge.node.type === 'retrospective'
   )?.node
 
-  const history = useHistory()
+  const history = useHistory<{prevCategory?: string}>()
 
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
@@ -141,7 +141,10 @@ const ActivityDetails = (props: Props) => {
     <div className='flex h-full bg-white'>
       <div className='ml-4 mt-4'>
         <div className='flex w-max items-center'>
-          <Link className='mr-4' to='/activity-library'>
+          <Link
+            className='mr-4'
+            to={`/activity-library/category/${history.location.state?.prevCategory ?? category}`}
+          >
             <IconLabel icon={'arrow_back'} iconLarge />
           </Link>
           <div className='w-max text-xl font-semibold'>Start Activity</div>

--- a/packages/client/components/ActivityLibrary/ActivityDetailsRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsRoute.tsx
@@ -1,0 +1,29 @@
+import React, {Suspense, useEffect} from 'react'
+import activityDetailsQuery, {
+  ActivityDetailsQuery
+} from '~/__generated__/ActivityDetailsQuery.graphql'
+import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
+import {renderLoader} from '../../utils/relay/renderLoader'
+import ActivityDetails from './ActivityDetails'
+import useRouter from '../../hooks/useRouter'
+
+const ActivityDetailsRoute = () => {
+  const {history, match} = useRouter<{templateId: string}>()
+  const {params} = match
+  const {templateId} = params
+  useEffect(() => {
+    if (!templateId) {
+      history.replace('/activity-library')
+    }
+  }, [])
+
+  const queryRef = useQueryLoaderNow<ActivityDetailsQuery>(activityDetailsQuery)
+
+  return (
+    <Suspense fallback={renderLoader()}>
+      {queryRef && <ActivityDetails queryRef={queryRef} templateId={templateId} />}
+    </Suspense>
+  )
+}
+
+export default ActivityDetailsRoute

--- a/packages/client/components/ActivityLibrary/ActivityDetailsRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsRoute.tsx
@@ -1,4 +1,4 @@
-import React, {Suspense, useEffect} from 'react'
+import React, {Suspense} from 'react'
 import activityDetailsQuery, {
   ActivityDetailsQuery
 } from '~/__generated__/ActivityDetailsQuery.graphql'
@@ -6,18 +6,16 @@ import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
 import {renderLoader} from '../../utils/relay/renderLoader'
 import ActivityDetails from './ActivityDetails'
 import useRouter from '../../hooks/useRouter'
+import {Redirect} from 'react-router'
 
 const ActivityDetailsRoute = () => {
-  const {history, match} = useRouter<{templateId: string}>()
+  const {match} = useRouter<{templateId: string}>()
   const {params} = match
   const {templateId} = params
-  useEffect(() => {
-    if (!templateId) {
-      history.replace('/activity-library')
-    }
-  }, [])
 
   const queryRef = useQueryLoaderNow<ActivityDetailsQuery>(activityDetailsQuery)
+
+  if (!templateId) return <Redirect to='/activity-library' />
 
   return (
     <Suspense fallback={renderLoader()}>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -202,7 +202,10 @@ export const ActivityLibrary = (props: Props) => {
                 return (
                   <Link
                     key={template.id}
-                    to={`/activity-library/details/${template.id}`}
+                    to={{
+                      pathname: `/activity-library/details/${template.id}`,
+                      state: {prevCategory: selectedCategory}
+                    }}
                     className='flex focus:rounded-md focus:outline-primary'
                   >
                     <ActivityLibraryCard

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -155,7 +155,9 @@ export const ActivityLibrary = (props: Props) => {
       <ScrollArea.Root className='w-full'>
         <ScrollArea.Viewport className='w-full'>
           <div className='flex gap-x-2 px-4 md:mx-[15%] md:pb-4'>
-            {(Object.keys(CATEGORY_ID_TO_NAME) as Array<CategoryID>).map((category) => (
+            {(
+              Object.keys(CATEGORY_ID_TO_NAME) as Array<CategoryID | typeof QUICK_START_CATEGORY_ID>
+            ).map((category) => (
               <Link
                 className={clsx(
                   'flex-shrink-0 cursor-pointer rounded-full py-2 px-4 text-xs font-semibold text-slate-700',
@@ -206,9 +208,7 @@ export const ActivityLibrary = (props: Props) => {
                     <ActivityLibraryCard
                       className='flex-1'
                       key={template.id}
-                      category={
-                        template.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
-                      }
+                      category={template.category as CategoryID}
                       title={template.name}
                       imageSrc={activityIllustration}
                       badge={

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -153,6 +153,23 @@ export const ActivityLibrary = (props: Props) => {
       </ActivityLibraryHeader>
       <ActivityLibraryMobileHeader className='flex md:hidden' onClose={handleCloseClick}>
         <SearchBar searchQuery={searchQuery} onChange={onQueryChange} />
+        <div className='ml-2 flex gap-x-2'>
+          {(Object.keys(CATEGORY_ID_TO_NAME) as Array<CategoryID>).map((category) => (
+            <Link
+              className={clsx(
+                'cursor-pointer rounded-full px-4 py-2 text-xs font-semibold text-slate-700',
+                category === selectedCategory && searchQuery.length === 0
+                  ? [CATEGORY_ID_TO_COLOR_CLASS[category], 'text-white focus:text-white']
+                  : 'bg-slate-200'
+              )}
+              to={`/activity-library/category/${category}`}
+              onClick={() => resetQuery()}
+              key={category}
+            >
+              {CATEGORY_ID_TO_NAME[category]}
+            </Link>
+          ))}
+        </div>
       </ActivityLibraryMobileHeader>
 
       <ScrollArea.Root className='w-full'>
@@ -209,7 +226,9 @@ export const ActivityLibrary = (props: Props) => {
                     <ActivityLibraryCard
                       className='flex-1'
                       key={template.id}
-                      type={template.type}
+                      category={
+                        template.category as Exclude<CategoryID, typeof QUICK_START_CATEGORY_ID>
+                      }
                       title={template.name}
                       imageSrc={activityIllustration}
                       badge={

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -15,6 +15,7 @@ import SearchBar from './SearchBar'
 import useSearchFilter from '../../hooks/useSearchFilter'
 import halloweenRetrospectiveTemplate from '../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 import clsx from 'clsx'
+import {CategoryID, MeetingThemes} from './ActivityCard'
 
 graphql`
   fragment ActivityLibrary_template on MeetingTemplate {
@@ -56,7 +57,7 @@ const getTemplateValue = (template: {name: string}) => template.name
 
 const QUICK_START_CATEGORY_ID = 'recommended'
 
-const CATEGORY_ID_TO_NAME = {
+export const CATEGORY_ID_TO_NAME: Record<CategoryID | typeof QUICK_START_CATEGORY_ID, string> = {
   [QUICK_START_CATEGORY_ID]: 'Quick Start',
   retrospective: 'Retrospective',
   estimation: 'Estimation',
@@ -65,18 +66,14 @@ const CATEGORY_ID_TO_NAME = {
   strategy: 'Strategy'
 }
 
-type CategoryID = keyof typeof CATEGORY_ID_TO_NAME
-
-// :TODO: (jmtaber129): Fold this into the 'MeetingThemes' to be added in
-// https://github.com/ParabolInc/parabol/pull/7908.
-const CATEGORY_ID_TO_COLOR_CLASS = {
+const CategoryIDToColorClass = {
   [QUICK_START_CATEGORY_ID]: 'bg-grape-700',
-  retrospective: 'bg-grape-500',
-  estimation: 'bg-tomato-500',
-  standup: 'bg-aqua-400',
-  feedback: 'bg-jade-400',
-  strategy: 'bg-rose-500'
-}
+  ...Object.fromEntries(
+    Object.entries(MeetingThemes).map(([key, value]) => {
+      return [key, value.primary]
+    })
+  )
+} as Record<CategoryID | typeof QUICK_START_CATEGORY_ID, string>
 
 export const ActivityLibrary = (props: Props) => {
   const {queryRef} = props
@@ -153,23 +150,6 @@ export const ActivityLibrary = (props: Props) => {
       </ActivityLibraryHeader>
       <ActivityLibraryMobileHeader className='flex md:hidden' onClose={handleCloseClick}>
         <SearchBar searchQuery={searchQuery} onChange={onQueryChange} />
-        <div className='ml-2 flex gap-x-2'>
-          {(Object.keys(CATEGORY_ID_TO_NAME) as Array<CategoryID>).map((category) => (
-            <Link
-              className={clsx(
-                'cursor-pointer rounded-full px-4 py-2 text-xs font-semibold text-slate-700',
-                category === selectedCategory && searchQuery.length === 0
-                  ? [CATEGORY_ID_TO_COLOR_CLASS[category], 'text-white focus:text-white']
-                  : 'bg-slate-200'
-              )}
-              to={`/activity-library/category/${category}`}
-              onClick={() => resetQuery()}
-              key={category}
-            >
-              {CATEGORY_ID_TO_NAME[category]}
-            </Link>
-          ))}
-        </div>
       </ActivityLibraryMobileHeader>
 
       <ScrollArea.Root className='w-full'>
@@ -180,7 +160,7 @@ export const ActivityLibrary = (props: Props) => {
                 className={clsx(
                   'flex-shrink-0 cursor-pointer rounded-full py-2 px-4 text-xs font-semibold text-slate-700',
                   category === selectedCategory && searchQuery.length === 0
-                    ? [CATEGORY_ID_TO_COLOR_CLASS[category], 'text-white focus:text-white']
+                    ? [CategoryIDToColorClass[category], 'text-white focus:text-white']
                     : 'bg-slate-200'
                 )}
                 to={`/activity-library/category/${category}`}

--- a/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
@@ -23,7 +23,7 @@ export const ActivityLibraryCardBadge = (props: ActivityLibraryCardBadgeProps) =
 }
 
 export const ActivityLibraryCard = (props: ActivityCardProps) => {
-  const {className, type, ...rest} = props
+  const {className, category, ...rest} = props
 
   return (
     <ActivityCard
@@ -31,7 +31,7 @@ export const ActivityLibraryCard = (props: ActivityCardProps) => {
         'group transition-shadow focus-within:ring-2 focus-within:ring-primary hover:shadow-md motion-reduce:transition-none',
         className
       )}
-      type={type}
+      category={category}
       {...rest}
     />
   )

--- a/packages/client/components/AzureDevOpsSVG.tsx
+++ b/packages/client/components/AzureDevOpsSVG.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 const AzureDevOpsSVG = React.memo(() => {
   return (
-    <svg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <svg width='24' height='24' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'>
       <defs>
         <linearGradient id='a' x1='9' y1='16.97' x2='9' y2='1.03' gradientUnits='userSpaceOnUse'>
           <stop offset='0' stopColor='#0078d4' />

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -40,6 +40,9 @@ const ViewerNotOnTeamRoot = lazy(
 const ActivityLibraryRoute = lazy(
   () => import(/* webpackChunkName: 'ActivityLibrary' */ './ActivityLibrary/ActivityLibraryRoute')
 )
+const ActivityDetailsRoute = lazy(
+  () => import(/* webpackChunkName: 'ActivityDetails' */ './ActivityLibrary/ActivityDetailsRoute')
+)
 
 const PrivateRoutes = () => {
   useAuthRoute()
@@ -48,6 +51,7 @@ const PrivateRoutes = () => {
     <Switch>
       <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
       <Route path='/activity-library/category/:categoryId' component={ActivityLibraryRoute} />
+      <Route path='/activity-library/details/:templateId' component={ActivityDetailsRoute} />
       <Route path='/activity-library' component={ActivityLibraryRoute} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />

--- a/packages/client/modules/meeting/components/EditableTemplateName.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplateName.tsx
@@ -14,6 +14,7 @@ interface Props {
   templateId: string
   teamTemplates: EditableTemplateName_teamTemplates$key
   isOwner: boolean
+  className?: string
 }
 
 const InheritedStyles = styled('div')({
@@ -27,7 +28,7 @@ const StyledEditableText = styled(EditableText)({
   lineHeight: '24px'
 })
 const EditableTemplateName = (props: Props) => {
-  const {name, templateId, teamTemplates: teamTemplatesRef, isOwner} = props
+  const {name, templateId, teamTemplates: teamTemplatesRef, isOwner, className} = props
   const teamTemplates = useFragment(
     graphql`
       fragment EditableTemplateName_teamTemplates on MeetingTemplate @relay(plural: true) {
@@ -76,6 +77,7 @@ const EditableTemplateName = (props: Props) => {
   return (
     <InheritedStyles>
       <StyledEditableText
+        className={className}
         autoFocus={autoFocus}
         disabled={!isOwner}
         error={error ? error.message : undefined}

--- a/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
@@ -176,7 +176,7 @@ const PokerTemplateDetails = (props: Props) => {
         </TemplateHeader>
         <TemplateDimensionList isOwner={isOwner} dimensions={dimensions} templateId={templateId} />
         {isOwner && <AddPokerTemplateDimension templateId={templateId} dimensions={dimensions} />}
-        <TemplateSharing teamId={teamId} template={activeTemplate} />
+        <TemplateSharing isOwner={isOwner} template={activeTemplate} />
       </Scrollable>
       {!isActiveTemplate && (
         <SelectTemplate closePortal={closePortal} template={activeTemplate} teamId={teamId} />

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -176,7 +176,7 @@ const ReflectTemplateDetails = (props: Props) => {
         </TemplateHeader>
         <TemplatePromptList isOwner={isOwner} prompts={prompts} templateId={templateId} />
         {isOwner && <AddTemplatePrompt templateId={templateId} prompts={prompts} />}
-        <TemplateSharing teamId={teamId} template={activeTemplate} />
+        <TemplateSharing isOwner={isOwner} template={activeTemplate} />
       </Scrollable>
       {!isActiveTemplate && (
         <SelectTemplate

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -73,6 +73,10 @@ interface Props {
 }
 
 const TemplateSharing = (props: Props) => {
+  const {isOwner} = props
+
+  if (!isOwner) return null
+
   return (
     <>
       <HR />

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -29,7 +29,7 @@ const HR = styled('hr')({
 })
 
 const DropdownDecoratorIcon = styled('div')({
-  margin: '8px 16px',
+  marginRight: '16px',
   color: PALETTE.SLATE_600,
   cursor: 'pointer',
   svg: {
@@ -60,7 +60,6 @@ const DropdownBlock = styled('div')<{disabled: boolean}>(({disabled}) => ({
   display: 'flex',
   fontSize: 16,
   lineHeight: '24px',
-  margin: '8px auto 8px 0',
   userSelect: 'none',
   ':hover': {
     color: disabled ? undefined : PALETTE.SLATE_900
@@ -68,19 +67,30 @@ const DropdownBlock = styled('div')<{disabled: boolean}>(({disabled}) => ({
 }))
 
 interface Props {
-  teamId: string
+  isOwner: boolean
   template: TemplateSharing_template$key
+  noModal?: boolean
 }
 
 const TemplateSharing = (props: Props) => {
-  const {template: templateRef, teamId} = props
+  return (
+    <>
+      <HR />
+      <div className='pr-auto ly-2 ml-4 py-2 pl-0'>
+        <UnstyledTemplateSharing {...props} />
+      </div>
+    </>
+  )
+}
+
+export const UnstyledTemplateSharing = (props: Props) => {
+  const {template: templateRef, isOwner, noModal} = props
   const template = useFragment(
     graphql`
       fragment TemplateSharing_template on MeetingTemplate {
         ...SelectSharingScopeDropdown_template
         id
         scope
-        teamId
         team {
           isLead
           name
@@ -95,13 +105,12 @@ const TemplateSharing = (props: Props) => {
   const {scope, team} = template
   const {name: teamName, organization, isLead} = team
   const {name: orgName} = organization
-  const isOwner = teamId === template.teamId
   const {togglePortal, menuPortal, originRef, menuProps} = useMenu<HTMLDivElement>(
     MenuPosition.UPPER_LEFT,
     {
       isDropdown: true,
       id: 'sharingScopeDropdown',
-      parentId: 'templateModal',
+      parentId: noModal ? undefined : 'templateModal',
       menuContentStyles: {
         minWidth: 320
       }
@@ -124,7 +133,6 @@ const TemplateSharing = (props: Props) => {
       : 'Sharing publicly'
   return (
     <>
-      <HR />
       <DropdownBlock
         onMouseEnter={SelectSharingScopeDropdown.preload}
         onClick={isLead ? togglePortal : undefined}


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7960

Implements the details view for retros primarily by reusing existing components, mutations, and GQL models.

I'm explicitly leaving mobile views out of scope for now.

Note that this doesn't match designs precisely, as some feature details are still somewhat ambiguous (e.g. cloning - to which team?) and/or requires disproportionate effort (e.g. distinct edit mode, modifying categories, etc.). We should punt on those features until the next iteration.

## Demo
https://www.loom.com/share/147d92e0c39b4d4f9c16ace0904d1823

## Testing scenarios
- [ ] Navigate to details view for each of the following and confirm UI is reasonable
  - [ ] Free public template
  - [ ] Premium public template
  - [ ] Org template (from team the user is _not_ on)
  - [ ] Team template
- [ ] On a team template
  - [ ] Edit the name, and confirm validation error if name matches a different template on the team
  - [ ] Edit a prompt
  - [ ] Add a prompt
  - [ ] Change visibility
  - [ ] Delete the template
- [ ] Navigation
  - [ ] Invalid or missing template ID - navigates back to activity library
  - [ ] back navigation - goes back to previous category, or falls back to template category
- [ ] Regression on existing template view
  - [ ] Go to team, org, and public templates in the current view and confirm no UI regressions are present.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
