### PR TITLE
chore: fix reviewers

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -3,10 +3,8 @@ reviewers:
     developers:
       - jmtaber129
       - igorlesnenko
-      - nickoferral
+      - nickoferrall
       - BartoszJarocki
-      - rafaelromcar-parabol
-      - adaniels-parabol
     maintainers:
       - mattkrick
       - Dschoordsch
@@ -16,6 +14,9 @@ reviewers:
     designers:
       - ackernaut
       - enriquesanchez
+    devops:
+      - rafaelromcar-parabol
+      - adaniels-parabol
     none:
 
   per_author:

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -28,6 +28,8 @@ reviewers:
       - none
     designers:
       - none
+    devops:
+      - none
 
   defaults:
     - developers


### PR DESCRIPTION
Fix typo and move devops out of developers to not assign them automatically to reviews.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
