### PR TITLE
fix: Rename makeTemplateDescription -> useTemplateDescription to satisfy hooks rules

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -11,7 +11,7 @@ import AddTemplatePrompt from '../../modules/meeting/components/AddTemplatePromp
 import {ActivityCard, CategoryID, MeetingThemes} from './ActivityCard'
 import {activityIllustrations} from './ActivityIllustrations'
 import customTemplateIllustration from '../../../../static/images/illustrations/customTemplate.png'
-import makeTemplateDescription from '../../utils/makeTemplateDescription'
+import useTemplateDescription from '../../utils/useTemplateDescription'
 import clsx from 'clsx'
 import {UnstyledTemplateSharing} from '../../modules/meeting/components/TemplateSharing'
 import DetailAction from '../DetailAction'
@@ -55,7 +55,7 @@ const query = graphql`
         id
       }
 
-      ...makeTemplateDescription_viewer
+      ...useTemplateDescription_viewer
     }
   }
 `
@@ -109,26 +109,27 @@ const ActivityDetails = (props: Props) => {
     )
   }, [templateId, submitting, submitMutation, onError, onCompleted])
 
+  const teamIds = teams.map((team) => team.id)
+  const orgIds = organizations.map((org) => org.id)
+
+  const isOwner = !!selectedTemplate && teamIds.includes(selectedTemplate.teamId)
+
+  const teamTemplates = availableTemplates.edges
+    .map((edge) => edge.node)
+    .filter((edge) => edge.teamId === selectedTemplate?.teamId)
+
+  const lowestScope = isOwner
+    ? 'TEAM'
+    : selectedTemplate && orgIds.includes(selectedTemplate.orgId)
+    ? 'ORGANIZATION'
+    : 'PUBLIC'
+  const description = useTemplateDescription(lowestScope, selectedTemplate, viewer, tier)
+
   if (!selectedTemplate) {
     return <Redirect to='/activity-library' />
   }
 
   const {name: templateName, prompts} = selectedTemplate
-  const teamIds = teams.map((team) => team.id)
-  const orgIds = organizations.map((org) => org.id)
-
-  const isOwner = teamIds.includes(selectedTemplate.teamId!)
-
-  const teamTemplates = availableTemplates.edges
-    .map((edge) => edge.node)
-    .filter((edge) => edge.teamId === selectedTemplate.teamId)
-
-  const lowestScope = isOwner
-    ? 'TEAM'
-    : orgIds.includes(selectedTemplate.orgId)
-    ? 'ORGANIZATION'
-    : 'PUBLIC'
-  const description = makeTemplateDescription(lowestScope, selectedTemplate, viewer, tier)
 
   const templateIllustration =
     activityIllustrations[selectedTemplate.id as keyof typeof activityIllustrations]

--- a/packages/client/components/TimelineEventTeamPromptComplete.tsx
+++ b/packages/client/components/TimelineEventTeamPromptComplete.tsx
@@ -53,6 +53,8 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
     timelineEventRef
   )
 
