### PR TITLE
chore: improve rate limit error handling

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -48,7 +48,6 @@ class OpenAIServerManager {
         }
         return null
       }
-
       const error = new Error('OpenAI failed to getSummary')
       sendToSentry(error)
       return null


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8200

The Sentry error logs suggest it's an axios error. By sending the `data.error` to Sentry, we should be able to find out if it's an RPM or TPM limit.

I haven't included testing steps in this PR as I'm not sure how you can test it unless you hit a 429 error. 