### PR TITLE
fix: default standup name

### DIFF
--- a/packages/server/graphql/public/mutations/startTeamPrompt.ts
+++ b/packages/server/graphql/public/mutations/startTeamPrompt.ts
@@ -43,7 +43,7 @@ const startTeamPrompt: MutationResolvers['startTeamPrompt'] = async (
 
   //TODO: use client timezone here (requires sending it from the client and passing it via gql context most likely)
   const meetingName = createTeamPromptTitle(
-    recurrenceSettings?.name ?? 'Standup',
+    recurrenceSettings?.name || 'Standup',
     new Date(),
     'UTC'
   )


### PR DESCRIPTION
# Description

Fixes creating a non-recurring standup meeting with a wrong name

## Demo

No demo

## Testing scenarios

- [ ] create a non recurring standup and see if the meeting has correct name
- [ ] create a recurring standup and see if the meeting has correct name

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
