### PR TITLE
fix(tiptap): Prevent showing edit components in readonly mode

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -258,56 +258,58 @@ const PromptResponseEditor = (props: Props) => {
   return (
     <>
       <StyledEditor>
-        {editor && (
-          <BubbleMenu editor={editor} tippyOptions={{duration: 100}}>
-            <BubbleMenuWrapper>
-              <BubbleMenuButton
-                onClick={() => editor.chain().focus().toggleBold().run()}
-                isActive={editor.isActive('bold')}
-              >
-                <b>B</b>
-              </BubbleMenuButton>
-              <BubbleMenuButton
-                onClick={() => editor.chain().focus().toggleItalic().run()}
-                isActive={editor.isActive('italic')}
-              >
-                <i>I</i>
-              </BubbleMenuButton>
-              <BubbleMenuButton
-                onClick={() => editor.chain().focus().toggleStrike().run()}
-                isActive={editor.isActive('strike')}
-              >
-                <s>S</s>
-              </BubbleMenuButton>
-              <BubbleMenuButton onClick={onAddHyperlink} isActive={editor.isActive('link')}>
-                <LinkIcon />
-              </BubbleMenuButton>
-            </BubbleMenuWrapper>
-          </BubbleMenu>
-        )}
-        {editor && <EmojiMenuTipTap tiptapEditor={editor} />}
-        {editor && teamId && <MentionsTipTap tiptapEditor={editor} teamId={teamId} />}
-        {editor && linkOverlayProps?.linkMenuProps && (
-          <EditorLinkChangerTipTap
-            text={linkOverlayProps.linkMenuProps.text}
-            link={linkOverlayProps.linkMenuProps.href}
-            tiptapEditor={editor}
-            originCoords={linkOverlayProps.linkMenuProps.originCoords}
-            removeModal={() => {
-              setLinkOverlayProps(undefined)
-            }}
-          />
-        )}
-        {editor && linkOverlayProps?.linkPreviewProps && (
-          <EditorLinkViewerTipTap
-            href={linkOverlayProps.linkPreviewProps.href}
-            tiptapEditor={editor}
-            addHyperlink={onAddHyperlink}
-            originCoords={linkOverlayProps.linkPreviewProps.originCoords}
-            removeModal={() => {
-              setLinkOverlayProps(undefined)
-            }}
-          />
+        {editor && !readOnly && (
+          <>
+            <BubbleMenu editor={editor} tippyOptions={{duration: 100}}>
+              <BubbleMenuWrapper>
+                <BubbleMenuButton
+                  onClick={() => editor.chain().focus().toggleBold().run()}
+                  isActive={editor.isActive('bold')}
+                >
+                  <b>B</b>
+                </BubbleMenuButton>
+                <BubbleMenuButton
+                  onClick={() => editor.chain().focus().toggleItalic().run()}
+                  isActive={editor.isActive('italic')}
+                >
+                  <i>I</i>
+                </BubbleMenuButton>
+                <BubbleMenuButton
+                  onClick={() => editor.chain().focus().toggleStrike().run()}
+                  isActive={editor.isActive('strike')}
+                >
+                  <s>S</s>
+                </BubbleMenuButton>
+                <BubbleMenuButton onClick={onAddHyperlink} isActive={editor.isActive('link')}>
+                  <LinkIcon />
+                </BubbleMenuButton>
+              </BubbleMenuWrapper>
+            </BubbleMenu>
+            <EmojiMenuTipTap tiptapEditor={editor} />
+            {teamId && <MentionsTipTap tiptapEditor={editor} teamId={teamId} />}
+            {linkOverlayProps?.linkMenuProps && (
+              <EditorLinkChangerTipTap
+                text={linkOverlayProps.linkMenuProps.text}
+                link={linkOverlayProps.linkMenuProps.href}
+                tiptapEditor={editor}
+                originCoords={linkOverlayProps.linkMenuProps.originCoords}
+                removeModal={() => {
+                  setLinkOverlayProps(undefined)
+                }}
+              />
+            )}
+            {linkOverlayProps?.linkPreviewProps && (
+              <EditorLinkViewerTipTap
+                href={linkOverlayProps.linkPreviewProps.href}
+                tiptapEditor={editor}
+                addHyperlink={onAddHyperlink}
+                originCoords={linkOverlayProps.linkPreviewProps.originCoords}
+                removeModal={() => {
+                  setLinkOverlayProps(undefined)
+                }}
+              />
+            )}
+          </>
         )}
         <EditorContent ref={editorRef} editor={editor} />
       </StyledEditor>


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7871

It's currently possible to trigger the link viewer overlays (a tool for editing links) for tiptap renderings in readonly mode.

Instead of relying on just not triggering these, disallow rendering link viewers (and similar edit-only components) entirely.

## Testing scenarios
- [ ] Try to trigger a link viewer overlay in a read-only response by clicking on or near a link, and fail

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
