### PR TITLE
feat(suggest-groups): click button to group reflections

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -68,6 +68,7 @@
           "NotifyRequestToJoinOrg": "../../database/types/NotificationRequestToJoinOrg#default",
           "Organization": "../../database/types/Organization#default as Organization",
           "PokerMeeting": "../../database/types/MeetingPoker#default as MeetingPoker",
+          "RetrospectiveMeeting": "../../database/types/MeetingRetrospective#default",
           "RRule": "rrule#RRule",
           "RemoveApprovedOrganizationDomainsSuccess": "./types/RemoveApprovedOrganizationDomainsSuccess#RemoveApprovedOrganizationDomainsSuccessSource",
           "RemoveIntegrationSearchQuerySuccess": "./types/RemoveIntegrationSearchQuerySuccess#RemoveIntegrationSearchQuerySuccessSource",

--- a/codegen.json
+++ b/codegen.json
@@ -41,6 +41,7 @@
           "AddedNotification": "./types/AddedNotification#AddedNotificationSource",
           "ArchiveTeamPayload": "./types/ArchiveTeamPayload#ArchiveTeamPayloadSource",
           "AuthTokenPayload": "./types/AuthTokenPayload#AuthTokenPayloadSource",
+          "AutogroupSuccess": "./types/AutogroupSuccess#AutogroupSuccessSource",
           "Comment": "../../database/types/Comment#default as CommentDB",
           "Company": "./types/Company#CompanySource",
           "CreateImposterTokenPayload": "./types/CreateImposterTokenPayload#CreateImposterTokenPayloadSource",

