### PR TITLE
fix(rid): Fix changing prompt colors in activity library

### DIFF
--- a/packages/client/modules/meeting/components/EditableTemplatePromptColor.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplatePromptColor.tsx
@@ -11,11 +11,13 @@ import PalettePicker from '../../../components/PalettePicker/PalettePicker'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useMenu from '../../../hooks/useMenu'
 import {PALETTE} from '../../../styles/paletteV3'
+import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
   prompt: EditableTemplatePromptColor_prompt$key
   prompts: EditableTemplatePromptColor_prompts$key
+  parentId?: PortalId
 }
 
 const PromptColor = styled(PlainButton)<{isOwner: boolean}>(({isOwner}) => ({
@@ -57,7 +59,7 @@ const DropdownIcon = styled('div')({
 })
 
 const EditableTemplatePromptColor = (props: Props) => {
-  const {isOwner, prompt: promptRef, prompts: promptsRef} = props
+  const {isOwner, prompt: promptRef, prompts: promptsRef, parentId} = props
   const prompts = useFragment(
     graphql`
       fragment EditableTemplatePromptColor_prompts on ReflectPrompt @relay(plural: true) {
@@ -78,7 +80,7 @@ const EditableTemplatePromptColor = (props: Props) => {
   const {groupColor} = prompt
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu<HTMLButtonElement>(
     MenuPosition.UPPER_LEFT,
-    {parentId: 'templateModal'}
+    {parentId: parentId}
   )
   return (
     <PromptColor ref={originRef} isOwner={isOwner} onClick={isOwner ? togglePortal : undefined}>

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -174,7 +174,12 @@ const ReflectTemplateDetails = (props: Props) => {
           </FirstLine>
           <Description>{description}</Description>
         </TemplateHeader>
-        <TemplatePromptList isOwner={isOwner} prompts={prompts} templateId={templateId} />
+        <TemplatePromptList
+          isOwner={isOwner}
+          prompts={prompts}
+          templateId={templateId}
+          parentId='templateModal'
+        />
         {isOwner && <AddTemplatePrompt templateId={templateId} prompts={prompts} />}
         <TemplateSharing isOwner={isOwner} template={activeTemplate} />
       </Scrollable>

--- a/packages/client/modules/meeting/components/TemplatePromptItem.tsx
+++ b/packages/client/modules/meeting/components/TemplatePromptItem.tsx
@@ -13,6 +13,7 @@ import {TemplatePromptItem_prompt$key} from '../../../__generated__/TemplateProm
 import EditableTemplateDescription from './EditableTemplateDescription'
 import EditableTemplatePrompt from './EditableTemplatePrompt'
 import EditableTemplatePromptColor from './EditableTemplatePromptColor'
+import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
@@ -20,6 +21,7 @@ interface Props {
   prompt: TemplatePromptItem_prompt$key
   prompts: TemplatePromptItem_prompts$key
   dragProvided: DraggableProvided
+  parentId?: PortalId
 }
 
 interface StyledProps {
@@ -64,7 +66,14 @@ const PromptAndDescription = styled('div')({
 })
 
 const TemplatePromptItem = (props: Props) => {
-  const {dragProvided, isDragging, isOwner, prompt: promptRef, prompts: promptsRef} = props
+  const {
+    dragProvided,
+    isDragging,
+    isOwner,
+    prompt: promptRef,
+    prompts: promptsRef,
+    parentId
+  } = props
   const prompts = useFragment(
     graphql`
       fragment TemplatePromptItem_prompts on ReflectPrompt @relay(plural: true) {
@@ -118,7 +127,12 @@ const TemplatePromptItem = (props: Props) => {
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <EditableTemplatePromptColor isOwner={isOwner} prompt={prompt} prompts={prompts} />
+      <EditableTemplatePromptColor
+        isOwner={isOwner}
+        prompt={prompt}
+        prompts={prompts}
+        parentId={parentId}
+      />
       <PromptAndDescription>
         <EditableTemplatePrompt
           isOwner={isOwner}

--- a/packages/client/modules/meeting/components/TemplatePromptList.tsx
+++ b/packages/client/modules/meeting/components/TemplatePromptList.tsx
@@ -9,11 +9,13 @@ import {TEMPLATE_PROMPT} from '../../../utils/constants'
 import dndNoise from '../../../utils/dndNoise'
 import {TemplatePromptList_prompts$key} from '../../../__generated__/TemplatePromptList_prompts.graphql'
 import TemplatePromptItem from './TemplatePromptItem'
+import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
   prompts: TemplatePromptList_prompts$key
   templateId: string
+  parentId?: PortalId
 }
 
 const PromptList = styled('div')({
@@ -23,7 +25,7 @@ const PromptList = styled('div')({
 })
 
 const TemplatePromptList = (props: Props) => {
-  const {isOwner, prompts: promptsRef, templateId} = props
+  const {isOwner, prompts: promptsRef, templateId, parentId} = props
   const prompts = useFragment(
     graphql`
       fragment TemplatePromptList_prompts on ReflectPrompt @relay(plural: true) {
@@ -94,6 +96,7 @@ const TemplatePromptList = (props: Props) => {
                             prompts={prompts}
                             isDragging={dragSnapshot.isDragging}
                             dragProvided={dragProvided}
+                            parentId={parentId}
                           />
                         )
                       }}


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8272

The prompt color picker assumed that it's in the old template picker modal, so it threw an error when it couldn't find the template picker modal in the activity library.

Refactor a bit to pass the parent modal ID down from the parent.

## Demo
https://www.loom.com/share/6c69352d8fda44bfbde26f39dbe28346

## Testing scenarios
- [ ] Change template color in old template picker
- [ ] Change template color in activity library.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
