### PR TITLE
docs: Adds new template for design issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/design_issue.md
+++ b/.github/ISSUE_TEMPLATE/design_issue.md
@@ -1,0 +1,20 @@
+---
+name: Design issue
+about: Create a design issue
+title: ''
+labels: design
+assignees: ''
+---
+
+### Design issue
+
+_Describe the goal of your work or the problem you are solving._
+
+## Design checklist
+
+- [ ] Is the end-to-end flow complete?
+- [ ] Have you considered all possible states and scenarios? ([See our UI State Checklist](https://www.notion.so/parabol/UI-State-Checklist-a90cc393612f4a0588144f897dee848a?pvs=4))
+- [ ] Have you confirmed that the interactive components in your work have all the necessary states designed? (focus, hover, disabled, etc)
+- [ ] Have you considered all the breakpoints required for a responsive interface? (S, M, L)
+- [ ] Have you had a design peer or maintainer review your work?
+- [ ] Have you had a developer review your work?


### PR DESCRIPTION
# Description

Adds a new template to be used for design issues. [See this Slack convo for more context](https://parabol.slack.com/archives/C02438U0VJ4/p1681931376785769).

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
