### PR TITLE
fix(stripe): Fix the bug when there's failed payment we charge customer extra amount

### DIFF
--- a/packages/server/billing/helpers/terminateSubscription.ts
+++ b/packages/server/billing/helpers/terminateSubscription.ts
@@ -18,7 +18,7 @@ const terminateSubscription = async (orgId: string) => {
             stripeSubscriptionId: null
           },
           {returnChanges: true}
-        )('changes')(0)('old_val')
+        )('changes')(0)('old_val')('stripeSubscriptionId')
         .default(null) as unknown as string
     }).run(),
     updateTeamByOrgId({isPaid: false}, orgId)
@@ -32,7 +32,7 @@ const terminateSubscription = async (orgId: string) => {
     try {
       await manager.deleteSubscription(stripeSubscriptionId)
     } catch (e) {
-      // noop
+      console.error(`cannot delete subscription ${stripeSubscriptionId}`, e)
     }
   }
   return stripeSubscriptionId

--- a/packages/server/billing/helpers/terminateSubscription.ts
+++ b/packages/server/billing/helpers/terminateSubscription.ts
@@ -27,8 +27,6 @@ const terminateSubscription = async (orgId: string) => {
   const {organization} = rethinkResult
   const {stripeSubscriptionId} = organization
 
-  // stripe already does this for us (per account settings) but we do it here so we don't have to wait an hour
-  // if this function is called by a paymentFailed hook, then the sub may not exist, so catch and release
   if (stripeSubscriptionId) {
     const manager = getStripeManager()
     try {

--- a/packages/server/billing/helpers/terminateSubscription.ts
+++ b/packages/server/billing/helpers/terminateSubscription.ts
@@ -1,4 +1,5 @@
 import getRethink from '../../database/rethinkDriver'
+import Organization from '../../database/types/Organization'
 import updateTeamByOrgId from '../../postgres/queries/updateTeamByOrgId'
 import {getStripeManager} from '../../utils/stripe'
 
@@ -8,7 +9,7 @@ const terminateSubscription = async (orgId: string) => {
   // flag teams as unpaid
   const [rethinkResult] = await Promise.all([
     r({
-      stripeSubscriptionId: r
+      organization: r
         .table('Organization')
         .get(orgId)
         .update(
@@ -18,12 +19,13 @@ const terminateSubscription = async (orgId: string) => {
             stripeSubscriptionId: null
           },
           {returnChanges: true}
-        )('changes')(0)('old_val')('stripeSubscriptionId')
-        .default(null) as unknown as string
+        )('changes')(0)('old_val')
+        .default(null) as unknown as Organization
     }).run(),
     updateTeamByOrgId({isPaid: false}, orgId)
   ])
-  const {stripeSubscriptionId} = rethinkResult
+  const {organization} = rethinkResult
+  const {stripeSubscriptionId} = organization
 
   // stripe already does this for us (per account settings) but we do it here so we don't have to wait an hour
   // if this function is called by a paymentFailed hook, then the sub may not exist, so catch and release


### PR DESCRIPTION
# Description

Fixes #8061. To reproduce the bug, on `master` branch:

1. [Install Stripe CLI](https://stripe.com/docs/stripe-cli) if you haven't
2. Setup Stripe webhook to forward to your local server: `stripe listen --forward-to localhost:3000/stripe`, and copy the webhook singing secret to replace the one in [your .env](https://github.com/ParabolInc/action-devops/blob/master/environments/local#L73)
3. Create a new team/org and go to the org billing page
4. Upgrade with this Stripe payment failure test card: `4000 0000 0000 3063`, expiration date any month in the future, CVC can be anything
<img width="287" alt="Screenshot 2023-04-19 at 12 26 52" src="https://user-images.githubusercontent.com/1879975/233153303-327a6d92-8fa0-439b-b804-7d693b675baf.png">

5. Observe the org is upgraded
6. Wait a moment and then refresh the page, you should see that one invoice is in the state of PENDING (because the payment wasn't successful) but another invoice for next month with 2x of the amount
<img width="664" alt="Screenshot 2023-04-19 at 12 28 00" src="https://user-images.githubusercontent.com/1879975/233153539-1211e8f6-6332-4e6c-937d-95ec80f680cc.png">

7. Now update the credit card number to `4242 4242 4242 4242`

8. Wait a moment and then refresh the page, you should see a new invoice generated and paid with 2x of the amount, indicating the customer has been double charged.
<img width="659" alt="Screenshot 2023-04-19 at 12 29 37" src="https://user-images.githubusercontent.com/1879975/233154108-f47c8c65-cabc-4c98-9eae-fbd802091b96.png">


## Testing scenarios
With this branch pulled and server started, repeat the above-mentioned steps 3 - 5.

6. Wait a moment and then refresh the page, you should see one invoice in the state of FAILED:
<img width="655" alt="Screenshot 2023-04-19 at 12 34 58" src="https://user-images.githubusercontent.com/1879975/233155189-1db8c76c-f990-46ff-b395-9cf6021a1773.png">

7. Now update the credit card number to `4242 4242 4242 4242`
8. Wait a moment and then refresh the page, you should see a new invoice generated and paid the correct amount, and an upcoming invoice also with the correct amount

<img width="653" alt="Screenshot 2023-04-19 at 12 37 15" src="https://user-images.githubusercontent.com/1879975/233155788-015381c7-4966-480a-9335-f40f93119ed0.png">


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
