### PR TITLE
feat(rid): Prompt user to change template scope to org

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -120,6 +120,29 @@ const ActivityDetailsSidebar = (props: Props) => {
     )
   }
 
+  const teamScopePopover = templateTeam && selectedTemplate.scope === 'TEAM' && (
+    <div className='w-[352px] p-4'>
+      <div>
+        This custom activity is private to the <b>{templateTeam.name}</b> team.
+      </div>
+      <br />
+      <div>
+        As a member of the team you can share this activity with the{' '}
+        <b>{templateTeam.organization.name}</b> organization so that any team can also use the
+        activity.
+      </div>
+      <button
+        onClick={handleShareToOrg}
+        className={
+          'mt-4 flex w-max cursor-pointer items-center rounded-full border border-solid border-slate-400 bg-white px-3 py-2 text-center font-sans text-sm font-semibold text-slate-700 hover:bg-slate-100'
+        }
+      >
+        <LockOpen style={{marginRight: '8px', color: PALETTE.SLATE_600}} />
+        Allow all teams to use this activity
+      </button>
+    </div>
+  )
+
   return (
     <>
       {isOpen && <div className='w-96' />}
@@ -141,64 +164,24 @@ const ActivityDetailsSidebar = (props: Props) => {
               }}
               selectedTeamRef={selectedTeam}
               teamsRef={availableTeams}
-              customPortal={
-                templateTeam &&
-                selectedTemplate.scope === 'TEAM' && (
-                  <div className='w-[352px] p-4'>
-                    <div>
-                      This custom activity is private to the <b>{templateTeam.name}</b> team.
-                    </div>
-                    <br />
-                    <div>
-                      As a member of the team you can share this activity with the{' '}
-                      <b>{templateTeam.organization.name}</b> organization so that any team can also
-                      use the activity.
-                    </div>
-                    <button
-                      onClick={handleShareToOrg}
-                      className={clsx(
-                        'mt-4 flex w-max cursor-pointer items-center rounded-full border border-solid border-slate-400 bg-white px-3 py-2 text-center font-sans text-base text-sm font-semibold text-slate-700 hover:bg-slate-100',
-                        submitting && 'cursor-wait'
-                      )}
-                    >
-                      <LockOpen style={{marginRight: '8px', color: PALETTE.SLATE_600}} />
-                      Allow all teams to use this activity
-                    </button>
-                  </div>
-                )
-              }
+              customPortal={teamScopePopover}
             />
           )}
-          <div className='mb-6 text-xl font-semibold'>Settings</div>
 
-          <div className='flex grow flex-col gap-2'>
-            {availableTeams.length > 0 && (
-              <NewMeetingTeamPicker
-                positionOverride={MenuPosition.UPPER_LEFT}
-                onSelectTeam={(teamId) => {
-                  const newTeam = availableTeams.find((team) => team.id === teamId)
-                  newTeam && setSelectedTeam(newTeam)
-                }}
-                selectedTeamRef={selectedTeam}
-                teamsRef={availableTeams}
-              />
-            )}
-
-            {selectedTemplate.type === 'retrospective' && (
-              <>
-                <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
-                <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
-              </>
-            )}
-            {selectedTemplate.type === 'poker' && (
-              <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.pokerSettings} />
-            )}
-            <div className='flex grow flex-col justify-end gap-2'>
-              <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
-              <FlatPrimaryButton onClick={handleStartRetro} waiting={submitting} className='h-14'>
-                <div className='text-lg'>Start Activity</div>
-              </FlatPrimaryButton>
-            </div>
+          {selectedTemplate.type === 'retrospective' && (
+            <>
+              <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
+              <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
+            </>
+          )}
+          {selectedTemplate.type === 'poker' && (
+            <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.pokerSettings} />
+          )}
+          <div className='flex grow flex-col justify-end gap-2'>
+            <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
+            <FlatPrimaryButton onClick={handleStartRetro} waiting={submitting} className='h-14'>
+              <div className='text-lg'>Start Activity</div>
+            </FlatPrimaryButton>
           </div>
         </div>
       </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -127,9 +127,8 @@ const ActivityDetailsSidebar = (props: Props) => {
       </div>
       <br />
       <div>
-        As a member of the team you can share this activity with the{' '}
-        <b>{templateTeam.organization.name}</b> organization so that any team can also use the
-        activity.
+        As a member of the team you can share this activity with other teams at the{' '}
+        <b>{templateTeam.organization.name}</b> organization so that they can also use the activity.
       </div>
       <button
         onClick={handleShareToOrg}
@@ -138,7 +137,7 @@ const ActivityDetailsSidebar = (props: Props) => {
         }
       >
         <LockOpen style={{marginRight: '8px', color: PALETTE.SLATE_600}} />
-        Allow all teams to use this activity
+        Allow other teams to use this activity
       </button>
     </div>
   )

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import StartRetrospectiveMutation from '~/mutations/StartRetrospectiveMutation'
 import StartSprintPokerMutation from '~/mutations/StartSprintPokerMutation'
