### PR TITLE
chore: remove User table from RethinkDB

### DIFF
--- a/packages/server/graphql/private/mutations/backupOrganization.ts
+++ b/packages/server/graphql/private/mutations/backupOrganization.ts
@@ -269,10 +269,7 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (
               r.branch(row('teamId'), r(teamIds).contains(row('teamId')), true)
             )
             .coerceTo('array')
-            .do((items: RValue) => r.db(DESTINATION).table('TimelineEvent').insert(items)),
-          user: (r.table('User').getAll(r.args(userIds)) as any)
-            .coerceTo('array')
-            .do((items: RValue) => r.db(DESTINATION).table('User').insert(items))
+            .do((items: RValue) => r.db(DESTINATION).table('TimelineEvent').insert(items))
         })
       }),
     activeDomains: r

--- a/packages/server/graphql/private/mutations/updateEmail.ts
+++ b/packages/server/graphql/private/mutations/updateEmail.ts
@@ -23,7 +23,6 @@ const updateEmail: MutationResolvers['updateEmail'] = async (_source, {oldEmail,
     updatedAt: new Date()
   }
   await Promise.all([
-    r.table('User').get(userId).update(updates).run(),
     r
       .table('TeamMember')
       .getAll(userId, {index: 'userId'})

--- a/packages/server/postgres/migrations/1682541572157_deleteUserRethink.ts
+++ b/packages/server/postgres/migrations/1682541572157_deleteUserRethink.ts
@@ -1,0 +1,26 @@
+import {r} from 'rethinkdb-ts'
+import {ParabolR} from '../../database/rethinkDriver'
+
+const connectRethinkDB = async () => {
+  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
+  await r.connectPool({
+    host,
+    port: parseInt(port, 10),
+    db: pathname.split('/')[1]
+  })
+  return r as any as ParabolR
+}
+
+export async function up() {
+  await connectRethinkDB()
+
+  try {
+    await r.tableDrop('User').run()
+  } catch (e) {
+    // table already dropped
+  }
+}
+
+export async function down() {
+  // noop, if we recreated the table it wouldn't have the same indexes, etc.
+}

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -1,7 +1,6 @@
 import getRethink from '../database/rethinkDriver'
-import {RDatum, RValue} from '../database/stricterR'
+import {RDatum} from '../database/stricterR'
 import OrganizationUser from '../database/types/OrganizationUser'
-import User from '../database/types/User'
 import {TierEnum} from '../postgres/queries/generated/updateUserQuery'
 import {getUsersByIds} from '../postgres/queries/getUsersByIds'
 import updateUserTiers from '../postgres/queries/updateUserTiers'
@@ -9,34 +8,6 @@ import segmentIo from './segmentIo'
 
 const setUserTierForUserIds = async (userIds: string[]) => {
   const r = await getRethink()
-  await r
-    .table('User')
-    .getAll(r.args(userIds))
-    .update(
-      (user: RDatum<User>) => ({
-        tier: r
-          .table('OrganizationUser')
-          .getAll(user('id'), {index: 'userId'})
-          .filter({removedAt: null})('orgId')
-          .coerceTo('array')
-          .distinct()
-          .do((orgIds: RValue) =>
-            r.table('Organization').getAll(r.args(orgIds))('tier').distinct().coerceTo('array')
-          )
-          .do((tiers: RDatum<string[]>) => {
-            return r.branch(
-              tiers.contains('enterprise'),
-              'enterprise',
-              tiers.contains('team'),
-              'team',
-              'starter'
-            )
-          })
-      }),
-      {nonAtomic: true}
-    )
-    .run()
-
   const userTiers = (await r
     .table('OrganizationUser')
     .getAll(r.args(userIds), {index: 'userId'})


### PR DESCRIPTION
# Description

Removes the User table from RethinkDB. We haven't used it in over a year, probably safe by now.
