### PR TITLE
fix(rid): Ignore category in search empty state

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -211,9 +211,7 @@ export const ActivityLibrary = (props: Props) => {
                   you have in mind.
                 </div>
                 <div className='h-40 w-64'>
-                  {CREATE_CUSTOM_ACTIVITY_ALLOW_LIST.includes(selectedCategory) && (
-                    <CreateActivityCard category={selectedCategory} className='h-full' />
-                  )}
+                  <CreateActivityCard category={QUICK_START_CATEGORY_ID} className='h-full' />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Description
Currently, the search empty state in the activity library grid view shows the "Create activity" card for whichever category is selected.

Because search is category-agnostic, this "create activity" card should actually be the generic card shown in the quick start view.

Before:
<img width="1276" alt="Screen Shot 2023-05-03 at 11 35 38 AM" src="https://user-images.githubusercontent.com/9013217/235966602-2fd73a2c-6c87-41e2-b562-7ff6dfee42ed.png">

<img width="993" alt="Screen Shot 2023-05-03 at 11 39 33 AM" src="https://user-images.githubusercontent.com/9013217/235966919-b4874448-0a20-4013-a6eb-d5702fa1bd1e.png">


After:
<img width="1256" alt="Screen Shot 2023-05-03 at 11 35 54 AM" src="https://user-images.githubusercontent.com/9013217/235966608-4f86477b-69d5-4f81-835e-252fa851ed60.png">

<img width="1061" alt="Screen Shot 2023-05-03 at 11 39 50 AM" src="https://user-images.githubusercontent.com/9013217/235966897-3ad62104-dd7b-482b-9803-1472dab48cfc.png">

## Testing scenarios
- [ ] Generic "Create activity" card is shown on empty state regardless of which category was most recently selected.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
