### PR TITLE
chore(prompt-to-join): disable buttons when running accept request mutation

### DIFF
--- a/packages/client/components/ReviewRequestToJoinOrgModal.tsx
+++ b/packages/client/components/ReviewRequestToJoinOrgModal.tsx
@@ -53,7 +53,7 @@ interface Props {
 const ReviewRequestToJoinOrgModal = (props: Props) => {
   const {closePortal, queryRef} = props
 
-  const [selectedTeams, setSelectedTeams] = useState<string[]>([])
+  const [selectedTeamsIds, setSelectedTeamsIds] = useState<string[]>([])
 
   const data = usePreloadedQuery<ReviewRequestToJoinOrgModalQuery>(query, queryRef)
   const viewer = useFragment<ReviewRequestToJoinOrgModal_viewer$key>(
@@ -100,7 +100,7 @@ const ReviewRequestToJoinOrgModal = (props: Props) => {
       {
         variables: {
           requestId,
-          teamIds: selectedTeams
+          teamIds: selectedTeamsIds
         }
       },
       {
@@ -124,17 +124,17 @@ const ReviewRequestToJoinOrgModal = (props: Props) => {
 
             // TODO: implement userId filter for teamMembers on API side
             const isAlreadyMember = teamMembers.some((member) => member.userId === createdBy)
-            const active = selectedTeams.includes(teamId) || isAlreadyMember
+            const active = selectedTeamsIds.includes(teamId) || isAlreadyMember
 
             const handleClick = () => {
               if (isAlreadyMember) return
 
               if (active) {
-                setSelectedTeams((prevSelectedTeams) =>
-                  prevSelectedTeams.filter((id) => id !== teamId)
+                setSelectedTeamsIds((prevSelectedTeamsIds) =>
+                  prevSelectedTeamsIds.filter((id) => id !== teamId)
                 )
               } else {
-                setSelectedTeams((prevSelectedTeams) => [...prevSelectedTeams, teamId])
+                setSelectedTeamsIds((prevSelectedTeamsIds) => [...prevSelectedTeamsIds, teamId])
               }
             }
 

--- a/packages/client/components/ReviewRequestToJoinOrgModal.tsx
+++ b/packages/client/components/ReviewRequestToJoinOrgModal.tsx
@@ -9,7 +9,7 @@ import SecondaryButton from './SecondaryButton'
 import {ReviewRequestToJoinOrgModalQuery} from '../__generated__/ReviewRequestToJoinOrgModalQuery.graphql'
 import {ReviewRequestToJoinOrgModal_viewer$key} from '../__generated__/ReviewRequestToJoinOrgModal_viewer.graphql'
 import Checkbox from './Checkbox'
-import useAcceptRequestToJoinDomainMutation from '../mutations/AcceptRequestToJoinDomainMutation'
+import useAcceptRequestToJoinDomainMutation from '../mutations/useAcceptRequestToJoinDomainMutation'
 
 const ReviewRequestToJoinOrgModalViewerFragment = graphql`
   fragment ReviewRequestToJoinOrgModal_viewer on User

--- a/packages/client/mutations/useAcceptRequestToJoinDomainMutation.ts
+++ b/packages/client/mutations/useAcceptRequestToJoinDomainMutation.ts
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMutation, UseMutationConfig} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
-import {AcceptRequestToJoinDomainMutation as TAcceptRequestToJoinDomainMutation} from '../__generated__/AcceptRequestToJoinDomainMutation.graphql'
+import {useAcceptRequestToJoinDomainMutation as TAcceptRequestToJoinDomainMutation} from '../__generated__/useAcceptRequestToJoinDomainMutation.graphql'
 import SendClientSegmentEventMutation from './SendClientSegmentEventMutation'
 
 graphql`
-  fragment AcceptRequestToJoinDomainMutation_success on AcceptRequestToJoinDomainSuccess
+  fragment useAcceptRequestToJoinDomainMutation_success on AcceptRequestToJoinDomainSuccess
   @argumentDefinitions(requestId: {type: "ID!"}) {
     viewer {
       ...ReviewRequestToJoinOrgModal_viewer @arguments(requestId: $requestId)
@@ -14,14 +14,14 @@ graphql`
 `
 
 const mutation = graphql`
-  mutation AcceptRequestToJoinDomainMutation($requestId: ID!, $teamIds: [ID!]!) {
+  mutation useAcceptRequestToJoinDomainMutation($requestId: ID!, $teamIds: [ID!]!) {
     acceptRequestToJoinDomain(requestId: $requestId, teamIds: $teamIds) {
       ... on ErrorPayload {
         error {
           message
         }
       }
-      ...AcceptRequestToJoinDomainMutation_success @arguments(requestId: $requestId)
+      ...useAcceptRequestToJoinDomainMutation_success @arguments(requestId: $requestId)
     }
   }
 `


### PR DESCRIPTION

<img width="519" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/6d905afc-48b2-4cbc-8f19-fc5850ecf12c">


**How to test:**

- Trigger prompt to join org
- See that add teammate dialog buttons become disabled when mutation is running
