### PR TITLE
chore(metrics): Add icloud.com as another generic domain

### DIFF
--- a/packages/server/utils/isCompanyDomain.ts
+++ b/packages/server/utils/isCompanyDomain.ts
@@ -4,7 +4,8 @@ const GENERIC_DOMAINS = new Set([
   'googlemail.com',
   'hotmail.com',
   'outlook.com',
-  'mail.com'
+  'mail.com',
+  'icloud.com'
 ])
 
 const isCompanyDomain = (domain: string) => !GENERIC_DOMAINS.has(domain)


### PR DESCRIPTION
# Description

@icloud.com is a personal email address. Apple Employee who works in iCloud department is not using this TLD in their work email. This makes us mistakenly thought we had an [Apple deal].(https://app.hubspot.com/contacts/3888472/company/1111839656)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
