### PR TITLE
fix: missing font styles on inputs, textareas etc

### DIFF
--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -74,7 +74,7 @@
     box-sizing: border-box;
     border-width: 0;
     border-style: solid;
-    border-color: theme('borderColor.DEFAULT'); 
+    border-color: theme('borderColor.DEFAULT');
   }
 
   html {
@@ -96,12 +96,16 @@
     text-decoration: none;
   }
 
-  input {
-    @apply antialiased;
-  }
-
+  button,
+  input,
+  select,
   textarea {
     @apply antialiased;
+    font-family: inherit;
+    font-size: 100%;
+    font-weight: inherit;
+    line-height: inherit;
+    color: inherit;
   }
 
   img {


### PR DESCRIPTION
# Description

Fixes missing global styles after migration to TailwindCSS causing inputs and text areas to have weird styles in some places. Commit that removed & replaced old global styles is [here](https://github.com/ParabolInc/parabol/pull/7597/files#diff-a9f489e548dfdf934bd307787386171bfd078dc3ccff91cb959969d46e594d33L103-L113).

## Testing scenarios

- [ ] See if search input on dashboard has correct font set

- [ ] See if editing meeting title doesn't have monospaced font

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
