### PR TITLE
fix(sentiment-analysis): write undefined as sentimentScore for meetings without reflections with scores

### DIFF
--- a/packages/server/graphql/mutations/helpers/generateWholeMeetingSentimentScore.ts
+++ b/packages/server/graphql/mutations/helpers/generateWholeMeetingSentimentScore.ts
@@ -10,11 +10,15 @@ const generateWholeMeetingSentimentScore = async (
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId)
   ])
   if (facilitator.featureFlags.includes('noAISummary') || reflections.length === 0) return undefined
-  return (
-    reflections
-      .filter(({sentimentScore}) => sentimentScore !== undefined)
-      .reduce((_prev, reflection) => _prev + reflection.sentimentScore!, 0.0) / reflections.length
+  const reflectionsWithSentimentScores = reflections.filter(
+    ({sentimentScore}) => sentimentScore !== undefined
   )
+  return reflectionsWithSentimentScores.length === 0
+    ? undefined
+    : reflectionsWithSentimentScores.reduce(
+        (_prev, reflection) => _prev + reflection.sentimentScore!,
+        0.0
+      ) / reflectionsWithSentimentScores.length
 }
 
 export default generateWholeMeetingSentimentScore


### PR DESCRIPTION
# Description
Fixing a bug where if there are no reflections with `sentimentScore` (e.g., because the team is not on a paid tier so we save ourselves from calculating the scores), we write 0 as the `sentimentScore` for the meeting. We should write `undefined` instead, as 0 can mean neutral sentiment.

## Testing scenarios

- [ ] Free tier team
  - Run a retro meeting from a free tier team, write a few meaningful reflections
  - Verify **no** reflections have the field `sentimentScore` in Rethink
  - Verify the meeting does **not** have the field `sentimentScore` in Rethink

- [ ] Paid tier team, with `aiSummary` feature flag
  - Run a retro meeting facilitated by someone having the `aiSummary` feature flag, from a paid tier team
  - Write a few meaningful reflections
  - Verify the reflections have the field `sentimentScore` in Rethink
  - Verify the meeting has the field `sentimentScore` in Rethink

- [ ] Paid tier team, with `noAISummary` feature flag
  - Run a retro meeting facilitated by someone having the `noAISummary` feature flag
  - Write a few meaningful reflections
  - Verify the meeting does **not** have the field `sentimentScore` in Rethink

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
