### PR TITLE
feat(recurrence): Prev/next meeting navigation

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
+import {Link} from 'react-router-dom'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
@@ -16,6 +17,7 @@ import {UpdateRecurrenceSettingsModal} from './Recurrence/UpdateRecurrenceSettin
 import {EndRecurringMeetingModal} from './Recurrence/EndRecurringMeetingModal'
 import {TeamPromptMeetingStatus} from './TeamPromptMeetingStatus'
 import TeamPromptOptions from './TeamPromptOptions'
+import {KeyboardArrowLeft, KeyboardArrowRight} from '@mui/icons-material'
 
 const TeamPromptLogoBlock = styled(LogoBlock)({
   marginRight: '8px',
@@ -94,6 +96,12 @@ const TeamPromptTopBar = (props: Props) => {
         id
         name
         facilitatorUserId
+        prevMeeting {
+          id
+        }
+        nextMeeting {
+          id
+        }
         meetingSeries {
           id
           cancelledAt
@@ -114,7 +122,14 @@ const TeamPromptTopBar = (props: Props) => {
     useModal({id: 'endRecurringMeetingModal'})
 
   const {viewerId} = atmosphere
-  const {id: meetingId, name: meetingName, facilitatorUserId, meetingSeries} = meeting
+  const {
+    id: meetingId,
+    name: meetingName,
+    facilitatorUserId,
+    meetingSeries,
+    prevMeeting,
+    nextMeeting
+  } = meeting
   const isFacilitator = viewerId === facilitatorUserId
   const {handleSubmit, validate, error} = useRenameMeeting(meetingId)
   const isRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
@@ -124,22 +139,36 @@ const TeamPromptTopBar = (props: Props) => {
       <MeetingTitleSection>
         <TeamPromptLogoBlock />
         <div>
-          {isFacilitator ? (
-            <EditableTeamPromptHeaderTitle
-              error={error?.message}
-              handleSubmit={handleSubmit}
-              initialValue={meetingName}
-              isWrap
-              maxLength={50}
-              validate={validate}
-              placeholder={'Best Meeting Ever!'}
-            />
-          ) : (
-            <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
-          )}
-          {isRecurrenceEnabled && (
-            <HumanReadableRecurrenceRule recurrenceRule={meetingSeries.recurrenceRule} />
-          )}
+          <div className='flex w-max gap-1'>
+            {isRecurrenceEnabled && prevMeeting && (
+              <Link className='text-slate-600' to={`/meet/${prevMeeting.id}`}>
+                <KeyboardArrowLeft />
+              </Link>
+            )}
+            <div>
+              {isFacilitator ? (
+                <EditableTeamPromptHeaderTitle
+                  error={error?.message}
+                  handleSubmit={handleSubmit}
+                  initialValue={meetingName}
+                  isWrap
+                  maxLength={50}
+                  validate={validate}
+                  placeholder={'Best Meeting Ever!'}
+                />
+              ) : (
+                <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
+              )}
+              {isRecurrenceEnabled && (
+                <HumanReadableRecurrenceRule recurrenceRule={meetingSeries.recurrenceRule} />
+              )}
+            </div>
+            {isRecurrenceEnabled && nextMeeting && (
+              <Link className='text-slate-600' to={`/meet/${nextMeeting.id}`}>
+                <KeyboardArrowRight />
+              </Link>
+            )}
+          </div>
         </div>
       </MeetingTitleSection>
       {isDesktop && (

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -6146,6 +6146,16 @@ type TeamPromptMeeting implements NewMeeting {
   The tasks created within the meeting
   """
   responses: [TeamPromptResponse!]!
+
+  """
+  The previous meeting in the series if this meeting is recurring
+  """
+  prevMeeting: TeamPromptMeeting
+
+  """
+  The next meeting in the series if this meeting is recurring
+  """
+  nextMeeting: TeamPromptMeeting
 }
 
 """

--- a/packages/server/graphql/public/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/public/types/TeamPromptMeeting.ts
@@ -12,57 +12,54 @@ const TeamPromptMeeting: TeamPromptMeetingResolvers = {
     return null
   },
   meetingSeries: async ({meetingSeriesId}, _args, {dataLoader}) => {
-    if (meetingSeriesId) {
-      const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
-      if (!series) {
-        return null
-      }
+    if (!meetingSeriesId) return null
 
-      return series
+    const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
+    if (!series) {
+      return null
     }
-    return null
+
+    return series
   },
   prevMeeting: async ({meetingSeriesId, createdAt}, _args, {dataLoader}) => {
-    if (meetingSeriesId) {
-      const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
-      if (!series || series.cancelledAt) {
-        return null
-      }
+    if (!meetingSeriesId) return null
 
-      const r = await getRethink()
-      const meetings = await r
-        .table('NewMeeting')
-        .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
-        .filter({meetingType: 'teamPrompt'})
-        .filter((row) => row('createdAt').lt(createdAt))
-        .orderBy(r.desc('createdAt'))
-        .limit(1)
-        .run()
-
-      return meetings[0] as MeetingTeamPrompt
+    const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
+    if (!series || series.cancelledAt) {
+      return null
     }
-    return null
+
+    const r = await getRethink()
+    const meetings = await r
+      .table('NewMeeting')
+      .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
+      .filter({meetingType: 'teamPrompt'})
+      .filter((row) => row('createdAt').lt(createdAt))
+      .orderBy(r.desc('createdAt'))
+      .limit(1)
+      .run()
+
+    return meetings[0] as MeetingTeamPrompt
   },
   nextMeeting: async ({meetingSeriesId, createdAt}, _args, {dataLoader}) => {
-    if (meetingSeriesId) {
-      const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
-      if (!series || series.cancelledAt) {
-        return null
-      }
+    if (!meetingSeriesId) return null
 
-      const r = await getRethink()
-      const meetings = await r
-        .table('NewMeeting')
-        .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
-        .filter({meetingType: 'teamPrompt'})
-        .filter((doc) => doc('createdAt').gt(createdAt))
-        .orderBy(r.asc('createdAt'))
-        .limit(1)
-        .run()
-
-      return meetings[0] as MeetingTeamPrompt
+    const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
+    if (!series || series.cancelledAt) {
+      return null
     }
-    return null
+
+    const r = await getRethink()
+    const meetings = await r
+      .table('NewMeeting')
+      .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
+      .filter({meetingType: 'teamPrompt'})
+      .filter((doc) => doc('createdAt').gt(createdAt))
+      .orderBy(r.asc('createdAt'))
+      .limit(1)
+      .run()
+
+    return meetings[0] as MeetingTeamPrompt
   }
 }
 

--- a/packages/server/graphql/public/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/public/types/TeamPromptMeeting.ts
@@ -1,5 +1,7 @@
 import MeetingSeriesId from 'parabol-client/shared/gqlIds/MeetingSeriesId'
 import {TeamPromptMeetingResolvers} from '../resolverTypes'
+import getRethink from '../../../database/rethinkDriver'
+import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 
 const TeamPromptMeeting: TeamPromptMeetingResolvers = {
   meetingSeriesId: ({meetingSeriesId}, _args, _context) => {
@@ -17,6 +19,48 @@ const TeamPromptMeeting: TeamPromptMeetingResolvers = {
       }
 
       return series
+    }
+    return null
+  },
+  prevMeeting: async ({meetingSeriesId, createdAt}, _args, {dataLoader}) => {
+    if (meetingSeriesId) {
+      const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
+      if (!series || series.cancelledAt) {
+        return null
+      }
+
+      const r = await getRethink()
+      const meetings = await r
+        .table('NewMeeting')
+        .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
+        .filter({meetingType: 'teamPrompt'})
+        .filter((row) => row('createdAt').lt(createdAt))
+        .orderBy(r.desc('createdAt'))
+        .limit(1)
+        .run()
+
+      return meetings[0] as MeetingTeamPrompt
+    }
+    return null
+  },
+  nextMeeting: async ({meetingSeriesId, createdAt}, _args, {dataLoader}) => {
+    if (meetingSeriesId) {
+      const series = await dataLoader.get('meetingSeries').load(meetingSeriesId)
+      if (!series || series.cancelledAt) {
+        return null
+      }
+
+      const r = await getRethink()
+      const meetings = await r
+        .table('NewMeeting')
+        .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
+        .filter({meetingType: 'teamPrompt'})
+        .filter((doc) => doc('createdAt').gt(createdAt))
+        .orderBy(r.asc('createdAt'))
+        .limit(1)
+        .run()
+
+      return meetings[0] as MeetingTeamPrompt
     }
     return null
   }


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8152

Adds prev+next buttons to recurring meetings to link to the previous or next meeting in the series, if applicable.

## Demo
https://www.loom.com/share/450680aacaaf44bca9b1a2d211e6cb29

## Testing scenarios
- [ ] For a recurring meeting with other meetings in the series, navigate back and forth through meetings.
- [ ] For non-recurring meetings, no buttons appear
- [ ] For recurring meetings with no other meetings in the series, no buttons appear.
- [ ] Prev/next buttons behave as links, and can be opened in new tabs

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
