### PR TITLE
fix(rid): Navigate to activity lib for floating action button

### DIFF
--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -45,6 +45,9 @@ const MeetingsDash = (props: Props) => {
         id
         dashSearch
         preferredName
+        featureFlags {
+          retrosInDisguise
+        }
         teams {
           ...MeetingsDashActiveMeetings @relay(mask: false)
         }
@@ -52,7 +55,12 @@ const MeetingsDash = (props: Props) => {
     `,
     viewerRef
   )
-  const {teams = [], preferredName = '', dashSearch} = viewer ?? {}
+  const {
+    teams = [],
+    preferredName = '',
+    dashSearch,
+    featureFlags = {retrosInDisguise: false}
+  } = viewer ?? {}
   const activeMeetings = useMemo(() => {
     const meetings = teams
       .flatMap((team) => team.activeMeetings)
@@ -124,7 +132,7 @@ const MeetingsDash = (props: Props) => {
           </Wrapper>
         </EmptyContainer>
       )}
-      <StartMeetingFAB />
+      <StartMeetingFAB hasRid={featureFlags.retrosInDisguise} />
     </>
   )
 }

--- a/packages/client/components/StartMeetingFAB.tsx
+++ b/packages/client/components/StartMeetingFAB.tsx
@@ -51,11 +51,12 @@ const MeetingLabel = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
 
 interface Props {
   className?: string
+  hasRid: boolean
 }
 
 const StartMeetingFAB = (props: Props) => {
   const location = useLocation()
-  const {className} = props
+  const {className, hasRid} = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const teamId = getTeamIdFromPathname()
   const {history} = useRouter()
@@ -91,7 +92,11 @@ const StartMeetingFAB = (props: Props) => {
     }
   }
   const onClick = () => {
-    history.replace(`/new-meeting/${teamId}`, {backgroundLocation: location})
+    if (hasRid) {
+      history.push('/activity-library')
+    } else {
+      history.replace(`/new-meeting/${teamId}`, {backgroundLocation: location})
+    }
   }
   // We use the SideBarStartMeetingButton in this case
   if (isDesktop) {

--- a/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
@@ -57,6 +57,9 @@ const TeamDashMain = (props: Props) => {
             name
             ...TeamTasksHeaderContainer_team
           }
+          featureFlags {
+            retrosInDisguise
+          }
           ...TeamColumnsContainer_viewer
           ...TeamDrawer_viewer
         }
@@ -79,7 +82,7 @@ const TeamDashMain = (props: Props) => {
         <TasksContent>
           <TeamColumnsContainer viewer={viewer} />
         </TasksContent>
-        <AbsoluteFab />
+        <AbsoluteFab hasRid={viewer.featureFlags.retrosInDisguise} />
       </TasksMain>
       <TeamDrawer viewer={viewer} />
     </RootBlock>

--- a/packages/client/modules/userDashboard/components/UserDashMain/UserDashMain.tsx
+++ b/packages/client/modules/userDashboard/components/UserDashMain/UserDashMain.tsx
@@ -1,11 +1,16 @@
 import React, {lazy, Suspense} from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {UserDashMainQuery} from '~/__generated__/UserDashMainQuery.graphql'
 import {Route, RouteComponentProps, Switch} from 'react-router'
 import DashContent from '~/components/Dashboard/DashContent'
 import LoadingComponent from '../../../../components/LoadingComponent/LoadingComponent'
 import StartMeetingFAB from '../../../../components/StartMeetingFAB'
 import {LoaderSize} from '../../../../types/constEnums'
 
-interface Props extends RouteComponentProps {}
+interface Props extends RouteComponentProps {
+  queryRef: PreloadedQuery<UserDashMainQuery>
+}
 
 const UserTaskViewRoot = lazy(
   () =>
@@ -19,7 +24,23 @@ const MyDashboardTimelineRoot = lazy(
 )
 
 const UserDashMain = (props: Props) => {
-  const {match} = props
+  const {match, queryRef} = props
+
+  const data = usePreloadedQuery<UserDashMainQuery>(
+    graphql`
+      query UserDashMainQuery {
+        viewer {
+          featureFlags {
+            retrosInDisguise
+          }
+        }
+      }
+    `,
+    queryRef
+  )
+
+  const {viewer} = data
+
   return (
     <DashContent>
       <Suspense fallback={<LoadingComponent spinnerSize={LoaderSize.PANEL} />}>
@@ -28,7 +49,7 @@ const UserDashMain = (props: Props) => {
           <Route path={match.url} component={MyDashboardTimelineRoot} />
         </Switch>
       </Suspense>
-      <StartMeetingFAB />
+      <StartMeetingFAB hasRid={viewer.featureFlags.retrosInDisguise} />
     </DashContent>
   )
 }

--- a/packages/client/modules/userDashboard/components/UserDashMain/UserDashMainRoot.tsx
+++ b/packages/client/modules/userDashboard/components/UserDashMain/UserDashMainRoot.tsx
@@ -1,0 +1,14 @@
+import React, {Suspense} from 'react'
+import useQueryLoaderNow from '~/hooks/useQueryLoaderNow'
+import userDashMainQuery, {UserDashMainQuery} from '~/__generated__/UserDashMainQuery.graphql'
+import UserDashMain from './UserDashMain'
+import {RouteComponentProps} from 'react-router'
+
+const UserDashMainRoot = (props: RouteComponentProps) => {
+  const queryRef = useQueryLoaderNow<UserDashMainQuery>(userDashMainQuery)
+  return (
+    <Suspense fallback={''}>{queryRef && <UserDashMain queryRef={queryRef} {...props} />}</Suspense>
+  )
+}
+
+export default UserDashMainRoot

--- a/packages/client/modules/userDashboard/components/UserDashboard/UserDashboard.tsx
+++ b/packages/client/modules/userDashboard/components/UserDashboard/UserDashboard.tsx
@@ -15,7 +15,7 @@ const Organization = lazy(
     )
 )
 const UserDashMain = lazy(
-  () => import(/* webpackChunkName: 'UserDashMain' */ '../UserDashMain/UserDashMain')
+  () => import(/* webpackChunkName: 'UserDashMain' */ '../UserDashMain/UserDashMainRoot')
 )
 const UserProfile = lazy(
   () => import(/* webpackChunkName: 'UserProfileRoot' */ '../UserProfileRoot')


### PR DESCRIPTION
# Description
In https://github.com/ParabolInc/parabol/pull/8210, we didn't update the floating action button, so tablet/mobile views would still navigate to the existing new meeting flow.

Fix that.

## Testing scenarios
- [ ] Test the FAB on the meeting dash, user dash, and team dash, both for feature flagged and non-feature flagged users.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
