### PR TITLE
fix(copy): Make copy for ending meeting consistent

### DIFF
--- a/packages/client/components/MeetingCardOptionsMenu.tsx
+++ b/packages/client/components/MeetingCardOptionsMenu.tsx
@@ -154,7 +154,7 @@ const MeetingCardOptionsMenu = (props: Props) => {
               <StyledIcon>
                 <CloseIcon />
               </StyledIcon>
-              <span>{'End the meeting'}</span>
+              <span>{'End this meeting'}</span>
             </OptionMenuItem>
           }
           onClick={() => {

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -136,7 +136,7 @@ const TeamPromptOptionsMenu = (props: Props) => {
         label={
           <OptionMenuItem>
             <FlagIcon />
-            <span>{'End this activity'}</span>
+            <span>{'End this meeting'}</span>
           </OptionMenuItem>
         }
         onClick={() => {


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7890

We currently refer to ending an "activity" in one place and ending a "meeting" in another. Though "activity" may be the terminology we'll want to present long term, most of the app currently uses the term "meeting", so using that term here will make things more consistent.

## Demo
<img width="341" alt="Screen Shot 2023-05-23 at 2 55 49 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/3d626d32-e5a0-4cdb-93e5-b90404f537dd">
<img width="331" alt="Screen Shot 2023-05-23 at 2 55 55 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/1b919a81-f038-484f-9e13-4997dbe60776">

## Testing scenarios
N/A

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
