### PR TITLE
fix: more logs for voting error

### DIFF
--- a/packages/client/components/PokerActiveVoting.tsx
+++ b/packages/client/components/PokerActiveVoting.tsx
@@ -5,11 +5,11 @@ import React, {useMemo} from 'react'
 import {useFragment} from 'react-relay'
 import useMutationProps from '~/hooks/useMutationProps'
 import {PALETTE} from '~/styles/paletteV3'
+import {PokerActiveVoting_meeting$key} from '../__generated__/PokerActiveVoting_meeting.graphql'
+import {PokerActiveVoting_stage$key} from '../__generated__/PokerActiveVoting_stage.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import PokerRevealVotesMutation from '../mutations/PokerRevealVotesMutation'
 import {BezierCurve, PokerCards} from '../types/constEnums'
-import {PokerActiveVoting_meeting$key} from '../__generated__/PokerActiveVoting_meeting.graphql'
-import {PokerActiveVoting_stage$key} from '../__generated__/PokerActiveVoting_stage.graphql'
 import AvatarList from './AvatarList'
 import CircularProgress from './CircularProgress'
 import MiniPokerCard from './MiniPokerCard'
@@ -40,9 +40,10 @@ const RevealButtonBlock = styled('div')({
 
 const StyledError = styled('div')({
   paddingLeft: 8,
+  paddingTop: 4,
   fontSize: 14,
   color: PALETTE.TOMATO_500,
-  fontWeight: 400
+  fontWeight: 600
 })
 
 const RevealLabel = styled('div')<{color: string}>(({color}) => ({
@@ -172,7 +173,7 @@ const PokerActiveVoting = (props: Props) => {
       </PokerVotingRowBase>
       <RevealButtonBlock>
         {showRevealButton && (
-          <RevealButton onClick={reveal} color={PALETTE.SLATE_600}>
+          <RevealButton disabled={submitting} onClick={reveal} color={PALETTE.SLATE_600}>
             <Progress radius={22} thickness={4} stroke={PALETTE.JADE_400} progress={votePercent} />
             <RevealButtonIcon color={allVotesIn ? PALETTE.JADE_400 : PALETTE.SLATE_400}>
               <CheckIcon />

--- a/packages/client/mutations/PokerRevealVotesMutation.ts
+++ b/packages/client/mutations/PokerRevealVotesMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {StandardMutation} from '../types/relayMutations'
 import {PokerRevealVotesMutation as TPokerRevealVotesMutation} from '../__generated__/PokerRevealVotesMutation.graphql'
+import {StandardMutation} from '../types/relayMutations'
 
 graphql`
   fragment PokerRevealVotesMutation_meeting on PokerRevealVotesSuccess {
@@ -36,12 +36,7 @@ const PokerRevealVotesMutation: StandardMutation<TPokerRevealVotesMutation> = (
   return commitMutation<TPokerRevealVotesMutation>(atmosphere, {
     mutation,
     variables,
-    optimisticUpdater: (store) => {
-      const {stageId} = variables
-      const stage = store.get(stageId)
-      if (!stage) return
-      stage.setValue(false, 'isVoting')
-    },
+    // don't be optimistic, we don't know what the scores will be
     onCompleted,
     onError
   })

--- a/packages/server/graphql/mutations/pokerRevealVotes.ts
+++ b/packages/server/graphql/mutations/pokerRevealVotes.ts
@@ -1,6 +1,5 @@
 import {GraphQLID, GraphQLNonNull} from 'graphql'
 import {PokerCards, SubscriptionChannel} from 'parabol-client/types/constEnums'
-import isPhaseComplete from 'parabol-client/utils/meetings/isPhaseComplete'
 import {RValue} from '../../database/stricterR'
 import EstimateUserScore from '../../database/types/EstimateUserScore'
 import MeetingPoker from '../../database/types/MeetingPoker'
@@ -52,9 +51,6 @@ const pokerRevealVotes = {
     }
     if (meetingType !== 'poker') {
       return {error: {message: 'Not a poker meeting'}}
-    }
-    if (isPhaseComplete('ESTIMATE', phases)) {
-      return {error: {message: 'Estimate phase is already complete'}}
     }
     if (viewerId !== facilitatorUserId) {
       if (viewerId !== createdBy) {


### PR DESCRIPTION
# Description

fix #8158

- removes optimistic updater so error shows up
- disables reveal button when it's already in flight so you can't click twice
- removes check for estimate phase having ended. Not sure, but if i had to bet, I'd say this is the server error they were hitting

## Demo

<img width="210" alt="Screenshot 2023-05-05 at 2 32 26 PM" src="https://user-images.githubusercontent.com/5514175/236574109-8e63b98e-1c77-465a-ad00-676aa8d56426.png">

## Testing scenarios

- can't reproduce the error that the user saw, so no great testing here 😕 