### PR TITLE
feat(recurrence): End Recurring Meeting Confirmation Modal

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -238,7 +238,6 @@ const MeetingCard = (props: Props) => {
             recurrenceRule
           }
         }
-        ...EndRecurringMeetingModal_meeting
       }
     `,
     meetingRef
@@ -344,7 +343,7 @@ const MeetingCard = (props: Props) => {
           {meeting &&
             endRecurringMeetingModal(
               <EndRecurringMeetingModal
-                meetingRef={meeting}
+                meetingId={meetingId}
                 recurrenceRule={isRecurring ? meetingSeries.recurrenceRule : undefined}
                 closeModal={toggleEndRecurringMeetingModal}
               />

--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -25,6 +25,8 @@ import AvatarList from './AvatarList'
 import CardButton from './CardButton'
 import IconLabel from './IconLabel'
 import MeetingCardOptionsMenuRoot from './MeetingCardOptionsMenuRoot'
+import useModal from '../hooks/useModal'
+import {EndRecurringMeetingModal} from './TeamPrompt/Recurrence/EndRecurringMeetingModal'
 
 const CardWrapper = styled('div')<{
   maybeTabletPlus: boolean
@@ -233,8 +235,10 @@ const MeetingCard = (props: Props) => {
             id
             title
             cancelledAt
+            recurrenceRule
           }
         }
+        ...EndRecurringMeetingModal_meeting
       }
     `,
     meetingRef
@@ -258,6 +262,10 @@ const MeetingCard = (props: Props) => {
     closeTooltip,
     originRef: tooltipRef
   } = useTooltip<HTMLDivElement>(MenuPosition.UPPER_RIGHT)
+
+  const {togglePortal: toggleEndRecurringMeetingModal, modalPortal: endRecurringMeetingModal} =
+    useModal({id: 'endRecurringMeetingModal'})
+
   if (!team) {
     // 95% sure there's a bug in relay causing this
     const errObj = {id: meetingId} as any
@@ -329,9 +337,18 @@ const MeetingCard = (props: Props) => {
               teamId={teamId}
               menuProps={menuProps}
               popTooltip={popTooltip}
+              openEndRecurringMeetingModal={toggleEndRecurringMeetingModal}
             />
           )}
           {tooltipPortal('Copied!')}
+          {meeting &&
+            endRecurringMeetingModal(
+              <EndRecurringMeetingModal
+                meetingRef={meeting}
+                recurrenceRule={isRecurring ? meetingSeries.recurrenceRule : undefined}
+                closeModal={toggleEndRecurringMeetingModal}
+              />
+            )}
         </InnerCard>
       </InnerCardWrapper>
     </CardWrapper>

