### PR TITLE
chore(prompt-to-join): domainJoinRequest replace string id with auto increment

### DIFF
--- a/packages/server/graphql/public/mutations/requestToJoinDomain.ts
+++ b/packages/server/graphql/public/mutations/requestToJoinDomain.ts
@@ -9,7 +9,6 @@ import NotificationRequestToJoinOrg from '../../../database/types/NotificationRe
 import publishNotification from './helpers/publishNotification'
 import getDomainFromEmail from '../../../utils/getDomainFromEmail'
 import standardError from '../../../utils/standardError'
-import generateUID from '../../../generateUID'
 
 const REQUEST_EXPIRATION_DAYS = 30
 
@@ -36,7 +35,6 @@ const requestToJoinDomain: MutationResolvers['requestToJoinDomain'] = async (
   const insertResult = await pg
     .insertInto('DomainJoinRequest')
     .values({
-      id: generateUID(),
       createdBy: viewerId,
       domain,
       expiresAt: new Date(now.getTime() + ms(`${REQUEST_EXPIRATION_DAYS}d`))

--- a/packages/server/postgres/migrations/1683902222006_domainJoinRequestAutoIncrementId.ts
+++ b/packages/server/postgres/migrations/1683902222006_domainJoinRequestAutoIncrementId.ts
@@ -1,0 +1,39 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    DROP TABLE IF EXISTS "DomainJoinRequest";
+
+    CREATE TABLE IF NOT EXISTS "DomainJoinRequest" (
+      "id" SERIAL PRIMARY KEY,
+      "createdBy" VARCHAR(100) NOT NULL,
+      "domain" VARCHAR(100) CHECK (lower(domain) = domain) NOT NULL,
+      "expiresAt" TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+      "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+      FOREIGN KEY("createdBy")
+        REFERENCES "User"("id")
+        ON DELETE CASCADE
+    );
+    
+    CREATE UNIQUE INDEX IF NOT EXISTS "DomainJoinRequest_createdBy_domain_unique"
+    ON "DomainJoinRequest" ("createdBy", "domain");
+    
+    DROP TRIGGER IF EXISTS "update_DomainJoinRequest_updatedAt" ON "DomainJoinRequest";
+    CREATE TRIGGER "update_DomainJoinRequest_updatedAt" BEFORE UPDATE ON "DomainJoinRequest" FOR EACH ROW EXECUTE PROCEDURE "set_updatedAt"();
+  `)
+
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    DROP TABLE IF EXISTS "DomainJoinRequest";
+  `)
+  await client.end()
+}

--- a/packages/server/postgres/pg.d.ts
+++ b/packages/server/postgres/pg.d.ts
@@ -181,6 +181,15 @@ export interface MeetingTemplate {
   type: 'action' | 'poker' | 'retrospective' | 'teamPrompt'
   isStarter: Generated<boolean>
   isFree: Generated<boolean>
+  illustrationUrl: string | null
+  hideStartingAt: Timestamp | null
+  hideEndingAt: Timestamp | null
+  mainCategory: string | null
+}
+
+export interface MeetingTemplateUserFavorite {
+  userId: string
+  templateId: string
 }
 
 export interface OrganizationApprovedDomain {
@@ -336,6 +345,7 @@ export interface DB {
   JiraServerDimensionFieldMap: JiraServerDimensionFieldMap
   MeetingSeries: MeetingSeries
   MeetingTemplate: MeetingTemplate
+  MeetingTemplateUserFavorite: MeetingTemplateUserFavorite
   OrganizationApprovedDomain: OrganizationApprovedDomain
   OrganizationUserAudit: OrganizationUserAudit
   Poll: Poll


### PR DESCRIPTION
Based on discussion here I change string id back to auto-increment


How to test:

- Run migration (it will clear all old data)
- Click on `request to join org` in the snackbar, see that new request is created, see that you can open add teammate modal

Old notifications might not work, but I decided to not include a fix, as the feature is not released yet
