### PR TITLE
feat: added button component

### DIFF
--- a/packages/client/ui/Button.tsx
+++ b/packages/client/ui/Button.tsx
@@ -1,0 +1,46 @@
+import React, {forwardRef, ElementType, ComponentPropsWithRef} from 'react'
+import clsx from 'clsx'
+
+type Type = 'primary' | 'secondary' | 'outline'
+type Shape = 'rounded' | 'circle' | 'pill'
+
+//TODO: implement proper styles
+const TYPE_STYLES: Record<Type, string> = {
+  primary: 'bg-blue-500 hover:bg-blue-600 text-white',
+  secondary: 'bg-gray-500 hover:bg-gray-600 text-white',
+  outline: 'border border-gray-500 hover:bg-gray-600 text-gray-500'
+}
+
+//TODO: implement proper styles
+const SHAPE_STYLES: Record<Shape, string> = {
+  rounded: 'rounded',
+  circle: 'rounded-full',
+  pill: 'rounded-full'
+}
+
+type Props<T extends ElementType> = {
+  as?: T
+  className?: string
+  type?: Type
+  shape?: Shape
+} & ComponentPropsWithRef<T>
+
+export const Button = forwardRef(
+  <T extends ElementType = 'button'>(
+    props: Props<T>,
+    ref: React.Ref<T extends keyof JSX.IntrinsicElements ? JSX.IntrinsicElements[T] : T>
+  ) => {
+    const {as: Component = 'button', className, type, shape, ...rest} = props
+
+    const typeStyle = type ? TYPE_STYLES[type] : ''
+    const shapeStyle = shape ? SHAPE_STYLES[shape] : ''
+
+    return (
+      <Component className={clsx(typeStyle, shapeStyle)} {...rest} ref={ref}>
+        {props.children}
+      </Component>
+    )
+  }
+)
+
+Button.displayName = 'Button'


### PR DESCRIPTION
# Description

This PR introduces a reusable button component that could render as `button`, `a` or other html tags. It attempts to reduce number of duplicate button components we have, while also keeping consistency and accessibility features.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
