### PR TITLE
feat(rid): Navigate to activity lib by default from CTA

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
-import {useRouteMatch} from 'react-router'
+import {useLocation, useRouteMatch} from 'react-router'
 import {PALETTE} from '../../styles/paletteV3'
 import {NavSidebar} from '../../types/constEnums'
 import {BILLING_PAGE, MEMBERS_PAGE} from '../../utils/constants'
@@ -10,6 +10,7 @@ import {DashSidebar_viewer$key} from '../../__generated__/DashSidebar_viewer.gra
 import DashNavList from '../DashNavList/DashNavList'
 import SideBarStartMeetingButton from '../SideBarStartMeetingButton'
 import LeftDashNavItem from './LeftDashNavItem'
+import getTeamIdFromPathname from '../../utils/getTeamIdFromPathname'
 
 const Nav = styled('nav')<{isOpen: boolean}>(({isOpen}) => ({
   // 78px is total height of 'Add meeting' block
@@ -90,6 +91,8 @@ const DashSidebar = (props: Props) => {
     viewerRef
   )
 
+  const location = useLocation()
+
   if (!viewer) return null
   const {featureFlags, organizations} = viewer
   const showOrgSidebar = featureFlags.checkoutFlow && match
@@ -100,7 +103,7 @@ const DashSidebar = (props: Props) => {
     const {id: orgId, name} = currentOrg ?? {}
     return (
       <Wrapper>
-        <SideBarStartMeetingButton isOpen={isOpen} />
+        <SideBarStartMeetingButton isOpen={isOpen} hasRid={featureFlags.retrosInDisguise} />
         <Nav isOpen={isOpen}>
           <Contents>
             <NavItemsWrap>
@@ -123,16 +126,15 @@ const DashSidebar = (props: Props) => {
     )
   }
 
+  const teamId = getTeamIdFromPathname()
+
   return (
     <Wrapper>
-      <SideBarStartMeetingButton isOpen={isOpen} />
+      <SideBarStartMeetingButton isOpen={isOpen} hasRid={featureFlags.retrosInDisguise} />
       <Nav isOpen={isOpen}>
         <Contents>
           <NavItemsWrap>
             <NavItem icon={'forum'} href={'/meetings'} label={'Meetings'} />
-            {featureFlags.retrosInDisguise && (
-              <NavItem icon={'magic'} href={'/activity-library'} label={'Activity Library'} />
-            )}
             <NavItem icon={'history'} href={'/me'} label={'History'} />
             <NavItem icon={'playlist_add_check'} href={'/me/tasks'} label={'Tasks'} />
           </NavItemsWrap>
@@ -143,6 +145,17 @@ const DashSidebar = (props: Props) => {
           <DashHR />
           <NavItemsWrap>
             <NavItem icon={'add'} href={'/newteam/1'} label={'Add a Team'} />
+          </NavItemsWrap>
+          <DashHR />
+          <NavItemsWrap>
+            {featureFlags.retrosInDisguise && (
+              <NavItem
+                icon={'magic'}
+                href={`/new-meeting/${teamId}`}
+                navState={{backgroundLocation: location}}
+                label={'Add meeting (legacy)'}
+              />
+            )}
           </NavItemsWrap>
         </Contents>
       </Nav>

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -73,16 +73,17 @@ interface Props {
   onClick?: () => void
   label: string
   href: string
+  navState?: unknown
   //FIXME 6062: change to React.ComponentType
   icon: keyof typeof iconLookup
 }
 
 const LeftDashNavItem = (props: Props) => {
-  const {className, label, icon, href, onClick} = props
+  const {className, label, icon, href, navState, onClick} = props
   const history = useHistory()
   const match = useRouteMatch(href)
   const handleClick = () => {
-    history.push(href)
+    history.push(href, navState)
     onClick?.()
   }
   return (

--- a/packages/client/components/SideBarStartMeetingButton.tsx
+++ b/packages/client/components/SideBarStartMeetingButton.tsx
@@ -30,13 +30,17 @@ const MeetingLabel = styled('div')<{isOpen: boolean}>(({isOpen}) => ({
   opacity: isOpen ? 1 : 0
 }))
 
-const SideBarStartMeetingButton = ({isOpen}: {isOpen: boolean}) => {
+const SideBarStartMeetingButton = ({isOpen, hasRid}: {isOpen: boolean; hasRid: boolean}) => {
   const location = useLocation()
   const teamId = getTeamIdFromPathname()
   const {history} = useRouter()
 
   const onClick = () => {
-    history.replace(`/new-meeting/${teamId}`, {backgroundLocation: location})
+    if (hasRid) {
+      history.push('/activity-library')
+    } else {
+      history.replace(`/new-meeting/${teamId}`, {backgroundLocation: location})
+    }
   }
   return (
     <Button isOpen={isOpen} onClick={onClick}>


### PR DESCRIPTION
# Description
Fixes https://github.com/ParabolInc/parabol/issues/8203

For RiD feature-flagged users (currently just internal users), navigate to the activity library by default, with a link to the "legacy" flow further down the nav bar. This is intended to promote the activity library from "here's something you can try out" to "here's something you should be using to start your meetings whenever possible" for internal Parabol users.

This should promote increased internal usage, allowing us to get more user feedback and identify more bugs.

## Demo
Before:
<img width="410" alt="Screen Shot 2023-05-16 at 3 57 49 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/cdafa924-05db-4aa0-89cc-b1c508d64aaf">


After:
<img width="377" alt="Screen Shot 2023-05-16 at 3 57 25 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/ffd073c0-dca2-4290-98ae-081c788d79a7">


## Testing scenarios
- [ ] For feature flagged user:
  - [ ] "Add meeting" CTA goes to activity library
  - [ ] "Add meeting (legacy)" nav button goes to existing add meeting flow
- [ ] For non feature flagged user:
  - [ ] "Add meeting" CTA goes to existing flow

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