--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -26,6 +26,7 @@ interface Props {
   menuProps: MenuProps
   popTooltip: () => void
   queryRef: PreloadedQuery<MeetingCardOptionsMenuQuery>
+  openEndRecurringMeetingModal: () => void
 }
 
 const StyledIcon = styled('div')({
@@ -83,7 +84,7 @@ const query = graphql`
 `
 
 const MeetingCardOptionsMenu = (props: Props) => {
-  const {menuProps, popTooltip, queryRef} = props
+  const {menuProps, popTooltip, queryRef, openEndRecurringMeetingModal} = props
   const data = usePreloadedQuery<MeetingCardOptionsMenuQuery>(query, queryRef)
   const {viewer} = data
   const {id: viewerId, team, meeting} = viewer
@@ -158,11 +159,15 @@ const MeetingCardOptionsMenu = (props: Props) => {
           }
           onClick={() => {
             closePortal()
-            EndMeetingMutationLookup[meetingType]?.(
-              atmosphere,
-              {meetingId},
-              {onError, onCompleted, history}
-            )
+            if (!hasRecurrenceEnabled) {
+              EndMeetingMutationLookup[meetingType]?.(
+                atmosphere,
+                {meetingId},
+                {onError, onCompleted, history}
+              )
+            } else {
+              openEndRecurringMeetingModal()
+            }
           }}
         />
       )}

--- a/packages/client/components/MeetingCardOptionsMenuRoot.tsx
+++ b/packages/client/components/MeetingCardOptionsMenuRoot.tsx
@@ -11,10 +11,11 @@ interface Props {
   teamId: string
   menuProps: MenuProps
   popTooltip: () => void
+  openEndRecurringMeetingModal: () => void
 }
 
 const MeetingCardOptionsMenuRoot = (props: Props) => {
-  const {meetingId, teamId, menuProps, popTooltip} = props
+  const {meetingId, teamId, menuProps, popTooltip, openEndRecurringMeetingModal} = props
   const queryRef = useQueryLoaderNow<MeetingCardOptionsMenuQuery>(meetingCardOptionsMenuQuery, {
     meetingId,
     teamId
@@ -22,7 +23,12 @@ const MeetingCardOptionsMenuRoot = (props: Props) => {
   return (
     <Suspense fallback={''}>
       {queryRef && (
-        <MeetingCardOptionsMenu queryRef={queryRef} menuProps={menuProps} popTooltip={popTooltip} />
+        <MeetingCardOptionsMenu
+          queryRef={queryRef}
+          menuProps={menuProps}
+          popTooltip={popTooltip}
+          openEndRecurringMeetingModal={openEndRecurringMeetingModal}
+        />
       )}
     </Suspense>
   )

--- a/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
@@ -1,8 +1,5 @@
 import React, {useMemo, useState} from 'react'
-import graphql from 'babel-plugin-relay/macro'
 import DialogContainer from '../../DialogContainer'
-import {EndRecurringMeetingModal_meeting$key} from '~/__generated__/EndRecurringMeetingModal_meeting.graphql'
-import {useFragment} from 'react-relay'
 import clsx from 'clsx'
 import EndTeamPromptMutation from '../../../mutations/EndTeamPromptMutation'
 import useAtmosphere from '../../../hooks/useAtmosphere'
@@ -37,7 +34,7 @@ const RadioToggle = (props: RadioToggleProps) => {
 }
 
 interface Props {
-  meetingRef: EndRecurringMeetingModal_meeting$key
+  meetingId: string
   recurrenceRule?: string
   closeModal: () => void
 }
@@ -46,17 +43,8 @@ const ACTION_BUTTON_CLASSES =
   'text-base font-medium cursor-pointer text-center rounded-full px-4 py-2'
 
 export const EndRecurringMeetingModal = (props: Props) => {
-  const {meetingRef, recurrenceRule, closeModal} = props
-  const meeting = useFragment(
-    graphql`
-      fragment EndRecurringMeetingModal_meeting on NewMeeting {
-        id
-      }
-    `,
-    meetingRef
-  )
+  const {meetingId, recurrenceRule, closeModal} = props
 
-  const {id: meetingId} = meeting
   const {onCompleted, onError} = useMutationProps()
   const {history} = useRouter()
 
@@ -68,7 +56,7 @@ export const EndRecurringMeetingModal = (props: Props) => {
     if (!isMeetingOnly) {
       UpdateRecurrenceSettingsMutation(
         atmosphere,
-        {meetingId: meetingId, recurrenceRule: null},
+        {meetingId, recurrenceRule: null},
         {onError, onCompleted}
       )
     }

--- a/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
@@ -74,6 +74,7 @@ export const EndRecurringMeetingModal = (props: Props) => {
     }
 
     EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, history})
+    closeModal()
   }
 
   const fromNow = useMemo(() => {

--- a/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
@@ -1,0 +1,110 @@
+import React, {useMemo, useState} from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import DialogContainer from '../../DialogContainer'
+import {EndRecurringMeetingModal_meeting$key} from '~/__generated__/EndRecurringMeetingModal_meeting.graphql'
+import {useFragment} from 'react-relay'
+import clsx from 'clsx'
+import EndTeamPromptMutation from '../../../mutations/EndTeamPromptMutation'
+import useAtmosphere from '../../../hooks/useAtmosphere'
+import useMutationProps from '../../../hooks/useMutationProps'
+import useRouter from '../../../hooks/useRouter'
+import UpdateRecurrenceSettingsMutation from '../../../mutations/UpdateRecurrenceSettingsMutation'
+import {RRule} from 'rrule'
+import {humanReadableCountdown} from '../../../utils/date/relativeDate'
+
+interface Props {
+  meetingRef: EndRecurringMeetingModal_meeting$key
+  recurrenceRule?: string
+  closeModal: () => void
+}
+
+const ACTION_BUTTON_CLASSES =
+  'text-base font-medium cursor-pointer text-center rounded-full px-4 py-2'
+
+export const EndRecurringMeetingModal = (props: Props) => {
+  const {meetingRef, recurrenceRule, closeModal} = props
+  const meeting = useFragment(
+    graphql`
+      fragment EndRecurringMeetingModal_meeting on NewMeeting {
+        id
+      }
+    `,
+    meetingRef
+  )
+
+  const {id: meetingId} = meeting
+  const {onCompleted, onError} = useMutationProps()
+  const {history} = useRouter()
+
+  const atmosphere = useAtmosphere()
+
+  const [isMeetingOnly, setIsMeetingOnly] = useState(true)
+
+  const onConfirm = () => {
+    if (!isMeetingOnly) {
+      UpdateRecurrenceSettingsMutation(
+        atmosphere,
+        {meetingId: meetingId, recurrenceRule: null},
+        {onError, onCompleted}
+      )
+    }
+
+    EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, history})
+  }
+
+  const fromNow = useMemo(() => {
+    if (!recurrenceRule) return null
+    const now = new Date()
+    const nextMeetingDate = RRule.fromString(recurrenceRule).after(now)
+    if (!nextMeetingDate) return null
+
+    return humanReadableCountdown(nextMeetingDate)
+  }, [recurrenceRule])
+
+  return (
+    <DialogContainer className='p-4'>
+      <div className='mb-4 text-xl font-semibold'>End Meeting</div>
+      <label className='mb-2 flex items-center'>
+        <input
+          className='h-5 w-5'
+          name='isMeetingOnly'
+          type='radio'
+          checked={isMeetingOnly}
+          value={'true'}
+          onChange={() => setIsMeetingOnly(true)}
+        />
+        <div className='ml-4'>
+          End this meeting (will restart {fromNow ? `in ${fromNow}` : 'soon'})
+        </div>
+      </label>
+      <label className='flex items-center'>
+        <input
+          className='h-5 w-5'
+          name='isMeetingOnly'
+          type='radio'
+          checked={!isMeetingOnly}
+          value={'false'}
+          onChange={() => setIsMeetingOnly(false)}
+        />
+        <div className='ml-4'>End this meeting and don't restart</div>
+      </label>
+      <div className='mt-4 flex justify-end gap-2.5'>
+        <button
+          className={clsx(
+            'border border-solid border-slate-400 bg-white text-slate-700 hover:bg-slate-100',
+            ACTION_BUTTON_CLASSES
+          )}
+          onClick={closeModal}
+        >
+          Cancel
+        </button>
+        <button
+          className={clsx('bg-sky-500 text-white hover:bg-sky-600', ACTION_BUTTON_CLASSES)}
+          onClick={onConfirm}
+        >
+          Confirm
+        </button>
+      </div>
+    </DialogContainer>
+  )
+}

--- a/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
@@ -12,6 +12,30 @@ import UpdateRecurrenceSettingsMutation from '../../../mutations/UpdateRecurrenc
 import {RRule} from 'rrule'
 import {humanReadableCountdown} from '../../../utils/date/relativeDate'
 
+interface RadioToggleProps {
+  checked: boolean
+  value: boolean
+  setChecked: (isChecked: boolean) => void
+  label: string
+}
+
+const RadioToggle = (props: RadioToggleProps) => {
+  const {checked, value, setChecked, label} = props
+  return (
+    <label className='flex items-center'>
+      <input
+        className='h-5 w-5'
+        name='isMeetingOnly'
+        type='radio'
+        checked={checked}
+        value={`${value}`}
+        onChange={() => setChecked(value)}
+      />
+      <div className='ml-4'>{label}</div>
+    </label>
+  )
+}
+
 interface Props {
   meetingRef: EndRecurringMeetingModal_meeting$key
   recurrenceRule?: string
@@ -64,31 +88,21 @@ export const EndRecurringMeetingModal = (props: Props) => {
   return (
     <DialogContainer className='p-4'>
       <div className='mb-4 text-xl font-semibold'>End Meeting</div>
-      <label className='mb-2 flex items-center'>
-        <input
-          className='h-5 w-5'
-          name='isMeetingOnly'
-          type='radio'
+      <div className='mb-4 flex flex-col gap-2'>
+        <RadioToggle
           checked={isMeetingOnly}
-          value={'true'}
-          onChange={() => setIsMeetingOnly(true)}
+          value={true}
+          setChecked={setIsMeetingOnly}
+          label={`End this meeting (will restart ${fromNow ? `in ${fromNow}` : 'soon'})`}
         />
-        <div className='ml-4'>
-          End this meeting (will restart {fromNow ? `in ${fromNow}` : 'soon'})
-        </div>
-      </label>
-      <label className='flex items-center'>
-        <input
-          className='h-5 w-5'
-          name='isMeetingOnly'
-          type='radio'
+        <RadioToggle
           checked={!isMeetingOnly}
-          value={'false'}
-          onChange={() => setIsMeetingOnly(false)}
+          value={false}
+          setChecked={setIsMeetingOnly}
+          label={"End this meeting and don't restart"}
         />
-        <div className='ml-4'>End this meeting and don't restart</div>
-      </label>
-      <div className='mt-4 flex justify-end gap-2.5'>
+      </div>
+      <div className='flex justify-end gap-2.5'>
         <button
           className={clsx(
             'border border-solid border-slate-400 bg-white text-slate-700 hover:bg-slate-100',

--- a/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/EndRecurringMeetingModal.tsx
@@ -8,6 +8,7 @@ import useRouter from '../../../hooks/useRouter'
 import UpdateRecurrenceSettingsMutation from '../../../mutations/UpdateRecurrenceSettingsMutation'
 import {RRule} from 'rrule'
 import {humanReadableCountdown} from '../../../utils/date/relativeDate'
+import {CompletedHandler} from '../../../types/relayMutations'
 
 interface RadioToggleProps {
   checked: boolean
@@ -40,7 +41,7 @@ interface Props {
 }
 
 const ACTION_BUTTON_CLASSES =
-  'text-base font-medium cursor-pointer text-center rounded-full px-4 py-2'
+  'font-sans text-base font-medium cursor-pointer text-center rounded-full px-4 py-2'
 
 export const EndRecurringMeetingModal = (props: Props) => {
   const {meetingId, recurrenceRule, closeModal} = props
@@ -52,17 +53,21 @@ export const EndRecurringMeetingModal = (props: Props) => {
 
   const [isMeetingOnly, setIsMeetingOnly] = useState(true)
 
-  const onConfirm = () => {
+  const handleCompleted: CompletedHandler = () => {
     if (!isMeetingOnly) {
       UpdateRecurrenceSettingsMutation(
         atmosphere,
         {meetingId, recurrenceRule: null},
         {onError, onCompleted}
       )
+    } else {
+      onCompleted()
     }
-
-    EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, history})
     closeModal()
+  }
+
+  const onConfirm = () => {
+    EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted: handleCompleted, onError, history})
   }
 
   const fromNow = useMemo(() => {

--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -30,6 +30,7 @@ const OptionsButton = styled(BaseButton)({
 interface Props {
   meetingRef: TeamPromptOptions_meeting$key
   openRecurrenceSettingsModal: () => void
+  openEndRecurringMeetingModal: () => void
 }
 
 const TeamPromptOptions = (props: Props) => {
@@ -46,7 +47,7 @@ const TeamPromptOptions = (props: Props) => {
     closeTooltip: closeCopiedTooltip,
     originRef: copiedTooltipRef
   } = useTooltip<HTMLButtonElement>(MenuPosition.UPPER_RIGHT)
-  const {meetingRef, openRecurrenceSettingsModal} = props
+  const {meetingRef, openRecurrenceSettingsModal, openEndRecurringMeetingModal} = props
 
   const meeting = useFragment(
     graphql`
@@ -81,6 +82,7 @@ const TeamPromptOptions = (props: Props) => {
           meetingRef={meeting}
           menuProps={menuProps}
           openRecurrenceSettingsModal={openRecurrenceSettingsModal}
+          openEndRecurringMeetingModal={openEndRecurringMeetingModal}
           popTooltip={popTooltip}
         />
       )}

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -40,11 +40,18 @@ interface Props {
   meetingRef: TeamPromptOptionsMenu_meeting$key
   menuProps: MenuProps
   openRecurrenceSettingsModal: () => void
+  openEndRecurringMeetingModal: () => void
   popTooltip: () => void
 }
 
 const TeamPromptOptionsMenu = (props: Props) => {
-  const {meetingRef, menuProps, openRecurrenceSettingsModal, popTooltip} = props
+  const {
+    meetingRef,
+    menuProps,
+    openRecurrenceSettingsModal,
+    openEndRecurringMeetingModal,
+    popTooltip
+  } = props
 
   const meeting = useFragment(
     graphql`
@@ -134,7 +141,11 @@ const TeamPromptOptionsMenu = (props: Props) => {
         }
         onClick={() => {
           menuProps.closePortal()
-          EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, history})
+          if (!hasRecurrenceEnabled) {
+            EndTeamPromptMutation(atmosphere, {meetingId}, {onCompleted, onError, history})
+          } else {
+            openEndRecurringMeetingModal()
+          }
         }}
       />
     </Menu>

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -13,6 +13,7 @@ import LogoBlock from '../LogoBlock/LogoBlock'
 import {IconGroupBlock, MeetingTopBarStyles} from '../MeetingTopBar'
 import {HumanReadableRecurrenceRule} from './Recurrence/HumanReadableRecurrenceRule'
 import {UpdateRecurrenceSettingsModal} from './Recurrence/UpdateRecurrenceSettingsModal'
+import {EndRecurringMeetingModal} from './Recurrence/EndRecurringMeetingModal'
 import {TeamPromptMeetingStatus} from './TeamPromptMeetingStatus'
 import TeamPromptOptions from './TeamPromptOptions'
 
@@ -102,6 +103,7 @@ const TeamPromptTopBar = (props: Props) => {
         ...NewMeetingAvatarGroup_meeting
         ...TeamPromptMeetingStatus_meeting
         ...UpdateRecurrenceSettingsModal_meeting
+        ...EndRecurringMeetingModal_meeting
       }
     `,
     meetingRef
@@ -109,6 +111,8 @@ const TeamPromptTopBar = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {togglePortal: toggleRecurrenceSettingsModal, modalPortal: recurrenceSettingsModal} =
     useModal({id: 'updateRecurrenceSettingsModal'})
+  const {togglePortal: toggleEndRecurringMeetingModal, modalPortal: endRecurringMeetingModal} =
+    useModal({id: 'endRecurringMeetingModal'})
 
   const {viewerId} = atmosphere
   const {id: meetingId, name: meetingName, facilitatorUserId, meetingSeries} = meeting
@@ -151,6 +155,7 @@ const TeamPromptTopBar = (props: Props) => {
             <TeamPromptOptions
               meetingRef={meeting}
               openRecurrenceSettingsModal={toggleRecurrenceSettingsModal}
+              openEndRecurringMeetingModal={toggleEndRecurringMeetingModal}
             />
           </ButtonContainer>
         </RightSectionContainer>
@@ -160,6 +165,13 @@ const TeamPromptTopBar = (props: Props) => {
           meeting={meeting}
           recurrenceRule={isRecurrenceEnabled ? meetingSeries.recurrenceRule : undefined}
           closeModal={toggleRecurrenceSettingsModal}
+        />
+      )}
+      {endRecurringMeetingModal(
+        <EndRecurringMeetingModal
+          meetingRef={meeting}
+          recurrenceRule={isRecurrenceEnabled ? meetingSeries.recurrenceRule : undefined}
+          closeModal={toggleEndRecurringMeetingModal}
         />
       )}
     </MeetingTopBarStyles>

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -103,7 +103,6 @@ const TeamPromptTopBar = (props: Props) => {
         ...NewMeetingAvatarGroup_meeting
         ...TeamPromptMeetingStatus_meeting
         ...UpdateRecurrenceSettingsModal_meeting
-        ...EndRecurringMeetingModal_meeting
       }
     `,
     meetingRef
@@ -169,7 +168,7 @@ const TeamPromptTopBar = (props: Props) => {
       )}
       {endRecurringMeetingModal(
         <EndRecurringMeetingModal
-          meetingRef={meeting}
+          meetingId={meetingId}
           recurrenceRule={isRecurrenceEnabled ? meetingSeries.recurrenceRule : undefined}
           closeModal={toggleEndRecurringMeetingModal}
         />

--- a/packages/client/hooks/usePortal.tsx
+++ b/packages/client/hooks/usePortal.tsx
@@ -35,6 +35,7 @@ export type PortalId =
   | 'newMeetingRecurrenceSettings'
   | 'updateRecurrenceSettingsModal'
   | 'recurrenceStartTimePicker'
+  | 'endRecurringMeetingModal'
 
 export interface UsePortalOptions {
   onOpen?: (el: HTMLElement) => void


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7973

## Demo
In meeting:
https://www.loom.com/share/fa634c3aa1574a69814549037d8ecb0b

Dashboard:
https://www.loom.com/share/4ce79e6c309e4d128d1f40e6647c2ccb

## Testing scenarios
On both dashboard and in meeting:
- [ ] Start a non-recurring standup, and end it (regression test)
- [ ] Start a recurring standup, end just the meeting, and confirm the meeting series is still active by observing the meeting status (should show "next one starts in N hours")
- [ ] Start a recurring standup, end the meeting and the series, and confirm the meeting series is no longer active by observing the meeting status (should only show "this activity has ended")

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
