### PR TITLE
feat(rid): Edit Mode

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -301,12 +301,14 @@ const ActivityDetails = (props: Props) => {
               </div>
             </div>
           </div>
-          {!isEditing && (
-            <ActivityDetailsSidebar selectedTemplateRef={selectedTemplate} teamsRef={teams} />
-          )}
+          <ActivityDetailsSidebar
+            selectedTemplateRef={selectedTemplate}
+            teamsRef={teams}
+            isOpen={!isEditing}
+          />
         </div>
         {isEditing && (
-          <div className='flex h-20 items-center justify-center bg-slate-200'>
+          <div className='absolute bottom-0 flex h-20 w-full items-center justify-center bg-slate-200'>
             <button
               onClick={() => setIsEditing(false)}
               className='w-max cursor-pointer rounded-full bg-sky-500 px-10 py-3 text-center font-sans text-base text-lg font-semibold text-white hover:bg-sky-600'

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -172,122 +172,132 @@ const ActivityDetails = (props: Props) => {
               </Link>
               <div className='w-max text-xl font-semibold'>Start Activity</div>
             </div>
-            <div className='flex w-full flex-col justify-start pl-4 pr-14 xl:flex-row xl:justify-center xl:pl-14'>
-              <ActivityCard
-                className='ml-14 mb-8 h-[200px] w-80 xl:ml-0 xl:mb-0'
-                theme={CATEGORY_THEMES[category]}
-                imageSrc={activityIllustration}
-                badge={null}
-              />
-              <div>
-                <div className='mb-10 pl-14'>
-                  <div className='mb-2 flex min-h-[40px] items-center'>
-                    <EditableTemplateName
-                      className='text-[32px] leading-9'
-                      key={templateId}
-                      name={templateName}
-                      templateId={templateId}
-                      teamTemplates={teamTemplates}
-                      isOwner={isOwner && isEditing}
-                    />
-                  </div>
-                  <div className='mb-4 flex gap-2'>
-                    <DetailsBadge className={clsx(CATEGORY_THEMES[category].primary, 'text-white')}>
-                      {CATEGORY_ID_TO_NAME[category]}
-                    </DetailsBadge>
-                    {!selectedTemplate.isFree &&
-                      (lowestScope === 'PUBLIC' ? (
-                        <DetailsBadge className='bg-gold-300 text-grape-700'>Premium</DetailsBadge>
-                      ) : (
-                        <DetailsBadge className='bg-grape-700 text-white'>Custom</DetailsBadge>
-                      ))}
-                  </div>
+            <div className='mx-auto w-min'>
+              <div
+                className={clsx(
+                  'flex w-full flex-col justify-start pl-4 pr-14 xl:flex-row xl:justify-center xl:pl-14',
+                  isEditing && 'lg:flex-row lg:justify-center lg:pl-14'
+                )}
+              >
+                <ActivityCard
+                  className='ml-14 mb-8 h-[200px] w-80 xl:ml-0 xl:mb-0'
+                  theme={CATEGORY_THEMES[category]}
+                  imageSrc={activityIllustration}
+                  badge={null}
+                />
+                <div>
+                  <div className='mb-10 pl-14'>
+                    <div className='mb-2 flex min-h-[40px] items-center'>
+                      <EditableTemplateName
+                        className='text-[32px] leading-9'
+                        key={templateId}
+                        name={templateName}
+                        templateId={templateId}
+                        teamTemplates={teamTemplates}
+                        isOwner={isOwner && isEditing}
+                      />
+                    </div>
+                    <div className='mb-4 flex gap-2'>
+                      <DetailsBadge className={clsx(CATEGORY_THEMES[category].primary, 'text-white')}>
+                        {CATEGORY_ID_TO_NAME[category]}
+                      </DetailsBadge>
+                      {!selectedTemplate.isFree &&
+                        (lowestScope === 'PUBLIC' ? (
+                          <DetailsBadge className='bg-gold-300 text-grape-700'>
+                            Premium
+                          </DetailsBadge>
+                        ) : (
+                          <DetailsBadge className='bg-grape-700 text-white'>Custom</DetailsBadge>
+                        ))}
+                    </div>
 
-                  <div className='w-[480px]'>
-                    <div className='mb-8'>
-                      {isOwner ? (
-                        <div className='flex items-center justify-between'>
-                          <div
-                            className={clsx(
-                              'w-max',
-                              isEditing && 'rounded-full border border-solid border-slate-400 pl-3'
-                            )}
-                          >
-                            <UnstyledTemplateSharing
-                              noModal={true}
-                              isOwner={isOwner}
-                              template={selectedTemplate}
-                              readOnly={!isEditing}
-                            />
-                          </div>
-                          <div className='flex gap-2'>
-                            {isEditing ? (
-                              <div className='rounded-full border border-solid border-slate-400'>
-                                <DetailAction
-                                  icon={'delete'}
-                                  tooltip={'Delete template'}
-                                  onClick={removeTemplate}
-                                />
-                              </div>
-                            ) : (
-                              <>
+                    <div className='w-[480px]'>
+                      <div className='mb-8'>
+                        {isOwner ? (
+                          <div className='flex items-center justify-between'>
+                            <div
+                              className={clsx(
+                                'w-max',
+                                isEditing &&
+                                  'rounded-full border border-solid border-slate-400 pl-3'
+                              )}
+                            >
+                              <UnstyledTemplateSharing
+                                noModal={true}
+                                isOwner={isOwner}
+                                template={selectedTemplate}
+                                readOnly={!isEditing}
+                              />
+                            </div>
+                            <div className='flex gap-2'>
+                              {isEditing ? (
                                 <div className='rounded-full border border-solid border-slate-400'>
                                   <DetailAction
-                                    icon={'edit'}
-                                    tooltip={'Edit template'}
-                                    onClick={() => setIsEditing(true)}
+                                    icon={'delete'}
+                                    tooltip={'Delete template'}
+                                    onClick={removeTemplate}
                                   />
                                 </div>
-                                <div className='rounded-full border border-solid border-slate-400'>
-                                  <CloneTemplate canClone={true} onClick={togglePortal} />
-                                </div>
-                              </>
-                            )}
+                              ) : (
+                                <>
+                                  <div className='rounded-full border border-solid border-slate-400'>
+                                    <DetailAction
+                                      icon={'edit'}
+                                      tooltip={'Edit template'}
+                                      onClick={() => setIsEditing(true)}
+                                    />
+                                  </div>
+                                  <div className='rounded-full border border-solid border-slate-400'>
+                                    <CloneTemplate canClone={true} onClick={togglePortal} />
+                                  </div>
+                                </>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      ) : (
-                        <div className='flex items-center justify-between'>
-                          <div className='py-2 text-sm font-semibold text-slate-600'>
-                            {description}
+                        ) : (
+                          <div className='flex items-center justify-between'>
+                            <div className='py-2 text-sm font-semibold text-slate-600'>
+                              {description}
+                            </div>
+                            <div className='rounded-full border border-solid border-slate-400 text-slate-600'>
+                              <FlatButton
+                                style={{padding: '8px 12px', border: '0'}}
+                                className='flex gap-1 px-12'
+                                onClick={togglePortal}
+                              >
+                                <ContentCopy className='text-slate-600' />
+                                <div className='font-semibold text-slate-700'>Clone & Edit</div>
+                              </FlatButton>
+                            </div>
                           </div>
-                          <div className='rounded-full border border-solid border-slate-400 text-slate-600'>
-                            <FlatButton
-                              style={{padding: '8px 12px', border: '0'}}
-                              className='flex gap-1 px-12'
-                              onClick={togglePortal}
-                            >
-                              <ContentCopy className='text-slate-600' />
-                              <div className='font-semibold text-slate-700'>Clone & Edit</div>
-                            </FlatButton>
-                          </div>
-                        </div>
-                      )}
+                        )}
+                      </div>
+                      <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common
+                      themes and vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
+                      <b>takeaway tasks</b> that can be integrated with your backlog.
                     </div>
-                    <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common themes
-                    and vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
-                    <b>takeaway tasks</b> that can be integrated with your backlog.
+                    <div className='mt-[18px] flex min-w-max items-center'>
+                      <div className='flex items-center gap-3'>
+                        <JiraSVG />
+                        <GitHubSVG />
+                        <JiraServerSVG />
+                        <GitLabSVG />
+                        <AzureDevOpsSVG />
+                      </div>
+                      <div className='ml-4'>
+                        <b>Tip:</b> push takeaway tasks to your backlog
+                      </div>
+                    </div>
                   </div>
-                  <div className='mt-[18px] flex min-w-max items-center'>
-                    <div className='flex items-center gap-3'>
-                      <JiraSVG />
-                      <GitHubSVG />
-                      <JiraServerSVG />
-                      <GitLabSVG />
-                      <AzureDevOpsSVG />
-                    </div>
-                    <div className='ml-4'>
-                      <b>Tip:</b> push takeaway tasks to your backlog
-                    </div>
-                  </div>
+                  <TemplatePromptList
+                    isOwner={isOwner && isEditing}
+                    prompts={prompts!}
+                    templateId={templateId}
+                  />
+                  {isOwner && isEditing && (
+                    <AddTemplatePrompt templateId={templateId} prompts={prompts!} />
+                  )}
                 </div>
-                <TemplatePromptList
-                  isOwner={isOwner && isEditing}
-                  prompts={prompts!}
-                  templateId={templateId}
-                />
-                {isOwner && isEditing && (
-                  <AddTemplatePrompt templateId={templateId} prompts={prompts!} />
-                )}
               </div>
             </div>
           </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -311,7 +311,7 @@ const ActivityDetails = (props: Props) => {
           <div className='absolute bottom-0 flex h-20 w-full items-center justify-center bg-slate-200'>
             <button
               onClick={() => setIsEditing(false)}
-              className='w-max cursor-pointer rounded-full bg-sky-500 px-10 py-3 text-center font-sans text-base text-lg font-semibold text-white hover:bg-sky-600'
+              className='w-max cursor-pointer rounded-full bg-sky-500 px-10 py-3 text-center font-sans text-lg font-semibold text-white hover:bg-sky-600'
             >
               Done Editing
             </button>

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {ContentCopy} from '@mui/icons-material'
-import React, {useCallback} from 'react'
+import React, {useCallback, useState} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {Redirect, useHistory} from 'react-router'
 import {ActivityDetailsQuery} from '~/__generated__/ActivityDetailsQuery.graphql'
@@ -142,6 +142,8 @@ const ActivityDetails = (props: Props) => {
     : 'PUBLIC'
   const description = useTemplateDescription(lowestScope, selectedTemplate, viewer, tier)
 
+  const [isEditing, setIsEditing] = useState(false)
+
   if (!selectedTemplate) {
     return <Redirect to='/activity-library' />
   }
@@ -183,7 +185,7 @@ const ActivityDetails = (props: Props) => {
                     name={templateName}
                     templateId={templateId}
                     teamTemplates={teamTemplates}
-                    isOwner={isOwner}
+                    isOwner={isOwner && isEditing}
                   />
                 </div>
                 <div className='mb-4 flex gap-2'>
@@ -202,24 +204,42 @@ const ActivityDetails = (props: Props) => {
                   <div className='mb-8'>
                     {isOwner ? (
                       <div className='flex items-center justify-between'>
-                        <div className='w-max rounded-full border border-solid border-slate-400 pl-3'>
+                        <div
+                          className={clsx(
+                            'w-max',
+                            isEditing && 'rounded-full border border-solid border-slate-400 pl-3'
+                          )}
+                        >
                           <UnstyledTemplateSharing
                             noModal={true}
                             isOwner={isOwner}
                             template={selectedTemplate}
+                            readOnly={!isEditing}
                           />
                         </div>
                         <div className='flex gap-2'>
-                          <div className='rounded-full border border-solid border-slate-400'>
-                            <DetailAction
-                              icon={'delete'}
-                              tooltip={'Delete template'}
-                              onClick={removeTemplate}
-                            />
-                          </div>
-                          <div className='rounded-full border border-solid border-slate-400'>
-                            <CloneTemplate canClone={true} onClick={togglePortal} />
-                          </div>
+                          {isEditing ? (
+                            <div className='rounded-full border border-solid border-slate-400'>
+                              <DetailAction
+                                icon={'delete'}
+                                tooltip={'Delete template'}
+                                onClick={removeTemplate}
+                              />
+                            </div>
+                          ) : (
+                            <>
+                              <div className='rounded-full border border-solid border-slate-400'>
+                                <DetailAction
+                                  icon={'edit'}
+                                  tooltip={'Edit template'}
+                                  onClick={() => setIsEditing(true)}
+                                />
+                              </div>
+                              <div className='rounded-full border border-solid border-slate-400'>
+                                <CloneTemplate canClone={true} onClick={togglePortal} />
+                              </div>
+                            </>
+                          )}
                         </div>
                       </div>
                     ) : (
@@ -257,8 +277,14 @@ const ActivityDetails = (props: Props) => {
                   </div>
                 </div>
               </div>
-              <TemplatePromptList isOwner={isOwner} prompts={prompts!} templateId={templateId} />
-              {isOwner && <AddTemplatePrompt templateId={templateId} prompts={prompts!} />}
+              <TemplatePromptList
+                isOwner={isOwner && isEditing}
+                prompts={prompts!}
+                templateId={templateId}
+              />
+              {isOwner && isEditing && (
+                <AddTemplatePrompt templateId={templateId} prompts={prompts!} />
+              )}
             </div>
           </div>
         </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -158,7 +158,7 @@ const ActivityDetails = (props: Props) => {
 
   return (
     <>
-      <div className='flex h-full flex-col bg-white'>
+      <div className='relative flex h-full flex-col bg-white'>
         <div className='flex grow'>
           <div className='mt-4 grow'>
             <div className='mb-14 ml-4 flex h-min w-max items-center'>
@@ -198,7 +198,9 @@ const ActivityDetails = (props: Props) => {
                       />
                     </div>
                     <div className='mb-4 flex gap-2'>
-                      <DetailsBadge className={clsx(CATEGORY_THEMES[category].primary, 'text-white')}>
+                      <DetailsBadge
+                        className={clsx(CATEGORY_THEMES[category].primary, 'text-white')}
+                      >
                         {CATEGORY_ID_TO_NAME[category]}
                       </DetailsBadge>
                       {!selectedTemplate.isFree &&

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -158,139 +158,154 @@ const ActivityDetails = (props: Props) => {
 
   return (
     <>
-      <div className='flex h-full bg-white'>
-        <div className='mt-4 grow'>
-          <div className='mb-14 ml-4 flex h-min w-max items-center'>
-            <Link
-              className='mr-4'
-              to={`/activity-library/category/${history.location.state?.prevCategory ?? category}`}
-            >
-              <IconLabel icon={'arrow_back'} iconLarge />
-            </Link>
-            <div className='w-max text-xl font-semibold'>Start Activity</div>
-          </div>
-          <div className='flex w-full flex-col justify-start pl-4 pr-14 xl:flex-row xl:justify-center xl:pl-14'>
-            <ActivityCard
-              className='ml-14 mb-8 h-[200px] w-80 xl:ml-0 xl:mb-0'
-              theme={CATEGORY_THEMES[category]}
-              imageSrc={activityIllustration}
-              badge={null}
-            />
-            <div>
-              <div className='mb-10 pl-14'>
-                <div className='mb-2 flex min-h-[40px] items-center'>
-                  <EditableTemplateName
-                    className='text-[32px] leading-9'
-                    key={templateId}
-                    name={templateName}
-                    templateId={templateId}
-                    teamTemplates={teamTemplates}
-                    isOwner={isOwner && isEditing}
-                  />
-                </div>
-                <div className='mb-4 flex gap-2'>
-                  <DetailsBadge className={clsx(CATEGORY_THEMES[category].primary, 'text-white')}>
-                    {CATEGORY_ID_TO_NAME[category]}
-                  </DetailsBadge>
-                  {!selectedTemplate.isFree &&
-                    (lowestScope === 'PUBLIC' ? (
-                      <DetailsBadge className='bg-gold-300 text-grape-700'>Premium</DetailsBadge>
-                    ) : (
-                      <DetailsBadge className='bg-grape-700 text-white'>Custom</DetailsBadge>
-                    ))}
-                </div>
+      <div className='flex h-full flex-col bg-white'>
+        <div className='flex grow'>
+          <div className='mt-4 grow'>
+            <div className='mb-14 ml-4 flex h-min w-max items-center'>
+              <Link
+                className='mr-4'
+                to={`/activity-library/category/${
+                  history.location.state?.prevCategory ?? category
+                }`}
+              >
+                <IconLabel icon={'arrow_back'} iconLarge />
+              </Link>
+              <div className='w-max text-xl font-semibold'>Start Activity</div>
+            </div>
+            <div className='flex w-full flex-col justify-start pl-4 pr-14 xl:flex-row xl:justify-center xl:pl-14'>
+              <ActivityCard
+                className='ml-14 mb-8 h-[200px] w-80 xl:ml-0 xl:mb-0'
+                theme={CATEGORY_THEMES[category]}
+                imageSrc={activityIllustration}
+                badge={null}
+              />
+              <div>
+                <div className='mb-10 pl-14'>
+                  <div className='mb-2 flex min-h-[40px] items-center'>
+                    <EditableTemplateName
+                      className='text-[32px] leading-9'
+                      key={templateId}
+                      name={templateName}
+                      templateId={templateId}
+                      teamTemplates={teamTemplates}
+                      isOwner={isOwner && isEditing}
+                    />
+                  </div>
+                  <div className='mb-4 flex gap-2'>
+                    <DetailsBadge className={clsx(CATEGORY_THEMES[category].primary, 'text-white')}>
+                      {CATEGORY_ID_TO_NAME[category]}
+                    </DetailsBadge>
+                    {!selectedTemplate.isFree &&
+                      (lowestScope === 'PUBLIC' ? (
+                        <DetailsBadge className='bg-gold-300 text-grape-700'>Premium</DetailsBadge>
+                      ) : (
+                        <DetailsBadge className='bg-grape-700 text-white'>Custom</DetailsBadge>
+                      ))}
+                  </div>
 
-                <div className='w-[480px]'>
-                  <div className='mb-8'>
-                    {isOwner ? (
-                      <div className='flex items-center justify-between'>
-                        <div
-                          className={clsx(
-                            'w-max',
-                            isEditing && 'rounded-full border border-solid border-slate-400 pl-3'
-                          )}
-                        >
-                          <UnstyledTemplateSharing
-                            noModal={true}
-                            isOwner={isOwner}
-                            template={selectedTemplate}
-                            readOnly={!isEditing}
-                          />
-                        </div>
-                        <div className='flex gap-2'>
-                          {isEditing ? (
-                            <div className='rounded-full border border-solid border-slate-400'>
-                              <DetailAction
-                                icon={'delete'}
-                                tooltip={'Delete template'}
-                                onClick={removeTemplate}
-                              />
-                            </div>
-                          ) : (
-                            <>
+                  <div className='w-[480px]'>
+                    <div className='mb-8'>
+                      {isOwner ? (
+                        <div className='flex items-center justify-between'>
+                          <div
+                            className={clsx(
+                              'w-max',
+                              isEditing && 'rounded-full border border-solid border-slate-400 pl-3'
+                            )}
+                          >
+                            <UnstyledTemplateSharing
+                              noModal={true}
+                              isOwner={isOwner}
+                              template={selectedTemplate}
+                              readOnly={!isEditing}
+                            />
+                          </div>
+                          <div className='flex gap-2'>
+                            {isEditing ? (
                               <div className='rounded-full border border-solid border-slate-400'>
                                 <DetailAction
-                                  icon={'edit'}
-                                  tooltip={'Edit template'}
-                                  onClick={() => setIsEditing(true)}
+                                  icon={'delete'}
+                                  tooltip={'Delete template'}
+                                  onClick={removeTemplate}
                                 />
                               </div>
-                              <div className='rounded-full border border-solid border-slate-400'>
-                                <CloneTemplate canClone={true} onClick={togglePortal} />
-                              </div>
-                            </>
-                          )}
+                            ) : (
+                              <>
+                                <div className='rounded-full border border-solid border-slate-400'>
+                                  <DetailAction
+                                    icon={'edit'}
+                                    tooltip={'Edit template'}
+                                    onClick={() => setIsEditing(true)}
+                                  />
+                                </div>
+                                <div className='rounded-full border border-solid border-slate-400'>
+                                  <CloneTemplate canClone={true} onClick={togglePortal} />
+                                </div>
+                              </>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    ) : (
-                      <div className='flex items-center justify-between'>
-                        <div className='py-2 text-sm font-semibold text-slate-600'>
-                          {description}
+                      ) : (
+                        <div className='flex items-center justify-between'>
+                          <div className='py-2 text-sm font-semibold text-slate-600'>
+                            {description}
+                          </div>
+                          <div className='rounded-full border border-solid border-slate-400 text-slate-600'>
+                            <FlatButton
+                              style={{padding: '8px 12px', border: '0'}}
+                              className='flex gap-1 px-12'
+                              onClick={togglePortal}
+                            >
+                              <ContentCopy className='text-slate-600' />
+                              <div className='font-semibold text-slate-700'>Clone & Edit</div>
+                            </FlatButton>
+                          </div>
                         </div>
-                        <div className='rounded-full border border-solid border-slate-400 text-slate-600'>
-                          <FlatButton
-                            style={{padding: '8px 12px', border: '0'}}
-                            className='flex gap-1 px-12'
-                            onClick={togglePortal}
-                          >
-                            <ContentCopy className='text-slate-600' />
-                            <div className='font-semibold text-slate-700'>Clone & Edit</div>
-                          </FlatButton>
-                        </div>
-                      </div>
-                    )}
+                      )}
+                    </div>
+                    <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common themes
+                    and vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
+                    <b>takeaway tasks</b> that can be integrated with your backlog.
                   </div>
-                  <b>Reflect</b> on what’s working or not on your team. <b>Group</b> common themes
-                  and vote on the hottest topics. As you <b>discuss topics</b>, create{' '}
-                  <b>takeaway tasks</b> that can be integrated with your backlog.
+                  <div className='mt-[18px] flex min-w-max items-center'>
+                    <div className='flex items-center gap-3'>
+                      <JiraSVG />
+                      <GitHubSVG />
+                      <JiraServerSVG />
+                      <GitLabSVG />
+                      <AzureDevOpsSVG />
+                    </div>
+                    <div className='ml-4'>
+                      <b>Tip:</b> push takeaway tasks to your backlog
+                    </div>
+                  </div>
                 </div>
-                <div className='mt-[18px] flex min-w-max items-center'>
-                  <div className='flex items-center gap-3'>
-                    <JiraSVG />
-                    <GitHubSVG />
-                    <JiraServerSVG />
-                    <GitLabSVG />
-                    <AzureDevOpsSVG />
-                  </div>
-                  <div className='ml-4'>
-                    <b>Tip:</b> push takeaway tasks to your backlog
-                  </div>
-                </div>
+                <TemplatePromptList
+                  isOwner={isOwner && isEditing}
+                  prompts={prompts!}
+                  templateId={templateId}
+                />
+                {isOwner && isEditing && (
+                  <AddTemplatePrompt templateId={templateId} prompts={prompts!} />
+                )}
               </div>
-              <TemplatePromptList
-                isOwner={isOwner && isEditing}
-                prompts={prompts!}
-                templateId={templateId}
-              />
-              {isOwner && isEditing && (
-                <AddTemplatePrompt templateId={templateId} prompts={prompts!} />
-              )}
             </div>
           </div>
+          {!isEditing && (
+            <ActivityDetailsSidebar selectedTemplateRef={selectedTemplate} teamsRef={teams} />
+          )}
         </div>
-        <ActivityDetailsSidebar selectedTemplateRef={selectedTemplate} teamsRef={teams} />
+        {isEditing && (
+          <div className='flex h-20 items-center justify-center bg-slate-200'>
+            <button
+              onClick={() => setIsEditing(false)}
+              className='w-max cursor-pointer rounded-full bg-sky-500 px-10 py-3 text-center font-sans text-base text-lg font-semibold text-white hover:bg-sky-600'
+            >
+              Done Editing
+            </button>
+          </div>
+        )}
       </div>
-
       {modalPortal(
         <TeamPickerModal
           category={category}

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -96,8 +96,8 @@ const ActivityDetailsSidebar = (props: Props) => {
   return (
     <div
       className={clsx(
-        'flex w-96 translate-x-0 flex-col border-l border-solid border-slate-300 px-4 pb-9 pt-14 transition-all',
-        !isOpen && 'w-0 overflow-hidden opacity-0'
+        'flex translate-x-0 flex-col border-l border-solid border-slate-300 px-4 pb-9 pt-14 transition-all',
+        isOpen ? ' w-96' : 'w-0 overflow-hidden opacity-0'
       )}
     >
       <div className='mb-6 text-xl font-semibold'>Settings</div>

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -15,14 +15,16 @@ import SelectTemplateMutation from '../../mutations/SelectTemplateMutation'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
 import {useHistory} from 'react-router'
+import clsx from 'clsx'
 
 interface Props {
   selectedTemplateRef: ActivityDetailsSidebar_template$key
   teamsRef: ActivityDetailsSidebar_teams$key
+  isOpen: boolean
 }
 
 const ActivityDetailsSidebar = (props: Props) => {
-  const {selectedTemplateRef, teamsRef} = props
+  const {selectedTemplateRef, teamsRef, isOpen} = props
   const selectedTemplate = useFragment(
     graphql`
       fragment ActivityDetailsSidebar_template on MeetingTemplate {
@@ -92,7 +94,12 @@ const ActivityDetailsSidebar = (props: Props) => {
   }
 
   return (
-    <div className='flex w-96 flex-col border-l border-solid border-slate-300 px-4 pb-9 pt-14'>
+    <div
+      className={clsx(
+        'flex w-96 translate-x-0 flex-col border-l border-solid border-slate-300 px-4 pb-9 pt-14 transition-all',
+        !isOpen && 'w-0 overflow-hidden opacity-0'
+      )}
+    >
       <div className='mb-6 text-xl font-semibold'>Settings</div>
 
       <div className='flex grow flex-col gap-2'>

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -53,23 +53,26 @@ const DropdownIcon = styled('div')({
   width: 24
 })
 
-const DropdownBlock = styled('div')<{disabled: boolean}>(({disabled}) => ({
-  color: PALETTE.SLATE_700,
-  cursor: disabled ? 'not-allowed' : 'pointer',
-  alignItems: 'center',
-  display: 'flex',
-  fontSize: 16,
-  lineHeight: '24px',
-  userSelect: 'none',
-  ':hover': {
-    color: disabled ? undefined : PALETTE.SLATE_900
-  }
-}))
+const DropdownBlock = styled('div')<{disabled: boolean; readOnly?: boolean}>(
+  ({disabled, readOnly}) => ({
+    color: PALETTE.SLATE_700,
+    cursor: disabled ? 'not-allowed' : readOnly ? undefined : 'pointer',
+    alignItems: 'center',
+    display: 'flex',
+    fontSize: 16,
+    lineHeight: '24px',
+    userSelect: 'none',
+    ':hover': {
+      color: disabled ? undefined : PALETTE.SLATE_900
+    }
+  })
+)
 
 interface Props {
   isOwner: boolean
   template: TemplateSharing_template$key
   noModal?: boolean
+  readOnly?: boolean
 }
 
 const TemplateSharing = (props: Props) => {
@@ -88,7 +91,7 @@ const TemplateSharing = (props: Props) => {
 }
 
 export const UnstyledTemplateSharing = (props: Props) => {
-  const {template: templateRef, isOwner, noModal} = props
+  const {template: templateRef, isOwner, noModal, readOnly} = props
   const template = useFragment(
     graphql`
       fragment TemplateSharing_template on MeetingTemplate {
@@ -144,14 +147,14 @@ export const UnstyledTemplateSharing = (props: Props) => {
         disabled={!isLead}
         onMouseOver={openTooltip}
         onMouseLeave={closeTooltip}
+        readOnly={readOnly}
       >
         <DropdownDecoratorIcon>
           <ShareIcon />
         </DropdownDecoratorIcon>
         <DropdownLabel>{label}</DropdownLabel>
-        <DropdownIcon>
-          <ExpandMoreIcon />
-        </DropdownIcon>
+
+        <DropdownIcon>{!readOnly && <ExpandMoreIcon />}</DropdownIcon>
       </DropdownBlock>
       {menuPortal(<SelectSharingScopeDropdown menuProps={menuProps} template={template} />)}
       {tooltipPortal(<div>Must be Team Lead to change</div>)}

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -142,7 +142,7 @@ export const UnstyledTemplateSharing = (props: Props) => {
     <>
       <DropdownBlock
         onMouseEnter={SelectSharingScopeDropdown.preload}
-        onClick={isLead ? togglePortal : undefined}
+        onClick={isLead && !readOnly ? togglePortal : undefined}
         ref={isLead ? originRef : tooltipRef}
         disabled={!isLead}
         onMouseOver={openTooltip}


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8099

Needs rebase once https://github.com/ParabolInc/parabol/pull/8111 lands.

Edit mode for RiD Details View. Clicking the pencil icon on owned templates makes all fields editable.

Note that all edits persist immediately (rather than after exiting edit mode). We may want to change this behavior in a future iteration.

## Demo
https://www.loom.com/share/257162a6f3eb4287a40ad80645d631a0

## Testing scenarios
- [ ] No changes to activity details for non-owned templates
- [ ] For owned templates, nothing is editable by default
- [ ] For an owned template, click the pencil button to enter edit mode
- [ ] When entering edit mode, that sidebar animates out smoothly
- [ ] In edit mode, edit all fields
- [ ] Click "done editing" to exit edit mode
- [ ] Enter edit mode, and delete the template

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
