### PR TITLE
feat(templates): Share to org by default

### DIFF
--- a/packages/server/database/types/MeetingTemplate.ts
+++ b/packages/server/database/types/MeetingTemplate.ts
@@ -42,7 +42,7 @@ export default class MeetingTemplate implements Insertable<MeetingTemplateDB> {
     this.name = name
     this.teamId = teamId
     this.updatedAt = now
-    this.scope = scope || 'TEAM'
+    this.scope = scope || 'ORGANIZATION'
     this.orgId = orgId
     this.parentTemplateId = parentTemplateId || null
     this.lastUsedAt = lastUsedAt || null


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8119

By default, share templates to org

## Demo
https://www.loom.com/share/922238657ba1460ea730674634d84356

## Testing scenarios
- [ ] On existing flow, create new template, and confirm shared to org
- [ ] On existing flow, clone template, and confirm shared to org
- [ ] On new flow, create new template, and confirm shared to org
- [ ] On new flow, clone template, and confirm shared to org

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