+import UpdateReflectTemplateScopeMutation from '~/mutations/UpdateReflectTemplateScopeMutation'
 import {ActivityDetailsSidebar_template$key} from '~/__generated__/ActivityDetailsSidebar_template.graphql'
 import {ActivityDetailsSidebar_teams$key} from '~/__generated__/ActivityDetailsSidebar_teams.graphql'
 import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
@@ -16,6 +17,8 @@ import SelectTemplateMutation from '../../mutations/SelectTemplateMutation'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useMutationProps from '../../hooks/useMutationProps'
 import {useHistory} from 'react-router'
+import {LockOpen} from '@mui/icons-material'
+import {PALETTE} from '../../styles/paletteV3'
 import clsx from 'clsx'
 
 interface Props {
@@ -47,6 +50,9 @@ const ActivityDetailsSidebar = (props: Props) => {
         name
         tier
         orgId
+        organization {
+          name
+        }
         retroSettings: meetingSettings(meetingType: retrospective) {
           ...NewMeetingSettingsToggleCheckIn_settings
           ...NewMeetingSettingsToggleAnonymity_settings
@@ -106,6 +112,14 @@ const ActivityDetailsSidebar = (props: Props) => {
     )
   }
 
+  const handleShareToOrg = () => {
+    UpdateReflectTemplateScopeMutation(
+      atmosphere,
+      {scope: 'ORGANIZATION', templateId: selectedTemplate.id},
+      {onError, onCompleted}
+    )
+  }
+
   return (
     <>
       {isOpen && <div className='w-96' />}
@@ -127,23 +141,64 @@ const ActivityDetailsSidebar = (props: Props) => {
               }}
               selectedTeamRef={selectedTeam}
               teamsRef={availableTeams}
+              customPortal={
+                templateTeam &&
+                selectedTemplate.scope === 'TEAM' && (
+                  <div className='w-[352px] p-4'>
+                    <div>
+                      This custom activity is private to the <b>{templateTeam.name}</b> team.
+                    </div>
+                    <br />
+                    <div>
+                      As a member of the team you can share this activity with the{' '}
+                      <b>{templateTeam.organization.name}</b> organization so that any team can also
+                      use the activity.
+                    </div>
+                    <button
+                      onClick={handleShareToOrg}
+                      className={clsx(
+                        'mt-4 flex w-max cursor-pointer items-center rounded-full border border-solid border-slate-400 bg-white px-3 py-2 text-center font-sans text-base text-sm font-semibold text-slate-700 hover:bg-slate-100',
+                        submitting && 'cursor-wait'
+                      )}
+                    >
+                      <LockOpen style={{marginRight: '8px', color: PALETTE.SLATE_600}} />
+                      Allow all teams to use this activity
+                    </button>
+                  </div>
+                )
+              }
             />
           )}
+          <div className='mb-6 text-xl font-semibold'>Settings</div>
 
