### PR TITLE
fix: NewMeeting dialog rendered the dashboard twice

### DIFF
--- a/packages/client/components/Dashboard.tsx
+++ b/packages/client/components/Dashboard.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import {Location} from 'history'
 import React, {lazy, useRef} from 'react'
 import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
-import {Route, Switch, useLocation} from 'react-router'
+import {Route, Switch} from 'react-router'
 import useBreakpoint from '~/hooks/useBreakpoint'
 import useSnackNag from '~/hooks/useSnackNag'
 import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
@@ -40,10 +39,6 @@ const NewTeam = lazy(
       /* webpackChunkName: 'NewTeamRoot' */ '../modules/newTeam/containers/NewTeamForm/NewTeamRoot'
     )
 )
-const NewMeetingRoot = lazy(
-  () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
-)
-
 interface Props {
   queryRef: PreloadedQuery<DashboardQuery>
 }
@@ -135,9 +130,6 @@ const Dashboard = (props: Props) => {
   useSnacksForNewMeetings(activeMeetings)
   useNewFeatureSnackbar(viewer)
 
-  const location = useLocation<{backgroundLocation?: Location}>()
-  const state = location.state
-
   return (
     <DashLayout>
       <SkipLink href='#main'>Skip to content</SkipLink>
@@ -155,7 +147,7 @@ const Dashboard = (props: Props) => {
           </SwipeableDashSidebar>
         )}
         <DashMain id='main' ref={meetingsDashRef}>
-          <Switch location={state?.backgroundLocation || location}>
+          <Switch>
             <Route
               path='(/meetings|/new-meeting)'
               render={(routeProps) => (
@@ -166,9 +158,6 @@ const Dashboard = (props: Props) => {
             <Route path='/team/:teamId' component={TeamRoot} />
             <Route path='/newteam/:defaultOrgId?' component={NewTeam} />
             <Route path='/usage' component={InsightsRoot} />
-          </Switch>
-          <Switch>
-            <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
           </Switch>
         </DashMain>
       </DashPanel>

--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -49,6 +49,10 @@ const ReviewRequestToJoinOrgRoot = lazy(
   () => import(/* webpackChunkName: 'ReviewRequestToJoinOrgRoot' */ './ReviewRequestToJoinOrgRoot')
 )
 
+const NewMeetingRoot = lazy(
+  () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
+)
+
 const PrivateRoutes = () => {
   useAuthRoute()
   useNoIndex()
@@ -74,7 +78,7 @@ const PrivateRoutes = () => {
           path='/organization-join-request/:requestId'
           component={ReviewRequestToJoinOrgRoot}
         />
-        <Route path='(/new-meeting)' component={DashboardRoot} />
+        <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
       </Switch>
     </>
   )


### PR DESCRIPTION
The backgroundLocation approach does not work properly when nesting, so move the NewMeeting dialog a level up as well.
This caused the background dashboard to be rendered twice

## Demo

https://www.loom.com/share/c18f23bd2c4444bda7dda015b4096b0b

## Testing scenarios

Easiest way for me to visually reproduce:
* on meeting dashboard press new meeting button
* go to sprint poker
* press on the template
* [ ] on master the whole app is scrolled up, dialog is half visible

Also check that the dashboard is not added twice to the DOM when the new meeting dialog is shown.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
