### PR TITLE
chore(ai-summary): revert chatgpt change

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -20,28 +20,21 @@ class OpenAIServerManager {
     if (!this.openAIApi) return null
     try {
       const location = summaryLocation ?? 'retro meeting'
-      const response = await this.openAIApi.createChatCompletion({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'user',
-            content: `Below is a comma-separated list of text from a ${location}.
-            Summarize the text for a second-grade student in one or two sentences.
-            If you can't provide a summary, simply say the word "No".
+      const response = await this.openAIApi.createCompletion({
+        model: 'text-davinci-003',
+        prompt: `Below is a comma-separated list of text from a ${location}. Summarize the text for a second-grade student in one or two sentences.
 
-            Text: """
-            ${text}
-            """`
-          }
-        ],
+        Text: """
+        ${text}
+        """`,
         temperature: 0.7,
         max_tokens: 256,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
-      return /^No\.*$/i.test(answer) ? null : answer
+
+      return (response.data.choices[0]?.text?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -33,7 +33,6 @@ class OpenAIServerManager {
         frequency_penalty: 0,
         presence_penalty: 0
       })
-
       return (response.data.choices[0]?.text?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')


### PR DESCRIPTION
I found a couple of small issues with the AI Summary following the change to ChatGPT in https://github.com/ParabolInc/parabol/pull/7958

I think we should use ChatGPT instead of the davinci model, but we should fix the following issues first.

I'd like to revert the ChatGPT change for now as the roll-out will happen today/tomorrow.  CC @tianrunhe 

Loom demo: https://www.loom.com/share/d0685ece343241578391432c42e192f7

Issues: 

- [ ] If there is some text that the model is unable to summarise, it doesn't create a whole meeting summary, meaning the loading state remains forever. This doesn't happen with the old davinci set-up:

![Screenshot 2023-04-05 at 11 01 46](https://user-images.githubusercontent.com/39854876/230053344-f86f1058-9823-4e57-b2cf-3815493e8b86.png)

- [ ] After writing nonsensical reflections, one summary said it was inappropriate

![Screenshot 2023-04-05 at 10 56 36](https://user-images.githubusercontent.com/39854876/230052284-8d5f8152-9c89-4b86-b533-3013421dfed6.png)

- [ ] The following [error message](https://github.com/ParabolInc/parabol/blob/57c0211e3e45bd3e7f207ce46b19defd4c43c1ec/packages/server/graphql/mutations/endRetrospective.ts#L52) is triggered when ChatGPT is unable to send a whole meeting summary, which happened quite a lot while I was testing
- [ ] We should increase the `max_tokens` for ChatGPT to its new limit of 4096 so it can digest a largest quantity of test
