### PR TITLE
fix: subscribe to acceptInvite paylods in subscription

### DIFF
--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -1,13 +1,14 @@
 import graphql from 'babel-plugin-relay/macro'
 import {RouterProps} from 'react-router'
 import {requestSubscription} from 'relay-runtime'
-import {archiveTimelineEventNotificationUpdater} from '~/mutations/ArchiveTimelineEventMutation'
-import {endCheckInNotificationUpdater} from '~/mutations/EndCheckInMutation'
-import {endRetrospectiveNotificationUpdater} from '~/mutations/EndRetrospectiveMutation'
 import {InvalidateSessionsMutation_notification$data} from '~/__generated__/InvalidateSessionsMutation_notification.graphql'
 import {NotificationSubscription_meetingStageTimeLimitEnd$data} from '~/__generated__/NotificationSubscription_meetingStageTimeLimitEnd.graphql'
 import {NotificationSubscription_paymentRejected$data} from '~/__generated__/NotificationSubscription_paymentRejected.graphql'
+import {archiveTimelineEventNotificationUpdater} from '~/mutations/ArchiveTimelineEventMutation'
+import {endCheckInNotificationUpdater} from '~/mutations/EndCheckInMutation'
+import {endRetrospectiveNotificationUpdater} from '~/mutations/EndRetrospectiveMutation'
 import Atmosphere from '../Atmosphere'
+import {NotificationSubscription as TNotificationSubscription} from '../__generated__/NotificationSubscription.graphql'
 import {acceptTeamInvitationNotificationUpdater} from '../mutations/AcceptTeamInvitationMutation'
 import {addOrgMutationNotificationUpdater} from '../mutations/AddOrgMutation'
 import {addTeamMutationNotificationUpdater} from '../mutations/AddTeamMutation'
@@ -15,7 +16,6 @@ import {
   createTaskNotificationOnNext,
   createTaskNotificationUpdater
 } from '../mutations/CreateTaskMutation'
-import handleAddNotifications from '../mutations/handlers/handleAddNotifications'
 import {
   inviteToTeamNotificationOnNext,
   inviteToTeamNotificationUpdater
@@ -24,11 +24,11 @@ import {
   removeOrgUserNotificationOnNext,
   removeOrgUserNotificationUpdater
 } from '../mutations/RemoveOrgUserMutation'
+import handleAddNotifications from '../mutations/handlers/handleAddNotifications'
 import {popNotificationToastOnNext} from '../mutations/toasts/popNotificationToast'
 import {updateNotificationToastOnNext} from '../mutations/toasts/updateNotificationToast'
 import {LocalStorageKey} from '../types/constEnums'
 import {OnNextHandler, OnNextHistoryContext, SharedUpdater} from '../types/relayMutations'
-import {NotificationSubscription as TNotificationSubscription} from '../__generated__/NotificationSubscription.graphql'
 import subscriptionOnNext from './subscriptionOnNext'
 import subscriptionUpdater from './subscriptionUpdater'
 
@@ -65,6 +65,10 @@ const subscription = graphql`
   subscription NotificationSubscription {
     notificationSubscription {
       fieldName
+      AcceptTeamInvitationPayload {
+        ...AcceptTeamInvitationMutationReply @relay(mask: false)
+        ...AcceptTeamInvitationMutation_notification @relay(mask: false)
+      }
       AddedNotification {
         addedNotification {
           ...NotificationPicker_notification @relay(mask: false)

--- a/packages/client/subscriptions/subscriptionOnNext.ts
+++ b/packages/client/subscriptions/subscriptionOnNext.ts
@@ -15,6 +15,11 @@ const subscriptionOnNext =
     if (!payload) return
     const {fieldName} = payload
     const field = payload[fieldName]
+    if (!field) {
+      /* this happens when an onNextHandler exists
+      but there is no matching fragment in the GQL subscription query. */
+      console.error('Notification Subscription Payload received without field:', fieldName)
+    }
     const handler = onNextHandlers[fieldName]
     handler?.(field, {...router, atmosphere})
   }

--- a/packages/client/subscriptions/subscriptionUpdater.ts
+++ b/packages/client/subscriptions/subscriptionUpdater.ts
@@ -13,6 +13,11 @@ const subscriptionUpdater =
     if (!payload) return
     const fieldName = payload.getValue('fieldName')
     const field = payload.getLinkedRecord(fieldName)
+    if (!field) {
+      /* this happens when an updateHandler exists
+      but there is no matching fragment in the GQL subscription query. */
+      console.error('Notification Subscription Payload received without field:', fieldName)
+    }
     const handler = updateHandlers[fieldName]
     handler?.(field, {atmosphere, store})
   }


### PR DESCRIPTION
# Description

fixes #8090 
builds on top of #8118 & the great repro that @jmtaber129 found

I also added in a fix to remove null values from the payload. I must've had a bad merge conflict because that used to be there 😅 Makes this stuff easier to debug & generally keeps payload size to 1 MTU, so mobile clients should be happy.

Worth noting that there could be other similar bugs like this out there!

## Demo

https://www.loom.com/share/733bcaafd1aa4f9a972cda8f62de4c48

## Testing scenarios

- [ ] See #8090 for a great repro!
- [ ] Look at the incoming subscription payload. it doesn't include an object with a bunch of nulls, it's just the fieldName & then 1 other prop
- [ ] both tabs of the user accepting the invite have access to the team without a refresh