### PR TITLE
feat(standups): Meeting ended integration notification

### DIFF
--- a/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
@@ -149,7 +149,7 @@ export const MSTeamsNotificationHelper: NotificationIntegrationHelper<MSTeamsNot
     summaryColumnSet.spacing = AdaptiveCards.Spacing.ExtraLarge
     const summaryColumn = new AdaptiveCards.Column()
     summaryColumn.width = 'stretch'
-    const summaryTextBlock = new AdaptiveCards.TextBlock(getSummaryText(meeting))
+    const summaryTextBlock = new AdaptiveCards.TextBlock(await getSummaryText(meeting))
     summaryTextBlock.wrap = true
     summaryColumn.addItem(summaryTextBlock)
     summaryColumnSet.addColumn(summaryColumn)

--- a/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
@@ -83,6 +83,13 @@ const makeEndMeetingButtons = (meeting: Meeting) => {
         link: pokerUrl
       }
       return makeHackedButtonPairFields(estimateButton, summaryButton)
+    case 'teamPrompt':
+      const teamPromptUrl = makeAppURL(appOrigin, `meet/${meetingId}/responses`)
+      const responseButton = {
+        label: 'See responses',
+        link: teamPromptUrl
+      }
+      return makeHackedButtonPairFields(responseButton, summaryButton)
     default:
       throw new Error('Invalid meeting type')
   }
@@ -182,7 +189,7 @@ const MattermostNotificationHelper: NotificationIntegrationHelper<MattermostNoti
     const {facilitatorUserId, summary} = meeting
     const {webhookUrl} = notificationChannel
 
-    const summaryText = getSummaryText(meeting)
+    const summaryText = await getSummaryText(meeting)
     const meetingUrl = makeAppURL(appOrigin, `meet/${meeting.id}`)
     const fields: Field[] = [
       {

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -102,6 +102,13 @@ const makeEndMeetingButtons = (meeting: Meeting) => {
         url: pokerUrl
       }
       return makeButtons([estimateButton, summaryButton])
+    case 'teamPrompt':
+      const teamPromptUrl = makeAppURL(appOrigin, `meet/${meetingId}/responses`)
+      const responsesButton = {
+        text: 'See responses',
+        url: teamPromptUrl
+      }
+      return makeButtons([responsesButton, summaryButton])
     default:
       throw new Error('Invalid meeting type')
   }
@@ -172,7 +179,7 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
   },
 
   async endMeeting(meeting, team) {
-    const summaryText = getSummaryText(meeting)
+    const summaryText = await getSummaryText(meeting)
     const title = 'Meeting completed :tada:'
     const blocks: Array<{type: string}> = [
       makeSection(title),

--- a/packages/server/graphql/mutations/helpers/notifications/getSummaryText.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/getSummaryText.ts
@@ -6,8 +6,9 @@ import {isMeetingPoker} from '../../../../database/types/MeetingPoker'
 import {isMeetingRetrospective} from '../../../../database/types/MeetingRetrospective'
 import {isMeetingTeamPrompt} from '../../../../database/types/MeetingTeamPrompt'
 import sendToSentry from '../../../../utils/sendToSentry'
+import {getTeamPromptResponsesByMeetingId} from '../../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 
-const getSummaryText = (meeting: Meeting) => {
+const getSummaryText = async (meeting: Meeting) => {
   if (isMeetingRetrospective(meeting)) {
     const {commentCount = 0, reflectionCount = 0, topicCount = 0, taskCount = 0} = meeting
     const hasNonZeroStat = commentCount || reflectionCount || topicCount || taskCount
@@ -39,7 +40,11 @@ const getSummaryText = (meeting: Meeting) => {
       'comment'
     )}.`
   } else if (isMeetingTeamPrompt(meeting)) {
-    return 'TODO: Implement teamPrompt summary text'
+    const responseCount = (await getTeamPromptResponsesByMeetingId(meeting.id)).filter(
+      (response) => !!response.plaintextContent
+    ).length
+    // :TODO: (jmtaber129): Add additional stats here.
+    return `Your team shared ${responseCount} ${plural(responseCount, 'response', 'responses')}.`
   } else if (isMeetingPoker(meeting)) {
     const {storyCount = 0, commentCount = 0} = meeting
     return `You voted on ${storyCount} ${plural(

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -9,6 +9,7 @@ import publish, {SubOptions} from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
 import {InternalContext} from '../../graphql'
 import sendNewMeetingSummary from './endMeeting/sendNewMeetingSummary'
+import {IntegrationNotifier} from './notifications/IntegrationNotifier'
 
 const safeEndTeamPrompt = async ({
   meeting,
@@ -68,6 +69,7 @@ const safeEndTeamPrompt = async ({
   )
   const timelineEventId = events[0]!.id
   await r.table('TimelineEvent').insert(events).run()
+  IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
   sendNewMeetingSummary(completedTeamPrompt, context).catch(console.log)
   checkTeamsLimit(team.orgId, dataLoader)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7885

Implements `getSummaryText` and integration-specific buttons for standups, and adds `IntegrationNotifier.endMeeting` call to `safeEndTeamPrompt` (same place where we send meeting summaries)

## Demo

<img width="724" alt="Screen Shot 2023-05-23 at 3 31 01 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/74da0a7d-9c3a-4970-8549-52480e66b0b1">


## Testing scenarios
- [ ] Smoke test standup ended notifications

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
