### PR TITLE
fix: Add subject explicitly to create Jira key script

### DIFF
--- a/scripts/create-jira-keys.sh
+++ b/scripts/create-jira-keys.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 openssl genrsa -out jira_privatekey.pem 1024
-openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365 -batch
+openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365 -subj "/C=US/O=Parabol, Inc./CN=parabol.co"
 openssl pkcs8 -topk8 -nocrypt -in jira_privatekey.pem -out jira_privatekey.pcks8
 openssl x509 -pubkey -noout -in jira_publickey.cer  > jira_publickey.pem
 openssl rand -base64 32 >consumerKey


### PR DESCRIPTION
If not supplied explicitly, these values will be taken from the local config file. These values might not be appropriate or totally absent causing the script to fail.

## Testing scenarios

Explicitly supply an empty configuration and run the script. It would fail on master but succeed with this PR
```sh
cd parabol
mkdir foo && cd foo
OPENSSL_CONF='' ../scripts/create-jira-keys.sh
```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
