### PR TITLE
fix(standups): Remove CSV download button in standups

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -95,40 +95,60 @@ const SummarySheet = (props: Props) => {
           </td>
         </tr>
         <SummarySheetCTA referrer={referrer} isDemo={isDemo} teamDashUrl={teamDashUrl} />
-        {referrer === 'meeting' ? (
-          <>
-            <tr>
-              <td>
-                <table width='90%' align='center' className='mt-8 rounded-lg bg-slate-200 py-4'>
-                  <tbody>
-                    <tr>
-                      <td align='center' width='100%'>
-                        <div className='flex justify-center gap-4'>
-                          {!!taskCount && taskCount > 0 && <ExportAllTasks meetingRef={meeting} />}
-                          <Link
-                            to={emailCSVUrl}
-                            className={
-                              'flex cursor-pointer items-center gap-2 rounded-full border border-solid border-slate-400 bg-white px-5 py-2 text-center font-sans text-sm font-semibold hover:bg-slate-100'
-                            }
-                          >
-                            <TableChart
-                              style={{width: '14px', height: '14px', color: PALETTE.SLATE_600}}
-                            />
-                            Export to CSV
-                          </Link>
-                        </div>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </td>
-            </tr>
-            {/* :HACK: The 'ExportToCSV' component both downloads the CSV if 'urlAction' is 'csv'
+        {referrer === 'meeting'
+          ? (meetingType !== 'teamPrompt' || (!!taskCount && taskCount > 0)) && (
+              <>
+                <tr>
+                  <td>
+                    <table width='90%' align='center' className='mt-8 rounded-lg bg-slate-200 py-4'>
+                      <tbody>
+                        <tr>
+                          <td align='center' width='100%'>
+                            <div className='flex justify-center gap-4'>
+                              {!!taskCount && taskCount > 0 && (
+                                <ExportAllTasks meetingRef={meeting} />
+                              )}
+                              {meetingType !== 'teamPrompt' && (
+                                <Link
+                                  to={emailCSVUrl}
+                                  className={
+                                    'flex cursor-pointer items-center gap-2 rounded-full border border-solid border-slate-400 bg-white px-5 py-2 text-center font-sans text-sm font-semibold hover:bg-slate-100'
+                                  }
+                                >
+                                  <TableChart
+                                    style={{
+                                      width: '14px',
+                                      height: '14px',
+                                      color: PALETTE.SLATE_600
+                                    }}
+                                  />
+                                  Export to CSV
+                                </Link>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                {/* :HACK: The 'ExportToCSV' component both downloads the CSV if 'urlAction' is 'csv'
                 and shows the 'Export to CSV' button. We need the download functionality, but we
                 don't want to show the button as-is, so hide it in the DOM */}
-            <div className='hidden'>
-              {/* :TODO: (jmtaber129): Decouple the download and button functionality of this
+                <div className='hidden'>
+                  {/* :TODO: (jmtaber129): Decouple the download and button functionality of this
                   component. */}
+                  <ExportToCSV
+                    emailCSVUrl={emailCSVUrl}
+                    meetingId={meetingId}
+                    urlAction={urlAction}
+                    referrer={referrer}
+                    corsOptions={corsOptions}
+                  />
+                </div>
+              </>
+            )
+          : meetingType !== 'teamPrompt' && (
               <ExportToCSV
                 emailCSVUrl={emailCSVUrl}
                 meetingId={meetingId}
@@ -136,17 +156,7 @@ const SummarySheet = (props: Props) => {
                 referrer={referrer}
                 corsOptions={corsOptions}
               />
-            </div>
-          </>
-        ) : (
-          <ExportToCSV
-            emailCSVUrl={emailCSVUrl}
-            meetingId={meetingId}
-            urlAction={urlAction}
-            referrer={referrer}
-            corsOptions={corsOptions}
-          />
-        )}
+            )}
         <EmailBorderBottom />
         <CreateAccountSection dataCy='create-account-section' isDemo={isDemo} />
         {meetingType === 'teamPrompt' ? (


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8184

Based on https://github.com/ParabolInc/parabol/pull/7933 since that PR changes some stuff around `ExportToCSV` rendering, and that PR should land soon. Will need rebase after that PR lands.

Recommend reviewers to review with whitespace ignored.

## Demo
No tasks, no CSV:
<img width="651" alt="Screen Shot 2023-05-23 at 2 19 50 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/896d1549-a305-4c66-bbb2-5e97c5edc0bf">

No tasks, CSV:
<img width="649" alt="Screen Shot 2023-05-23 at 2 20 14 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/4ce111ff-ac4a-4d81-bd16-5d31366a7011">

Tasks, no CSV:
<img width="643" alt="Screen Shot 2023-05-23 at 2 45 13 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/76070680-716e-4924-ae90-c298a499dca9">


Tasks and CSV:
<img width="711" alt="Screen Shot 2023-05-23 at 2 20 00 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/2675762e-cfe6-4a92-b6ef-1440a60e7893">


## Testing scenarios
- [ ] Check meeting summaries for
  - [x] retro with tasks
  - [ ] retro without tasks
  - [x] standup with tasks
  - [x] standup without tasks

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