-          {selectedTemplate.type === 'retrospective' && (
-            <>
-              <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
-              <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
-            </>
-          )}
-          {selectedTemplate.type === 'poker' && (
-            <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.pokerSettings} />
-          )}
-          <div className='flex grow flex-col justify-end gap-2'>
-            <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
-            <FlatPrimaryButton onClick={handleStartRetro} waiting={submitting} className='h-14'>
-              <div className='text-lg'>Start Activity</div>
-            </FlatPrimaryButton>
+          <div className='flex grow flex-col gap-2'>
+            {availableTeams.length > 0 && (
+              <NewMeetingTeamPicker
+                positionOverride={MenuPosition.UPPER_LEFT}
+                onSelectTeam={(teamId) => {
+                  const newTeam = availableTeams.find((team) => team.id === teamId)
+                  newTeam && setSelectedTeam(newTeam)
+                }}
+                selectedTeamRef={selectedTeam}
+                teamsRef={availableTeams}
+              />
+            )}
+
+            {selectedTemplate.type === 'retrospective' && (
+              <>
+                <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
+                <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
+              </>
+            )}
+            {selectedTemplate.type === 'poker' && (
+              <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.pokerSettings} />
+            )}
+            <div className='flex grow flex-col justify-end gap-2'>
+              <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
+              <FlatPrimaryButton onClick={handleStartRetro} waiting={submitting} className='h-14'>
+                <div className='text-lg'>Start Activity</div>
+              </FlatPrimaryButton>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -24,10 +24,11 @@ interface Props {
   onSelectTeam: (teamId: string) => void
   parentId?: PortalId
   positionOverride?: MenuPosition
+  customPortal?: React.ReactNode
 }
 
 const NewMeetingTeamPicker = (props: Props) => {
-  const {selectedTeamRef, teamsRef, onSelectTeam, parentId, positionOverride} = props
+  const {selectedTeamRef, teamsRef, onSelectTeam, parentId, positionOverride, customPortal} = props
   const {togglePortal, menuPortal, originRef, menuProps, portalStatus} = useMenu<HTMLDivElement>(
     positionOverride ?? MenuPosition.LOWER_RIGHT,
     {
@@ -71,7 +72,11 @@ const NewMeetingTeamPicker = (props: Props) => {
         opened={[PortalStatus.Entering, PortalStatus.Entered].includes(portalStatus)}
       />
       {menuPortal(
-        <SelectTeamDropdown menuProps={menuProps} teams={teams} teamHandleClick={onSelectTeam} />
+        customPortal ? (
+          customPortal
+        ) : (
+          <SelectTeamDropdown menuProps={menuProps} teams={teams} teamHandleClick={onSelectTeam} />
+        )
       )}
     </>
   )

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -5,7 +5,6 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useMenu from '../../../hooks/useMenu'
-import useTooltip from '../../../hooks/useTooltip'
 import {PALETTE} from '../../../styles/paletteV3'
 import lazyPreload from '../../../utils/lazyPreload'
 import {TemplateSharing_template$key} from '../../../__generated__/TemplateSharing_template.graphql'
@@ -53,17 +52,17 @@ const DropdownIcon = styled('div')({
   width: 24
 })
 
-const DropdownBlock = styled('div')<{disabled: boolean; readOnly?: boolean}>(
-  ({disabled, readOnly}) => ({
+const DropdownBlock = styled('div')<{readOnly?: boolean}>(
+  ({readOnly}) => ({
     color: PALETTE.SLATE_700,
-    cursor: disabled ? 'not-allowed' : readOnly ? undefined : 'pointer',
+    cursor: readOnly ? undefined : 'pointer',
     alignItems: 'center',
     display: 'flex',
     fontSize: 16,
     lineHeight: '24px',
     userSelect: 'none',
     ':hover': {
-      color: disabled ? undefined : PALETTE.SLATE_900
+      color: PALETTE.SLATE_900
     }
   })
 )
@@ -99,7 +98,6 @@ export const UnstyledTemplateSharing = (props: Props) => {
         id
         scope
         team {
-          isLead
           name
           organization {
             name
@@ -110,7 +108,7 @@ export const UnstyledTemplateSharing = (props: Props) => {
     templateRef
   )
   const {scope, team} = template
-  const {name: teamName, organization, isLead} = team
+  const {name: teamName, organization} = team
   const {name: orgName} = organization
   const {togglePortal, menuPortal, originRef, menuProps} = useMenu<HTMLDivElement>(
     MenuPosition.UPPER_LEFT,
@@ -123,14 +121,6 @@ export const UnstyledTemplateSharing = (props: Props) => {
       }
     }
   )
-  const {
-    openTooltip,
-    tooltipPortal,
-    closeTooltip,
-    originRef: tooltipRef
-  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER, {
-    disabled: isLead
-  })
   if (!isOwner) return null
   const label =
     scope === 'TEAM'
@@ -142,11 +132,8 @@ export const UnstyledTemplateSharing = (props: Props) => {
     <>
       <DropdownBlock
         onMouseEnter={SelectSharingScopeDropdown.preload}
-        onClick={isLead && !readOnly ? togglePortal : undefined}
-        ref={isLead ? originRef : tooltipRef}
-        disabled={!isLead}
-        onMouseOver={openTooltip}
-        onMouseLeave={closeTooltip}
+        onClick={togglePortal}
+        ref={originRef}
         readOnly={readOnly}
       >
         <DropdownDecoratorIcon>
@@ -157,7 +144,6 @@ export const UnstyledTemplateSharing = (props: Props) => {
         <DropdownIcon>{!readOnly && <ExpandMoreIcon />}</DropdownIcon>
       </DropdownBlock>
       {menuPortal(<SelectSharingScopeDropdown menuProps={menuProps} template={template} />)}
-      {tooltipPortal(<div>Must be Team Lead to change</div>)}
     </>
   )
 }

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -52,20 +52,18 @@ const DropdownIcon = styled('div')({
   width: 24
 })
 
-const DropdownBlock = styled('div')<{readOnly?: boolean}>(
-  ({readOnly}) => ({
-    color: PALETTE.SLATE_700,
-    cursor: readOnly ? undefined : 'pointer',
-    alignItems: 'center',
-    display: 'flex',
-    fontSize: 16,
-    lineHeight: '24px',
-    userSelect: 'none',
-    ':hover': {
-      color: PALETTE.SLATE_900
-    }
-  })
-)
+const DropdownBlock = styled('div')<{readOnly?: boolean}>(({readOnly}) => ({
+  color: PALETTE.SLATE_700,
+  cursor: readOnly ? undefined : 'pointer',
+  alignItems: 'center',
+  display: 'flex',
+  fontSize: 16,
+  lineHeight: '24px',
+  userSelect: 'none',
+  ':hover': {
+    color: PALETTE.SLATE_900
+  }
+}))
 
 interface Props {
   isOwner: boolean

--- a/packages/server/graphql/mutations/updateTemplateScope.ts
+++ b/packages/server/graphql/mutations/updateTemplateScope.ts
@@ -1,6 +1,5 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import {SharingScopeEnum as ESharingScope} from '../../database/types/MeetingTemplate'
@@ -49,11 +48,6 @@ const updateTemplateScope = {
     const {name, teamId, orgId, scope} = template
     if (!isTeamMember(authToken, teamId)) {
       return {error: {message: `Not a member of the team`}}
-    }
-    const teamMemberId = toTeamMemberId(teamId, viewerId)
-    const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
-    if (!teamMember.isLead) {
-      return {error: {message: `Not the team leader`}}
     }
 
     // VALIDATION


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8026

When a template is team-scoped, the activity can only be started on the owning team, so the team dropdown in the details view would only show the owning team.

Instead, show a popover that prompts the user to change the scope to "org".

This loosens the template scope update mutation such that any team member can update the scope (not just team leads)

## Demo
https://www.loom.com/share/0f4486618b4344a2a5924b281befb361

## Testing scenarios
- [ ] Team-scoped template:
  - [ ] Clicking the team selector shows the popover
  - [ ] Clicking the button in the popover updates the scope, and replaces the popover with the team selector menu for teams in the org.
- [ ] Org-scoped templates always show the normal team dropdown
- [ ] Non-team-leads can change template scope.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
