### PR TITLE
feat(Team Health): Add summary

### DIFF
--- a/packages/client/components/TeamHealth.tsx
+++ b/packages/client/components/TeamHealth.tsx
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {ReactElement, useMemo} from 'react'
+import React, {ReactElement} from 'react'
 import {useFragment} from 'react-relay'
 import useGotoStageId from '~/hooks/useGotoStageId'
 import {TeamHealth_meeting$key} from '~/__generated__/TeamHealth_meeting.graphql'
@@ -17,6 +17,7 @@ import RevealTeamHealthVotesMutation from '../mutations/RevealTeamHealthVotesMut
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import clsx from 'clsx'
 import RaisedButton from './RaisedButton'
+import getTeamHealthVoteColor from '../utils/getTeamHealthVoteColor'
 
 interface Props {
   avatarGroup: ReactElement
@@ -24,8 +25,6 @@ interface Props {
   toggleSidebar: () => void
   gotoStageId?: ReturnType<typeof useGotoStageId>
 }
-
-const VoteBackgroundColors = ['bg-grape-700', 'bg-grape-600', 'bg-grape-500']
 
 const TeamHealth = (props: Props) => {
   const {avatarGroup, meeting: meetingRef, toggleSidebar} = props
@@ -67,18 +66,6 @@ const TeamHealth = (props: Props) => {
     SetTeamHealthVoteMutation(atmosphere, {meetingId, stageId, label}, {onError, onCompleted})
   }
 
-  const backgroundColorMap = useMemo(() => {
-    const deduped = Array.from(new Set(votes)).sort().reverse()
-    const colorMap = new Map<number, string>()
-    deduped.forEach((vote, index) => {
-      colorMap.set(
-        vote,
-        VoteBackgroundColors[index] ?? VoteBackgroundColors[VoteBackgroundColors.length - 1]!
-      )
-    })
-    return colorMap
-  }, [votes])
-
   const onRevealVotes = () => {
     if (!canReveal || submitting) return
     submitMutation()
@@ -104,14 +91,12 @@ const TeamHealth = (props: Props) => {
                   {labels?.map((label, index) => (
                     <div
                       key={label}
-                      className={clsx(
-                        'm-3 flex h-32 w-20 flex-col justify-start rounded',
-                        backgroundColorMap.get(votes[index]!)
-                      )}
+                      className='m-3 flex h-32 w-20 flex-col justify-start rounded'
+                      style={{backgroundColor: getTeamHealthVoteColor(votes, votes[index]!)}}
                     >
                       <div className='flex h-24 items-center justify-center text-4xl'>{label}</div>
                       <label className='text-center text-xl font-semibold text-white'>
-                        {votes?.[index]}
+                        {votes[index]}
                       </label>
                     </div>
                   ))}

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -13,6 +13,7 @@ import MeetingMembersWithoutTasks from './MeetingMembersWithoutTasks'
 import MeetingMembersWithTasks from './MeetingMembersWithTasks'
 import {MeetingSummaryReferrer} from './MeetingSummaryEmail'
 import QuickStats from './QuickStats'
+import TeamHealthSummary from './TeamHealthSummary'
 import RetroTopics from './RetroTopics'
 import SummaryHeader from './SummaryHeader'
 import SummaryPokerStories from './SummaryPokerStories'
@@ -70,6 +71,7 @@ const SummarySheet = (props: Props) => {
         ...WholeMeetingSummary_meeting
         ...SummaryHeader_meeting
         ...QuickStats_meeting
+        ...TeamHealthSummary_meeting
         ...MeetingMembersWithTasks_meeting
         ...MeetingMembersWithoutTasks_meeting
         ...RetroTopics_meeting
@@ -92,6 +94,7 @@ const SummarySheet = (props: Props) => {
           <td>
             <SummaryHeader meeting={meeting} corsOptions={corsOptions} />
             <QuickStats meeting={meeting} />
+            <TeamHealthSummary meeting={meeting} />
           </td>
         </tr>
         <SummarySheetCTA referrer={referrer} isDemo={isDemo} teamDashUrl={teamDashUrl} />

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamHealthSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamHealthSummary.tsx
@@ -1,0 +1,72 @@
+import graphql from 'babel-plugin-relay/macro'
+import {TeamHealthSummary_meeting$key} from 'parabol-client/__generated__/TeamHealthSummary_meeting.graphql'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import getTeamHealthVoteColor from 'parabol-client/utils/getTeamHealthVoteColor'
+
+interface Props {
+  meeting: TeamHealthSummary_meeting$key
+}
+
+const TeamHealthSummary = (props: Props) => {
+  const {meeting: meetingRef} = props
+  const meeting = useFragment(
+    graphql`
+      fragment TeamHealthSummary_meeting on NewMeeting {
+        __typename
+        phases {
+          phaseType
+          ... on TeamHealthPhase {
+            stages {
+              __typename
+              question
+              labels
+              votes
+              isRevealed
+            }
+          }
+        }
+      }
+    `,
+    meetingRef
+  )
+  const {phases} = meeting
+  const teamHealthPhase = phases.find(({phaseType}) => phaseType === 'TEAM_HEALTH')
+  const stages = teamHealthPhase?.stages?.filter(({isRevealed, votes}) => isRevealed && votes)
+  if (!stages || stages.length === 0) return null
+  return (
+    <table width='90%' align='center' className='mt-8 rounded-lg bg-slate-200 py-4 pt-2 pb-0'>
+      <tbody>
+        <tr>
+          <td align='center' width='100%'>
+            <h2 className='m-0 mb-1 text-lg font-semibold'>Team Health</h2>
+            {stages.map(
+              ({question, labels, votes}) =>
+                votes && (
+                  <div key={question}>
+                    <h3 className='m-0 text-base font-normal'>{question}</h3>
+                    <div className='flex flex-row'>
+                      {labels.map((label, index) => (
+                        <div
+                          key={label}
+                          className='m-3 flex flex-grow flex-col justify-start rounded pt-2'
+                          style={{backgroundColor: getTeamHealthVoteColor(votes, votes[index]!)}}
+                        >
+                          <div className='flex items-center justify-center text-2xl'>{label}</div>
+                          <label className='text-center text-lg font-semibold text-white'>
+                            {votes[index]}
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )
+            )}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  )
+}
+
+export default TeamHealthSummary

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamHealthSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamHealthSummary.tsx
@@ -1,4 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
+import {PALETTE} from 'parabol-client/styles/paletteV3'
+import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
 import {TeamHealthSummary_meeting$key} from 'parabol-client/__generated__/TeamHealthSummary_meeting.graphql'
 import React from 'react'
 import {useFragment} from 'react-relay'
@@ -35,36 +37,91 @@ const TeamHealthSummary = (props: Props) => {
   const stages = teamHealthPhase?.stages?.filter(({isRevealed, votes}) => isRevealed && votes)
   if (!stages || stages.length === 0) return null
   return (
-    <table width='90%' align='center' className='mt-8 rounded-lg bg-slate-200 py-4 pt-2 pb-0'>
-      <tbody>
+    <table
+      width='90%'
+      align='center'
+      style={{
+        padding: '0 16px 16px 8px',
+        marginTop: '32px',
+        borderRadius: '8px',
+        borderCollapse: 'collapse',
+        backgroundColor: PALETTE.SLATE_200
+      }}
+    >
+      <thead>
         <tr>
           <td align='center' width='100%'>
-            <h2 className='m-0 mb-1 text-lg font-semibold'>Team Health</h2>
-            {stages.map(
-              ({question, labels, votes}) =>
-                votes && (
-                  <div key={question}>
-                    <h3 className='m-0 text-base font-normal'>{question}</h3>
-                    <div className='flex flex-row'>
-                      {labels.map((label, index) => (
-                        <div
-                          key={label}
-                          className='m-3 flex flex-grow flex-col justify-start rounded pt-2'
-                          style={{backgroundColor: getTeamHealthVoteColor(votes, votes[index]!)}}
-                        >
-                          <div className='flex items-center justify-center text-2xl'>{label}</div>
-                          <label className='text-center text-lg font-semibold text-white'>
-                            {votes[index]}
-                          </label>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )
-            )}
+            <h2
+              style={{
+                color: PALETTE.SLATE_700,
+                fontFamily: FONT_FAMILY.SANS_SERIF,
+                fontSize: '18px',
+                fontWeight: 600
+              }}
+            >
+              Team Health
+            </h2>
           </td>
         </tr>
-      </tbody>
+      </thead>
+      {stages.map(
+        ({question, labels, votes}) =>
+          votes && (
+            <tr key={question}>
+              <td align='center'>
+                <h3
+                  style={{
+                    color: PALETTE.SLATE_700,
+                    fontFamily: FONT_FAMILY.SANS_SERIF,
+                    fontSize: '16px',
+                    fontWeight: 400,
+                    margin: 0
+                  }}
+                >
+                  {question}
+                </h3>
+                <table width='100%' align='center' cellSpacing='16px'>
+                  <tr>
+                    {labels.map((label, idx) => (
+                      <td
+                        key={idx}
+                        style={{
+                          backgroundColor: getTeamHealthVoteColor(votes, votes[idx]!),
+                          fontFamily: FONT_FAMILY.SANS_SERIF,
+                          fontSize: '24px',
+                          borderRadius: '4px',
+                          paddingTop: '8px',
+                          paddingBottom: '4px'
+                        }}
+                        align='center'
+                        width={`${100 / labels.length}%`}
+                      >
+                        <span
+                          style={{
+                            fontSize: '24px'
+                          }}
+                        >
+                          {label}
+                        </span>
+                        <br />
+                        <span
+                          style={{
+                            color: PALETTE.WHITE,
+                            fontSize: '18px',
+                            fontWeight: 600,
+                            textAlign: 'center'
+                          }}
+                        >
+                          {votes[idx]}
+                        </span>
+                      </td>
+                    ))}
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          )
+      )}
     </table>
   )
 }

--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -13,7 +13,7 @@
 
 @font-face {
   font-family: 'IBM Plex Mono';
-  src: url('static/fonts/IBMPlexMono-SemiBold.woff2') format('woff2');
+  src: url('/static/fonts/IBMPlexMono-SemiBold.woff2') format('woff2');
   font-style: normal;
   font-weight: 600;
   font-stretch: normal;
@@ -65,7 +65,7 @@
     2) prevent a horizontal scrollbar from causing a vertical scrollbar due to the 100vh
   */
   #root {
-    @apply m-0 h-screen w-full bg-slate-200 p-0;
+    @apply w-full h-screen p-0 m-0 bg-slate-200;
   }
 
   *,

--- a/packages/client/utils/blendColors.ts
+++ b/packages/client/utils/blendColors.ts
@@ -1,0 +1,17 @@
+function blendColors(color1: string, color2: string, ratio: number) {
+  const r1 = parseInt(color1.substring(1, 3), 16)
+  const g1 = parseInt(color1.substring(3, 5), 16)
+  const b1 = parseInt(color1.substring(5, 7), 16)
+
+  const r2 = parseInt(color2.substring(1, 3), 16)
+  const g2 = parseInt(color2.substring(3, 5), 16)
+  const b2 = parseInt(color2.substring(5, 7), 16)
+
+  const r = Math.round(r1 + (r2 - r1) * ratio)
+  const g = Math.round(g1 + (g2 - g1) * ratio)
+  const b = Math.round(b1 + (b2 - b1) * ratio)
+
+  return `rgb(${r}, ${g}, ${b})`
+}
+
+export default blendColors

--- a/packages/client/utils/getTeamHealthVoteColor.ts
+++ b/packages/client/utils/getTeamHealthVoteColor.ts
@@ -1,0 +1,11 @@
+import blendColors from './blendColors'
+import {PALETTE} from '../styles/paletteV3'
+
+function getTeamHealthVoteColor(allVotes: readonly number[], vote: number) {
+  const sumVotes = allVotes.reduce((acc, vote) => acc + vote, 0)
+  const ratio = (vote * 1.0) / sumVotes
+  const blended = blendColors(PALETTE.GRAPE_500, PALETTE.GRAPE_700, ratio)
+  return blended
+}
+
+export default getTeamHealthVoteColor

--- a/packages/client/utils/getTeamHealthVoteColor.ts
+++ b/packages/client/utils/getTeamHealthVoteColor.ts
@@ -2,8 +2,9 @@ import blendColors from './blendColors'
 import {PALETTE} from '../styles/paletteV3'
 
 function getTeamHealthVoteColor(allVotes: readonly number[], vote: number) {
-  const sumVotes = allVotes.reduce((acc, vote) => acc + vote, 0)
-  const ratio = (vote * 1.0) / sumVotes
+  const minVote = Math.min(...allVotes)
+  const maxVote = Math.max(...allVotes)
+  const ratio = ((vote - minVote) * 1.0) / maxVote
   const blended = blendColors(PALETTE.GRAPE_500, PALETTE.GRAPE_700, ratio)
   return blended
 }

--- a/packages/server/email/MailManagerDebug.ts
+++ b/packages/server/email/MailManagerDebug.ts
@@ -1,4 +1,5 @@
 import MailManager, {MailManagerOptions} from './MailManager'
+import fs from 'fs'
 
 export default class MailManagerDebug extends MailManager {
   async sendEmail(options: MailManagerOptions) {
@@ -7,6 +8,11 @@ export default class MailManagerDebug extends MailManager {
     To: ${to}
     Subject: ${subject}
     Body: ${body}`)
+
+    const {html} = options
+    const filename = `/tmp/${to}-${subject.replaceAll(' ', '-')}.html`
+    fs.writeFileSync(filename, html)
+    console.warn(`Wrote email to ${filename}`)
     return true
   }
 }


### PR DESCRIPTION
# Description

Fixes #7941
Also blend colors based on the votes percentage.

## Demo
![Screenshot from 2023-06-06 08-57-36](https://github.com/ParabolInc/parabol/assets/7331043/9e9812f2-f49f-4c49-a62b-09af70eaf6d5)

## Testing scenarios

Run retros with `teamHealth` org flag and team health phase
* [ ] if votes were revealed, check the summary matches
* [ ] if votes were not revealed, check summary does not contain team health
* [ ] check HTML email

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
