### PR TITLE
chore: Move new feature announcement to main Dashboard

### DIFF
--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import {Route, Switch, useLocation} from 'react-router'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import useSnackNag from '~/hooks/useSnackNag'
 import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
+import useNewFeatureSnackbar from '~/hooks/useNewFeatureSnackbar'
 import {PALETTE} from '~/styles/paletteV3'
 import {Breakpoint} from '~/types/constEnums'
 import useSidebar from '../hooks/useSidebar'
@@ -106,6 +107,7 @@ const Dashboard = (props: Props) => {
           ...MeetingsDash_viewer
           ...MobileDashSidebar_viewer
           ...DashSidebar_viewer
+          ...useNewFeatureSnackbar_viewer
           overLimitCopy
           featureFlags {
             insights
@@ -131,6 +133,7 @@ const Dashboard = (props: Props) => {
   useSnackNag(overLimitCopy)
   useUsageSnackNag(insights)
   useSnacksForNewMeetings(activeMeetings)
+  useNewFeatureSnackbar(viewer)
 
   const location = useLocation<{backgroundLocation?: Location}>()
   const state = location.state

--- a/packages/client/components/MyDashboardTimeline.tsx
+++ b/packages/client/components/MyDashboardTimeline.tsx
@@ -3,7 +3,6 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import useDocumentTitle from '~/hooks/useDocumentTitle'
-import useNewFeatureSnackbar from '../hooks/useNewFeatureSnackbar'
 import {DashTimeline} from '../types/constEnums'
 import {MyDashboardTimelineQuery} from '../__generated__/MyDashboardTimelineQuery.graphql'
 import ErrorBoundary from './ErrorBoundary'
@@ -45,7 +44,6 @@ const MyDashboardTimeline = (props: Props) => {
         viewer {
           ...TimelineSuggestedAction_viewer
           ...TimelineRightDrawer_viewer
-          ...useNewFeatureSnackbar_viewer
         }
         ...TimelineFeedList_query
       }
@@ -53,7 +51,6 @@ const MyDashboardTimeline = (props: Props) => {
     queryRef
   )
   const {viewer} = data
-  useNewFeatureSnackbar(viewer)
   useDocumentTitle('My History | Parabol', 'History')
   return (
     <FeedAndDrawer>


### PR DESCRIPTION
# Description

Previously it was only visible on the timeline, so it had limited reach. Moving it to the main dashboard shouldn't distract from meetings either while reaching a broader audience.

## Demo

https://www.loom.com/share/60ab5f31a27649d3b436d48218f0e2e3

## Testing scenarios

Add a new feature announcement by running
```graphql
mutation AnnounceNewFeature {
  addNewFeature(
		actionButtonCopy: "Why 🔍", 
		snackbarMessage: "New: Find and group similar reflections more quickly and easily", 
		url: "https://www.example.com") {
    __typename
    newFeature {
      id
    }
  }
}
```

- [ ] user in meeting, snackbar does not appear until user goes back to dashboard
- [ ] user on dashboard, snackbar appears immediately
- [ ] user logged out, snackbar appears after login

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
