### PR TITLE
fix: Fix team change in new meeting window

### DIFF
--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -62,7 +62,10 @@ const PrivateRoutes = () => {
     <>
       <Switch location={state?.backgroundLocation || location}>
         <Route path='/activity-library' component={ActivityLibraryRoutes} />
-        <Route path='(/meetings|/me|/newteam|/team|/usage)' component={DashboardRoot} />
+        <Route
+          path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)'
+          component={DashboardRoot}
+        />
         <Route path='/meet/:meetingId' component={MeetingRoot} />
         <Route path='/meeting-series/:meetingId' component={MeetingSeriesRoot} />
         <Route path='/invoice/:invoiceId' component={Invoice} />


### PR DESCRIPTION
prev pr: #8246

Additional fix: when changing a team in a new meeting window, background shows 404 error:

<img width="1739" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/62703801-4ba4-45f7-8a7c-c24d0c26b54b">


**How to test:**
- Open new meeting window, switch teams in team selector
- Play with windows and routes, see everything works as expected