### PR TITLE
fix: Workaround for adding Parabol tasks in Sprint Poker

### DIFF
--- a/packages/client/mutations/CreateTaskMutation.ts
+++ b/packages/client/mutations/CreateTaskMutation.ts
@@ -239,7 +239,8 @@ const CreateTaskMutation: StandardMutation<TCreateTaskMutation, OptionalHandlers
       }
       const editorPayload = getOptimisticTaskEditor(store, taskId, isEditing)
       handleEditTask(editorPayload, store)
-      handleUpsertTasks(task as any, store)
+      //TODO #7943 Optimistic updates on arrays has a bug in Relay. As a workaround until it's fixed properly, let's just not do optimistic updates
+      //handleUpsertTasks(task as any, store)
       handleJiraCreateIssue(task, store)
       handleGitHubCreateIssue(task as any, store)
       handleGitLabCreateIssue(task as any, store)


### PR DESCRIPTION
# Description

Workaround for #7943 

There is a bug with Relay: adding an optimistic result to an array will cause it to be undefined once the real result arrives. This workaround just skips the optimistic update adding to unblock users until there is a better fix.

## Testing scenarios

- [ ] Start Sprint Poker
- [ ] Add a Parabol task in the scope phase

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
