### PR TITLE
fix(prompt-to-join): fix add teammate routing when opened on a new tab

### DIFF
--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -63,7 +63,7 @@ const PrivateRoutes = () => {
       <Switch location={state?.backgroundLocation || location}>
         <Route path='/activity-library' component={ActivityLibraryRoutes} />
         <Route
-          path='(/meetings|/me|/newteam|/team|/usage|/new-meeting)'
+          path='(/meetings|/me|/newteam|/team|/usage|/new-meeting|/organization-join-request)'
           component={DashboardRoot}
         />
         <Route path='/meet/:meetingId' component={MeetingRoot} />


### PR DESCRIPTION

<img width="1335" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/25a13594-a49a-4fce-9a98-0ac0d81c8c69">

When copy pasting add teammate modal url in a new tab, it shows 404 on the background. 

Works on just page refresh, that is why I didn't notice it.

How to test:

- trigger prompt to join org
- open add teammate dialog
- copy the URL
- paste in a new tab
- see everything is fine
