### PR TITLE
fix(recurrence): Incorrect start times due to timezone weirdness

### DIFF
--- a/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import dayjs from 'dayjs'
 import utcPlugin from 'dayjs/plugin/utc'
 import React, {PropsWithChildren, useEffect} from 'react'
-import {Frequency, RRule, datetime} from 'rrule'
+import {Frequency, RRule} from 'rrule'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useMenu from '../../../hooks/useMenu'
 import {PortalId} from '../../../hooks/usePortal'
@@ -13,7 +13,7 @@ import {Day, RecurrenceDayCheckbox} from './RecurrenceDayCheckbox'
 import {RecurrenceTimePicker} from './RecurrenceTimePicker'
 import Legitity from '../../../validation/Legitity'
 import {isNotNull} from '../../../utils/predicates'
-import {getJSDateFromRRuleDate} from '../../../shared/rruleUtil'
+import {getJSDateFromRRuleDate, getRRuleDateFromJSDate} from '../../../shared/rruleUtil'
 dayjs.extend(utcPlugin)
 
 export const ALL_DAYS: Day[] = [
@@ -252,13 +252,7 @@ export const RecurrenceSettings = (props: Props) => {
             freq: Frequency.WEEKLY,
             interval: recurrenceInterval,
             byweekday: recurrenceDays.map((day) => day.rruleVal),
-            dtstart: datetime(
-              recurrenceStartTime.getFullYear(),
-              recurrenceStartTime.getMonth() + 1,
-              recurrenceStartTime.getDate(),
-              recurrenceStartTime.getHours(),
-              recurrenceStartTime.getMinutes()
-            ),
+            dtstart: getRRuleDateFromJSDate(recurrenceStartTime),
             tzid: timeZone
           })
         : null

--- a/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx'
 import dayjs from 'dayjs'
 import utcPlugin from 'dayjs/plugin/utc'
 import React, {PropsWithChildren, useEffect} from 'react'
-import {Frequency, RRule} from 'rrule'
+import {Frequency, RRule, datetime} from 'rrule'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useMenu from '../../../hooks/useMenu'
 import {PortalId} from '../../../hooks/usePortal'
@@ -178,6 +178,16 @@ interface Props {
   recurrenceSettings: RecurrenceSettings
 }
 
