### PR TITLE
feat: add a feature flag for public teams

### DIFF
--- a/packages/server/graphql/private/typeDefs/addFeatureFlagToOrg.graphql
+++ b/packages/server/graphql/private/typeDefs/addFeatureFlagToOrg.graphql
@@ -5,6 +5,7 @@ enum OrganizationFeatureFlagsEnum {
   teamsLimit
   SAMLUI
   promptToJoinOrg
+  publicTeams
 }
 
 extend type Mutation {

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -171,4 +171,5 @@ type OrganizationFeatureFlags {
   teamsLimit: Boolean!
   SAMLUI: Boolean!
   promptToJoinOrg: Boolean!
+  publicTeams: Boolean!
 }

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -3,7 +3,8 @@ import {OrganizationFeatureFlagsResolvers} from '../resolverTypes'
 const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   SAMLUI: ({SAMLUI}) => !!SAMLUI,
   teamsLimit: ({teamsLimit}) => !!teamsLimit,
-  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg
+  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg,
+  publicTeams: ({publicTeams}) => !!publicTeams
 }
 
 export default OrganizationFeatureFlags

--- a/packages/server/graphql/types/Organization.ts
+++ b/packages/server/graphql/types/Organization.ts
@@ -70,10 +70,12 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
     },
     teams: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Team))),
-      description: 'all the teams the viewer is on in the organization',
+      description: 'all the teams the viewer is on and the public teams in the organization',
       resolve: async ({id: orgId}, _args: unknown, {authToken, dataLoader}) => {
-        const allTeamsOnOrg = await dataLoader.get('teamsByOrgIds').load(orgId)
-        const org = await dataLoader.get('organizations').load(orgId)
+        const [allTeamsOnOrg, org] = await Promise.all([
+          dataLoader.get('teamsByOrgIds').load(orgId),
+          dataLoader.get('organizations').load(orgId)
+        ])
 
         if (isSuperUser(authToken)) return allTeamsOnOrg
         else if (org.featureFlags?.includes('publicTeams')) {

--- a/packages/server/graphql/types/Organization.ts
+++ b/packages/server/graphql/types/Organization.ts
@@ -76,7 +76,7 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
         const org = await dataLoader.get('organizations').load(orgId)
 
         if (isSuperUser(authToken)) return allTeamsOnOrg
-        else if (org?.featureFlags?.includes('publicTeams')) {
+        else if (org.featureFlags?.includes('publicTeams')) {
           return allTeamsOnOrg
         }
         return allTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -562,7 +562,7 @@ const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLC
       ) => {
         const viewerId = getUserId(authToken)
         const [user, organizationUsers] = await Promise.all([
-          dataLoader.get('users').load(userId),
+          dataLoader.get('users').loadNonNull(userId),
           dataLoader.get('organizationUsersByUserId').load(userId)
         ])
         const orgIds = organizationUsers.map(({orgId}) => orgId)

--- a/packages/server/graphql/types/User.ts
+++ b/packages/server/graphql/types/User.ts
@@ -585,8 +585,8 @@ const User: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<any, GQLC
           ? user!.tms
           : user!.tms.filter((teamId) => authToken.tms.includes(teamId))
 
-        const teams = (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
-        const allVisibleTeams = [...teams, ...organizationTmsWithPublicFlag]
+        const teamsUserBelongsTo = (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
+        const allVisibleTeams = [...teamsUserBelongsTo, ...organizationTmsWithPublicFlag]
         allVisibleTeams.sort((a, b) => (a.name > b.name ? 1 : -1))
         return allVisibleTeams
       }


### PR DESCRIPTION
# Description
This adds a feature flag to make public teams visible to users

#7979 

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Add feature flag `publicTeam` to organisation
  - Users in any team in the organisation should be able to view other teams in the organisation

- [ ] Scenario B
  - Organisations without publicTeams flag should still have existing view permission

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
