### PR TITLE
fix(rid): Correct styles for non-owner readonly scales

### DIFF
--- a/packages/client/modules/meeting/components/PokerTemplateScalePicker.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateScalePicker.tsx
@@ -32,7 +32,7 @@ const DropdownIcon = styled(ExpandMore)({
 
 const DropdownBlock = styled('div')<{disabled: boolean; readOnly: boolean}>(
   ({disabled, readOnly}) => ({
-    background: disabled ? PALETTE.SLATE_200 : '#fff',
+    background: disabled && !readOnly ? PALETTE.SLATE_200 : '#fff',
     border: readOnly ? undefined : `1px solid ${PALETTE.SLATE_400}`,
     borderRadius: '30px',
     cursor: readOnly ? undefined : disabled ? 'not-allowed' : 'pointer',
@@ -99,7 +99,7 @@ const PokerTemplateScalePicker = (props: Props) => {
     closeTooltip,
     originRef: tooltipRef
   } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER, {
-    disabled: isOwner
+    disabled: isOwner || readOnly
   })
   return (
     <>
@@ -115,7 +115,7 @@ const PokerTemplateScalePicker = (props: Props) => {
         <MenuToggleInner>
           <MenuToggleLabel>{selectedScale.name}</MenuToggleLabel>
         </MenuToggleInner>
-        {(!readOnly || !isOwner) && <DropdownIcon />}
+        {!readOnly && <DropdownIcon />}
       </DropdownBlock>
       {menuPortal(<SelectScaleDropdown menuProps={menuProps} dimension={dimension} />)}
       {tooltipPortal(<div>Must be the template owner to change</div>)}


### PR DESCRIPTION
# Description
see [slack](https://parabol.slack.com/archives/C02438U0VJ4/p1685491486297169) 🔒 

Currently, readonly mode differs for poker scales between owned + non-owned templates.

This PR fixes those styles.

## Demo
Non-owned:
<img width="541" alt="Screen Shot 2023-05-31 at 11 34 43 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/dea0c68b-aa39-45b3-9ee1-6f311961748c">
Owned:
<img width="526" alt="Screen Shot 2023-05-31 at 11 34 47 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/9b930b59-10cd-403a-ae57-4db3d0a2da1f">
Owned + edit-mode:
<img width="532" alt="Screen Shot 2023-05-31 at 11 34 50 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/c8bc3b9c-6906-40a0-b92a-df8b47f06b6e">
Existing owned:
<img width="543" alt="Screen Shot 2023-05-31 at 11 35 00 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/c4a55c76-ead6-47c5-92e8-e25d5d9e20f9">
Existing non-owned
<img width="550" alt="Screen Shot 2023-05-31 at 11 34 56 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/a806fe73-a6cb-434a-a4d3-cd9fc772b7dd">


## Testing scenarios
- [ ] Test read-only + edit modes for both owned + non-owned poker templates
- [ ] Smoke test poker template picker in existing flow

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
