### PR TITLE
feat: pick a fun name for the default team when user signs up

### DIFF
--- a/packages/client/utils/makeDefaultTeamName.ts
+++ b/packages/client/utils/makeDefaultTeamName.ts
@@ -1,0 +1,8 @@
+const defaultTeamNames = ['Bug Writers', 'Long Meeting Lovers', 'Work Procrastinators']
+
+export const makeDefaultTeamName = (teamId: string) => {
+  const seed = [...teamId].reduce((prev, cur) => prev + cur.charCodeAt(0), 0)
+  const idx = seed % defaultTeamNames.length
+  // Guaranteed not out of bounds
+  return defaultTeamNames[idx]!
+}

--- a/packages/client/utils/makeDefaultTeamName.ts
+++ b/packages/client/utils/makeDefaultTeamName.ts
@@ -10,7 +10,7 @@ export const DEFAULT_TEAM_NAMES = [
   'Highly Caffeinated ☕',
   'Mute Slack & Chill 😎',
   'Friday Afternoon Meetings Should Be Illegal 🙈',
-  "MacGuyver's of Fixing Bugs 🛠️",
+  'MacGuyvers of Fixing Bugs 🛠️',
   'Verified Swifties 🤠',
   'Excel is Hell 🔥',
   'Ice Cold Seltzer ✨',

--- a/packages/client/utils/makeDefaultTeamName.ts
+++ b/packages/client/utils/makeDefaultTeamName.ts
@@ -1,8 +1,8 @@
-const defaultTeamNames = ['Bug Writers', 'Long Meeting Lovers', 'Work Procrastinators']
+export const DEFAULT_TEAM_NAMES = ['Bug Writers', 'Long Meeting Lovers', 'Work Procrastinators']
 
 export const makeDefaultTeamName = (teamId: string) => {
   const seed = [...teamId].reduce((prev, cur) => prev + cur.charCodeAt(0), 0)
-  const idx = seed % defaultTeamNames.length
+  const idx = seed % DEFAULT_TEAM_NAMES.length
   // Guaranteed not out of bounds
-  return defaultTeamNames[idx]!
+  return DEFAULT_TEAM_NAMES[idx]!
 }

--- a/packages/client/utils/makeDefaultTeamName.ts
+++ b/packages/client/utils/makeDefaultTeamName.ts
@@ -1,8 +1,54 @@
-export const DEFAULT_TEAM_NAMES = ['Bug Writers', 'Long Meeting Lovers', 'Work Procrastinators']
+export const DEFAULT_TEAM_NAMES = [
+  'Bug Writers 🪲',
+  'Long Meeting Lovers ❣️',
+  'Work Procrastinators ⏱️',
+  'Eat Lunch at 11AM 🥪',
+  'Midday Nap 😴',
+  'Show Us Your Cat 🐱',
+  'Comb Your Hair for Zoom 💅',
+  'Pajama Pants🌛',
+  'Highly Caffeinated ☕',
+  'Mute Slack & Chill 😎',
+  'Friday Afternoon Meetings Should Be Illegal 🙈',
+  "MacGuyver's of Fixing Bugs 🛠️",
+  'Verified Swifties 🤠',
+  'Excel is Hell 🔥',
+  'Ice Cold Seltzer ✨',
+  '5 Minutes Late 😏',
+  'Top Chefs 🧑‍🍳',
+  'Clean Code or Bust 🧽',
+  'Google It 👨‍💻',
+  'AI-Generated Image 🦄',
+  'Circling Back ⭕',
+  'As Per My Last Email 😐',
+  'Mute Button 🔕',
+  'Comfy Socks 🧦',
+  'Show Me the Data ‼️',
+  "Shakira's Strawberry Jam 🍓",
+  "5 O'clock Somewhere 🍻",
+  'Trending on TikTok 🕺',
+  'Sourdough Starter 🍞',
+  'Collaboration Station 🤝',
+  'Keyboard Warriors 🤺',
+  'Sprinting Squirrels 🐿️',
+  'Desk Jockeys 🎵',
+  'Agenda Avengers 📝',
+  'More Cheese 🧀',
+  'Make it Work 💁‍♀️',
+  'We ❤️ Dogs',
+  'Extra Guac 🥑',
+  'Copy/Paste 👬',
+  'SEO Optimized 🔍',
+  'Experience Architects 🏰',
+  'User Interfacers 💡',
+  '404 Error 👾',
+  'Commit and Push 🤓',
+  'Crocs 4 Life 🐊',
+  'Special Coffee Mug ☕'
+]
 
 export const makeDefaultTeamName = (teamId: string) => {
   const seed = [...teamId].reduce((prev, cur) => prev + cur.charCodeAt(0), 0)
   const idx = seed % DEFAULT_TEAM_NAMES.length
-  // Guaranteed not out of bounds
-  return DEFAULT_TEAM_NAMES[idx]!
+  return `Team ${DEFAULT_TEAM_NAMES[idx]!}`
 }

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -67,7 +67,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
     const validNewTeam = {
       id: teamId,
       orgId,
-      name: `Team ${makeDefaultTeamName(teamId)}`,
+      name: makeDefaultTeamName(teamId),
       isOnboardTeam: true
     }
     const orgName = `${newUser.preferredName}’s Org`

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -17,6 +17,7 @@ import createNewOrg from './createNewOrg'
 import createTeamAndLeader from './createTeamAndLeader'
 import isPatientZero from './isPatientZero'
 import getUsersbyDomain from '../../../postgres/queries/getUsersByDomain'
+import {makeDefaultTeamName} from 'parabol-client/utils/makeDefaultTeamName'
 
 const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
   const {id: userId, createdAt, preferredName, email, featureFlags, tier, segmentId} = newUser
@@ -66,7 +67,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean) => {
     const validNewTeam = {
       id: teamId,
       orgId,
-      name: `${preferredName}’s Team`,
+      name: `Team ${makeDefaultTeamName(teamId)}`,
       isOnboardTeam: true
     }
     const orgName = `${newUser.preferredName}’s Org`

--- a/packages/server/graphql/mutations/updateTeamName.ts
+++ b/packages/server/graphql/mutations/updateTeamName.ts
@@ -3,12 +3,14 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import teamNameValidation from 'parabol-client/validation/teamNameValidation'
 import getTeamsByIds from '../../postgres/queries/getTeamsByIds'
 import updateTeamByTeamId from '../../postgres/queries/updateTeamByTeamId'
+import {analytics} from '../../utils/analytics/analytics'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import UpdatedTeamInput, {UpdatedTeamInputType} from '../types/UpdatedTeamInput'
 import UpdateTeamNamePayload from '../types/UpdateTeamNamePayload'
+import {DEFAULT_TEAM_NAMES} from 'parabol-client/utils/makeDefaultTeamName'
 
 export default {
   type: UpdateTeamNamePayload,
@@ -37,9 +39,11 @@ export default {
     // VALIDATION
     const teams = await getTeamsByIds([teamId])
     const team = teams[0]!
+    const oldName = team.name
+    const newName = updatedTeam.name
     const orgTeams = await dataLoader.get('teamsByOrgIds').load(team.orgId)
     const orgTeamNames = orgTeams.filter((team) => team.id !== teamId).map((team) => team.name)
-    const {error, value: name} = teamNameValidation(updatedTeam.name, orgTeamNames)
+    const {error, value: name} = teamNameValidation(newName, orgTeamNames)
     if (error) {
       return standardError(new Error('Failed validation'), {userId: viewerId})
     }
@@ -53,6 +57,13 @@ export default {
       updatedAt: now
     }
     await updateTeamByTeamId(dbUpdate, teamId)
+    analytics.teamNameChanged(
+      viewerId,
+      teamId,
+      oldName,
+      newName,
+      DEFAULT_TEAM_NAMES.includes(oldName)
+    )
 
     const data = {teamId}
     publish(SubscriptionChannel.TEAM, teamId, 'UpdateTeamNamePayload', data, subOptions)

--- a/packages/server/graphql/mutations/updateTeamName.ts
+++ b/packages/server/graphql/mutations/updateTeamName.ts
@@ -10,7 +10,7 @@ import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import UpdatedTeamInput, {UpdatedTeamInputType} from '../types/UpdatedTeamInput'
 import UpdateTeamNamePayload from '../types/UpdateTeamNamePayload'
-import {DEFAULT_TEAM_NAMES} from 'parabol-client/utils/makeDefaultTeamName'
+import {makeDefaultTeamName} from 'parabol-client/utils/makeDefaultTeamName'
 
 export default {
   type: UpdateTeamNamePayload,
@@ -62,7 +62,7 @@ export default {
       teamId,
       oldName,
       newName,
-      DEFAULT_TEAM_NAMES.includes(oldName)
+      makeDefaultTeamName(teamId) === oldName
     )
 
     const data = {teamId}

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -72,6 +72,7 @@ export type AnalyticsEvent =
   | 'Meeting Recurrence Stopped'
   | 'Meeting Settings Changed'
   // team
+  | 'Team Name Changed'
   | 'Integration Added'
   | 'Integration Removed'
   | 'Invite Email Sent'
@@ -254,6 +255,21 @@ class Analytics {
   }
 
   // team
+  teamNameChanged = (
+    userId: string,
+    teamId: string,
+    oldName: string,
+    newName: string,
+    isOldNameDefault: boolean
+  ) => {
+    this.track(userId, 'Team Name Changed', {
+      teamId,
+      oldName,
+      newName,
+      isOldNameDefault
+    })
+  }
+
   integrationAdded = (
     userId: string,
     teamId: string,


### PR DESCRIPTION
# Description
Coming from #terrrible-ideas [here](https://parabol.slack.com/archives/C03NGEJUKCN/p1679935808804259). The idea is we have a list of funny names, when user signs up, we pick one randomly and make that the name for the default team. Also add a new metric to track when user changes team name.

## Demo
![2023-04-04 15 51 19](https://user-images.githubusercontent.com/1879975/229939905-6fa3c5e7-9735-471e-979c-87b202849f6f.gif)


Metrics: 
<img width="372" alt="Screenshot 2023-04-04 at 15 50 50" src="https://user-images.githubusercontent.com/1879975/229939808-c5f639a5-f046-4e70-8ae5-1969439a7127.png">


## Testing scenarios

- [ ] Default team name
  - Create a new account
  - See a default team is created, with a fun name chosen randomly from the list

- [ ] `Team Name Changed` metrics
  - Create a new account
  - See a default team is created, with a fun name chosen randomly from the list
  - Change the default team name to something else
  - Go to [Segment Debugger](https://app.segment.com/parabol-jordan/sources/action_local/debugger) and verify a metric called `Team Name Changed` is populated and the `isOldNameDefault` property is `true`

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
