### PR TITLE
chore: AI opt out at org level

### DIFF
--- a/packages/server/graphql/mutations/helpers/canAccessAISummary.ts
+++ b/packages/server/graphql/mutations/helpers/canAccessAISummary.ts
@@ -1,10 +1,16 @@
 import {Threshold} from 'parabol-client/types/constEnums'
 import {Team} from '../../../postgres/queries/getTeamsByIds'
+import {DataLoaderWorker} from '../../graphql'
 
-const canAccessAISummary = (team: Team, featureFlags: string[]) => {
+const canAccessAISummary = async (
+  team: Team,
+  featureFlags: string[],
+  dataLoader: DataLoaderWorker
+) => {
   if (featureFlags.includes('noAISummary') || !team) return false
-
-  const {qualAIMeetingsCount, tier} = team
+  const {qualAIMeetingsCount, tier, orgId} = team
+  const organization = await dataLoader.get('organizations').load(orgId)
+  if (organization.featureFlags?.includes('noAISummary')) return false
   if (tier !== 'starter') return true
   return qualAIMeetingsCount < Threshold.MAX_QUAL_AI_MEETINGS
 }

--- a/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
@@ -17,7 +17,8 @@ const generateDiscussionSummary = async (
     dataLoader.get('users').loadNonNull(facilitatorUserId),
     dataLoader.get('teams').loadNonNull(teamId)
   ])
-  if (!canAccessAISummary(team, facilitator.featureFlags)) return
+  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  if (!isAISummaryAccessible) return
   const [comments, tasks] = await Promise.all([
     dataLoader.get('commentsByDiscussionId').load(discussionId),
     dataLoader.get('tasksByDiscussionId').load(discussionId)

--- a/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
@@ -14,7 +14,8 @@ const generateGroupSummaries = async (
     dataLoader.get('users').loadNonNull(facilitatorUserId),
     dataLoader.get('teams').loadNonNull(teamId)
   ])
-  if (!canAccessAISummary(team, facilitator.featureFlags)) return
+  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  if (!isAISummaryAccessible) return
   const [reflections, reflectionGroups] = await Promise.all([
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId),
     dataLoader.get('retroReflectionGroupsByMeetingId').load(meetingId)

--- a/packages/server/graphql/mutations/helpers/generateWholeMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateWholeMeetingSummary.ts
@@ -16,7 +16,8 @@ const generateWholeMeetingSummary = async (
     dataLoader.get('users').loadNonNull(facilitatorUserId),
     dataLoader.get('teams').loadNonNull(teamId)
   ])
-  if (!canAccessAISummary(team, facilitator.featureFlags)) return
+  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  if (!isAISummaryAccessible) return
   const [commentsByDiscussions, tasksByDiscussions, reflections] = await Promise.all([
     dataLoader.get('commentsByDiscussionId').loadMany(discussionIds),
     dataLoader.get('tasksByDiscussionId').loadMany(discussionIds),

--- a/packages/server/graphql/private/typeDefs/addFeatureFlagToOrg.graphql
+++ b/packages/server/graphql/private/typeDefs/addFeatureFlagToOrg.graphql
@@ -6,6 +6,7 @@ enum OrganizationFeatureFlagsEnum {
   SAMLUI
   promptToJoinOrg
   suggestGroups
+  noAISummary
 }
 
 extend type Mutation {

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -172,4 +172,5 @@ type OrganizationFeatureFlags {
   SAMLUI: Boolean!
   promptToJoinOrg: Boolean!
   suggestGroups: Boolean!
+  noAISummary: Boolean!
 }

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -4,7 +4,8 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   SAMLUI: ({SAMLUI}) => !!SAMLUI,
   teamsLimit: ({teamsLimit}) => !!teamsLimit,
   suggestGroups: ({suggestGroups}) => !!suggestGroups,
-  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg
+  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg,
+  noAISummary: ({noAISummary}) => !!noAISummary
 }
 
 export default OrganizationFeatureFlags


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8023

I'd like to:
- Add this org level feature flag
- Once it's in prod, get all of the org ids of the users that have opted out so far
- Add this feature flag to all of those orgs
- Remove the user feature flag

If you're happy with this approach, I'll create an issue to remove the `noAISummary` feature flag.

### To test

- [ ] Add the `noAISummary` org feature flag
- [ ] Create a retro and see that none of the AI Summaries are generated