### PR TITLE
feat(recurrence): Use the prompt from the most recent meeting in the series

### DIFF
--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -17,6 +17,7 @@ import {MutationResolvers} from '../resolverTypes'
 
 const startRecurringTeamPrompt = async (
   meetingSeries: MeetingSeries,
+  lastMeeting: MeetingTeamPrompt | null,
   startTime: Date,
   dataLoader: DataLoaderWorker,
   r: ParabolR,
@@ -37,7 +38,8 @@ const startRecurringTeamPrompt = async (
   )
   const meeting = await safeCreateTeamPrompt(meetingName, teamId, facilitatorId, r, dataLoader, {
     scheduledEndTime: nextMeetingStartDate,
-    meetingSeriesId: meetingSeries.id
+    meetingSeriesId: meetingSeries.id,
+    meetingPrompt: lastMeeting ? lastMeeting.meetingPrompt : undefined
   })
 
   await r.table('NewMeeting').insert(meeting).run()
@@ -88,14 +90,14 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
         return
       }
 
-      const lastMeeting = await r
+      const lastMeeting = (await r
         .table('NewMeeting')
         .getAll(meetingSeries.id, {index: 'meetingSeriesId'})
         .filter({meetingType: 'teamPrompt'})
         .orderBy(r.desc('createdAt'))
         .nth(0)
         .default(null)
-        .run()
+        .run()) as MeetingTeamPrompt | null
 
       // For meetings that should still be active, start the meeting and set its end time.
       // Any subscriptions are handled by the shared meeting start code
@@ -116,6 +118,7 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
       for (const startTime of newMeetingsStartTimes) {
         const err = await startRecurringTeamPrompt(
           meetingSeries,
+          lastMeeting,
           startTime,
           dataLoader,
           r,


### PR DESCRIPTION
# Description
Fixes https://github.com/ParabolInc/parabol/issues/8092

Currently, we use the hard-coded default prompt for all standup meetings. Instead, when restarting a recurring meeting, just use the prompt from the most recent meeting in the series.

## Demo
https://www.loom.com/share/fe44272fbaaa4b0a9f416138cd7ed689

## Testing scenarios
- [ ] Smoke test creating standups
- [ ] Create recurring standup meeting
- [ ] Change the prompt
- [ ] Time travel and run process recurrence
- [ ] Confirm new meeting uses previous meeting's prompt.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
