### PR TITLE
fix(recurrence): prevent repeating date in standups name

### DIFF
--- a/packages/server/database/types/MeetingTeamPrompt.ts
+++ b/packages/server/database/types/MeetingTeamPrompt.ts
@@ -57,8 +57,7 @@ export default class MeetingTeamPrompt extends Meeting {
       phases,
       facilitatorUserId,
       meetingType: 'teamPrompt',
-      //TODO: use client timezone here (requires sending it from the client and passing it via gql context most likely)
-      name: createTeamPromptTitle(name || 'Standup', new Date(), 'UTC'),
+      name,
       meetingSeriesId,
       scheduledEndTime
     })

--- a/packages/server/graphql/mutations/helpers/safeCreateTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeCreateTeamPrompt.ts
@@ -6,6 +6,7 @@ import {DataLoaderWorker} from '../../graphql'
 import createNewMeetingPhases from './createNewMeetingPhases'
 
 const safeCreateTeamPrompt = async (
+  name: string,
   teamId: string,
   facilitatorId: string,
   r: ParabolR,
@@ -31,6 +32,7 @@ const safeCreateTeamPrompt = async (
   )
   return new MeetingTeamPrompt({
     id: meetingId,
+    name,
     teamId,
     meetingCount,
     phases,

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -30,8 +30,12 @@ const startRecurringTeamPrompt = async (
 
   const rrule = RRule.fromString(meetingSeries.recurrenceRule)
   const nextMeetingStartDate = rrule.after(startTime)
-  const meeting = await safeCreateTeamPrompt(teamId, facilitatorId, r, dataLoader, {
-    name: createTeamPromptTitle(meetingSeries.title, startTime, rrule.options.tzid ?? 'UTC'),
+  const meetingName = createTeamPromptTitle(
+    meetingSeries.title,
+    startTime,
+    rrule.options.tzid ?? 'UTC'
+  )
+  const meeting = await safeCreateTeamPrompt(meetingName, teamId, facilitatorId, r, dataLoader, {
     scheduledEndTime: nextMeetingStartDate,
     meetingSeriesId: meetingSeries.id
   })

--- a/packages/server/graphql/public/mutations/startTeamPrompt.ts
+++ b/packages/server/graphql/public/mutations/startTeamPrompt.ts
@@ -11,6 +11,7 @@ import {IntegrationNotifier} from '../../mutations/helpers/notifications/Integra
 import safeCreateTeamPrompt from '../../mutations/helpers/safeCreateTeamPrompt'
 import {MutationResolvers} from '../resolverTypes'
 import {startNewMeetingSeries} from './updateRecurrenceSettings'
+import {createTeamPromptTitle} from '../../../database/types/MeetingTeamPrompt'
 
 const MEETING_START_DELAY_MS = 3000
 
@@ -40,9 +41,13 @@ const startTeamPrompt: MutationResolvers['startTeamPrompt'] = async (
     })
   }
 
-  const meeting = await safeCreateTeamPrompt(teamId, viewerId, r, dataLoader, {
-    name: recurrenceSettings?.name
-  })
+  //TODO: use client timezone here (requires sending it from the client and passing it via gql context most likely)
+  const meetingName = createTeamPromptTitle(
+    recurrenceSettings?.name ?? 'Standup',
+    new Date(),
+    'UTC'
+  )
+  const meeting = await safeCreateTeamPrompt(meetingName, teamId, viewerId, r, dataLoader)
 
   await Promise.all([
     r.table('NewMeeting').insert(meeting).run(),


### PR DESCRIPTION
# Description

Fixes an issue where the standup title would be like `Friday Ship - April 17 - April 17`. The issue was caused by the implementation detail, where `MeetingTeamPrompt` constructor would always append a date to a title, no matter if it was already there or not. I moved creating title outside of the constructor for all cases as eventually we'll use a different timezone when creating a single instance meeting vs meeting series.

## Demo

No demo

## Testing scenarios

- [ ] Run process recurrence a couple of times to make sure it's not happening anymore

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
