### PR TITLE
feat(rid): Create retro template from retro categories view

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -42,12 +42,13 @@ export interface ActivityCardProps {
   className?: string
   category: CategoryID
   title?: string
-  imageSrc: string
+  imageSrc?: string
   badge: React.ReactNode | null
+  children?: React.ReactNode
 }
 
 export const ActivityCard = (props: ActivityCardProps) => {
-  const {className, category, title, imageSrc, badge} = props
+  const {className, category, title, imageSrc, badge, children} = props
   return (
     <div
       className={clsx(
@@ -65,9 +66,12 @@ export const ActivityCard = (props: ActivityCardProps) => {
           )}
         />
       </div>
-      <div className='my-1 flex flex-1 items-center justify-center px-4'>
-        <ActivityCardImage src={imageSrc} />
-      </div>
+      {imageSrc && (
+        <div className='my-1 flex flex-1 items-center justify-center px-4'>
+          <ActivityCardImage src={imageSrc} />
+        </div>
+      )}
+      {children}
       <div className='flex flex-shrink-0'>
         <div
           className={clsx('h-8 w-8 flex-shrink-0 rounded-tr-full', MeetingThemes[category].primary)}

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -98,7 +98,6 @@ const ActivityDetailsSidebar = (props: Props) => {
       <div className='flex grow flex-col gap-2'>
         {availableTeams.length > 0 && (
           <NewMeetingTeamPicker
-            noModal={true}
             positionOverride={MenuPosition.UPPER_LEFT}
             onSelectTeam={(teamId) => {
               const newTeam = availableTeams.find((team) => team.id === teamId)

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -39,6 +39,7 @@ const query = graphql`
         edges {
           node {
             ...ActivityLibrary_template @relay(mask: false)
+            ...CreateActivityCard_templates
           }
         }
       }
@@ -204,6 +205,9 @@ export const ActivityLibrary = (props: Props) => {
                   className='flex-1 max-sm:hidden'
                   category={selectedCategory as CategoryID}
                   teamsRef={teams}
+                  templatesRef={availableTemplates.edges
+                    .map((edge) => edge.node)
+                    .filter((template) => template.type === 'retrospective')}
                 />
               )}
               {templatesToRender.map((template) => {

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -6,7 +6,6 @@ import * as ScrollArea from '@radix-ui/react-scroll-area'
 import {ActivityLibraryQuery} from '~/__generated__/ActivityLibraryQuery.graphql'
 import {ActivityLibraryHeader, ActivityLibraryMobileHeader} from './ActivityLibraryHeader'
 import {ActivityLibraryCard, ActivityLibraryCardBadge} from './ActivityLibraryCard'
-
 import customTemplateIllustration from '../../../../static/images/illustrations/customTemplate.png'
 import {activityIllustrations} from './ActivityIllustrations'
 import {Link} from 'react-router-dom'
@@ -16,6 +15,7 @@ import useSearchFilter from '../../hooks/useSearchFilter'
 import halloweenRetrospectiveTemplate from '../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 import clsx from 'clsx'
 import {CategoryID, MeetingThemes} from './ActivityCard'
+import CreateActivityCard from './CreateActivityCard'
 
 graphql`
   fragment ActivityLibrary_template on MeetingTemplate {
@@ -65,6 +65,8 @@ export const CATEGORY_ID_TO_NAME: Record<CategoryID | typeof QUICK_START_CATEGOR
   feedback: 'Feedback',
   strategy: 'Strategy'
 }
+
+const RETRO_CATEGORIES: Array<CategoryID> = ['retrospective', 'feedback', 'strategy']
 
 const CategoryIDToColorClass = {
   [QUICK_START_CATEGORY_ID]: 'bg-grape-700',
@@ -194,6 +196,12 @@ export const ActivityLibrary = (props: Props) => {
             </div>
           ) : (
             <div className='mx-auto mt-1 grid auto-rows-[1fr] grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
+              {RETRO_CATEGORIES.includes(selectedCategory as CategoryID) && (
+                <CreateActivityCard
+                  className='flex-1 max-sm:hidden'
+                  category={selectedCategory as CategoryID}
+                />
+              )}
               {templatesToRender.map((template) => {
                 const templateIllustration =
                   activityIllustrations[template.id as keyof typeof activityIllustrations]

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -45,6 +45,9 @@ const query = graphql`
       featureFlags {
         retrosInDisguise
       }
+      teams {
+        ...CreateActivityCard_teams
+      }
     }
   }
 `
@@ -82,7 +85,7 @@ export const ActivityLibrary = (props: Props) => {
   const data = usePreloadedQuery<ActivityLibraryQuery>(query, queryRef)
   const {history} = useRouter()
   const {viewer} = data
-  const {featureFlags, availableTemplates} = viewer
+  const {featureFlags, availableTemplates, teams} = viewer
 
   const handleCloseClick = () => {
     history.goBack()
@@ -200,6 +203,7 @@ export const ActivityLibrary = (props: Props) => {
                 <CreateActivityCard
                   className='flex-1 max-sm:hidden'
                   category={selectedCategory as CategoryID}
+                  teamsRef={teams}
                 />
               )}
               {templatesToRender.map((template) => {

--- a/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
@@ -5,8 +5,18 @@ import activityLibraryQuery, {
 import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
 import {renderLoader} from '../../utils/relay/renderLoader'
 import {ActivityLibrary} from './ActivityLibrary'
+import TeamSubscription from '../../subscriptions/TeamSubscription'
+import useSubscription from '../../hooks/useSubscription'
+import TaskSubscription from '../../subscriptions/TaskSubscription'
+import NotificationSubscription from '../../subscriptions/NotificationSubscription'
+import OrganizationSubscription from '../../subscriptions/OrganizationSubscription'
 
 const ActivityLibaryRoute = () => {
+  useSubscription('ActivityLibraryRoute', NotificationSubscription)
+  useSubscription('ActivityLibraryRoute', OrganizationSubscription)
+  useSubscription('ActivityLibraryRoute', TaskSubscription)
+  useSubscription('ActivityLibraryRoute', TeamSubscription)
+
   const queryRef = useQueryLoaderNow<ActivityLibraryQuery>(activityLibraryQuery)
 
   return (

--- a/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react'
+import React from 'react'
 import graphql from 'babel-plugin-relay/macro'
 import {CategoryID} from './ActivityCard'
 import {ActivityLibraryCard, ActivityLibraryCardBadge} from './ActivityLibraryCard'
@@ -6,20 +6,10 @@ import {Add as AddIcon} from '@mui/icons-material'
 import {CATEGORY_ID_TO_NAME} from './ActivityLibrary'
 import clsx from 'clsx'
 import useModal from '../../hooks/useModal'
-import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
-import {MenuPosition} from '../../hooks/useCoords'
 import {useFragment} from 'react-relay'
 import {CreateActivityCard_teams$key} from '~/__generated__/CreateActivityCard_teams.graphql'
 import {CreateActivityCard_templates$key} from '~/__generated__/CreateActivityCard_templates.graphql'
-import {CreateActivityCard_modalTemplates$key} from '~/__generated__/CreateActivityCard_modalTemplates.graphql'
-import {CreateActivityCard_modalTeams$key} from '~/__generated__/CreateActivityCard_modalTeams.graphql'
-import sortByTier from '../../utils/sortByTier'
-import useMutationProps from '../../hooks/useMutationProps'
-import useAtmosphere from '../../hooks/useAtmosphere'
-import AddReflectTemplateMutation from '../../mutations/AddReflectTemplateMutation'
-import {AddReflectTemplateMutation$data} from '~/__generated__/AddReflectTemplateMutation.graphql'
-import {useHistory} from 'react-router'
-import {Threshold} from '../../types/constEnums'
+import TeamPickerModal from './TeamPickerModal'
 
 interface Props {
   category: CategoryID
@@ -33,7 +23,7 @@ const CreateActivityCard = (props: Props) => {
   const teams = useFragment(
     graphql`
       fragment CreateActivityCard_teams on Team @relay(plural: true) {
-        ...CreateActivityCard_modalTeams
+        ...TeamPickerModal_teams
       }
     `,
     teamsRef
@@ -42,7 +32,7 @@ const CreateActivityCard = (props: Props) => {
   const templates = useFragment(
     graphql`
       fragment CreateActivityCard_templates on MeetingTemplate @relay(plural: true) {
-        ...CreateActivityCard_modalTemplates
+        ...TeamPickerModal_templates
       }
     `,
     templatesRef
@@ -69,116 +59,14 @@ const CreateActivityCard = (props: Props) => {
         </ActivityLibraryCard>
       </div>
       {modalPortal(
-        <TeamPickerModal teamsRef={teams} templatesRef={templates} closePortal={closePortal} />
+        <TeamPickerModal
+          category={category}
+          teamsRef={teams}
+          templatesRef={templates}
+          closePortal={closePortal}
+        />
       )}
     </>
-  )
-}
-
-interface TeamPickerModalProps {
-  teamsRef: CreateActivityCard_modalTeams$key
-  templatesRef: CreateActivityCard_modalTemplates$key
-  closePortal: () => void
-}
-
-const TeamPickerModal = (props: TeamPickerModalProps) => {
-  const {teamsRef, templatesRef, closePortal} = props
-  const teams = useFragment(
-    graphql`
-      fragment CreateActivityCard_modalTeams on Team @relay(plural: true) {
-        id
-        tier
-        name
-        ...NewMeetingTeamPicker_selectedTeam
-        ...NewMeetingTeamPicker_teams
-      }
-    `,
-    teamsRef
-  )
-
-  const templates = useFragment(
-    graphql`
-      fragment CreateActivityCard_modalTemplates on MeetingTemplate @relay(plural: true) {
-        name
-        teamId
-      }
-    `,
-    templatesRef
-  )
-
-  const [selectedTeam, setSelectedTeam] = useState(sortByTier(teams)[0]!)
-
-  const atmosphere = useAtmosphere()
-  const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()
-
-  useEffect(() => {
-    onCompleted()
-  }, [selectedTeam.id])
-
-  const history = useHistory()
-
-  const handleSelectTeam = () => {
-    if (submitting) {
-      return
-    }
-
-    const teamTemplates = templates.filter((template) => template.teamId === selectedTeam.id)
-
-    if (teamTemplates.length >= Threshold.MAX_RETRO_TEAM_TEMPLATES) {
-      onError(new Error('You may only have 20 templates per team. Please remove one first.'))
-      return
-    }
-    if (teamTemplates.find((template) => template.name === '*New Template')) {
-      onError(new Error('You already have a new template. Try renaming that one first.'))
-      return
-    }
-
-    closePortal()
-
-    submitMutation()
-    AddReflectTemplateMutation(
-      atmosphere,
-      {teamId: selectedTeam.id},
-      {
-        onError,
-        onCompleted: (res: AddReflectTemplateMutation$data) => {
-          const templateId = res.addReflectTemplate?.reflectTemplate?.id
-          if (templateId) {
-            history.push(`/activity-library/details/${templateId}`)
-          }
-          onCompleted()
-        }
-      }
-    )
-  }
-
-  return (
-    <div className='w-[440px] bg-white p-6'>
-      <div className='flex flex-col gap-4'>
-        <div>
-          <b>Select the team</b> to manage this new activity template:
-        </div>
-        <NewMeetingTeamPicker
-          parentId='templateTeamPickerModal'
-          positionOverride={MenuPosition.UPPER_LEFT}
-          onSelectTeam={(teamId) => {
-            const newTeam = teams.find((team) => team.id === teamId)
-            newTeam && setSelectedTeam(newTeam)
-          }}
-          selectedTeamRef={selectedTeam}
-          teamsRef={teams}
-        />
-        {error?.message && <div className='w-full text-tomato-500'>{error.message}</div>}
-        <button
-          className={clsx(
-            'w-max cursor-pointer self-end rounded-full bg-sky-500 px-4 py-2 text-center font-sans text-base font-medium text-white hover:bg-sky-600'
-          )}
-          onClick={handleSelectTeam}
-        >
-          Select Team
-        </button>
-      </div>
-    </div>
   )
 }
 

--- a/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
@@ -1,30 +1,157 @@
-import React from 'react'
+import React, {useState} from 'react'
+import graphql from 'babel-plugin-relay/macro'
 import {CategoryID} from './ActivityCard'
 import {ActivityLibraryCard, ActivityLibraryCardBadge} from './ActivityLibraryCard'
 import {Add as AddIcon} from '@mui/icons-material'
 import {CATEGORY_ID_TO_NAME} from './ActivityLibrary'
 import clsx from 'clsx'
+import useModal from '../../hooks/useModal'
+import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
+import {MenuPosition} from '../../hooks/useCoords'
+import {useFragment} from 'react-relay'
+import {CreateActivityCard_teams$key} from '~/__generated__/CreateActivityCard_teams.graphql'
+import {CreateActivityCard_modalTeams$key} from '~/__generated__/CreateActivityCard_modalTeams.graphql'
+import sortByTier from '../../utils/sortByTier'
+import useMutationProps from '../../hooks/useMutationProps'
+import useAtmosphere from '../../hooks/useAtmosphere'
+import AddReflectTemplateMutation from '../../mutations/AddReflectTemplateMutation'
+import {AddReflectTemplateMutation$data} from '~/__generated__/AddReflectTemplateMutation.graphql'
+import {useHistory} from 'react-router'
 
 interface Props {
   category: CategoryID
   className?: string
+  teamsRef: CreateActivityCard_teams$key
 }
 
 const CreateActivityCard = (props: Props) => {
-  const {category, className} = props
+  const {category, className, teamsRef} = props
+  const teams = useFragment(
+    graphql`
+      fragment CreateActivityCard_teams on Team @relay(plural: true) {
+        ...CreateActivityCard_modalTeams
+      }
+    `,
+    teamsRef
+  )
+
+  const {togglePortal, modalPortal, closePortal} = useModal({
+    id: 'templateTeamPickerModal'
+  })
+
+  const atmosphere = useAtmosphere()
+  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
+
+  const history = useHistory()
+
+  const handleSelectTeam = (teamId: string) => {
+    if (submitting) {
+      return
+    }
+
+    closePortal()
+
+    // if (reflectTemplates.length >= Threshold.MAX_RETRO_TEAM_TEMPLATES) {
+    //   onError(new Error('You may only have 20 templates per team. Please remove one first.'))
+    //   errorTimerId.current = window.setTimeout(() => {
+    //     onCompleted()
+    //   }, 8000)
+    //   return
+    // }
+    // if (reflectTemplates.find((template) => template.name === '*New Template')) {
+    //   onError(new Error('You already have a new template. Try renaming that one first.'))
+    //   errorTimerId.current = window.setTimeout(() => {
+    //     onCompleted()
+    //   }, 8000)
+    //   return
+    // }
+
+    submitMutation()
+    AddReflectTemplateMutation(
+      atmosphere,
+      {teamId},
+      {
+        onError,
+        onCompleted: (res: AddReflectTemplateMutation$data) => {
+          const templateId = res.addReflectTemplate?.reflectTemplate?.id
+          if (templateId) {
+            history.push(`/activity-library/details/${templateId}`)
+          }
+          onCompleted()
+        }
+      }
+    )
+  }
+
   return (
-    <ActivityLibraryCard
-      className={clsx('cursor-pointer', className)}
-      category={category}
-      badge={<ActivityLibraryCardBadge>Premium</ActivityLibraryCardBadge>}
-    >
-      <div className='mx-10 flex flex-1 flex-col items-center justify-center text-center font-semibold'>
-        <div className='h-12 w-12'>
-          <AddIcon style={{width: '100%', height: '100%'}} className='text-slate-700' />
-        </div>
-        Create Custom {CATEGORY_ID_TO_NAME[category]} Activity
+    <>
+      <div className='flex' onClick={togglePortal}>
+        <ActivityLibraryCard
+          className={clsx('cursor-pointer', className)}
+          category={category}
+          badge={<ActivityLibraryCardBadge>Premium</ActivityLibraryCardBadge>}
+        >
+          <div className='mx-10 flex flex-1 flex-col items-center justify-center text-center font-semibold'>
+            <div className='h-12 w-12'>
+              <AddIcon style={{width: '100%', height: '100%'}} className='text-slate-700' />
+            </div>
+            Create Custom {CATEGORY_ID_TO_NAME[category]} Activity
+          </div>
+        </ActivityLibraryCard>
       </div>
-    </ActivityLibraryCard>
+      {modalPortal(<TeamPickerModal teamsRef={teams} onPickTeam={handleSelectTeam} />)}
+    </>
+  )
+}
+
+interface TeamPickerModalProps {
+  teamsRef: CreateActivityCard_modalTeams$key
+  onPickTeam: (teamId: string) => void
+}
+
+const TeamPickerModal = (props: TeamPickerModalProps) => {
+  const {teamsRef, onPickTeam} = props
+  const teams = useFragment(
+    graphql`
+      fragment CreateActivityCard_modalTeams on Team @relay(plural: true) {
+        id
+        tier
+        name
+        ...NewMeetingTeamPicker_selectedTeam
+        ...NewMeetingTeamPicker_teams
+      }
+    `,
+    teamsRef
+  )
+
+  const [selectedTeam, setSelectedTeam] = useState(sortByTier(teams)[0]!)
+
+  return (
+    <div className='bg-white p-6'>
+      <div className='flex flex-col gap-4'>
+        <div>
+          <b>Select the team</b> to manage this new activity template:
+        </div>
+        <NewMeetingTeamPicker
+          parentId='templateTeamPickerModal'
+          positionOverride={MenuPosition.UPPER_LEFT}
+          onSelectTeam={(teamId) => {
+            const newTeam = teams.find((team) => team.id === teamId)
+            newTeam && setSelectedTeam(newTeam)
+          }}
+          selectedTeamRef={selectedTeam}
+          teamsRef={teams}
+        />
+        <button
+          className={clsx(
+            'w-max cursor-pointer self-end rounded-full bg-sky-500 px-4 py-2 text-center font-sans text-base font-medium text-white hover:bg-sky-600'
+          )}
+          onClick={() => onPickTeam(selectedTeam.id)}
+        >
+          Select Team
+        </button>
+      </div>
+    </div>
   )
 }
 

--- a/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import {CategoryID} from './ActivityCard'
+import {ActivityLibraryCard, ActivityLibraryCardBadge} from './ActivityLibraryCard'
+import {Add as AddIcon} from '@mui/icons-material'
+import {CATEGORY_ID_TO_NAME} from './ActivityLibrary'
+import clsx from 'clsx'
+
+interface Props {
+  category: CategoryID
+  className?: string
+}
+
+const CreateActivityCard = (props: Props) => {
+  const {category, className} = props
+  return (
+    <ActivityLibraryCard
+      className={clsx('cursor-pointer', className)}
+      category={category}
+      badge={<ActivityLibraryCardBadge>Premium</ActivityLibraryCardBadge>}
+    >
+      <div className='mx-10 flex flex-1 flex-col items-center justify-center text-center font-semibold'>
+        <div className='h-12 w-12'>
+          <AddIcon style={{width: '100%', height: '100%'}} className='text-slate-700' />
+        </div>
+        Create Custom {CATEGORY_ID_TO_NAME[category]} Activity
+      </div>
+    </ActivityLibraryCard>
+  )
+}
+
+export default CreateActivityCard

--- a/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import graphql from 'babel-plugin-relay/macro'
 import {CategoryID} from './ActivityCard'
 import {ActivityLibraryCard, ActivityLibraryCardBadge} from './ActivityLibraryCard'
@@ -10,6 +10,8 @@ import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
 import {MenuPosition} from '../../hooks/useCoords'
 import {useFragment} from 'react-relay'
 import {CreateActivityCard_teams$key} from '~/__generated__/CreateActivityCard_teams.graphql'
+import {CreateActivityCard_templates$key} from '~/__generated__/CreateActivityCard_templates.graphql'
+import {CreateActivityCard_modalTemplates$key} from '~/__generated__/CreateActivityCard_modalTemplates.graphql'
 import {CreateActivityCard_modalTeams$key} from '~/__generated__/CreateActivityCard_modalTeams.graphql'
 import sortByTier from '../../utils/sortByTier'
 import useMutationProps from '../../hooks/useMutationProps'
@@ -17,15 +19,17 @@ import useAtmosphere from '../../hooks/useAtmosphere'
 import AddReflectTemplateMutation from '../../mutations/AddReflectTemplateMutation'
 import {AddReflectTemplateMutation$data} from '~/__generated__/AddReflectTemplateMutation.graphql'
 import {useHistory} from 'react-router'
+import {Threshold} from '../../types/constEnums'
 
 interface Props {
   category: CategoryID
   className?: string
   teamsRef: CreateActivityCard_teams$key
+  templatesRef: CreateActivityCard_templates$key
 }
 
 const CreateActivityCard = (props: Props) => {
-  const {category, className, teamsRef} = props
+  const {category, className, teamsRef, templatesRef} = props
   const teams = useFragment(
     graphql`
       fragment CreateActivityCard_teams on Team @relay(plural: true) {
@@ -35,53 +39,18 @@ const CreateActivityCard = (props: Props) => {
     teamsRef
   )
 
+  const templates = useFragment(
+    graphql`
+      fragment CreateActivityCard_templates on MeetingTemplate @relay(plural: true) {
+        ...CreateActivityCard_modalTemplates
+      }
+    `,
+    templatesRef
+  )
+
   const {togglePortal, modalPortal, closePortal} = useModal({
     id: 'templateTeamPickerModal'
   })
-
-  const atmosphere = useAtmosphere()
-  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
-
-  const history = useHistory()
-
-  const handleSelectTeam = (teamId: string) => {
-    if (submitting) {
-      return
-    }
-
-    closePortal()
-
-    // if (reflectTemplates.length >= Threshold.MAX_RETRO_TEAM_TEMPLATES) {
-    //   onError(new Error('You may only have 20 templates per team. Please remove one first.'))
-    //   errorTimerId.current = window.setTimeout(() => {
-    //     onCompleted()
-    //   }, 8000)
-    //   return
-    // }
-    // if (reflectTemplates.find((template) => template.name === '*New Template')) {
-    //   onError(new Error('You already have a new template. Try renaming that one first.'))
-    //   errorTimerId.current = window.setTimeout(() => {
-    //     onCompleted()
-    //   }, 8000)
-    //   return
-    // }
-
-    submitMutation()
-    AddReflectTemplateMutation(
-      atmosphere,
-      {teamId},
-      {
-        onError,
-        onCompleted: (res: AddReflectTemplateMutation$data) => {
-          const templateId = res.addReflectTemplate?.reflectTemplate?.id
-          if (templateId) {
-            history.push(`/activity-library/details/${templateId}`)
-          }
-          onCompleted()
-        }
-      }
-    )
-  }
 
   return (
     <>
@@ -99,18 +68,21 @@ const CreateActivityCard = (props: Props) => {
           </div>
         </ActivityLibraryCard>
       </div>
-      {modalPortal(<TeamPickerModal teamsRef={teams} onPickTeam={handleSelectTeam} />)}
+      {modalPortal(
+        <TeamPickerModal teamsRef={teams} templatesRef={templates} closePortal={closePortal} />
+      )}
     </>
   )
 }
 
 interface TeamPickerModalProps {
   teamsRef: CreateActivityCard_modalTeams$key
-  onPickTeam: (teamId: string) => void
+  templatesRef: CreateActivityCard_modalTemplates$key
+  closePortal: () => void
 }
 
 const TeamPickerModal = (props: TeamPickerModalProps) => {
-  const {teamsRef, onPickTeam} = props
+  const {teamsRef, templatesRef, closePortal} = props
   const teams = useFragment(
     graphql`
       fragment CreateActivityCard_modalTeams on Team @relay(plural: true) {
@@ -124,10 +96,64 @@ const TeamPickerModal = (props: TeamPickerModalProps) => {
     teamsRef
   )
 
+  const templates = useFragment(
+    graphql`
+      fragment CreateActivityCard_modalTemplates on MeetingTemplate @relay(plural: true) {
+        name
+        teamId
+      }
+    `,
+    templatesRef
+  )
+
   const [selectedTeam, setSelectedTeam] = useState(sortByTier(teams)[0]!)
 
+  const atmosphere = useAtmosphere()
+  const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()
+
+  useEffect(() => {
+    onCompleted()
+  }, [selectedTeam.id])
+
+  const history = useHistory()
+
+  const handleSelectTeam = () => {
+    if (submitting) {
+      return
+    }
+
+    const teamTemplates = templates.filter((template) => template.teamId === selectedTeam.id)
+
+    if (teamTemplates.length >= Threshold.MAX_RETRO_TEAM_TEMPLATES) {
+      onError(new Error('You may only have 20 templates per team. Please remove one first.'))
+      return
+    }
+    if (teamTemplates.find((template) => template.name === '*New Template')) {
+      onError(new Error('You already have a new template. Try renaming that one first.'))
+      return
+    }
+
+    closePortal()
+
+    submitMutation()
+    AddReflectTemplateMutation(
+      atmosphere,
+      {teamId: selectedTeam.id},
+      {
+        onError,
+        onCompleted: (res: AddReflectTemplateMutation$data) => {
+          const templateId = res.addReflectTemplate?.reflectTemplate?.id
+          if (templateId) {
+            history.push(`/activity-library/details/${templateId}`)
+          }
+          onCompleted()
+        }
+      }
+    )
+  }
+
   return (
-    <div className='bg-white p-6'>
+    <div className='w-[440px] bg-white p-6'>
       <div className='flex flex-col gap-4'>
         <div>
           <b>Select the team</b> to manage this new activity template:
@@ -142,11 +168,12 @@ const TeamPickerModal = (props: TeamPickerModalProps) => {
           selectedTeamRef={selectedTeam}
           teamsRef={teams}
         />
+        {error?.message && <div className='w-full text-tomato-500'>{error.message}</div>}
         <button
           className={clsx(
             'w-max cursor-pointer self-end rounded-full bg-sky-500 px-4 py-2 text-center font-sans text-base font-medium text-white hover:bg-sky-600'
           )}
-          onClick={() => onPickTeam(selectedTeam.id)}
+          onClick={handleSelectTeam}
         >
           Select Team
         </button>

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -1,0 +1,128 @@
+import React, {useEffect, useState} from 'react'
+import graphql from 'babel-plugin-relay/macro'
+
+import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
+import {MenuPosition} from '../../hooks/useCoords'
+import {TeamPickerModal_templates$key} from '~/__generated__/TeamPickerModal_templates.graphql'
+import {TeamPickerModal_teams$key} from '~/__generated__/TeamPickerModal_teams.graphql'
+import sortByTier from '../../utils/sortByTier'
+import useMutationProps from '../../hooks/useMutationProps'
+import useAtmosphere from '../../hooks/useAtmosphere'
+import AddReflectTemplateMutation from '../../mutations/AddReflectTemplateMutation'
+import {AddReflectTemplateMutation$data} from '~/__generated__/AddReflectTemplateMutation.graphql'
+import {useHistory} from 'react-router'
+import {Threshold} from '../../types/constEnums'
+import {useFragment} from 'react-relay'
+import clsx from 'clsx'
+
+interface TeamPickerModalProps {
+  teamsRef: TeamPickerModal_teams$key
+  templatesRef: TeamPickerModal_templates$key
+  closePortal: () => void
+  category: string
+}
+
+const TeamPickerModal = (props: TeamPickerModalProps) => {
+  const {teamsRef, templatesRef, closePortal, category} = props
+  const teams = useFragment(
+    graphql`
+      fragment TeamPickerModal_teams on Team @relay(plural: true) {
+        id
+        tier
+        name
+        ...NewMeetingTeamPicker_selectedTeam
+        ...NewMeetingTeamPicker_teams
+      }
+    `,
+    teamsRef
+  )
+
+  const templates = useFragment(
+    graphql`
+      fragment TeamPickerModal_templates on MeetingTemplate @relay(plural: true) {
+        name
+        teamId
+      }
+    `,
+    templatesRef
+  )
+
+  const [selectedTeam, setSelectedTeam] = useState(sortByTier(teams)[0]!)
+
+  const atmosphere = useAtmosphere()
+  const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()
+
+  useEffect(() => {
+    onCompleted()
+  }, [selectedTeam.id])
+
+  const history = useHistory()
+
+  const handleSelectTeam = () => {
+    if (submitting) {
+      return
+    }
+
+    const teamTemplates = templates.filter((template) => template.teamId === selectedTeam.id)
+
+    if (teamTemplates.length >= Threshold.MAX_RETRO_TEAM_TEMPLATES) {
+      onError(new Error('You may only have 20 templates per team. Please remove one first.'))
+      return
+    }
+    if (teamTemplates.find((template) => template.name === '*New Template')) {
+      onError(new Error('You already have a new template. Try renaming that one first.'))
+      return
+    }
+
+    closePortal()
+
+    submitMutation()
+    AddReflectTemplateMutation(
+      atmosphere,
+      {teamId: selectedTeam.id},
+      {
+        onError,
+        onCompleted: (res: AddReflectTemplateMutation$data) => {
+          const templateId = res.addReflectTemplate?.reflectTemplate?.id
+          if (templateId) {
+            history.push(`/activity-library/details/${templateId}`, {
+              prevCategory: category
+            })
+          }
+          onCompleted()
+        }
+      }
+    )
+  }
+
+  return (
+    <div className='w-[440px] bg-white p-6'>
+      <div className='flex flex-col gap-4'>
+        <div>
+          <b>Select the team</b> to manage this new activity template:
+        </div>
+        <NewMeetingTeamPicker
+          parentId='templateTeamPickerModal'
+          positionOverride={MenuPosition.UPPER_LEFT}
+          onSelectTeam={(teamId) => {
+            const newTeam = teams.find((team) => team.id === teamId)
+            newTeam && setSelectedTeam(newTeam)
+          }}
+          selectedTeamRef={selectedTeam}
+          teamsRef={teams}
+        />
+        {error?.message && <div className='w-full text-tomato-500'>{error.message}</div>}
+        <button
+          className={clsx(
+            'w-max cursor-pointer self-end rounded-full bg-sky-500 px-4 py-2 text-center font-sans text-base font-medium text-white hover:bg-sky-600'
+          )}
+          onClick={handleSelectTeam}
+        >
+          Select Team
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default TeamPickerModal

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -15,14 +15,14 @@ import {Threshold} from '../../types/constEnums'
 import {useFragment} from 'react-relay'
 import clsx from 'clsx'
 
-interface TeamPickerModalProps {
+interface Props {
   teamsRef: TeamPickerModal_teams$key
   templatesRef: TeamPickerModal_templates$key
   closePortal: () => void
   category: string
 }
 
-const TeamPickerModal = (props: TeamPickerModalProps) => {
+const TeamPickerModal = (props: Props) => {
   const {teamsRef, templatesRef, closePortal, category} = props
   const teams = useFragment(
     graphql`

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -208,6 +208,7 @@ const NewMeeting = (props: Props) => {
               onSelectTeam={(teamId) => history.replace(`/new-meeting/${teamId}`)}
               selectedTeamRef={selectedTeam}
               teamsRef={teams}
+              parentId='newMeetingRoot'
             />
           </SettingsFirstRow>
           <SettingsRow>

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -5,7 +5,7 @@ import {NewMeetingTeamPicker_selectedTeam$key} from '~/__generated__/NewMeetingT
 import {NewMeetingTeamPicker_teams$key} from '~/__generated__/NewMeetingTeamPicker_teams.graphql'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
-import {PortalStatus} from '../hooks/usePortal'
+import {PortalId, PortalStatus} from '../hooks/usePortal'
 import lazyPreload from '../utils/lazyPreload'
 import NewMeetingDropdown from './NewMeetingDropdown'
 import NewMeetingTeamPickerAvatars from './NewMeetingTeamPickerAvatars'
@@ -22,16 +22,16 @@ interface Props {
   selectedTeamRef: NewMeetingTeamPicker_selectedTeam$key
   teamsRef: NewMeetingTeamPicker_teams$key
   onSelectTeam: (teamId: string) => void
-  noModal?: boolean
+  parentId?: PortalId
   positionOverride?: MenuPosition
 }
 
 const NewMeetingTeamPicker = (props: Props) => {
-  const {selectedTeamRef, teamsRef, onSelectTeam, noModal, positionOverride} = props
+  const {selectedTeamRef, teamsRef, onSelectTeam, parentId, positionOverride} = props
   const {togglePortal, menuPortal, originRef, menuProps, portalStatus} = useMenu<HTMLDivElement>(
     positionOverride ?? MenuPosition.LOWER_RIGHT,
     {
-      parentId: noModal ? undefined : 'newMeetingRoot',
+      parentId: parentId,
       isDropdown: true
     }
   )

--- a/packages/client/hooks/usePortal.tsx
+++ b/packages/client/hooks/usePortal.tsx
@@ -36,6 +36,7 @@ export type PortalId =
   | 'updateRecurrenceSettingsModal'
   | 'recurrenceStartTimePicker'
   | 'endRecurringMeetingModal'
+  | 'templateTeamPickerModal'
 
 export interface UsePortalOptions {
   onOpen?: (el: HTMLElement) => void

--- a/packages/client/mutations/UpdateReflectTemplateScopeMutation.ts
+++ b/packages/client/mutations/UpdateReflectTemplateScopeMutation.ts
@@ -62,7 +62,7 @@ const removeTemplateFromCurrentScope = (
   // not possible for the public list to get mutated because this is an org subscription
 }
 
-const putTemplateInConnection = (
+export const putTemplateInConnection = (
   template: RecordProxy,
   connection: RecordProxy | null | undefined,
   store: RecordSourceSelectorProxy

--- a/packages/client/mutations/handlers/handleAddReflectTemplate.ts
+++ b/packages/client/mutations/handlers/handleAddReflectTemplate.ts
@@ -1,5 +1,6 @@
-import {RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
+import {ConnectionHandler, RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
 import addNodeToArray from '../../utils/relay/addNodeToArray'
+import {putTemplateInConnection} from '../UpdateReflectTemplateScopeMutation'
 
 const handleAddReflectTemplate = (
   newNode: RecordProxy | null,
@@ -14,6 +15,11 @@ const handleAddReflectTemplate = (
   })
   if (!meetingSettings) return
   addNodeToArray(newNode, meetingSettings, 'teamTemplates', 'name')
+
+  const viewer = store.getRoot().getLinkedRecord('viewer')
+  const allTemplatesConn =
+    viewer && ConnectionHandler.getConnection(viewer, 'ActivityDetails_availableTemplates')
+  putTemplateInConnection(newNode, allTemplatesConn, store)
 }
 
 export default handleAddReflectTemplate

--- a/packages/client/mutations/handlers/handleRemoveReflectTemplate.ts
+++ b/packages/client/mutations/handlers/handleRemoveReflectTemplate.ts
@@ -1,4 +1,4 @@
-import {RecordSourceSelectorProxy} from 'relay-runtime'
+import {ConnectionHandler, RecordSourceSelectorProxy} from 'relay-runtime'
 import safeRemoveNodeFromArray from '../../utils/relay/safeRemoveNodeFromArray'
 import safeRemoveNodeFromConn from '../../utils/relay/safeRemoveNodeFromConn'
 import getReflectTemplateOrgConn from '../connections/getReflectTemplateOrgConn'
@@ -19,6 +19,11 @@ const handleRemoveReflectTemplate = (
   const publicConn = getReflectTemplatePublicConn(settings)
   safeRemoveNodeFromConn(templateId, orgConn)
   safeRemoveNodeFromConn(templateId, publicConn)
+
+  const viewer = store.getRoot().getLinkedRecord('viewer')
+  const allAvailableConn =
+    viewer && ConnectionHandler.getConnection(viewer, 'ActivityLibrary_availableTemplates')
+  safeRemoveNodeFromConn(templateId, allAvailableConn)
 }
 
 const handleRemoveReflectTemplates = pluralizeHandler(handleRemoveReflectTemplate)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8025

~Needs rebase once https://github.com/ParabolInc/parabol/pull/8008 lands~

Create a new retro template from the "Create New {category} Activity" button under retro categories in the activity lib.

Note that templates don't keep the category they're created from - this will be added when we move categories to the DB and allow them to be changed.

## Demo

https://www.loom.com/share/10160e33bb334a2ab55f8ae0d3687267

## Testing scenarios
- [ ] Create a new template from the "create custom {category} activity" button
- [ ] Select a team from the dropdown
- [ ] Click "select team", and confirm the window navigates to a fresh new retro template
- [ ] Give the template a name + prompts
- [ ] Go back without refreshing, and confirm the template is present
- [ ] Errors
  - [ ] Create a new template, then go back without updating name
  - [ ] Create a new template on the same team, and confirm an error message appears

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
