### PR TITLE
fix: fix loader.load with undefined in accept team invitation

### DIFF
--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -43,7 +43,7 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   if (invitationRes.error) {
     const {error: message, teamId, meetingId} = invitationRes
     if (message === InvitationTokenError.ALREADY_ACCEPTED) {
-      return {error: {message}, teamId, meetingId}
+      return {error: {message}, teamId, meetingId, teamMemberId: toTeamMemberId(teamId, viewerId)}
     }
     return {error: {message}}
   }


### PR DESCRIPTION
Probably a solution for #7771 
(At least some of errors)


<img width="446" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/954120f9-c7ad-4074-81d8-b9d087c29ce9">


**How to test:**

- Invite a user using email
- Click accept invitation, see it works
- Click accept invitation again, see no error in logs