### PR TITLE
fix: checkbox color overriden by styled components

### DIFF
--- a/packages/client/components/Checkbox.tsx
+++ b/packages/client/components/Checkbox.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx'
 
 interface Props {
   active: boolean | null
-  color?: string
   className?: string
   disabled?: boolean
   onClick?: (e: React.MouseEvent) => void

--- a/packages/client/components/EmailNotifications.tsx
+++ b/packages/client/components/EmailNotifications.tsx
@@ -27,10 +27,12 @@ const ErrorMessage = styled(StyledError)({
 })
 
 const StyledCheckbox = styled(Checkbox)({
-  width: 24,
-  height: 24,
-  marginRight: 8,
-  color: PALETTE.SKY_500
+  '&&': {
+    width: 24,
+    height: 24,
+    marginRight: 8,
+    color: PALETTE.SKY_500
+  }
 })
 
 type Props = {

--- a/packages/client/components/NewMeetingSettingsToggleAnonymity.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleAnonymity.tsx
@@ -37,14 +37,16 @@ const Label = styled('div')({
 })
 
 const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
-  color: active ? PALETTE.SKY_500 : PALETTE.SLATE_700,
-  svg: {
-    fontSize: 28
-  },
-  width: 28,
-  height: 28,
-  textAlign: 'center',
-  userSelect: 'none'
+  '&&': {
+    color: active ? PALETTE.SKY_500 : PALETTE.SLATE_700,
+    svg: {
+      fontSize: 28
+    },
+    width: 28,
+    height: 28,
+    textAlign: 'center',
+    userSelect: 'none'
+  }
 }))
 
 interface Props {

--- a/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleCheckIn.tsx
@@ -37,14 +37,16 @@ const Label = styled('div')({
 })
 
 const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
-  color: active ? PALETTE.SKY_500 : PALETTE.SLATE_700,
-  svg: {
-    fontSize: 28
-  },
-  width: 28,
-  height: 28,
-  textAlign: 'center',
-  userSelect: 'none'
+  '&&': {
+    color: active ? PALETTE.SKY_500 : PALETTE.SLATE_700,
+    svg: {
+      fontSize: 28
+    },
+    width: 28,
+    height: 28,
+    textAlign: 'center',
+    userSelect: 'none'
+  }
 }))
 
 interface Props {


### PR DESCRIPTION
After rewriting `Checkbox` to tailwind, we can't simply override color with style component.

This happens because tailwind defines clasees like `body .text-slate-600` which is more specific than classname added by styled components.

By using `&&` it is possible to make styled components class more specific, it will look like `.css-ry6kcf.css-ry6kcf`

<img width="536" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/5f6f86bb-61e4-4cb9-9f84-56ac779324db">

**How to test:**
- see that checkbox shows the correct color

**Alternative possible approach:** refactor `Checkbox` and introduce `size` prop and `color` prop

Because of order of classes in tailwind stylesheet, one class would always be preferable:
<img width="476" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/5154228d-ffee-4684-a2e8-3b40ed4bea6d">

**Another approach:**
Remove default color at all