### PR TITLE
chore: ignore generated files in PR size

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,4 +24,7 @@ jobs:
             This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR will be delayed and might be rejected due to its size.
-          files_to_ignore: "generated/**"
+          files_to_ignore: |
+            "generated/**"
+            "yarn.lock"
+            "pg.d.ts"


### PR DESCRIPTION
# Description

My PRs aren't that big, honest! They just trigger generated file changes.
This ignores generated files that are checked into version control.