+  const atmosphere = useAtmosphere()
+
   const {meeting, team} = timelineEvent
   if (!meeting) {
     return null
@@ -71,7 +73,6 @@ const TimelineEventTeamPromptComplete = (props: Props) => {
   const {id: orgId, viewerOrganizationUser} = organization
   const canUpgrade = !!viewerOrganizationUser
 
-  const atmosphere = useAtmosphere()
   const onUpgrade = () => {
     SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
       upgradeCTALocation: 'timelineHistoryLock',

--- a/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
@@ -10,7 +10,7 @@ import AddPokerTemplateMutation from '../../../mutations/AddPokerTemplateMutatio
 import {PALETTE} from '../../../styles/paletteV3'
 import {Threshold} from '../../../types/constEnums'
 import getTemplateList from '../../../utils/getTemplateList'
-import makeTemplateDescription from '../../../utils/makeTemplateDescription'
+import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {PokerTemplateDetails_settings$key} from '../../../__generated__/PokerTemplateDetails_settings.graphql'
 import {PokerTemplateDetails_viewer$key} from '../../../__generated__/PokerTemplateDetails_viewer.graphql'
 import AddPokerTemplateDimension from './AddPokerTemplateDimension'
@@ -116,7 +116,7 @@ const PokerTemplateDetails = (props: Props) => {
         featureFlags {
           templateLimit
         }
-        ...makeTemplateDescription_viewer
+        ...useTemplateDescription_viewer
       }
     `,
     viewerRef
@@ -129,7 +129,7 @@ const PokerTemplateDetails = (props: Props) => {
   const {id: teamId, orgId, tier} = team
   const lowestScope = getTemplateList(teamId, orgId, activeTemplate)
   const isOwner = activeTemplate.teamId === teamId
-  const description = makeTemplateDescription(lowestScope, activeTemplate, viewer)
+  const description = useTemplateDescription(lowestScope, activeTemplate, viewer)
   const templateCount = teamTemplates.length
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
@@ -189,7 +189,7 @@ graphql`
   fragment PokerTemplateDetailsTemplate on PokerTemplate {
     ...TemplateSharing_template
     ...getTemplateList_template
-    ...makeTemplateDescription_template
+    ...useTemplateDescription_template
     id
     name
     dimensions {

--- a/packages/client/modules/meeting/components/PokerTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateItem.tsx
@@ -8,7 +8,7 @@ import SendClientSegmentEventMutation from '../../../mutations/SendClientSegment
 import {DECELERATE} from '../../../styles/animation'
 import textOverflow from '../../../styles/helpers/textOverflow'
 import {PALETTE} from '../../../styles/paletteV3'
-import makeTemplateDescription from '../../../utils/makeTemplateDescription'
+import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
 import {PokerTemplateItem_template$key} from '../../../__generated__/PokerTemplateItem_template.graphql'
 import {PokerTemplateItem_viewer$key} from '../../../__generated__/PokerTemplateItem_viewer.graphql'
@@ -66,7 +66,7 @@ const PokerTemplateItem = (props: Props) => {
       fragment PokerTemplateItem_template on PokerTemplate {
         #get the details here so we can show them in the details view
         ...PokerTemplateDetailsTemplate
-        ...makeTemplateDescription_template
+        ...useTemplateDescription_template
         id
         name
         lastUsedAt
@@ -79,13 +79,13 @@ const PokerTemplateItem = (props: Props) => {
   const viewer = useFragment(
     graphql`
       fragment PokerTemplateItem_viewer on User {
-        ...makeTemplateDescription_viewer
+        ...useTemplateDescription_viewer
       }
     `,
     viewerRef ?? null
   )
   const {id: templateId, name: templateName, scope, isFree} = template
-  const description = makeTemplateDescription(lowestScope, template, viewer ?? undefined)
+  const description = useTemplateDescription(lowestScope, template, viewer ?? undefined)
   const atmosphere = useAtmosphere()
   const ref = useRef<HTMLLIElement>(null)
   useScrollIntoView(ref, isActive)

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -9,7 +9,7 @@ import AddReflectTemplateMutation from '../../../mutations/AddReflectTemplateMut
 import {PALETTE} from '../../../styles/paletteV3'
 import {Threshold} from '../../../types/constEnums'
 import getTemplateList from '../../../utils/getTemplateList'
-import makeTemplateDescription from '../../../utils/makeTemplateDescription'
+import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {ReflectTemplateDetails_settings$key} from '../../../__generated__/ReflectTemplateDetails_settings.graphql'
 import {ReflectTemplateDetails_viewer$key} from '../../../__generated__/ReflectTemplateDetails_viewer.graphql'
 import AddTemplatePrompt from './AddTemplatePrompt'
@@ -116,7 +116,7 @@ const ReflectTemplateDetails = (props: Props) => {
         featureFlags {
           templateLimit
         }
-        ...makeTemplateDescription_viewer
+        ...useTemplateDescription_viewer
       }
     `,
     viewerRef
@@ -129,7 +129,7 @@ const ReflectTemplateDetails = (props: Props) => {
   const {id: teamId, orgId, tier} = team
   const lowestScope = getTemplateList(teamId, orgId, activeTemplate)
   const isOwner = activeTemplate.teamId === teamId
-  const description = makeTemplateDescription(lowestScope, activeTemplate, viewer, tier)
+  const description = useTemplateDescription(lowestScope, activeTemplate, viewer, tier)
   const templateCount = teamTemplates.length
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
@@ -196,7 +196,7 @@ graphql`
   fragment ReflectTemplateDetailsTemplate on ReflectTemplate {
     ...TemplateSharing_template
     ...getTemplateList_template
-    ...makeTemplateDescription_template
+    ...useTemplateDescription_template
     id
     name
     prompts {

--- a/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
@@ -9,7 +9,7 @@ import SendClientSegmentEventMutation from '../../../mutations/SendClientSegment
 import {DECELERATE} from '../../../styles/animation'
 import textOverflow from '../../../styles/helpers/textOverflow'
 import {PALETTE} from '../../../styles/paletteV3'
-import makeTemplateDescription from '../../../utils/makeTemplateDescription'
+import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
 import {ReflectTemplateItem_template$key} from '../../../__generated__/ReflectTemplateItem_template.graphql'
 import {ReflectTemplateItem_viewer$key} from '../../../__generated__/ReflectTemplateItem_viewer.graphql'
@@ -78,7 +78,7 @@ const ReflectTemplateItem = (props: Props) => {
       fragment ReflectTemplateItem_template on ReflectTemplate {
         #get the details here so we can show them in the details view
         ...ReflectTemplateDetailsTemplate
-        ...makeTemplateDescription_template
+        ...useTemplateDescription_template
         id
         name
         lastUsedAt
@@ -91,13 +91,13 @@ const ReflectTemplateItem = (props: Props) => {
   const viewer = useFragment(
     graphql`
       fragment ReflectTemplateItem_viewer on User {
-        ...makeTemplateDescription_viewer
+        ...useTemplateDescription_viewer
       }
     `,
     viewerRef ?? null
   )
   const {id: templateId, name: templateName, scope, isFree} = template
-  const description = makeTemplateDescription(lowestScope, template, viewer, tier)
+  const description = useTemplateDescription(lowestScope, template, viewer, tier)
   const atmosphere = useAtmosphere()
   const ref = useRef<HTMLLIElement>(null)
   useScrollIntoView(ref, isActive, true)

--- a/packages/client/mutations/toasts/promptToJoinOrgSuccessToast.ts
+++ b/packages/client/mutations/toasts/promptToJoinOrgSuccessToast.ts
@@ -1,8 +1,8 @@
 const promptToJoinOrgSuccessToast = {
-    key: 'promptToJoinOrgSuccess',
-    autoDismiss: 5,
-    showDismissButton: true,
-    message: `🎉 Success! We've let your team know you'd like to join them`
+  key: 'promptToJoinOrgSuccess',
+  autoDismiss: 5,
+  showDismissButton: true,
+  message: `🎉 Success! We've let your team know you'd like to join them`
 }
 
 export default promptToJoinOrgSuccessToast

--- a/packages/client/utils/useTemplateDescription.ts
+++ b/packages/client/utils/useTemplateDescription.ts
@@ -1,19 +1,34 @@
 import graphql from 'babel-plugin-relay/macro'
 import {readInlineData, useFragment} from 'react-relay'
-import {makeTemplateDescription_template$key} from '../__generated__/makeTemplateDescription_template.graphql'
-import {makeTemplateDescription_viewer$key} from '../__generated__/makeTemplateDescription_viewer.graphql'
+import {useTemplateDescription_template$key} from '../__generated__/useTemplateDescription_template.graphql'
+import {useTemplateDescription_viewer$key} from '../__generated__/useTemplateDescription_viewer.graphql'
 import {TierEnum} from '../__generated__/SendClientSegmentEventMutation.graphql'
 import relativeDate from './date/relativeDate'
 
-const makeTemplateDescription = (
+const useTemplateDescription = (
   lowestScope: string,
-  templateRef: makeTemplateDescription_template$key,
-  viewerRef?: makeTemplateDescription_viewer$key | null,
+  templateRef?: useTemplateDescription_template$key,
+  viewerRef?: useTemplateDescription_viewer$key | null,
   tier?: TierEnum
 ) => {
+  const viewer = useFragment(
+    graphql`
+      fragment useTemplateDescription_viewer on User {
+        featureFlags {
+          templateLimit
+        }
+      }
+    `,
+    viewerRef ?? null
+  )
+
+  if (!templateRef) {
+    return null
+  }
+
   const template = readInlineData(
     graphql`
-      fragment makeTemplateDescription_template on MeetingTemplate @inline {
+      fragment useTemplateDescription_template on MeetingTemplate @inline {
         lastUsedAt
         scope
         isFree
@@ -24,16 +39,7 @@ const makeTemplateDescription = (
     `,
     templateRef
   )
-  const viewer = useFragment(
-    graphql`
-      fragment makeTemplateDescription_viewer on User {
-        featureFlags {
-          templateLimit
-        }
-      }
-    `,
-    viewerRef ?? null
-  )
+
   const showTemplateLimit = viewer?.featureFlags.templateLimit
   const {lastUsedAt, team, isFree} = template
   const {name: teamName} = team
@@ -47,4 +53,4 @@ const makeTemplateDescription = (
   return `Created by ${teamName}`
 }
 
-export default makeTemplateDescription
+export default useTemplateDescription


### PR DESCRIPTION
# Description
FIxes errors in https://github.com/ParabolInc/parabol/actions/runs/4726296812/jobs/8385744221?pr=8036

`makeTemplateDescription` (not a hook) calls `useFragment` (a hook), which breaks React hook rules, since hooks can only be called from function components and other hooks.

Rename `makeTemplateDescription` to `useTemplateDescription` to make it a hook + rearrange code that calls it conditionally.

Also includes a minor fix where `useAtmosphere` was called conditionally.

Also fixes prettier in a file (what's actually breaking code style on master)

## Demo
N/A

## Testing scenarios
Smoke test places where template descriptions are used.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
