### PR TITLE
chore(metrics): Add event parameter is_patient_0 to GA4 sign up events

### DIFF
--- a/packages/client/utils/handleSuccessfulLogin.ts
+++ b/packages/client/utils/handleSuccessfulLogin.ts
@@ -31,7 +31,8 @@ const emitGA4SignUpEvent = (args: GA4SignUpEventEmissionRequiredArgs) => {
       userId,
       user_properties: {
         is_patient_0: isPatient0
-      }
+      },
+      is_patient_0: isPatient0
     })
   }
 }


### PR DESCRIPTION
# Description

Patient 0 tracking in GA4 is still weird... This is yet another try.

I'd like to create a custom event `p0_sign_up`:

<img width="1044" alt="Screenshot 2023-05-17 at 15 47 32" src="https://github.com/ParabolInc/parabol/assets/1879975/e3f1bd59-034f-4f1a-81d9-26f79f43e36c">

To do that, I need an **event level parameter** `is_patient_0` hence this small PR

## Demo

<img width="960" alt="Screenshot 2023-05-17 at 15 41 56" src="https://github.com/ParabolInc/parabol/assets/1879975/77202f41-525f-471f-8b0a-7e99055788c7">

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
