### PR TITLE
fix: when user leaves team, do not remove estimate stages they created

### DIFF
--- a/packages/server/graphql/mutations/helpers/removeTeamMember.ts
+++ b/packages/server/graphql/mutations/helpers/removeTeamMember.ts
@@ -114,7 +114,6 @@ const removeTeamMember = async (
   // if a new meeting was currently running, remove them from it
   const filterFn = (stage: CheckInStage | UpdatesStage | EstimateStage | AgendaItemsStage) =>
     (stage as CheckInStage | UpdatesStage).teamMemberId === teamMemberId ||
-    (stage as EstimateStage).creatorUserId === userId ||
     agendaItemIds.includes((stage as AgendaItemsStage).agendaItemId)
   removeSlackAuths(userId, teamId)
   await removeStagesFromMeetings(filterFn, teamId, dataLoader)


### PR DESCRIPTION
# Description

fix #7625

when a user leaves a team, their estimate stages stay put. their credentials are still used to fetch the issue, same as today.
It's not clear what we should do if access to a task is lost, so that's out of scope for this until we can arrive at a good resolution for that separate issue.

