### PR TITLE
chore: update max token limit

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -18,6 +18,7 @@ class OpenAIServerManager {
 
   async getSummary(text: string | string[], summaryLocation?: 'discussion thread') {
     if (!this.openAIApi) return null
+
     try {
       const location = summaryLocation ?? 'retro meeting'
       const response = await this.openAIApi.createCompletion({
@@ -28,7 +29,7 @@ class OpenAIServerManager {
         ${text}
         """`,
         temperature: 0.7,
-        max_tokens: 256,
+        max_tokens: 80,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -18,7 +18,6 @@ class OpenAIServerManager {
 
   async getSummary(text: string | string[], summaryLocation?: 'discussion thread') {
     if (!this.openAIApi) return null
-
     try {
       const location = summaryLocation ?? 'retro meeting'
       const response = await this.openAIApi.createCompletion({


### PR DESCRIPTION
Related to (and may fix) https://github.com/ParabolInc/parabol/issues/8200

`max_tokens` refers to the max number of tokens OpenAI should allocate to the completion, i.e. the text it generates. We want it to create a 1-2 sentence summary, which should cost ~30 tokens (see [here](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them)). 

We shouldn't need the 256 tokens we're currently allocating to the completion. However, the summary could be incomplete if we set a token limit that's too low. While we probably only need ~30 tokens, to be on the safe side, I've set a new limit of 80, which should help us stay within OpenAI's rate limits while ensuring the summaries are still complete.

### To test

- [ ] Create a retro meeting and add real meeting content. You can copy and paste it from a recent retro meeting
- [ ] See that the discussion, topic, and whole meeting summaries are still accurate 