### PR TITLE
feat(rid): Retro Details Sidebar

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -148,7 +148,7 @@ const ActivityDetails = (props: Props) => {
           </Link>
           <div className='w-max text-xl font-semibold'>Start Activity</div>
         </div>
-        <div className='mx-auto flex w-min flex-col justify-start xl:flex-row xl:justify-center'>
+        <div className='flex w-full flex-col justify-start pl-4 pr-14 xl:flex-row xl:justify-center xl:pl-14'>
           <ActivityCard
             className='ml-14 mb-8 h-[200px] w-80 xl:ml-0 xl:mb-0'
             category={category}
@@ -178,35 +178,35 @@ const ActivityDetails = (props: Props) => {
                     <DetailsBadge className='bg-grape-700 text-white'>Custom</DetailsBadge>
                   ))}
               </div>
-              <div className='mb-8'>
-                {isOwner ? (
-                  <div className='flex items-center justify-between'>
-                    <div className='w-max rounded-full border border-solid border-slate-400 pl-3'>
-                      <UnstyledTemplateSharing
-                        noModal={true}
-                        isOwner={isOwner}
-                        template={selectedTemplate}
-                      />
-                    </div>
-                    <div className='rounded-full border border-solid border-slate-400'>
-                      <DetailAction
-                        icon={'delete'}
-                        tooltip={'Delete template'}
-                        onClick={removeTemplate}
-                      />
-                    </div>
-                  </div>
-                ) : (
-                  <div className='py-2 text-sm font-semibold text-slate-600'>{description}</div>
-                )}
-              </div>
 
               <div className='w-[480px]'>
+                <div className='mb-8'>
+                  {isOwner ? (
+                    <div className='flex items-center justify-between'>
+                      <div className='w-max rounded-full border border-solid border-slate-400 pl-3'>
+                        <UnstyledTemplateSharing
+                          noModal={true}
+                          isOwner={isOwner}
+                          template={selectedTemplate}
+                        />
+                      </div>
+                      <div className='rounded-full border border-solid border-slate-400'>
+                        <DetailAction
+                          icon={'delete'}
+                          tooltip={'Delete template'}
+                          onClick={removeTemplate}
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <div className='py-2 text-sm font-semibold text-slate-600'>{description}</div>
+                  )}
+                </div>
                 <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common themes and
                 vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
                 <b>takeaway tasks</b> that can be integrated with your backlog.
               </div>