+const getDateFromRRuleDateTime = (rruleDate: Date) => {
+  return new Date(
+    rruleDate.getUTCFullYear(),
+    rruleDate.getUTCMonth(),
+    rruleDate.getUTCDate(),
+    rruleDate.getUTCHours(),
+    rruleDate.getUTCMinutes()
+  )
+}
+
 export const RecurrenceSettings = (props: Props) => {
   const {parentId, onRecurrenceSettingsUpdated, recurrenceSettings} = props
   const {name: meetingSeriesName, rrule: recurrenceRule} = recurrenceSettings
@@ -196,7 +206,7 @@ export const RecurrenceSettings = (props: Props) => {
   )
   const [recurrenceStartTime, setRecurrenceStartTime] = React.useState<Date>(
     recurrenceRule
-      ? recurrenceRule.options.dtstart
+      ? getDateFromRRuleDateTime(recurrenceRule.options.dtstart)
       : dayjs()
           .add(1, 'day')
           .set('hour', 6)
@@ -251,7 +261,13 @@ export const RecurrenceSettings = (props: Props) => {
             freq: Frequency.WEEKLY,
             interval: recurrenceInterval,
             byweekday: recurrenceDays.map((day) => day.rruleVal),
-            dtstart: dayjs(recurrenceStartTime).utc().toDate(),
+            dtstart: datetime(
+              recurrenceStartTime.getFullYear(),
+              recurrenceStartTime.getMonth() + 1,
+              recurrenceStartTime.getDate(),
+              recurrenceStartTime.getHours(),
+              recurrenceStartTime.getMinutes()
+            ),
             tzid: timeZone
           })
         : null

--- a/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
@@ -13,6 +13,7 @@ import {Day, RecurrenceDayCheckbox} from './RecurrenceDayCheckbox'
 import {RecurrenceTimePicker} from './RecurrenceTimePicker'
 import Legitity from '../../../validation/Legitity'
 import {isNotNull} from '../../../utils/predicates'
+import {getJSDateFromRRuleDate} from '../../../shared/rruleUtil'
 dayjs.extend(utcPlugin)
 
 export const ALL_DAYS: Day[] = [
@@ -178,16 +179,6 @@ interface Props {
   recurrenceSettings: RecurrenceSettings
 }
 
-const getDateFromRRuleDateTime = (rruleDate: Date) => {
-  return new Date(
-    rruleDate.getUTCFullYear(),
-    rruleDate.getUTCMonth(),
-    rruleDate.getUTCDate(),
-    rruleDate.getUTCHours(),
-    rruleDate.getUTCMinutes()
-  )
-}
-
 export const RecurrenceSettings = (props: Props) => {
   const {parentId, onRecurrenceSettingsUpdated, recurrenceSettings} = props
   const {name: meetingSeriesName, rrule: recurrenceRule} = recurrenceSettings
@@ -206,7 +197,7 @@ export const RecurrenceSettings = (props: Props) => {
   )
   const [recurrenceStartTime, setRecurrenceStartTime] = React.useState<Date>(
     recurrenceRule
-      ? getDateFromRRuleDateTime(recurrenceRule.options.dtstart)
+      ? getJSDateFromRRuleDate(recurrenceRule.options.dtstart)
       : dayjs()
           .add(1, 'day')
           .set('hour', 6)

--- a/packages/client/shared/rruleUtil.ts
+++ b/packages/client/shared/rruleUtil.ts
@@ -1,0 +1,21 @@
+import {datetime} from 'rrule'
+
+export const getRRuleDateFromJSDate = (date: Date) => {
+  return datetime(
+    date.getFullYear(),
+    date.getMonth() + 1,
+    date.getDate(),
+    date.getHours(),
+    date.getMinutes()
+  )
+}
+
+export const getJSDateFromRRuleDate = (rruleDate: Date) => {
+  return new Date(
+    rruleDate.getUTCFullYear(),
+    rruleDate.getUTCMonth(),
+    rruleDate.getUTCDate(),
+    rruleDate.getUTCHours(),
+    rruleDate.getUTCMinutes()
+  )
+}


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7953

The `rrule` library we're using handles times + time zones in a way that's very... strange. Basically, `rrule` assumes the UTC equivalent of all dates it sees are actually just in the system's time zone. So a time of `12:00:00Z` for a system in PST is actually interpreted by `rrule` as 12 PST, or `21:00:00Z` true UTC.

The immediate fix is simple but tedious - convert these "UTC" local time zone times returned by `rrule` to the true JS `Date`, and convert JS `Date`s to the weird "local as UTC" time before passing them to any `rrule` methods.

The long-term fix is probably to rip out the `rrule` lib and roll our own (or fork the lib and make changes for improved time zone support), but that's probably not worth it for now.

## Demo
https://www.loom.com/share/b15157c0c1714513bfa1547c2669caf5

## Testing scenarios
Full test of recurrence, across time zones:
- [ ] Set up the environment by starting your dev server, changing your system time zone, then reloading the client
  - [ ] This will put your server in a different time zone from your client, which is when these bugs manifest
- [ ] Start a new team prompt meeting, and start recurrence
- [ ] Confirm that the next meeting start time is correct
- [ ] Open the edit recurrence modal, and confirm the default start time is the same as what was selected when starting recurrence
- [ ] Change the start time, confirm the update, and confirm the next meeting start time is updated to the correct time
- [ ] Process recurrence
  - [ ] Make sure no other meeting series are active except the one created earlier
  - [ ] Change your system time to just before the restart time, run the `processRecurrence` mutation, and confirm no meetings were started or ended
  - [ ] Change your system time to just after the restart time, run the `processRecurrence` mutation, and confirm the meeting was restarted (one meeting started, one meeting ended)
  - [ ] Confirm the new meeting has the correct end time.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
