### PR TITLE
fix: slack notification race condition

### DIFF
--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -91,6 +91,7 @@ const finishRetroMeeting = async (meeting: MeetingRetrospective, context: GQLCon
       {nonAtomic: true}
     )
     .run()
+  dataLoader.get('newMeetings').clear(meetingId)
   // wait for whole meeting summary to be generated before sending summary email and updating qualAIMeetingCount
   sendNewMeetingSummary(meeting, context).catch(console.log)
   updateQualAIMeetingsCount(meetingId, teamId, dataLoader)

--- a/packages/server/graphql/mutations/helpers/generateWholeMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateWholeMeetingSummary.ts
@@ -1,5 +1,4 @@
 import {PARABOL_AI_USER_ID} from 'parabol-client/utils/constants'
-import getRethink from '../../../database/rethinkDriver'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import {DataLoaderWorker} from '../../graphql'
 import isValid from '../../isValid'
@@ -37,12 +36,9 @@ const generateWholeMeetingSummary = async (
     .flatMap((tasksByDiscussion) => tasksByDiscussion.map(({plaintextContent}) => plaintextContent))
   const contentToSummarize = [...commentsContent, ...tasksContent, ...reflectionsContent]
   if (contentToSummarize.length <= 1) return
-  const [r, summary] = await Promise.all([getRethink(), manager.getSummary(contentToSummarize)])
+  const summary = await manager.getSummary(contentToSummarize)
   if (!summary) return
-  await Promise.all([
-    dataLoader.get('newMeetings').updateCache(meetingId, {summary}),
-    r.table('NewMeeting').get(meetingId).update({summary}).run()
-  ])
+  return summary
 }
 
 export default generateWholeMeetingSummary

--- a/packages/server/graphql/types/NewMeeting.ts
+++ b/packages/server/graphql/types/NewMeeting.ts
@@ -153,7 +153,7 @@ export const newMeetingFields = () => ({
   },
   summary: {
     type: GraphQLString,
-    description: `The GPT-3 generated summary of all the content in the meeting, such as reflections, tasks, and comments. Undefined if the user doesnt have access to the feature or it's unavailable in this meeting type`
+    description: `The OpenAI generated summary of all the content in the meeting, such as reflections, tasks, and comments. Undefined if the user doesnt have access to the feature or it's unavailable in this meeting type`
   },
   sentimentScore: {
     type: GraphQLFloat,


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7674

Occasionally, the Slack stats are all 0. This could be because:
- The `generateWholeMeetingSummary` is updating the meeting object at the same time the Slack stats are being inserted into the meeting object.
- The meeting object cache is stale when the `SlackNotifier` requests it

### To test

- [ ] End a retro and see an AI Summary and a Slack notification with the accurate meeting stats