### PR TITLE
chore(retros-in-disguise): improve activity library routing 

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryRoute.tsx
@@ -5,18 +5,8 @@ import activityLibraryQuery, {
 import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
 import {renderLoader} from '../../utils/relay/renderLoader'
 import {ActivityLibrary} from './ActivityLibrary'
-import TeamSubscription from '../../subscriptions/TeamSubscription'
-import useSubscription from '../../hooks/useSubscription'
-import TaskSubscription from '../../subscriptions/TaskSubscription'
-import NotificationSubscription from '../../subscriptions/NotificationSubscription'
-import OrganizationSubscription from '../../subscriptions/OrganizationSubscription'
 
 const ActivityLibraryRoute = () => {
-  useSubscription('ActivityLibraryRoute', NotificationSubscription)
-  useSubscription('ActivityLibraryRoute', OrganizationSubscription)
-  useSubscription('ActivityLibraryRoute', TaskSubscription)
-  useSubscription('ActivityLibraryRoute', TeamSubscription)
-
   const queryRef = useQueryLoaderNow<ActivityLibraryQuery>(activityLibraryQuery)
 
   return (

--- a/packages/client/components/ActivityLibrary/ActivityLibraryRoutes.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryRoutes.tsx
@@ -1,0 +1,40 @@
+import React, {lazy} from 'react'
+import TeamSubscription from '../../subscriptions/TeamSubscription'
+import useSubscription from '../../hooks/useSubscription'
+import TaskSubscription from '../../subscriptions/TaskSubscription'
+import NotificationSubscription from '../../subscriptions/NotificationSubscription'
+import OrganizationSubscription from '../../subscriptions/OrganizationSubscription'
+import {Route, Switch, useRouteMatch} from 'react-router'
+
+const ActivityDetailsRoute = lazy(
+  () => import(/* webpackChunkName: 'ActivityDetails' */ './ActivityDetailsRoute')
+)
+const CreateNewActivityRoute = lazy(
+  () =>
+    import(
+      /* webpackChunkName: 'CreateNewActivityRoute' */ './CreateNewActivity/CreateNewActivityRoute'
+    )
+)
+
+const ActivityLibraryRoute = lazy(
+  () => import(/* webpackChunkName: 'AcitivityLibraryRoute' */ './ActivityLibraryRoute')
+)
+
+const ActivityLibraryRoutes = () => {
+  useSubscription('ActivityLibraryRoutes', NotificationSubscription)
+  useSubscription('ActivityLibraryRoutes', OrganizationSubscription)
+  useSubscription('ActivityLibraryRoutes', TaskSubscription)
+  useSubscription('ActivityLibraryRoutes', TeamSubscription)
+
+  const {path} = useRouteMatch()
+
+  return (
+    <Switch>
+      <Route path={`${path}/new-activity/:categoryId`} component={CreateNewActivityRoute} />
+      <Route path={`${path}/details/:templateId`} component={ActivityDetailsRoute} />
+      <Route exact path={[path, `${path}/category/:categoryId`]} component={ActivityLibraryRoute} />
+    </Switch>
+  )
+}
+
+export default ActivityLibraryRoutes

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivityRoute.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivityRoute.tsx
@@ -2,11 +2,6 @@ import React, {Suspense} from 'react'
 
 import useQueryLoaderNow from '../../../hooks/useQueryLoaderNow'
 import {renderLoader} from '../../../utils/relay/renderLoader'
-import TeamSubscription from '../../../subscriptions/TeamSubscription'
-import useSubscription from '../../../hooks/useSubscription'
-import TaskSubscription from '../../../subscriptions/TaskSubscription'
-import NotificationSubscription from '../../../subscriptions/NotificationSubscription'
-import OrganizationSubscription from '../../../subscriptions/OrganizationSubscription'
 import {CreateNewActivity} from './CreateNewActivity'
 
 import createNewActivityQuery, {
@@ -14,11 +9,6 @@ import createNewActivityQuery, {
 } from '~/__generated__/CreateNewActivityQuery.graphql'
 
 const CreateNewActivityRoute = () => {
-  useSubscription('CreateNewActivityRoute', NotificationSubscription)
-  useSubscription('CreateNewActivityRoute', OrganizationSubscription)
-  useSubscription('CreateNewActivityRoute', TaskSubscription)
-  useSubscription('CreateNewActivityRoute', TeamSubscription)
-
   const queryRef = useQueryLoaderNow<CreateNewActivityQuery>(createNewActivityQuery)
 
   return (

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -37,16 +37,10 @@ const ViewerNotOnTeamRoot = lazy(
   () => import(/* webpackChunkName: 'ViewerNotOnTeamRoot' */ './ViewerNotOnTeamRoot')
 )
 
-const ActivityLibraryRoute = lazy(
-  () => import(/* webpackChunkName: 'ActivityLibrary' */ './ActivityLibrary/ActivityLibraryRoute')
-)
-const ActivityDetailsRoute = lazy(
-  () => import(/* webpackChunkName: 'ActivityDetails' */ './ActivityLibrary/ActivityDetailsRoute')
-)
-const CreateNewActivityRoute = lazy(
+const ActivityLibraryRoutes = lazy(
   () =>
     import(
-      /* webpackChunkName: 'CreateNewActivityRoute' */ './ActivityLibrary/CreateNewActivity/CreateNewActivityRoute'
+      /* webpackChunkName: 'ActivityLibraryRoutes' */ './ActivityLibrary/ActivityLibraryRoutes'
     )
 )
 
@@ -55,11 +49,8 @@ const PrivateRoutes = () => {
   useNoIndex()
   return (
     <Switch>
+      <Route path='/activity-library' component={ActivityLibraryRoutes} />
       <Route path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)' component={DashboardRoot} />
-      <Route path='/activity-library/new-activity/:categoryId' component={CreateNewActivityRoute} />
-      <Route path='/activity-library/category/:categoryId' component={ActivityLibraryRoute} />
-      <Route path='/activity-library/details/:templateId' component={ActivityDetailsRoute} />
-      <Route path='/activity-library' component={ActivityLibraryRoute} />
       <Route path='/meet/:meetingId' component={MeetingRoot} />
       <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />
       <Route path='/invoice/:invoiceId' component={Invoice} />


### PR DESCRIPTION
# Description

Improves routing per https://github.com/ParabolInc/parabol/pull/8069#discussion_r1178351313

## Demo

## Testing scenarios

- [ ] check if root activity library route is displayed correctly `/activity-library`
- [ ] check if `/activity-library/category/retrospective` etc is displayed correctly
- [ ] check if `/activity-library/new-activity/retrospective` etc is displayed correctly
- [ ] check if `/activity-library/details/:templateId` is displayed correctly

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