-              <div className='mt-[18px] flex items-center'>
+              <div className='mt-[18px] flex min-w-max items-center'>
                 <div className='flex items-center gap-3'>
                   <JiraSVG />
                   <GitHubSVG />

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -159,7 +159,7 @@ const ActivityDetails = (props: Props) => {
             <div className='mb-10 pl-14'>
               <div className='mb-2 flex min-h-[40px] items-center'>
                 <EditableTemplateName
-                  className='text-[32px]'
+                  className='text-[32px] leading-9'
                   key={templateId}
                   name={templateName}
                   templateId={templateId}

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -176,6 +176,7 @@ const ActivityDetails = (props: Props) => {
 
   const handleStartRetro = () => {
     if (submitting) return
+    submitMutation()
     SelectTemplateMutation(
       atmosphere,
       {selectedTemplateId: templateId, teamId: selectedTeam.id},
@@ -301,7 +302,7 @@ const ActivityDetails = (props: Props) => {
           <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
           <div className='flex grow flex-col justify-end gap-2'>
             <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
-            <FlatPrimaryButton onClick={handleStartRetro} className='h-14'>
+            <FlatPrimaryButton onClick={handleStartRetro} waiting={submitting} className='h-14'>
               <div className='text-lg'>Start Activity</div>
             </FlatPrimaryButton>
           </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -6,6 +6,7 @@ import {Redirect, useHistory} from 'react-router'
 import {ActivityDetailsQuery} from '~/__generated__/ActivityDetailsQuery.graphql'
 import {Link} from 'react-router-dom'
 import IconLabel from '../IconLabel'
+import StartRetrospectiveMutation from '~/mutations/StartRetrospectiveMutation'
 import EditableTemplateName from '../../modules/meeting/components/EditableTemplateName'
 import TemplatePromptList from '../../modules/meeting/components/TemplatePromptList'
 import AddTemplatePrompt from '../../modules/meeting/components/AddTemplatePrompt'
@@ -32,6 +33,7 @@ import NewMeetingSettingsToggleCheckIn from '../NewMeetingSettingsToggleCheckIn'
 import NewMeetingSettingsToggleAnonymity from '../NewMeetingSettingsToggleAnonymity'
 import NewMeetingActionsCurrentMeetings from '../NewMeetingActionsCurrentMeetings'
 import FlatPrimaryButton from '../FlatPrimaryButton'
+import SelectTemplateMutation from '../../mutations/SelectTemplateMutation'
 
 const query = graphql`
   query ActivityDetailsQuery {
@@ -172,6 +174,24 @@ const ActivityDetails = (props: Props) => {
       ? [templateTeam]
       : []
 
+  const handleStartRetro = () => {
+    if (submitting) return
+    SelectTemplateMutation(
+      atmosphere,
+      {selectedTemplateId: templateId, teamId: selectedTeam.id},
+      {
+        onCompleted: () => {
+          StartRetrospectiveMutation(
+            atmosphere,
+            {teamId: selectedTeam.id},
+            {history, onError, onCompleted}
+          )
+        },
+        onError
+      }
+    )
+  }
+
   return (
     <div className='flex h-full bg-white'>
       <div className='mt-4 grow'>
@@ -281,7 +301,7 @@ const ActivityDetails = (props: Props) => {
           <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
           <div className='flex grow flex-col justify-end gap-2'>
             <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
-            <FlatPrimaryButton className='h-14'>
+            <FlatPrimaryButton onClick={handleStartRetro} className='h-14'>
               <div className='text-lg'>Start Activity</div>
             </FlatPrimaryButton>
           </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -163,8 +163,6 @@ const ActivityDetails = (props: Props) => {
 
   const templateTeam = teams.find((team) => team.id === selectedTemplate.teamId)
 
-  const [selectedTeam, setSelectedTeam] = useState(templateTeam ?? sortByTier(teams)[0]!)
-
   const availableTeams =
     selectedTemplate.scope === 'PUBLIC'
       ? teams
@@ -173,6 +171,8 @@ const ActivityDetails = (props: Props) => {
       : templateTeam
       ? [templateTeam]
       : []
+
+  const [selectedTeam, setSelectedTeam] = useState(templateTeam ?? sortByTier(availableTeams)[0]!)
 
   const handleStartRetro = () => {
     if (submitting) return

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -1,0 +1,125 @@
+import React, {useState} from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import {useFragment} from 'react-relay'
+import StartRetrospectiveMutation from '~/mutations/StartRetrospectiveMutation'
+import {ActivityDetailsSidebar_template$key} from '~/__generated__/ActivityDetailsSidebar_template.graphql'
+import {ActivityDetailsSidebar_teams$key} from '~/__generated__/ActivityDetailsSidebar_teams.graphql'
+import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
+import {MenuPosition} from '../../hooks/useCoords'
+import sortByTier from '../../utils/sortByTier'
+import NewMeetingSettingsToggleCheckIn from '../NewMeetingSettingsToggleCheckIn'
+import NewMeetingSettingsToggleAnonymity from '../NewMeetingSettingsToggleAnonymity'
+import NewMeetingActionsCurrentMeetings from '../NewMeetingActionsCurrentMeetings'
+import FlatPrimaryButton from '../FlatPrimaryButton'
+import SelectTemplateMutation from '../../mutations/SelectTemplateMutation'
+import useAtmosphere from '../../hooks/useAtmosphere'
+import useMutationProps from '../../hooks/useMutationProps'
+import {useHistory} from 'react-router'
+
+interface Props {
+  selectedTemplateRef: ActivityDetailsSidebar_template$key
+  teamsRef: ActivityDetailsSidebar_teams$key
+}
+
+const ActivityDetailsSidebar = (props: Props) => {
+  const {selectedTemplateRef, teamsRef} = props
+  const selectedTemplate = useFragment(
+    graphql`
+      fragment ActivityDetailsSidebar_template on MeetingTemplate {
+        id
+        teamId
+        orgId
+        scope
+      }
+    `,
+    selectedTemplateRef
+  )
+
+  const teams = useFragment(
+    graphql`
+      fragment ActivityDetailsSidebar_teams on Team @relay(plural: true) {
+        id
+        lastMeetingType
+        name
+        tier
+        orgId
+        retroSettings: meetingSettings(meetingType: retrospective) {
+          ...NewMeetingSettingsToggleCheckIn_settings
+          ...NewMeetingSettingsToggleAnonymity_settings
+        }
+        ...NewMeetingTeamPicker_selectedTeam
+        ...NewMeetingTeamPicker_teams
+        ...NewMeetingActionsCurrentMeetings_team
+      }
+    `,
+    teamsRef
+  )
+
+  const atmosphere = useAtmosphere()
+
+  const templateTeam = teams.find((team) => team.id === selectedTemplate.teamId)
+
+  const availableTeams =
+    selectedTemplate.scope === 'PUBLIC'
+      ? teams
+      : selectedTemplate.scope === 'ORGANIZATION'
+      ? teams.filter((team) => team.orgId === selectedTemplate.orgId)
+      : templateTeam
+      ? [templateTeam]
+      : []
+
+  const [selectedTeam, setSelectedTeam] = useState(templateTeam ?? sortByTier(availableTeams)[0]!)
+  const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
+  const history = useHistory()
+
+  const handleStartRetro = () => {
+    if (submitting) return
+    submitMutation()
+    SelectTemplateMutation(
+      atmosphere,
+      {selectedTemplateId: selectedTemplate.id, teamId: selectedTeam.id},
+      {
+        onCompleted: () => {
+          StartRetrospectiveMutation(
+            atmosphere,
+            {teamId: selectedTeam.id},
+            {history, onError, onCompleted}
+          )
+        },
+        onError
+      }
+    )
+  }
+
+  return (
+    <div className='flex w-96 flex-col border-l border-solid border-slate-300 px-4 pb-9 pt-14'>
+      <div className='mb-6 text-xl font-semibold'>Settings</div>
+
+      <div className='flex grow flex-col gap-2'>
+        {availableTeams && (
+          <NewMeetingTeamPicker
+            noModal={true}
+            positionOverride={MenuPosition.UPPER_LEFT}
+            onSelectTeam={(teamId) => {
+              const newTeam = availableTeams.find((team) => team.id === teamId)
+              newTeam && setSelectedTeam(newTeam)
+            }}
+            selectedTeamRef={selectedTeam}
+            teamsRef={availableTeams}
+          />
+        )}
+
+        <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
+        <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
+        <div className='flex grow flex-col justify-end gap-2'>
+          <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
+          <FlatPrimaryButton onClick={handleStartRetro} waiting={submitting} className='h-14'>
+            <div className='text-lg'>Start Activity</div>
+          </FlatPrimaryButton>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ActivityDetailsSidebar

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -96,7 +96,7 @@ const ActivityDetailsSidebar = (props: Props) => {
       <div className='mb-6 text-xl font-semibold'>Settings</div>
 
       <div className='flex grow flex-col gap-2'>
-        {availableTeams && (
+        {availableTeams.length > 0 && (
           <NewMeetingTeamPicker
             noModal={true}
             positionOverride={MenuPosition.UPPER_LEFT}

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -204,7 +204,11 @@ const NewMeeting = (props: Props) => {
         />
         <TeamAndSettings>
           <SettingsFirstRow>
-            <NewMeetingTeamPicker selectedTeamRef={selectedTeam} teamsRef={teams} />
+            <NewMeetingTeamPicker
+              onSelectTeam={(teamId) => history.replace(`/new-meeting/${teamId}`)}
+              selectedTeamRef={selectedTeam}
+              teamsRef={teams}
+            />
           </SettingsFirstRow>
           <SettingsRow>
             <NewMeetingSettings

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -26,10 +26,11 @@ const ForumIcon = styled(Forum)({
 
 interface Props {
   team: NewMeetingActionsCurrentMeetings_team$key
+  noModal?: boolean
 }
 
 const NewMeetingActionsCurrentMeetings = (props: Props) => {
-  const {team: teamRef} = props
+  const {team: teamRef, noModal} = props
   const team = useFragment(
     graphql`
       fragment NewMeetingActionsCurrentMeetings_team on Team {
@@ -46,7 +47,7 @@ const NewMeetingActionsCurrentMeetings = (props: Props) => {
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu<HTMLButtonElement>(
     MenuPosition.LOWER_RIGHT,
     {
-      parentId: 'newMeetingRoot',
+      parentId: noModal ? undefined : 'newMeetingRoot',
       isDropdown: true
     }
   )

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -6,7 +6,6 @@ import {NewMeetingTeamPicker_teams$key} from '~/__generated__/NewMeetingTeamPick
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
 import {PortalStatus} from '../hooks/usePortal'
-import useRouter from '../hooks/useRouter'
 import lazyPreload from '../utils/lazyPreload'
 import NewMeetingDropdown from './NewMeetingDropdown'
 import NewMeetingTeamPickerAvatars from './NewMeetingTeamPickerAvatars'
@@ -22,15 +21,17 @@ const SelectTeamDropdown = lazyPreload(
 interface Props {
   selectedTeamRef: NewMeetingTeamPicker_selectedTeam$key
   teamsRef: NewMeetingTeamPicker_teams$key
+  onSelectTeam: (teamId: string) => void
+  noModal?: boolean
+  positionOverride?: MenuPosition
 }
 
 const NewMeetingTeamPicker = (props: Props) => {
-  const {selectedTeamRef, teamsRef} = props
-  const {history} = useRouter()
+  const {selectedTeamRef, teamsRef, onSelectTeam, noModal, positionOverride} = props
   const {togglePortal, menuPortal, originRef, menuProps, portalStatus} = useMenu<HTMLDivElement>(
-    MenuPosition.LOWER_RIGHT,
+    positionOverride ?? MenuPosition.LOWER_RIGHT,
     {
-      parentId: 'newMeetingRoot',
+      parentId: noModal ? undefined : 'newMeetingRoot',
       isDropdown: true
     }
   )
@@ -57,9 +58,6 @@ const NewMeetingTeamPicker = (props: Props) => {
   )
 
   const {name} = selectedTeam
-  const handleSelect = (teamId: string) => {
-    history.replace(`/new-meeting/${teamId}`)
-  }
   return (
     <>
       <NewMeetingDropdown
@@ -73,7 +71,7 @@ const NewMeetingTeamPicker = (props: Props) => {
         opened={[PortalStatus.Entering, PortalStatus.Entered].includes(portalStatus)}
       />
       {menuPortal(
-        <SelectTeamDropdown menuProps={menuProps} teams={teams} teamHandleClick={handleSelect} />
+        <SelectTeamDropdown menuProps={menuProps} teams={teams} teamHandleClick={onSelectTeam} />
       )}
     </>
   )

--- a/packages/client/modules/meeting/components/EditableTemplateName.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplateName.tsx
@@ -8,6 +8,7 @@ import useMutationProps from '../../../hooks/useMutationProps'
 import RenameMeetingTemplateMutation from '../../../mutations/RenameMeetingTemplateMutation'
 import Legitity from '../../../validation/Legitity'
 import {EditableTemplateName_teamTemplates$key} from '../../../__generated__/EditableTemplateName_teamTemplates.graphql'
+import clsx from 'clsx'
 
 interface Props {
   name: string
@@ -24,9 +25,6 @@ const InheritedStyles = styled('div')({
   lineHeight: '24px'
 })
 
-const StyledEditableText = styled(EditableText)({
-  lineHeight: '24px'
-})
 const EditableTemplateName = (props: Props) => {
   const {name, templateId, teamTemplates: teamTemplatesRef, isOwner, className} = props
   const teamTemplates = useFragment(
@@ -76,17 +74,18 @@ const EditableTemplateName = (props: Props) => {
 
   return (
     <InheritedStyles>
-      <StyledEditableText
-        className={className}
-        autoFocus={autoFocus}
-        disabled={!isOwner}
-        error={error ? error.message : undefined}
-        handleSubmit={handleSubmit}
-        initialValue={name}
-        maxLength={100}
-        validate={validate}
-        placeholder={'*New Template'}
-      />
+      <div className={clsx('leading-6', className)}>
+        <EditableText
+          autoFocus={autoFocus}
+          disabled={!isOwner}
+          error={error ? error.message : undefined}
+          handleSubmit={handleSubmit}
+          initialValue={name}
+          maxLength={100}
+          validate={validate}
+          placeholder={'*New Template'}
+        />
+      </div>
     </InheritedStyles>
   )
 }

--- a/packages/client/modules/meeting/components/SelectTemplate.tsx
+++ b/packages/client/modules/meeting/components/SelectTemplate.tsx
@@ -75,9 +75,13 @@ const SelectTemplate = (props: Props) => {
   const {id: templateId, isFree, type, scope} = template
   const atmosphere = useAtmosphere()
   const history = useHistory()
-  const {submitting, error} = useMutationProps()
+  const {submitting, error, onCompleted, onError} = useMutationProps()
   const selectTemplate = () => {
-    SelectTemplateMutation(atmosphere, {selectedTemplateId: templateId, teamId})
+    SelectTemplateMutation(
+      atmosphere,
+      {selectedTemplateId: templateId, teamId},
+      {onCompleted, onError}
+    )
     closePortal()
   }
   const goToBilling = () => {

--- a/packages/client/mutations/SelectTemplateMutation.ts
+++ b/packages/client/mutations/SelectTemplateMutation.ts
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {SimpleMutation} from '../types/relayMutations'
+import {StandardMutation} from '../types/relayMutations'
 import {SelectTemplateMutation as TSelectTemplateMutation} from '../__generated__/SelectTemplateMutation.graphql'
 
 graphql`
@@ -32,7 +32,11 @@ const mutation = graphql`
 
 type SelectTemplate = NonNullable<TSelectTemplateMutation['response']['selectTemplate']>
 
-const SelectTemplateMutation: SimpleMutation<TSelectTemplateMutation> = (atmosphere, variables) => {
+const SelectTemplateMutation: StandardMutation<TSelectTemplateMutation> = (
+  atmosphere,
+  variables,
+  {onCompleted, onError}
+) => {
   return commitMutation(atmosphere, {
     mutation,
     variables,
@@ -47,7 +51,9 @@ const SelectTemplateMutation: SimpleMutation<TSelectTemplateMutation> = (atmosph
       if (!meetingSettings) return
       meetingSettings.setValue(selectedTemplateId, 'selectedTemplateId')
       meetingSettings.setLinkedRecord(selectedTemplate, 'selectedTemplate')
-    }
+    },
+    onCompleted,
+    onError
   })
 }
 


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7962

Implement retro details sidebar + improve responsiveness for smaller desktop screens.

The team selection dropdown case when the template is limited to team (vs org) is out of scope for this PR and will be implemented later - team selection here is reasonable for now.

Parts of the diff would benefit from `?w=1`

Needs rebase once https://github.com/ParabolInc/parabol/pull/7990 lands

## Demo
https://www.loom.com/share/f9f857bf626d42acbd560c89e8dc0511

## Testing scenarios
- [ ] Smoke test responsiveness
- [ ] Smoke test active meetings
- [ ] Team-scoped template
  - [ ] Confirm no other teams included in team dropdown
  - [ ] toggle a setting
  - [ ] Start retro, and confirm team, setting, and template
- [ ] Org-scoped template on team that user is on
  - [ ] Confirm only teams in org included in team dropdown
  - [ ] Select a non-owner team
  - [ ] Start retro, and confirm team, setting, and template
- [ ] Org-scoped template on team that user is not on
  - [ ] Confirm only teams in org included in team dropdown
  - [ ] Start retro, and confirm team, setting, and template
- [ ] Public template
  - [ ] Confirm all teams the user is on are included in team dropdown
  - [ ] Start retro, and confirm team, setting, and template
- [ ] Smoke test regressions
  - [ ] Team picker in existing flow
  - [ ] current meetings in existing flow
  - [ ] Editable template name
  - [ ] Template selection

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
