### PR TITLE
fix: remove leading slash on dist nested dirs

### DIFF
--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -138,7 +138,7 @@ module.exports = ({isDeploy, noDeps}) => ({
               {
                 loader: 'file-loader',
                 options: {
-                  name: '/templates/[name].[ext]',
+                  name: 'templates/[name].[ext]',
                   publicPath: distPath
                 }
               }
@@ -165,7 +165,7 @@ module.exports = ({isDeploy, noDeps}) => ({
             options: {
               // sharp's bindings.gyp is hardcoded to look for libvips 2 directories up
               // rather than do a custom build, we just output it 2 directories down (/node/binaries)
-              name: '/node/binaries/[name].[ext]'
+              name: 'node/binaries/[name].[ext]'
             }
           }
         ]


### PR DESCRIPTION
# Description

Removes a leading slash.
POSIX states that extra slashes get condensed to 1. Not sure why it's not working here...

Teaming this PR with Aaron directly on staging so no testing necessary 
