### PR TITLE
fix: ensure teamMembers exist in payload

### DIFF
--- a/packages/client/mutations/RemoveOrgUserMutation.ts
+++ b/packages/client/mutations/RemoveOrgUserMutation.ts
@@ -136,7 +136,7 @@ export const removeOrgUserTeamUpdater: SharedUpdater<RemoveOrgUserMutation_team$
     handleRemoveTeams(teamIds, store)
   } else {
     const teamMembers = payload.getLinkedRecords('teamMembers')
-    const teamMemberIds = teamMembers.map((teamMember) => teamMember.getValue('id'))
+    const teamMemberIds = teamMembers?.map((teamMember) => teamMember.getValue('id'))
     handleRemoveTeamMembers(teamMemberIds, store)
   }
 }


### PR DESCRIPTION
# Description

fixes #7717 makes sure teamMember array exists in payload.
the root cause is actually in the type def file, but that'll take a lot longer to fix & get merged.

