### PR TITLE
chore: refactor addFeatureFlagToOrg to updateOrgFeatureFlag

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -10,7 +10,7 @@
       "config": {
         "contextType": "../graphql#InternalContext",
         "mappers": {
-          "AddFeatureFlagToOrgSuccess": "./types/AddFeatureFlagToOrgSuccess#AddFeatureFlagToOrgSuccessSource",
+          "UpdateOrgFeatureFlagSuccess": "./types/UpdateOrgFeatureFlagSuccess#UpdateOrgFeatureFlagSuccessSource",
           "ChangeEmailDomainSuccess": "./types/ChangeEmailDomainSuccess#ChangeEmailDomainSuccessSource",
           "Company": "./queries/company#CompanySource",
           "DraftEnterpriseInvoicePayload": "./types/DraftEnterpriseInvoicePayload#DraftEnterpriseInvoicePayloadSource",

--- a/packages/server/graphql/private/mutations/updateOrgFeatureFlag.ts
+++ b/packages/server/graphql/private/mutations/updateOrgFeatureFlag.ts
@@ -1,7 +1,7 @@
 import getRethink from '../../../database/rethinkDriver'
 import {MutationResolvers} from '../resolverTypes'
 
-const addFeatureFlagToOrg: MutationResolvers['addFeatureFlagToOrg'] = async (
+const updateOrgFeatureFlag: MutationResolvers['updateOrgFeatureFlag'] = async (
   _source,
   {orgIds, flag}
 ) => {
@@ -30,4 +30,4 @@ const addFeatureFlagToOrg: MutationResolvers['addFeatureFlagToOrg'] = async (
   return {updatedOrgIds}
 }
 
-export default addFeatureFlagToOrg
+export default updateOrgFeatureFlag

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -23,6 +23,10 @@ extend type Mutation {
     the flag that you want to give to the organization
     """
     flag: OrganizationFeatureFlagsEnum!
+    """
+    whether or not you want to give the organization the flag
+    """
+    addFlag: Boolean!
   ): UpdateOrgFeatureFlagPayload!
 }
 

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -13,7 +13,7 @@ extend type Mutation {
   """
   Give some organizations advanced features in a flag
   """
-  addFeatureFlagToOrg(
+  updateOrgFeatureFlag(
     """
     a list of organization ids
     """
@@ -23,12 +23,12 @@ extend type Mutation {
     the flag that you want to give to the organization
     """
     flag: OrganizationFeatureFlagsEnum!
-  ): AddFeatureFlagToOrgPayload!
+  ): UpdateOrgFeatureFlagPayload!
 }
 
-union AddFeatureFlagToOrgPayload = ErrorPayload | AddFeatureFlagToOrgSuccess
+union UpdateOrgFeatureFlagPayload = ErrorPayload | UpdateOrgFeatureFlagSuccess
 
-type AddFeatureFlagToOrgSuccess {
+type UpdateOrgFeatureFlagSuccess {
   """
   the organizations given the super power
   """

--- a/packages/server/graphql/private/types/UpdateOrgFeatureFlagSuccess.ts
+++ b/packages/server/graphql/private/types/UpdateOrgFeatureFlagSuccess.ts
@@ -1,11 +1,11 @@
 import isValid from '../../isValid'
-import {AddFeatureFlagToOrgSuccessResolvers} from '../resolverTypes'
+import {UpdateOrgFeatureFlagSuccessResolvers} from '../resolverTypes'
 
-export type AddFeatureFlagToOrgSuccessSource =
+export type UpdateOrgFeatureFlagSuccessSource =
   | {updatedOrgIds: string[]}
   | {error: {message: string}}
 
-const AddFeatureFlagToOrgSuccess: AddFeatureFlagToOrgSuccessResolvers = {
+const UpdateOrgFeatureFlagSuccess: UpdateOrgFeatureFlagSuccessResolvers = {
   updatedOrganizations: async (source, _args, {dataLoader}) => {
     if ('error' in source) return []
     const {updatedOrgIds} = source
@@ -14,4 +14,4 @@ const AddFeatureFlagToOrgSuccess: AddFeatureFlagToOrgSuccessResolvers = {
   }
 }
 
-export default AddFeatureFlagToOrgSuccess
+export default UpdateOrgFeatureFlagSuccess


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8243

I don't see any documentation in Notion about an org feature flag, so I created my own: https://www.notion.so/parabol/How-to-enable-or-remove-an-org-feature-flag-4b4be190ed674bf8903340d6b5fa50e4

### To test

- [ ] Can add an org feature flag
- [ ] Can remove an org feature flag