### PR TITLE
fix: require accepted invites before sending more

### DIFF
--- a/packages/client/components/AddTeamMemberModal.tsx
+++ b/packages/client/components/AddTeamMemberModal.tsx
@@ -7,12 +7,12 @@ import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import {PALETTE} from '~/styles/paletteV3'
 import modalTeamInvitePng from '../../../static/images/illustrations/illus-modal-team-invite.png'
+import {AddTeamMemberModal_teamMembers$key} from '../__generated__/AddTeamMemberModal_teamMembers.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
 import InviteToTeamMutation from '../mutations/InviteToTeamMutation'
 import {CompletedHandler} from '../types/relayMutations'
 import parseEmailAddressList from '../utils/parseEmailAddressList'
 import plural from '../utils/plural'
-import {AddTeamMemberModal_teamMembers$key} from '../__generated__/AddTeamMemberModal_teamMembers.graphql'
 import AddTeamMemberModalSuccess from './AddTeamMemberModalSuccess'
 import DialogContainer from './DialogContainer'
 import DialogContent from './DialogContent'
@@ -199,7 +199,10 @@ const AddTeamMemberModal = (props: Props) => {
 
           onError(
             new Error(
-              `Could not send an invitation to the above ${plural(badInvitees.length, 'email')}`
+              `Could not send an invitation to the above ${plural(
+                badInvitees.length,
+                'email'
+              )}. Try sharing the link`
             )
           )
           setInvitees(badInvitees)

--- a/packages/server/graphql/mutations/inviteToTeam.ts
+++ b/packages/server/graphql/mutations/inviteToTeam.ts
@@ -16,6 +16,7 @@ import removeSuggestedAction from '../../safeMutations/removeSuggestedAction'
 import {analytics} from '../../utils/analytics/analytics'
 import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import getBestInvitationMeeting from '../../utils/getBestInvitationMeeting'
+import getDomainFromEmail from '../../utils/getDomainFromEmail'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
@@ -63,6 +64,34 @@ export default {
       }
 
       // RESOLUTION
+      const getInviteTrustScore = async (userId: string, teamId: string) => {
+        const untrustedDomains = ['tempmail.cn']
+        const user = await dataLoader.get('users').loadNonNull(userId)
+        const {email} = user
+        const userDomain = getDomainFromEmail(email).toLowerCase()
+        const isUntrustedDomain = untrustedDomains.includes(userDomain)
+        if (isUntrustedDomain) return 0.05
+        const [total, pending] = await Promise.all([
+          r.table('TeamInvitation').getAll(teamId, {index: 'teamId'}).count().run(),
+          r
+            .table('TeamInvitation')
+            .getAll(teamId, {index: 'teamId'})
+            .filter({acceptedAt: null})
+            .count()
+            .run()
+        ])
+        // trust their first 5 invites
+        if (total <= 5) return 0.95
+        const accepted = total - pending
+        // if no one has accepted one of their 5+ invites, don't trust them
+        if (accepted === 0) return 0.05
+        // the more folks accept their invite, the more trust they get
+        return accepted / total
+      }
+
+      const trustScore = await getInviteTrustScore(viewerId, teamId)
+      if (trustScore < 0.15)
+        return {error: {message: 'Cannot invite by email. Try using invite link'}, invitees: []}
       const subOptions = {mutatorId, operationId}
       const [users, team, inviter] = await Promise.all([
         getUsersByEmails(invitees),


### PR DESCRIPTION
# Description

We've had some spam invites going out.
To fix, we'll exclude trouble domain.
Next, we'll trust the first 5 invites.
After 5, we'll require:
- At least 1 invite to have been accepted
- At least 15% of all invites sent via email have been accepted

