### PR TITLE
chore: Allow super users to archive teams

### DIFF
--- a/packages/server/graphql/mutations/archiveTeam.ts
+++ b/packages/server/graphql/mutations/archiveTeam.ts
@@ -5,7 +5,7 @@ import getRethink from '../../database/rethinkDriver'
 import NotificationTeamArchived from '../../database/types/NotificationTeamArchived'
 import removeMeetingTemplatesForTeam from '../../postgres/queries/removeMeetingTemplatesForTeam'
 import safeArchiveTeam from '../../safeMutations/safeArchiveTeam'
-import {getUserId, isTeamLead} from '../../utils/authorization'
+import {getUserId, isSuperUser, isTeamLead} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import segmentIo from '../../utils/segmentIo'
 import standardError from '../../utils/standardError'
@@ -31,7 +31,7 @@ export default {
 
     // AUTH
     const viewerId = getUserId(authToken)
-    if (!(await isTeamLead(viewerId, teamId))) {
+    if (!(await isTeamLead(viewerId, teamId)) && !isSuperUser(authToken)) {
       return standardError(new Error('Not team lead'), {userId: viewerId})
     }
 


### PR DESCRIPTION
# Description

Allow super users to archive teams to process support requests.

## Testing scenarios

Run the mutation
```graphql
mutation DeleteTeam {
  archiveTeam(teamId: "kLdw73VT4A") {
    error {
      message
    }
    team {
      id
    }
  }
}
```
with a team id where you're not team lead on **master** and see the error message
```json
{
  "data": {
    "archiveTeam": {
      "error": {
        "message": "Not team lead"
      },
      "team": null
    }
  }
}
```
with the **PR** rerun it
```json
{
  "data": {
    "archiveTeam": {
      "error": null,
      "team": {
        "id": "kLdw73VT4A"
      }
    }
  }
}
```
## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
