### PR TITLE
feat(rid): Enter edit mode automatically for new templates

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -205,6 +205,11 @@ const ActivityDetails = (props: Props) => {
 
   const [isEditing, setIsEditing] = useState(false)
 
+  useEffect(() => {
+    const params = new URLSearchParams(history.location.search)
+    setIsEditing(!!params.get('edit'))
+  }, [history.location.search, setIsEditing])
+
   useEffect(
     () =>
       selectedTemplate &&

--- a/packages/client/components/ActivityLibrary/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails.tsx
@@ -119,7 +119,7 @@ const ActivityDetails = (props: Props) => {
     (edge) => edge.node.id === templateId && SUPPORTED_TYPES.includes(edge.node.type)
   )?.node
 
-  const history = useHistory<{prevCategory?: string}>()
+  const history = useHistory<{prevCategory?: string; edit?: boolean}>()
 
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()
@@ -206,9 +206,8 @@ const ActivityDetails = (props: Props) => {
   const [isEditing, setIsEditing] = useState(false)
 
   useEffect(() => {
-    const params = new URLSearchParams(history.location.search)
-    setIsEditing(!!params.get('edit'))
-  }, [history.location.search, setIsEditing])
+    setIsEditing(!!history.location.state?.edit)
+  }, [history.location.state?.edit, setIsEditing])
 
   useEffect(
     () =>

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -189,8 +189,9 @@ export const CreateNewActivity = (props: Props) => {
         onCompleted: (res: AddReflectTemplateMutation$data) => {
           const templateId = res.addReflectTemplate?.reflectTemplate?.id
           if (templateId) {
-            history.push(`/activity-library/details/${templateId}?edit=1`, {
-              prevCategory: params.categoryId
+            history.push(`/activity-library/details/${templateId}`, {
+              prevCategory: params.categoryId,
+              edit: true
             })
           }
           onCompleted()
@@ -226,8 +227,9 @@ export const CreateNewActivity = (props: Props) => {
         onCompleted: (res: AddPokerTemplateMutation$data) => {
           const templateId = res.addPokerTemplate?.pokerTemplate?.id
           if (templateId) {
-            history.push(`/activity-library/details/${templateId}?edit=1`, {
-              prevCategory: params.categoryId
+            history.push(`/activity-library/details/${templateId}`, {
+              prevCategory: params.categoryId,
+              edit: true
             })
           }
           onCompleted()

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -189,7 +189,7 @@ export const CreateNewActivity = (props: Props) => {
         onCompleted: (res: AddReflectTemplateMutation$data) => {
           const templateId = res.addReflectTemplate?.reflectTemplate?.id
           if (templateId) {
-            history.push(`/activity-library/details/${templateId}`, {
+            history.push(`/activity-library/details/${templateId}?edit=1`, {
               prevCategory: params.categoryId
             })
           }
@@ -226,7 +226,7 @@ export const CreateNewActivity = (props: Props) => {
         onCompleted: (res: AddPokerTemplateMutation$data) => {
           const templateId = res.addPokerTemplate?.pokerTemplate?.id
           if (templateId) {
-            history.push(`/activity-library/details/${templateId}`, {
+            history.push(`/activity-library/details/${templateId}?edit=1`, {
               prevCategory: params.categoryId
             })
           }

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -99,7 +99,7 @@ const TeamPickerModal = (props: Props) => {
             closePortal()
             const templateId = res.addReflectTemplate?.reflectTemplate?.id
             if (templateId) {
-              history.push(`/activity-library/details/${templateId}`, {
+              history.push(`/activity-library/details/${templateId}?edit=1`, {
                 prevCategory: category
               })
             }
@@ -118,7 +118,7 @@ const TeamPickerModal = (props: Props) => {
             closePortal()
             const templateId = res.addPokerTemplate?.pokerTemplate?.id
             if (templateId) {
-              history.push(`/activity-library/details/${templateId}`, {
+              history.push(`/activity-library/details/${templateId}?edit=1`, {
                 prevCategory: category
               })
             }

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -99,8 +99,9 @@ const TeamPickerModal = (props: Props) => {
             closePortal()
             const templateId = res.addReflectTemplate?.reflectTemplate?.id
             if (templateId) {
-              history.push(`/activity-library/details/${templateId}?edit=1`, {
-                prevCategory: category
+              history.push(`/activity-library/details/${templateId}`, {
+                prevCategory: category,
+                edit: true
               })
             }
             onCompleted()
@@ -118,8 +119,9 @@ const TeamPickerModal = (props: Props) => {
             closePortal()
             const templateId = res.addPokerTemplate?.pokerTemplate?.id
             if (templateId) {
-              history.push(`/activity-library/details/${templateId}?edit=1`, {
-                prevCategory: category
+              history.push(`/activity-library/details/${templateId}`, {
+                prevCategory: category,
+                edit: true
               })
             }
             onCompleted()


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8151

Automatically enter edit mode from template cloning+creation via `edit` nav state.

## Demo
https://www.loom.com/share/4ebf1bb32d554e8c9ba27d480801ca17

## Testing scenarios
- [ ] Create new retro and poker templates, and confirm edit mode is entered automatically
- [ ] Clone retro and poker templates, and confirm edit mode is entered automatically
- [ ] Confirm edit mode is not entered when clicking into template from activity grid, even for templates with "New Template" and "X Copy" titles.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
