### PR TITLE
feat(retros-in-disguise): added activity library to sidebar 

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -79,6 +79,7 @@ const DashSidebar = (props: Props) => {
         ...DashNavList_viewer
         featureFlags {
           checkoutFlow
+          retrosInDisguise
         }
         organizations {
           id
@@ -129,6 +130,9 @@ const DashSidebar = (props: Props) => {
         <Contents>
           <NavItemsWrap>
             <NavItem icon={'forum'} href={'/meetings'} label={'Meetings'} />
+            {featureFlags.retrosInDisguise && (
+              <NavItem icon={'magic'} href={'/activity-library'} label={'Activity Library'} />
+            )}
             <NavItem icon={'history'} href={'/me'} label={'History'} />
             <NavItem icon={'playlist_add_check'} href={'/me/tasks'} label={'Tasks'} />
           </NavItemsWrap>

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import {
   Add,
   ArrowBack,
+  AutoAwesome,
   CreditScore,
   ExitToApp,
   Forum,
@@ -55,6 +56,7 @@ const Label = styled('div')({
 })
 
 const iconLookup = {
+  magic: <AutoAwesome />,
   arrowBack: <ArrowBack />,
   creditScore: <CreditScore />,
   forum: <Forum />,

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -91,6 +91,7 @@ const MobileDashSidebar = (props: Props) => {
         ...DashNavList_viewer
         featureFlags {
           checkoutFlow
+          retrosInDisguise
         }
         organizations {
           id
@@ -152,6 +153,14 @@ const MobileDashSidebar = (props: Props) => {
               href={'/meetings'}
               label={'Meetings'}
             />
+            {featureFlags.retrosInDisguise && (
+              <LeftDashNavItem
+                onClick={handleMenuClick}
+                icon={'magic'}
+                href={'/activity-library'}
+                label={'Activity Library'}
+              />
+            )}
             <LeftDashNavItem
               onClick={handleMenuClick}
               icon={'history'}


### PR DESCRIPTION
# Description

Fixes #7828 

## Demo
<img width="2029" alt="CleanShot 2023-04-12 at 11 33 23@2x" src="https://user-images.githubusercontent.com/1017620/231417594-6953d5f3-01e3-434c-a107-9f674e59a1bf.png">
<img width="2073" alt="CleanShot 2023-04-12 at 11 33 37@2x" src="https://user-images.githubusercontent.com/1017620/231417601-59091152-bfe7-40eb-b4c3-ca0c80b86a94.png">



## Testing scenarios

- [ ] See if the `Activity Library` is showing after enabling `retrosInDisguise` feature flag

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