--- a/packages/client/components/RetroGroupPhase.tsx
+++ b/packages/client/components/RetroGroupPhase.tsx
@@ -63,7 +63,6 @@ const RetroGroupPhase = (props: Props) => {
   const {id: meetingId, endedAt, showSidebar, organization} = meeting
   const {featureFlags} = organization
   const {suggestGroups} = featureFlags
-  console.log('🚀 ~ organization:', organization)
 
   const handleAutoGroupClick = () => {
     AutogroupMutation(atmosphere, {meetingId}, {onError, onCompleted})
@@ -82,11 +81,11 @@ const RetroGroupPhase = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <StageTimerDisplay meeting={meeting} canUndo={true} />
-          {suggestGroups && (
-            <ButtonWrapper>
-              <PrimaryButton onClick={handleAutoGroupClick}>{'Suggest Groups ✨'}</PrimaryButton>
-            </ButtonWrapper>
-          )}
+          {/* {suggestGroups && ( */}
+          <ButtonWrapper>
+            <PrimaryButton onClick={handleAutoGroupClick}>{'Suggest Groups ✨'}</PrimaryButton>
+          </ButtonWrapper>
+          {/* )} */}
           <MeetingPhaseWrapper>
             <GroupingKanban meeting={meeting} phaseRef={phaseRef} />
           </MeetingPhaseWrapper>

--- a/packages/client/components/RetroGroupPhase.tsx
+++ b/packages/client/components/RetroGroupPhase.tsx
@@ -46,6 +46,11 @@ const RetroGroupPhase = (props: Props) => {
         id
         endedAt
         showSidebar
+        organization {
+          featureFlags {
+            suggestGroups
+          }
+        }
       }
     `,
     meetingRef
@@ -55,7 +60,10 @@ const RetroGroupPhase = (props: Props) => {
 
   const {onError, onCompleted} = useMutationProps()
 
-  const {id: meetingId, endedAt, showSidebar} = meeting
+  const {id: meetingId, endedAt, showSidebar, organization} = meeting
+  const {featureFlags} = organization
+  const {suggestGroups} = featureFlags
+  console.log('🚀 ~ organization:', organization)
 
   const handleAutoGroupClick = () => {
     AutogroupMutation(atmosphere, {meetingId}, {onError, onCompleted})
@@ -74,9 +82,11 @@ const RetroGroupPhase = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <StageTimerDisplay meeting={meeting} canUndo={true} />
-          <ButtonWrapper>
-            <PrimaryButton onClick={handleAutoGroupClick}>{'Auto Group ✨'}</PrimaryButton>
-          </ButtonWrapper>
+          {suggestGroups && (
+            <ButtonWrapper>
+              <PrimaryButton onClick={handleAutoGroupClick}>{'Suggest Groups ✨'}</PrimaryButton>
+            </ButtonWrapper>
+          )}
           <MeetingPhaseWrapper>
             <GroupingKanban meeting={meeting} phaseRef={phaseRef} />
           </MeetingPhaseWrapper>

--- a/packages/client/components/RetroGroupPhase.tsx
+++ b/packages/client/components/RetroGroupPhase.tsx
@@ -18,6 +18,18 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PhaseWrapper from './PhaseWrapper'
 import {RetroMeetingPhaseProps} from './RetroMeeting'
 import StageTimerDisplay from './StageTimerDisplay'
+import PrimaryButton from './PrimaryButton'
+import styled from '@emotion/styled'
+import AutogroupMutation from '../mutations/AutogroupMutation'
+import useAtmosphere from '../hooks/useAtmosphere'
+import useMutationProps from '../hooks/useMutationProps'
+
+const ButtonWrapper = styled('div')({
+  display: 'flex',
+  width: '100%',
+  paddingBottom: 32,
+  paddingLeft: 338 // TODO: super hacky, only for demo
+})
 
 interface Props extends RetroMeetingPhaseProps {
   meeting: RetroGroupPhase_meeting$key
@@ -31,6 +43,7 @@ const RetroGroupPhase = (props: Props) => {
         ...StageTimerControl_meeting
         ...StageTimerDisplay_meeting
         ...GroupingKanban_meeting
+        id
         endedAt
         showSidebar
       }
@@ -38,7 +51,15 @@ const RetroGroupPhase = (props: Props) => {
     meetingRef
   )
   const [callbackRef, phaseRef] = useCallbackRef()
-  const {endedAt, showSidebar} = meeting
+  const atmosphere = useAtmosphere()
+
+  const {onError, onCompleted} = useMutationProps()
+
+  const {id: meetingId, endedAt, showSidebar} = meeting
+
+  const handleAutoGroupClick = () => {
+    AutogroupMutation(atmosphere, {meetingId}, {onError, onCompleted})
+  }
 
   return (
     <MeetingContent ref={callbackRef}>
@@ -53,6 +74,9 @@ const RetroGroupPhase = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <StageTimerDisplay meeting={meeting} canUndo={true} />
+          <ButtonWrapper>
+            <PrimaryButton onClick={handleAutoGroupClick}>{'Auto Group ✨'}</PrimaryButton>
+          </ButtonWrapper>
           <MeetingPhaseWrapper>
             <GroupingKanban meeting={meeting} phaseRef={phaseRef} />
           </MeetingPhaseWrapper>

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -1,8 +1,10 @@
+import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
 import {useFragment} from 'react-relay'
 import useCallbackRef from '~/hooks/useCallbackRef'
 import {RetroReflectPhase_meeting$key} from '~/__generated__/RetroReflectPhase_meeting.graphql'
+import useAtmosphere from '../../hooks/useAtmosphere'
 import useBreakpoint from '../../hooks/useBreakpoint'
 import {Breakpoint} from '../../types/constEnums'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
@@ -12,11 +14,21 @@ import MeetingTopBar from '../MeetingTopBar'
 import PhaseHeaderDescription from '../PhaseHeaderDescription'
 import PhaseHeaderTitle from '../PhaseHeaderTitle'
 import PhaseWrapper from '../PhaseWrapper'
+import PrimaryButton from '../PrimaryButton'
 import {RetroMeetingPhaseProps} from '../RetroMeeting'
 import StageTimerDisplay from '../StageTimerDisplay'
 import PhaseItemColumn from './PhaseItemColumn'
 import ReflectWrapperMobile from './ReflectionWrapperMobile'
 import ReflectWrapperDesktop from './ReflectWrapperDesktop'
+import AutogroupMutation from '../../mutations/AutogroupMutation'
+import useMutationProps from '../../hooks/useMutationProps'
+
+const ButtonWrapper = styled('div')({
+  display: 'flex',
+  width: '100%',
+  paddingBottom: 32,
+  paddingLeft: 80 // TODO: super hacky, only for demo
+})
 
 interface Props extends RetroMeetingPhaseProps {
   meeting: RetroReflectPhase_meeting$key
@@ -30,6 +42,7 @@ const RetroReflectPhase = (props: Props) => {
         ...StageTimerDisplay_meeting
         ...StageTimerControl_meeting
         ...PhaseItemColumn_meeting
+        id
         endedAt
         localPhase {
           ...RetroReflectPhase_phase @relay(mask: false)
@@ -49,14 +62,21 @@ const RetroReflectPhase = (props: Props) => {
     meetingRef
   )
   const [callbackRef, phaseRef] = useCallbackRef()
+  const atmosphere = useAtmosphere()
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
-  const {localPhase, endedAt, showSidebar, settings} = meeting
+  const {id: meetingId, localPhase, endedAt, showSidebar, settings} = meeting
   const {disableAnonymity} = settings
   if (!localPhase || !localPhase.reflectPrompts) return null
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId
   const ColumnWrapper = isDesktop ? ReflectWrapperDesktop : ReflectWrapperMobile
+  const {onError, onCompleted} = useMutationProps()
+
+  const handleClick = () => {
+    AutogroupMutation(atmosphere, {meetingId}, {onError, onCompleted})
+  }
+
   return (
     <MeetingContent ref={callbackRef}>
       <MeetingHeaderAndPhase hideBottomBar={!!endedAt}>
@@ -72,6 +92,9 @@ const RetroReflectPhase = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <StageTimerDisplay meeting={meeting} />
+          <ButtonWrapper>
+            <PrimaryButton onClick={handleClick}>{'Auto Group ✨'}</PrimaryButton>
+          </ButtonWrapper>
           <ColumnWrapper
             setActiveIdx={setActiveIdx}
             activeIdx={activeIdx}

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -14,7 +14,6 @@ import MeetingTopBar from '../MeetingTopBar'
 import PhaseHeaderDescription from '../PhaseHeaderDescription'
 import PhaseHeaderTitle from '../PhaseHeaderTitle'
 import PhaseWrapper from '../PhaseWrapper'
-import PrimaryButton from '../PrimaryButton'
 import {RetroMeetingPhaseProps} from '../RetroMeeting'
 import StageTimerDisplay from '../StageTimerDisplay'
 import PhaseItemColumn from './PhaseItemColumn'
@@ -22,13 +21,6 @@ import ReflectWrapperMobile from './ReflectionWrapperMobile'
 import ReflectWrapperDesktop from './ReflectWrapperDesktop'
 import AutogroupMutation from '../../mutations/AutogroupMutation'
 import useMutationProps from '../../hooks/useMutationProps'
-
-const ButtonWrapper = styled('div')({
-  display: 'flex',
-  width: '100%',
-  paddingBottom: 32,
-  paddingLeft: 80 // TODO: super hacky, only for demo
-})
 
 interface Props extends RetroMeetingPhaseProps {
   meeting: RetroReflectPhase_meeting$key
@@ -42,7 +34,6 @@ const RetroReflectPhase = (props: Props) => {
         ...StageTimerDisplay_meeting
         ...StageTimerControl_meeting
         ...PhaseItemColumn_meeting
-        id
         endedAt
         localPhase {
           ...RetroReflectPhase_phase @relay(mask: false)
@@ -62,20 +53,14 @@ const RetroReflectPhase = (props: Props) => {
     meetingRef
   )
   const [callbackRef, phaseRef] = useCallbackRef()
-  const atmosphere = useAtmosphere()
   const [activeIdx, setActiveIdx] = useState(0)
   const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
-  const {id: meetingId, localPhase, endedAt, showSidebar, settings} = meeting
+  const {localPhase, endedAt, showSidebar, settings} = meeting
   const {disableAnonymity} = settings
   if (!localPhase || !localPhase.reflectPrompts) return null
   const reflectPrompts = localPhase!.reflectPrompts
   const focusedPromptId = localPhase!.focusedPromptId
   const ColumnWrapper = isDesktop ? ReflectWrapperDesktop : ReflectWrapperMobile
-  const {onError, onCompleted} = useMutationProps()
-
-  const handleClick = () => {
-    AutogroupMutation(atmosphere, {meetingId}, {onError, onCompleted})
-  }
 
   return (
     <MeetingContent ref={callbackRef}>
@@ -92,9 +77,6 @@ const RetroReflectPhase = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <StageTimerDisplay meeting={meeting} />
-          <ButtonWrapper>
-            <PrimaryButton onClick={handleClick}>{'Auto Group ✨'}</PrimaryButton>
-          </ButtonWrapper>
           <ColumnWrapper
             setActiveIdx={setActiveIdx}
             activeIdx={activeIdx}

--- a/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
+++ b/packages/client/components/RetroReflectPhase/RetroReflectPhase.tsx
@@ -1,10 +1,8 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
 import {useFragment} from 'react-relay'
 import useCallbackRef from '~/hooks/useCallbackRef'
 import {RetroReflectPhase_meeting$key} from '~/__generated__/RetroReflectPhase_meeting.graphql'
-import useAtmosphere from '../../hooks/useAtmosphere'
 import useBreakpoint from '../../hooks/useBreakpoint'
 import {Breakpoint} from '../../types/constEnums'
 import {phaseLabelLookup} from '../../utils/meetings/lookups'
@@ -19,8 +17,6 @@ import StageTimerDisplay from '../StageTimerDisplay'
 import PhaseItemColumn from './PhaseItemColumn'
 import ReflectWrapperMobile from './ReflectionWrapperMobile'
 import ReflectWrapperDesktop from './ReflectWrapperDesktop'
-import AutogroupMutation from '../../mutations/AutogroupMutation'
-import useMutationProps from '../../hooks/useMutationProps'
 
 interface Props extends RetroMeetingPhaseProps {
   meeting: RetroReflectPhase_meeting$key

--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -297,6 +297,12 @@ const initDemoOrg = () => {
       activeUserCount: 5,
       inactiveUserCount: 0
     },
+    featureFlags: {
+      SAMLUI: false,
+      suggestGroups: false,
+      teamsLimit: false,
+      promptToJoinOrg: false
+    },
     showConversionModal: false
   } as const
 }

--- a/packages/client/mutations/AutogroupMutation.ts
+++ b/packages/client/mutations/AutogroupMutation.ts
@@ -5,7 +5,18 @@ import {AutogroupMutation as TAutogroupMutation} from '../__generated__/Autogrou
 
 graphql`
   fragment AutogroupMutation_meeting on AutogroupSuccess {
-    successField
+    meeting {
+      id
+      reflectionGroups {
+        id
+        title
+        smartTitle
+        reflections {
+          id
+          plaintextContent
+        }
+      }
+    }
   }
 `
 
@@ -30,9 +41,6 @@ const AutogroupMutation: StandardMutation<TAutogroupMutation> = (
   return commitMutation<TAutogroupMutation>(atmosphere, {
     mutation,
     variables,
-    optimisticUpdater: (store) => {
-      const {} = variables
-    },
     onCompleted,
     onError
   })

--- a/packages/client/mutations/AutogroupMutation.ts
+++ b/packages/client/mutations/AutogroupMutation.ts
@@ -1,0 +1,41 @@
+import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
+import {StandardMutation} from '../types/relayMutations'
+import {AutogroupMutation as TAutogroupMutation} from '../__generated__/AutogroupMutation.graphql'
+
+graphql`
+  fragment AutogroupMutation_meeting on AutogroupSuccess {
+    successField
+  }
+`
+
+const mutation = graphql`
+  mutation AutogroupMutation($meetingId: ID!) {
+    autogroup(meetingId: $meetingId) {
+      ... on ErrorPayload {
+        error {
+          message
+        }
+      }
+      ...AutogroupMutation_meeting @relay(mask: false)
+    }
+  }
+`
+
+const AutogroupMutation: StandardMutation<TAutogroupMutation> = (
+  atmosphere,
+  variables,
+  {onError, onCompleted}
+) => {
+  return commitMutation<TAutogroupMutation>(atmosphere, {
+    mutation,
+    variables,
+    optimisticUpdater: (store) => {
+      const {} = variables
+    },
+    onCompleted,
+    onError
+  })
+}
+
+export default AutogroupMutation

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -192,3 +192,7 @@ export const reasonsToDowngradeLookup: Record<
   "Not using Parabol's paid features": 'notUsingPaidFeatures',
   'Moving to another tool (please specify)': 'anotherTool'
 }
+
+/* OpenAI */
+export const MAX_GPT_3_5_TOKENS = 4096 // https://platform.openai.com/docs/models/gpt-3-5
+export const AVG_CHARS_PER_TOKEN = 4 // 1 token ~= 4 chars https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them

--- a/packages/server/database/types/MeetingRetrospective.ts
+++ b/packages/server/database/types/MeetingRetrospective.ts
@@ -1,3 +1,4 @@
+import {AutogroupReflectionGroupType} from '../../graphql/types/AutogroupReflectionGroup'
 import GenericMeetingPhase from './GenericMeetingPhase'
 import Meeting from './Meeting'
 
@@ -13,7 +14,7 @@ interface Input {
   totalVotes: number
   maxVotesPerGroup: number
   disableAnonymity: boolean
-  groupedReflectionsJSON?: string
+  autogroupReflectionGroups?: AutogroupReflectionGroupType[]
 }
 
 export function isMeetingRetrospective(meeting: Meeting): meeting is MeetingRetrospective {
@@ -34,7 +35,7 @@ export default class MeetingRetrospective extends Meeting {
   templateId: string
   topicCount?: number
   reflectionCount?: number
-  groupedReflectionsJSON?: string
+  autogroupReflectionGroups?: AutogroupReflectionGroupType[]
 
   constructor(input: Input) {
     const {
@@ -49,7 +50,7 @@ export default class MeetingRetrospective extends Meeting {
       totalVotes,
       maxVotesPerGroup,
       disableAnonymity,
-      groupedReflectionsJSON
+      autogroupReflectionGroups
     } = input
     super({
       id,
@@ -65,6 +66,6 @@ export default class MeetingRetrospective extends Meeting {
     this.showConversionModal = showConversionModal
     this.templateId = templateId
     this.disableAnonymity = disableAnonymity
-    this.groupedReflectionsJSON = groupedReflectionsJSON
+    this.autogroupReflectionGroups = autogroupReflectionGroups
   }
 }

--- a/packages/server/database/types/MeetingRetrospective.ts
+++ b/packages/server/database/types/MeetingRetrospective.ts
@@ -1,6 +1,10 @@
-import {AutogroupReflectionGroupType} from '../../graphql/types/AutogroupReflectionGroup'
 import GenericMeetingPhase from './GenericMeetingPhase'
 import Meeting from './Meeting'
+
+export type AutogroupReflectionGroupType = {
+  groupTitle: string
+  reflectionIds: string[]
+}
 
 interface Input {
   id?: string

--- a/packages/server/database/types/MeetingRetrospective.ts
+++ b/packages/server/database/types/MeetingRetrospective.ts
@@ -13,6 +13,7 @@ interface Input {
   totalVotes: number
   maxVotesPerGroup: number
   disableAnonymity: boolean
+  groupedReflectionsJSON?: string
 }
 
 export function isMeetingRetrospective(meeting: Meeting): meeting is MeetingRetrospective {
@@ -33,6 +34,7 @@ export default class MeetingRetrospective extends Meeting {
   templateId: string
   topicCount?: number
   reflectionCount?: number
+  groupedReflectionsJSON?: string
 
   constructor(input: Input) {
     const {
@@ -46,7 +48,8 @@ export default class MeetingRetrospective extends Meeting {
       templateId,
       totalVotes,
       maxVotesPerGroup,
-      disableAnonymity
+      disableAnonymity,
+      groupedReflectionsJSON
     } = input
     super({
       id,
@@ -62,5 +65,6 @@ export default class MeetingRetrospective extends Meeting {
     this.showConversionModal = showConversionModal
     this.templateId = templateId
     this.disableAnonymity = disableAnonymity
+    this.groupedReflectionsJSON = groupedReflectionsJSON
   }
 }

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -1,0 +1,25 @@
+import getRethink from '../../../database/rethinkDriver'
+import Reflection from '../../../database/types/Reflection'
+import OpenAIServerManager from '../../../utils/OpenAIServerManager'
+import sendToSentry from '../../../utils/sendToSentry'
+
+const generateGroups = async (reflections: Reflection[]) => {
+  const meetingId = reflections[0]!.meetingId
+  const groupReflectionsInput = reflections.map((reflection) => reflection.plaintextContent)
+  const manager = new OpenAIServerManager()
+  const groupedReflectionsJSON = await manager.groupReflections(groupReflectionsInput)
+  console.log('🚀 ~ groupedReflectionsJSON:', groupedReflectionsJSON)
+  if (!groupedReflectionsJSON) {
+    const error = new Error('Error using OpenAI to group reflections')
+    const joinedInput = groupReflectionsInput.join(', ')
+    sendToSentry(error, {tags: {joinedInput}})
+    return
+  }
+  const parsedGroupedReflections = JSON.parse(groupedReflectionsJSON)
+  console.log('🚀 ~ parsedGroupedReflections:', parsedGroupedReflections)
+  const r = await getRethink()
+  const test = await r.table('NewMeeting').get(meetingId).update({groupedReflectionsJSON}).run()
+  console.log('🚀 ~ test:', test)
+}
+
+export default generateGroups

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -2,24 +2,30 @@ import getRethink from '../../../database/rethinkDriver'
 import Reflection from '../../../database/types/Reflection'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import sendToSentry from '../../../utils/sendToSentry'
+import {DataLoaderWorker} from '../../graphql'
 
-const generateGroups = async (reflections: Reflection[]) => {
-  const meetingId = reflections[0]!.meetingId
+const generateGroups = async (
+  reflections: Reflection[],
+  teamId: string,
+  dataLoader: DataLoaderWorker
+) => {
+  const {meetingId} = reflections[0]!
+  const team = await dataLoader.get('teams').loadNonNull(teamId)
+  const organization = await dataLoader.get('organizations').load(team.orgId)
+  const {featureFlags} = organization
+  const hasSuggestGroupsFlag = featureFlags?.includes('suggestGroups')
+  if (!hasSuggestGroupsFlag) return
+  const r = await getRethink()
   const groupReflectionsInput = reflections.map((reflection) => reflection.plaintextContent)
   const manager = new OpenAIServerManager()
   const groupedReflectionsJSON = await manager.groupReflections(groupReflectionsInput)
-  console.log('🚀 ~ groupedReflectionsJSON:', groupedReflectionsJSON)
   if (!groupedReflectionsJSON) {
     const error = new Error('Error using OpenAI to group reflections')
     const joinedInput = groupReflectionsInput.join(', ')
     sendToSentry(error, {tags: {joinedInput}})
     return
   }
-  const parsedGroupedReflections = JSON.parse(groupedReflectionsJSON)
-  console.log('🚀 ~ parsedGroupedReflections:', parsedGroupedReflections)
-  const r = await getRethink()
-  const test = await r.table('NewMeeting').get(meetingId).update({groupedReflectionsJSON}).run()
-  console.log('🚀 ~ test:', test)
+  await r.table('NewMeeting').get(meetingId).update({groupedReflectionsJSON}).run()
 }
 
 export default generateGroups

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -2,7 +2,7 @@ import getRethink from '../../../database/rethinkDriver'
 import Reflection from '../../../database/types/Reflection'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import {DataLoaderWorker} from '../../graphql'
-import {AutogroupReflectionGroupType} from '../../types/AutogroupReflectionGroup'
+import {AutogroupReflectionGroupType} from '../../../database/types/MeetingRetrospective'
 
 const generateGroups = async (
   reflections: Reflection[],

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -1,7 +1,6 @@
 import getRethink from '../../../database/rethinkDriver'
 import Reflection from '../../../database/types/Reflection'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
-import sendToSentry from '../../../utils/sendToSentry'
 import {DataLoaderWorker} from '../../graphql'
 
 const generateGroups = async (
@@ -20,9 +19,7 @@ const generateGroups = async (
   const manager = new OpenAIServerManager()
   const groupedReflectionsJSON = await manager.groupReflections(groupReflectionsInput)
   if (!groupedReflectionsJSON) {
-    const error = new Error('Error using OpenAI to group reflections')
-    const joinedInput = groupReflectionsInput.join(', ')
-    sendToSentry(error, {tags: {joinedInput}})
+    console.warn('ChatGPT was unable to group the reflections')
     return
   }
   await r.table('NewMeeting').get(meetingId).update({groupedReflectionsJSON}).run()

--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -67,7 +67,7 @@ const handleCompletedRetrospectiveStage = async (
       )
 
       data.reflectionGroups = sortedReflectionGroups
-      generateGroups(reflections)
+      generateGroups(reflections, meeting.teamId, dataLoader)
     } else if (stage.phaseType === GROUP) {
       const {facilitatorUserId, phases, teamId} = meeting
       unlockAllStagesForPhase(phases, 'discuss', true)

--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -14,6 +14,7 @@ import addSummariesToThreads from './addSummariesToThreads'
 import generateDiscussionSummary from './generateDiscussionSummary'
 import generateGroupSummaries from './generateGroupSummaries'
 import removeEmptyReflections from './removeEmptyReflections'
+import generateGroups from './generateGroups'
 
 /*
  * handle side effects when a stage is completed
@@ -66,6 +67,7 @@ const handleCompletedRetrospectiveStage = async (
       )
 
       data.reflectionGroups = sortedReflectionGroups
+      generateGroups(reflections)
     } else if (stage.phaseType === GROUP) {
       const {facilitatorUserId, phases, teamId} = meeting
       unlockAllStagesForPhase(phases, 'discuss', true)

--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -8,12 +8,14 @@ import GenericMeetingStage from '../../../database/types/GenericMeetingStage'
 import MeetingRetrospective from '../../../database/types/MeetingRetrospective'
 import insertDiscussions from '../../../postgres/queries/insertDiscussions'
 import {AnyMeeting} from '../../../postgres/types/Meeting'
+import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import {DataLoaderWorker} from '../../graphql'
 import addDiscussionTopics from './addDiscussionTopics'
 import addSummariesToThreads from './addSummariesToThreads'
 import generateDiscussionSummary from './generateDiscussionSummary'
 import generateGroupSummaries from './generateGroupSummaries'
 import removeEmptyReflections from './removeEmptyReflections'
+import addReflectionToGroup from './updateReflectionLocation/addReflectionToGroup'
 
 /*
  * handle side effects when a stage is completed
@@ -41,6 +43,40 @@ const handleCompletedRetrospectiveStage = async (
           .orderBy('createdAt')
           .run()
       ])
+
+      const reflectionText = reflections.map((reflection) => reflection.plaintextContent)
+      const manager = new OpenAIServerManager()
+      const groupedReflections = await manager.groupReflections(reflectionText)
+      console.log('🚀 ~ groupedReflections:', groupedReflections)
+      groupedReflections.forEach(async (group, index) => {
+        const reflectionsTextInGroup = Object.values(group).flat()
+        const smartTitle = Object.keys(group).join(', ')
+        console.log('🚀 ~ reflectionsTextInGroup:', {reflectionsTextInGroup, smartTitle})
+        if (reflectionsTextInGroup.length === 1) {
+          console.log('only one')
+          return
+        }
+        const firstReflection = reflections.find(
+          (reflection) => reflection.plaintextContent === reflectionsTextInGroup[0]
+        )
+        console.log('🚀 ~ firstReflection:', firstReflection)
+        const promises = reflectionsTextInGroup.slice(1).map((reflectionTextInGroup) => {
+          const originalReflection = reflections.find(
+            (reflection) => reflectionTextInGroup === reflection.plaintextContent
+          )
+          console.log('🚀 ~ originalReflection:', originalReflection)
+          if (!originalReflection || !firstReflection) return null
+          return addReflectionToGroup(
+            originalReflection.id,
+            firstReflection.reflectionGroupId,
+            {
+              dataLoader
+            } as any,
+            smartTitle
+          )
+        })
+        await Promise.all(promises)
+      })
 
       const {reflectionGroupMapping} = groupReflections(reflections.slice(), {
         groupingThreshold: AUTO_GROUPING_THRESHOLD

--- a/packages/server/graphql/mutations/helpers/updateReflectionLocation/addReflectionToGroup.ts
+++ b/packages/server/graphql/mutations/helpers/updateReflectionLocation/addReflectionToGroup.ts
@@ -9,7 +9,8 @@ import updateSmartGroupTitle from './updateSmartGroupTitle'
 const addReflectionToGroup = async (
   reflectionId: string,
   reflectionGroupId: string,
-  {dataLoader}: GQLContext
+  {dataLoader}: GQLContext,
+  smartTitle?: string
 ) => {
   const r = await getRethink()
   const now = new Date()
@@ -70,7 +71,7 @@ const addReflectionToGroup = async (
         .coerceTo('array') as unknown as Reflection[]
     }).run()
 
-    const nextTitle = getGroupSmartTitle(nextReflections)
+    const nextTitle = smartTitle ?? getGroupSmartTitle(nextReflections)
     const oldGroupHasSingleReflectionCustomTitle =
       oldReflectionGroup.title !== oldReflectionGroup.smartTitle && oldReflections.length === 0
     const newGroupHasSmartTitle = reflectionGroup.title === reflectionGroup.smartTitle

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -1,6 +1,8 @@
 import getRethink from '../../../database/rethinkDriver'
-import {getUserId} from '../../../utils/authorization'
+import {getUserId, isTeamMember} from '../../../utils/authorization'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
+import sendToSentry from '../../../utils/sendToSentry'
+import standardError from '../../../utils/standardError'
 import {GQLContext} from '../../graphql'
 import addReflectionToGroup from '../../mutations/helpers/updateReflectionLocation/addReflectionToGroup'
 import {MutationResolvers} from '../resolverTypes'
@@ -10,9 +12,8 @@ const autogroup: MutationResolvers['autogroup'] = async (
   {meetingId}: {meetingId: string},
   context: GQLContext
 ) => {
-  // const
-  // const viewerId = getUserId(authToken)
-  console.log('🚀 ~ autogroup....:', {meetingId})
+  const {authToken} = context
+  const viewerId = getUserId(authToken)
   const r = await getRethink()
 
   // VALIDATION
@@ -23,58 +24,48 @@ const autogroup: MutationResolvers['autogroup'] = async (
     .orderBy('createdAt')
     .run()
 
-  // const groupReflectionsInput = reflections.map((reflection) => {
-  //   return {
-  //     id: reflection.id,
-  //     content: reflection.plaintextContent
-  //   }
-  // })
-  const groupReflectionsInput = reflections.map((reflection) => reflection.plaintextContent)
-  console.log('🚀 ~ groupReflectionsInput:', groupReflectionsInput)
-  const manager = new OpenAIServerManager()
+  const meeting = await r.table('NewMeeting').get(meetingId).run()
 
-  const groupedReflections = await manager.groupReflections(groupReflectionsInput)
-  console.log('🚀 ~ groupedReflections:', groupedReflections)
-  if (!groupedReflections) {
-    throw new Error('Error grouping reflections')
+  if (!meeting) {
+    return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
-  const parsedGroupedReflections = JSON.parse(groupedReflections)
+  if (meeting.meetingType !== 'retrospective') {
+    return standardError(new Error('Incorrect meeting type'), {userId: viewerId})
+  }
+  const {groupedReflectionsJSON, teamId} = meeting
+  if (!isTeamMember(authToken, teamId)) {
+    return standardError(new Error('Team not found'), {userId: viewerId})
+  }
+
+  if (!groupedReflectionsJSON) {
+    return standardError(new Error('groupedReflectionsJSON not found'), {
+      userId: viewerId,
+      tags: {meetingId}
+    })
+  }
+
+  const parsedGroupedReflections = JSON.parse(groupedReflectionsJSON)
 
   for (const group of parsedGroupedReflections) {
-    const reflectionsTextInGroup = Object.values(group).flat()
+    const reflectionsTextInGroup = Object.values(group).flat() as string[]
     const smartTitle = Object.keys(group).join(', ')
-
-    console.log('🚀 ~ reflectionsTextInGroup:', {
-      reflectionsTextInGroup,
-      smartTitle,
-      firstOne: reflectionsTextInGroup[0]
-    })
-
-    if (reflectionsTextInGroup.length === 1) {
-      console.log('only one')
-      continue
-    }
-
-    const [firstReflection] = reflections.filter(
+    const [firstReflectionInGroup] = reflections.filter(
       ({plaintextContent}) => reflectionsTextInGroup[0] === plaintextContent
     )
-
-    if (!firstReflection) {
-      console.log('🚀 ~ firstReflection:', {firstReflection, firstText: reflectionsTextInGroup[0]})
-    }
-
+    if (!firstReflectionInGroup) continue
     for (const reflectionTextInGroup of reflectionsTextInGroup.slice(1)) {
       const originalReflection = reflections.find(
         ({plaintextContent}) => plaintextContent === reflectionTextInGroup
       )
-      // console.log('🚀 ~ originalReflection:', originalReflection)
-
-      if (!originalReflection || !firstReflection) continue
-
+      if (!originalReflection) {
+        const error = new Error('Unable to match OpenAI reflection with original reflection')
+        sendToSentry(error, {tags: {reflectionTextInGroup}})
+        continue
+      }
       try {
         await addReflectionToGroup(
           originalReflection.id,
-          firstReflection.reflectionGroupId,
+          firstReflectionInGroup.reflectionGroupId,
           context,
           smartTitle
         )

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -38,9 +38,9 @@ const autogroup: MutationResolvers['autogroup'] = async (
   if (!groupedReflections) {
     throw new Error('Error grouping reflections')
   }
-  // const parsedGroupedReflections = JSON.parse(groupedReflections)
+  const parsedGroupedReflections = JSON.parse(groupedReflections)
 
-  for (const group of groupedReflections) {
+  for (const group of parsedGroupedReflections) {
     const reflectionsTextInGroup = Object.values(group).flat()
     const smartTitle = Object.keys(group).join(', ')
 

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -1,0 +1,64 @@
+import getRethink from '../../../database/rethinkDriver'
+import {getUserId} from '../../../utils/authorization'
+import OpenAIServerManager from '../../../utils/OpenAIServerManager'
+import addReflectionToGroup from '../../mutations/helpers/updateReflectionLocation/addReflectionToGroup'
+import {MutationResolvers} from '../resolverTypes'
+
+const autogroup: MutationResolvers['autogroup'] = async (
+  _source,
+  {meetingId}: {meetingId: string},
+  {authToken, dataLoader, socketId: mutatorId}
+) => {
+  const viewerId = getUserId(authToken)
+  console.log('🚀 ~ autogroup....:', {viewerId, meetingId})
+  const now = new Date()
+  const r = await getRethink()
+
+  // VALIDATION
+  const reflections = await r
+    .table('RetroReflection')
+    .getAll(meetingId, {index: 'meetingId'})
+    .filter({isActive: true})
+    .orderBy('createdAt')
+    .run()
+
+  const reflectionText = reflections.map((reflection) => reflection.plaintextContent)
+  const manager = new OpenAIServerManager()
+  const groupedReflections = await manager.groupReflections(reflectionText)
+  console.log('🚀 ~ groupedReflections:', groupedReflections)
+  groupedReflections.forEach(async (group, index) => {
+    const reflectionsTextInGroup = Object.values(group).flat()
+    const smartTitle = Object.keys(group).join(', ')
+    console.log('🚀 ~ reflectionsTextInGroup:', {reflectionsTextInGroup, smartTitle})
+    if (reflectionsTextInGroup.length === 1) {
+      console.log('only one')
+      return
+    }
+    const firstReflection = reflections.find(
+      (reflection) => reflection.plaintextContent === reflectionsTextInGroup[0]
+    )
+    console.log('🚀 ~ firstReflection:', firstReflection)
+    const promises = reflectionsTextInGroup.slice(1).map((reflectionTextInGroup) => {
+      const originalReflection = reflections.find(
+        (reflection) => reflectionTextInGroup === reflection.plaintextContent
+      )
+      console.log('🚀 ~ originalReflection:', originalReflection)
+      if (!originalReflection || !firstReflection) return null
+      return addReflectionToGroup(
+        originalReflection.id,
+        firstReflection.reflectionGroupId,
+        {
+          dataLoader
+        } as any,
+        smartTitle
+      )
+    })
+    await Promise.all(promises)
+  })
+
+  // RESOLUTION
+  const data = {}
+  return data
+}
+
+export default autogroup

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -23,11 +23,22 @@ const autogroup: MutationResolvers['autogroup'] = async (
     .orderBy('createdAt')
     .run()
 
-  const reflectionText = reflections.map(({plaintextContent}) => plaintextContent)
-  console.log('🚀 ~ reflectionText:', reflectionText)
+  // const groupReflectionsInput = reflections.map((reflection) => {
+  //   return {
+  //     id: reflection.id,
+  //     content: reflection.plaintextContent
+  //   }
+  // })
+  const groupReflectionsInput = reflections.map((reflection) => reflection.plaintextContent)
+  console.log('🚀 ~ groupReflectionsInput:', groupReflectionsInput)
   const manager = new OpenAIServerManager()
 
-  const groupedReflections = await manager.groupReflections(reflectionText)
+  const groupedReflections = await manager.groupReflections(groupReflectionsInput)
+  console.log('🚀 ~ groupedReflections:', groupedReflections)
+  if (!groupedReflections) {
+    throw new Error('Error grouping reflections')
+  }
+  // const parsedGroupedReflections = JSON.parse(groupedReflections)
 
   for (const group of groupedReflections) {
     const reflectionsTextInGroup = Object.values(group).flat()

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -25,11 +25,11 @@ const autogroup: MutationResolvers['autogroup'] = async (
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
   if (meeting.meetingType !== 'retrospective') {
-    return standardError(new Error('Incorrect meeting type'), {userId: viewerId})
+    return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
   const {groupedReflectionsJSON, teamId} = meeting
   if (!isTeamMember(authToken, teamId)) {
-    return standardError(new Error('Team not found'), {userId: viewerId})
+    return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
 
   if (!groupedReflectionsJSON) {

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -15,11 +15,15 @@ const autogroup: MutationResolvers['autogroup'] = async (
     dataLoader.get('newMeetings').load(meetingId),
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId)
   ])
-  const {meetingType, autogroupReflectionGroups, teamId} = meeting
-
   if (!meeting) {
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
+
+  const {meetingType, autogroupReflectionGroups, teamId} = meeting
+  if (!autogroupReflectionGroups) {
+    return standardError(new Error('No autogroup reflection groups found'), {userId: viewerId})
+  }
+
   if (meetingType !== 'retrospective') {
     return standardError(new Error('Incorrect meeting type'), {userId: viewerId})
   }

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -1,7 +1,4 @@
-import getRethink from '../../../database/rethinkDriver'
-import Reflection from '../../../database/types/Reflection'
 import {getUserId, isTeamMember} from '../../../utils/authorization'
-import sendToSentry from '../../../utils/sendToSentry'
 import standardError from '../../../utils/standardError'
 import {GQLContext} from '../../graphql'
 import addReflectionToGroup from '../../mutations/helpers/updateReflectionLocation/addReflectionToGroup'
@@ -16,90 +13,40 @@ const autogroup: MutationResolvers['autogroup'] = async (
   {meetingId}: {meetingId: string},
   context: GQLContext
 ) => {
-  const {authToken} = context
+  const {authToken, dataLoader} = context
   const viewerId = getUserId(authToken)
-  const r = await getRethink()
-  const meeting = await r.table('NewMeeting').get(meetingId).run()
+  const [meeting, reflections] = await Promise.all([
+    dataLoader.get('newMeetings').load(meetingId),
+    dataLoader.get('retroReflectionsByMeetingId').load(meetingId)
+  ])
+  const {meetingType, autogroupReflectionGroups, teamId} = meeting
 
   if (!meeting) {
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
-  if (meeting.meetingType !== 'retrospective') {
+  if (meetingType !== 'retrospective') {
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
-  const {groupedReflectionsJSON, teamId} = meeting
+
   if (!isTeamMember(authToken, teamId)) {
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
 
-  if (!groupedReflectionsJSON) {
-    return standardError(new Error('groupedReflectionsJSON not found'), {
-      userId: viewerId,
-      tags: {meetingId}
-    })
-  }
-
-  const reflections = await r
-    .table('RetroReflection')
-    .getAll(meetingId, {index: 'meetingId'})
-    .filter({isActive: true})
-    .orderBy('createdAt')
-    .run()
-
-  const parsedGroupedReflections: GroupedReflection[] = JSON.parse(groupedReflectionsJSON)
-
-  const processReflectionInGroup = async (
-    firstReflectionInGroup: Reflection,
-    reflectionTextInGroup: string,
-    group: GroupedReflection
-  ) => {
-    const originalReflection = reflections.find(
-      ({plaintextContent}) => plaintextContent === reflectionTextInGroup
-    )
-
-    if (!originalReflection) {
-      const error = new Error('Unable to match OpenAI reflection with original reflection')
-      sendToSentry(error, {tags: {reflectionTextInGroup}})
-      return
-    }
-
-    try {
-      const smartTitle = Object.keys(group).join(', ')
-      return await addReflectionToGroup(
-        originalReflection.id,
+  const promises = autogroupReflectionGroups.flatMap((group) => {
+    const {groupTitle, reflectionIds} = group
+    const reflectionsInGroup = reflections.filter(({id}) => reflectionIds.includes(id))
+    const firstReflectionInGroup = reflectionsInGroup[0]
+    return reflectionsInGroup.map((reflection) =>
+      addReflectionToGroup(
+        reflection.id,
         firstReflectionInGroup.reflectionGroupId,
         context,
-        smartTitle
+        groupTitle
       )
-    } catch (error) {
-      console.error('Error adding reflection to group:', error)
-    }
-  }
-
-  const processGroup = async (group: GroupedReflection) => {
-    const reflectionsTextInGroup = Object.values(group).flat() as string[]
-    const firstReflectionInGroup = reflections.find(
-      ({plaintextContent}) => reflectionsTextInGroup[0].trim() === plaintextContent.trim()
     )
+  })
 
-    if (!firstReflectionInGroup) {
-      const error = new Error('Unable to match OpenAI reflection with original reflection')
-      const problematicReflection = reflectionsTextInGroup[0]
-      sendToSentry(error, {tags: {problematicReflection}})
-      return
-    }
-
-    const reflectionPromises = reflectionsTextInGroup
-      .slice(1)
-      .map((reflectionTextInGroup) =>
-        processReflectionInGroup(firstReflectionInGroup, reflectionTextInGroup, group)
-      )
-    await Promise.all(reflectionPromises)
-  }
-
-  const groupPromises = parsedGroupedReflections.map(processGroup)
-  await Promise.all(groupPromises)
-
+  await Promise.all(promises)
   const data = {meetingId}
   return data
 }

--- a/packages/server/graphql/public/typeDefs/autogroup.graphql
+++ b/packages/server/graphql/public/typeDefs/autogroup.graphql
@@ -1,6 +1,6 @@
 extend type Mutation {
   """
-  This groups the reflections together using OpenAI
+  Creates suggested reflection groups using OpenAI
   """
   autogroup(meetingId: ID!): AutogroupPayload!
 }
@@ -11,8 +11,5 @@ Return value for autogroup, which could be an error
 union AutogroupPayload = ErrorPayload | AutogroupSuccess
 
 type AutogroupSuccess {
-  """
-  The meeting that was autogrouped
-  """
   meeting: RetrospectiveMeeting!
 }

--- a/packages/server/graphql/public/typeDefs/autogroup.graphql
+++ b/packages/server/graphql/public/typeDefs/autogroup.graphql
@@ -1,13 +1,8 @@
 extend type Mutation {
   """
-  Describe the mutation here
+  This groups the reflections together using OpenAI
   """
-  autogroup(
-    """
-    Describe the first arg here
-    """
-    meetingId: ID!
-  ): AutogroupPayload!
+  autogroup(meetingId: ID!): AutogroupPayload!
 }
 
 """
@@ -17,7 +12,7 @@ union AutogroupPayload = ErrorPayload | AutogroupSuccess
 
 type AutogroupSuccess {
   """
-  Describe the first return field here
+  The meeting that was autogrouped
   """
-  successField: Boolean!
+  meeting: RetrospectiveMeeting!
 }

--- a/packages/server/graphql/public/typeDefs/autogroup.graphql
+++ b/packages/server/graphql/public/typeDefs/autogroup.graphql
@@ -1,0 +1,23 @@
+extend type Mutation {
+  """
+  Describe the mutation here
+  """
+  autogroup(
+    """
+    Describe the first arg here
+    """
+    meetingId: ID!
+  ): AutogroupPayload!
+}
+
+"""
+Return value for autogroup, which could be an error
+"""
+union AutogroupPayload = ErrorPayload | AutogroupSuccess
+
+type AutogroupSuccess {
+  """
+  Describe the first return field here
+  """
+  successField: Boolean!
+}

--- a/packages/server/graphql/public/types/AutogroupSuccess.ts
+++ b/packages/server/graphql/public/types/AutogroupSuccess.ts
@@ -1,0 +1,14 @@
+import {AutogroupSuccessResolvers} from '../resolverTypes'
+
+export type AutogroupSuccessSource = {
+  id: string
+}
+
+const AutogroupSuccess: AutogroupSuccessResolvers = {
+  successField: async ({id}, _args, {dataLoader}) => {
+    // return dataLoader.get('').load(id)
+    return true
+  }
+}
+
+export default AutogroupSuccess

--- a/packages/server/graphql/public/types/AutogroupSuccess.ts
+++ b/packages/server/graphql/public/types/AutogroupSuccess.ts
@@ -1,13 +1,12 @@
 import {AutogroupSuccessResolvers} from '../resolverTypes'
 
 export type AutogroupSuccessSource = {
-  id: string
+  meetingId: string
 }
 
 const AutogroupSuccess: AutogroupSuccessResolvers = {
-  successField: async ({id}, _args, {dataLoader}) => {
-    // return dataLoader.get('').load(id)
-    return true
+  meeting: async ({meetingId}, _args, {dataLoader}) => {
+    return dataLoader.get('newMeetings').load(meetingId)
   }
 }
 

--- a/packages/server/graphql/public/types/AutogroupSuccess.ts
+++ b/packages/server/graphql/public/types/AutogroupSuccess.ts
@@ -1,3 +1,4 @@
+import MeetingRetrospective from '../../../database/types/MeetingRetrospective'
 import {AutogroupSuccessResolvers} from '../resolverTypes'
 
 export type AutogroupSuccessSource = {
@@ -6,7 +7,8 @@ export type AutogroupSuccessSource = {
 
 const AutogroupSuccess: AutogroupSuccessResolvers = {
   meeting: async ({meetingId}, _args, {dataLoader}) => {
-    return dataLoader.get('newMeetings').load(meetingId)
+    const meeting = await dataLoader.get('newMeetings').load(meetingId)
+    return meeting as MeetingRetrospective
   }
 }
 

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -7,7 +7,8 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   suggestGroups: ({suggestGroups}) => !!suggestGroups,
   teamHealth: ({teamHealth}) => !!teamHealth,
   teamsLimit: ({teamsLimit}) => !!teamsLimit,
-  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg
+  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg,
+  suggestGroups: ({suggestGroups}) => !!suggestGroups
 }
 
 export default OrganizationFeatureFlags

--- a/packages/server/graphql/types/AutogroupReflectionGroup.ts
+++ b/packages/server/graphql/types/AutogroupReflectionGroup.ts
@@ -1,11 +1,6 @@
 import {GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'graphql'
 import {GQLContext} from '../graphql'
 
-export type AutogroupReflectionGroupType = {
-  groupTitle: string
-  reflectionIds: string[]
-}
-
 const AutogroupReflectionGroup = new GraphQLObjectType<any, GQLContext>({
   name: 'AutogroupReflectionGroup',
   description: 'A suggested reflection group created by OpenAI',

--- a/packages/server/graphql/types/AutogroupReflectionGroup.ts
+++ b/packages/server/graphql/types/AutogroupReflectionGroup.ts
@@ -1,0 +1,24 @@
+import {GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'graphql'
+import {GQLContext} from '../graphql'
+
+export type AutogroupReflectionGroupType = {
+  groupTitle: string
+  reflectionIds: string[]
+}
+
+const AutogroupReflectionGroup = new GraphQLObjectType<any, GQLContext>({
+  name: 'AutogroupReflectionGroup',
+  description: 'A suggested reflection group created by OpenAI',
+  fields: () => ({
+    groupTitle: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: 'The smart title for the reflection group created by OpenAI'
+    },
+    reflectionIds: {
+      type: new GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLID))),
+      description: 'The ids of the reflections in the group'
+    }
+  })
+})
+
+export default AutogroupReflectionGroup

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -54,11 +54,6 @@ const RetrospectiveMeeting: GraphQLObjectType<any, GQLContext> = new GraphQLObje
       description: 'The number of comments generated in the meeting',
       resolve: ({commentCount}) => commentCount || 0
     },
-    groupedReflectionsJSON: {
-      type: GraphQLString,
-      description:
-        'The JSON stringified version of the grouped reflections. Null if not grouped, they dont have access to OpenAI, or OpenAI was unable to create the groups'
-    },
     autogroupReflectionGroups: {
       type: new GraphQLList(new GraphQLNonNull(AutogroupReflectionGroup)),
       description: 'The suggested reflection groups created by OpenAI'

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -22,6 +22,7 @@ import RetroReflectionGroup from './RetroReflectionGroup'
 import RetrospectiveMeetingMember from './RetrospectiveMeetingMember'
 import RetrospectiveMeetingSettings from './RetrospectiveMeetingSettings'
 import Task from './Task'
+import AutogroupReflectionGroup from './AutogroupReflectionGroup'
 
 const ReflectionGroupSortEnum = new GraphQLEnumType({
   name: 'ReflectionGroupSortEnum',
@@ -57,6 +58,10 @@ const RetrospectiveMeeting: GraphQLObjectType<any, GQLContext> = new GraphQLObje
       type: GraphQLString,
       description:
         'The JSON stringified version of the grouped reflections. Null if not grouped, they dont have access to OpenAI, or OpenAI was unable to create the groups'
+    },
+    autogroupReflectionGroups: {
+      type: new GraphQLList(new GraphQLNonNull(AutogroupReflectionGroup)),
+      description: 'The suggested reflection groups created by OpenAI'
     },
     maxVotesPerGroup: {
       type: new GraphQLNonNull(GraphQLInt),

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -6,7 +6,8 @@ import {
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLObjectType
+  GraphQLObjectType,
+  GraphQLString
 } from 'graphql'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import ReflectionGroupType from '../../database/types/ReflectionGroup'
@@ -51,6 +52,11 @@ const RetrospectiveMeeting: GraphQLObjectType<any, GQLContext> = new GraphQLObje
       type: new GraphQLNonNull(GraphQLInt),
       description: 'The number of comments generated in the meeting',
       resolve: ({commentCount}) => commentCount || 0
+    },
+    groupedReflectionsJSON: {
+      type: GraphQLString,
+      description:
+        'The JSON stringified version of the grouped reflections. Null if not grouped, they dont have access to OpenAI, or OpenAI was unable to create the groups'
     },
     maxVotesPerGroup: {
       type: new GraphQLNonNull(GraphQLInt),

--- a/packages/server/graphql/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/types/RetrospectiveMeeting.ts
@@ -6,8 +6,7 @@ import {
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLString
+  GraphQLObjectType
 } from 'graphql'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import ReflectionGroupType from '../../database/types/ReflectionGroup'

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -116,8 +116,10 @@ class OpenAIServerManager {
         return null
       }
       return answer
-    } catch (error) {
-      console.error(error)
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
+      console.error(error.message)
+      sendToSentry(error)
       return null
     }
   }

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -1,7 +1,8 @@
 import {Configuration, OpenAIApi} from 'openai'
 import sendToSentry from './sendToSentry'
 import {isValidJSON} from './isValidJSON'
-
+import {estimateTokens} from './estimateTokens'
+import {AVG_CHARS_PER_TOKEN, MAX_GPT_3_5_TOKENS} from '../../client/utils/constants'
 class OpenAIServerManager {
   private openAIApi: OpenAIApi | null
 
@@ -42,8 +43,65 @@ class OpenAIServerManager {
     }
   }
 
+  // setting the minimal max_tokens limit increases the speed of the request and reduces the tokens used
+  estimateOutputTokens(reflectionsText: string[]) {
+    const avgGroupNameLength = 10 // assume an average group name length of 10 tokens
+    const totalLengthInTokens = reflectionsText.reduce(
+      (total, reflectionText) => total + Math.ceil(reflectionText.length / AVG_CHARS_PER_TOKEN),
+      0
+    )
+    const avgReflectionLength = totalLengthInTokens / reflectionsText.length
+
+    const avgReflectionsPerGroup = 3 // assume each group will have around 3 reflections
+    const numGroups = Math.ceil(reflectionsText.length / avgReflectionsPerGroup)
+
+    const outputTokens = Math.round(
+      numGroups * (avgGroupNameLength + avgReflectionsPerGroup * avgReflectionLength)
+    )
+
+    return Math.min(MAX_GPT_3_5_TOKENS, outputTokens)
+  }
+
   async groupReflections(reflectionsText: string[]) {
     if (!this.openAIApi) return null
+    const prompt = `You are given a list of reflections from a meeting, separated by commas. Your task is to group these reflections into topics and return an array of JavaScript objects. Each object represents a topic and contains an array of reflections that belong to that topic. Don't change the input text at all, even if it's spelt incorrectly or has special characters. Groups should have at least 2 reflections.
+
+    Example Input:
+    ['The retreat went well', 'The project might not be ready in time', 'The deadline is really tight', 'I liked that the length of the retreat', 'I enjoyed the hotel', 'Feeling overworked']
+
+    Example Output:
+    [
+    {
+    "The Retreat": [
+      "The retreat went well",
+      "I liked that the length of the retreat",
+      "I enjoyed the hotel"
+    ]
+    },
+    {
+    "Deadlines": [
+      "Feeling overworked",
+      "The project might not be ready in time",
+      "The deadline is really tight"
+    ]
+    }
+    ]
+
+    In the output, "The Retreat" and "Deadlines" are example topic names that you can create to group the reflections.
+    Do not give me code to run. Give me the output as valid JSON in the format above.
+
+    Here is the list of reflections: """
+    ${reflectionsText}
+    """
+    `
+
+    const buffer = 1.2 // add a 20% buffer to be on the safe side
+    const estimatedInputTokens = estimateTokens(prompt) * buffer
+    const estimatedOutputTokens = this.estimateOutputTokens(reflectionsText) * buffer
+
+    const max_tokens = Math.round(
+      Math.min(MAX_GPT_3_5_TOKENS, estimatedInputTokens + estimatedOutputTokens)
+    )
     try {
       const response = await this.openAIApi.createChatCompletion(
         {
@@ -51,42 +109,12 @@ class OpenAIServerManager {
           messages: [
             {
               role: 'user',
-              content: `You are given a list of reflections from a meeting, separated by commas. Your task is to group these reflections into similar topics and return an array of JavaScript objects, where each object represents a topic and contains an array of reflections that belong to that topic.
-              Don't change the input text at all, even if it's spelt incorrectly or has special characters.
-              Groups should have at least 2 reflection.
-
-      Example Input:
-      ['The retreat went well', 'The project might not be ready in time', 'The deadline is really tight', 'I liked that the length of the retreat', 'I enjoyed the hotel', 'Feeling overworked']
-
-      Example Output:
-      [
-        {
-          "The Retreat": [
-            "The retreat went well",
-            "I liked that the length of the retreat",
-            "I enjoyed the hotel"
-          ]
-        },
-        {
-          "Deadlines": [
-            "Feeling overworked",
-            "The project might not be ready in time",
-            "The deadline is really tight"
-          ]
-        }
-      ]
-
-      In the output, "The Retreat" and "Deadlines" are example topic names that you can create to group the reflections.
-      Do not give me code to run. Give me the output in the format above.
-
-      Here is the list of reflections: """
-      ${reflectionsText}
-      """
-      `
+              content: prompt
             }
           ],
           temperature: 0.7,
           top_p: 1,
+          max_tokens,
           frequency_penalty: 0,
           presence_penalty: 0
         },

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -45,59 +45,6 @@ class OpenAIServerManager {
   async groupReflections(text: string[]) {
     if (!this.openAIApi) return null
     try {
-      // const response = await this.openAIApi.createChatCompletion(
-      //   {
-      //     model: 'gpt-3.5-turbo',
-      //     messages: [
-      //       {
-      //         role: 'user',
-      //         content: `You are given a list of objects, each containing an "id" and a "content" key, representing reflections from a meeting. Your task is to group these reflections into similar topics based on the "content" fields and return an array of JavaScript objects, where each object represents a topic and contains an array of reflection ids that belong to that topic.
-
-      //         Example Input:
-      //         [
-      //           { "id": 1, "content": "The retreat went well" },
-      //           { "id": 2, "content": "The project might not be ready in time" },
-      //           { "id": 3, "content": "The deadline is really tight" },
-      //           { "id": 4, "content": "I liked that the length of the retreat" },
-      //           { "id": 5, "content": "I enjoyed the hotel" },
-      //           { "id": 6, "content": "Feeling overworked" }
-      //         ]
-
-      //         Example Output:
-      //         [
-      //           {
-      //             "topic": "The Retreat",
-      //             "reflectionIds": [1, 4, 5]
-      //           },
-      //           {
-      //             "topic": "Deadlines",
-      //             "reflectionIds": [2, 3, 6]
-      //           }
-      //         ]
-
-      //         In the output, "The Retreat" and "Deadlines" are example topic names that you can create to group the reflections.
-
-      //         Here is the list of reflections: """
-      //         ${reflections}
-      //         """
-      //         `
-      //       }
-      //     ],
-      //     temperature: 0.7,
-      //     top_p: 1,
-      //     frequency_penalty: 0,
-      //     presence_penalty: 0
-      //   }
-      //   // {
-      //   //   timeout: 60000
-      //   // }
-      // )
-
-      // const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
-      // const nullableAnswer = /^No\.*$/i.test(answer) ? null : answer
-      // if (!nullableAnswer) return null
-      // return nullableAnswer
-
       const response = await this.openAIApi.createChatCompletion(
         {
           model: 'gpt-3.5-turbo',
@@ -148,7 +95,7 @@ class OpenAIServerManager {
       const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
       const nullableAnswer = /^No\.*$/i.test(answer) ? null : answer
       if (!nullableAnswer) return null
-      return JSON.parse(nullableAnswer)
+      return nullableAnswer
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -52,6 +52,7 @@ class OpenAIServerManager {
               role: 'user',
               content: `You are given a list of reflections from a meeting, separated by commas. Your task is to group these reflections into similar topics and return an array of JavaScript objects, where each object represents a topic and contains an array of reflections that belong to that topic.
               Don't change the input text at all, even if it's spelt incorrectly.
+              If you're unable to group the reflections, simply say "No".
 
       Example Input:
       ['The retreat went well', 'The project might not be ready in time', 'The deadline is really tight', 'I liked that the length of the retreat', 'I enjoyed the hotel', 'Feeling overworked']
@@ -92,8 +93,9 @@ class OpenAIServerManager {
         }
       )
       const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
-      if (!answer) return null
-      return answer
+      const nullableAnswer = /^No\.*$/i.test(answer) ? null : answer
+      if (!nullableAnswer) return null
+      return nullableAnswer
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -41,9 +41,63 @@ class OpenAIServerManager {
     }
   }
 
-  async groupReflections(text: string | string[]) {
+  // async groupReflections(reflections: {id: string; content: string}[]) {
+  async groupReflections(text: string[]) {
     if (!this.openAIApi) return null
     try {
+      // const response = await this.openAIApi.createChatCompletion(
+      //   {
+      //     model: 'gpt-3.5-turbo',
+      //     messages: [
+      //       {
+      //         role: 'user',
+      //         content: `You are given a list of objects, each containing an "id" and a "content" key, representing reflections from a meeting. Your task is to group these reflections into similar topics based on the "content" fields and return an array of JavaScript objects, where each object represents a topic and contains an array of reflection ids that belong to that topic.
+
+      //         Example Input:
+      //         [
+      //           { "id": 1, "content": "The retreat went well" },
+      //           { "id": 2, "content": "The project might not be ready in time" },
+      //           { "id": 3, "content": "The deadline is really tight" },
+      //           { "id": 4, "content": "I liked that the length of the retreat" },
+      //           { "id": 5, "content": "I enjoyed the hotel" },
+      //           { "id": 6, "content": "Feeling overworked" }
+      //         ]
+
+      //         Example Output:
+      //         [
+      //           {
+      //             "topic": "The Retreat",
+      //             "reflectionIds": [1, 4, 5]
+      //           },
+      //           {
+      //             "topic": "Deadlines",
+      //             "reflectionIds": [2, 3, 6]
+      //           }
+      //         ]
+
+      //         In the output, "The Retreat" and "Deadlines" are example topic names that you can create to group the reflections.
+
+      //         Here is the list of reflections: """
+      //         ${reflections}
+      //         """
+      //         `
+      //       }
+      //     ],
+      //     temperature: 0.7,
+      //     top_p: 1,
+      //     frequency_penalty: 0,
+      //     presence_penalty: 0
+      //   }
+      //   // {
+      //   //   timeout: 60000
+      //   // }
+      // )
+
+      // const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
+      // const nullableAnswer = /^No\.*$/i.test(answer) ? null : answer
+      // if (!nullableAnswer) return null
+      // return nullableAnswer
+
       const response = await this.openAIApi.createChatCompletion(
         {
           model: 'gpt-3.5-turbo',
@@ -51,6 +105,7 @@ class OpenAIServerManager {
             {
               role: 'user',
               content: `You are given a list of reflections from a meeting, separated by commas. Your task is to group these reflections into similar topics and return an array of JavaScript objects, where each object represents a topic and contains an array of reflections that belong to that topic.
+              Don't change the input text at all, even if it's spelt incorrectly.
 
       Example Input:
       ['The retreat went well', 'The project might not be ready in time', 'The deadline is really tight', 'I liked that the length of the retreat', 'I enjoyed the hotel', 'Feeling overworked']

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -41,8 +41,7 @@ class OpenAIServerManager {
     }
   }
 
-  // async groupReflections(reflections: {id: string; content: string}[]) {
-  async groupReflections(text: string[]) {
+  async groupReflections(reflectionsText: string[]) {
     if (!this.openAIApi) return null
     try {
       const response = await this.openAIApi.createChatCompletion(
@@ -78,7 +77,7 @@ class OpenAIServerManager {
       In the output, "The Retreat" and "Deadlines" are example topic names that you can create to group the reflections.
 
       Here is the list of reflections: """
-      ${text}
+      ${reflectionsText}
       """
       `
             }
@@ -93,9 +92,8 @@ class OpenAIServerManager {
         }
       )
       const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
-      const nullableAnswer = /^No\.*$/i.test(answer) ? null : answer
-      if (!nullableAnswer) return null
-      return nullableAnswer
+      if (!answer) return null
+      return answer
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -50,14 +50,10 @@ class OpenAIServerManager {
       (total, reflectionText) => total + Math.ceil(reflectionText.length / AVG_CHARS_PER_TOKEN),
       0
     )
-    const avgReflectionLength = totalLengthInTokens / reflectionsText.length
-
     const avgReflectionsPerGroup = 3 // assume each group will have around 3 reflections
     const numGroups = Math.ceil(reflectionsText.length / avgReflectionsPerGroup)
 
-    const outputTokens = Math.round(
-      numGroups * (avgGroupNameLength + avgReflectionsPerGroup * avgReflectionLength)
-    )
+    const outputTokens = Math.round(numGroups * avgGroupNameLength + totalLengthInTokens)
 
     return Math.min(MAX_GPT_3_5_TOKENS, outputTokens)
   }

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -53,7 +53,7 @@ class OpenAIServerManager {
               role: 'user',
               content: `You are given a list of reflections from a meeting, separated by commas. Your task is to group these reflections into similar topics and return an array of JavaScript objects, where each object represents a topic and contains an array of reflections that belong to that topic.
               Don't change the input text at all, even if it's spelt incorrectly or has special characters.
-              If you're unable to group any reflections, simply say "No".
+              Groups should have at least 2 reflection.
 
       Example Input:
       ['The retreat went well', 'The project might not be ready in time', 'The deadline is really tight', 'I liked that the length of the retreat', 'I enjoyed the hotel', 'Feeling overworked']

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -87,12 +87,13 @@ class OpenAIServerManager {
           presence_penalty: 0
         },
         {
-          timeout: 30000
+          timeout: 60000
         }
       )
       const answer = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
-      // const  /^No\.*$/i.test(answer) ? null : answer
-      return JSON.parse(answer)
+      const nullableAnswer = /^No\.*$/i.test(answer) ? null : answer
+      if (!nullableAnswer) return null
+      return JSON.parse(nullableAnswer)
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)

--- a/packages/server/utils/estimateTokens.ts
+++ b/packages/server/utils/estimateTokens.ts
@@ -1,0 +1,10 @@
+import {AVG_CHARS_PER_TOKEN} from '../../client/utils/constants'
+
+export const estimateTokens = (text: string[] | string) => {
+  const textArray = typeof text === 'string' ? [text] : text
+  const tokensInReflectionText = textArray.reduce(
+    (acc, val) => acc + val.length / AVG_CHARS_PER_TOKEN,
+    0
+  )
+  return tokensInReflectionText
+}

--- a/packages/server/utils/isValidJSON.ts
+++ b/packages/server/utils/isValidJSON.ts
@@ -1,0 +1,8 @@
+export const isValidJSON = (json: string) => {
+  try {
+    JSON.parse(json)
+    return true
+  } catch (error) {
+    return false
+  }
+}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8123

Demo: https://www.loom.com/share/c453d1b30fca44c7b74066b64fe81343

Note:
- If you quickly click the "Suggest Groups" button after proceeding to the Group phase, it won't work as ChatGPT won't have responded. In a later PR, I'll add some error/loading feedback text. See: https://github.com/ParabolInc/parabol/issues/8133
- Non-viewers will need to refresh the page to see the change. See https://github.com/ParabolInc/parabol/issues/8126

### AC

- [ ] Add the org feature flag 
- [ ] Create a retro and add several reflections
- [ ] Move to the Group phase and see the "Suggest Groups" button
- [ ] Wait ~30 seconds, click on "Suggest Groups", and see that the reflections are grouped