### PR TITLE
chore: remove slackin broken link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Parabol - We're [hiring](https://www.parabol.co/join)!
 
-[![Slack Status](https://slackin.parabol.co/badge.svg)](https://slackin.parabol.co/)
 [![CircleCI](https://circleci.com/gh/ParabolInc/parabol.svg?style=svg)](https://circleci.com/gh/ParabolInc/parabol)
 
 ## Overview


### PR DESCRIPTION
# Description

We no longer have slack community so the link in our readme was broken. 

## Demo

No demo

## Testing scenarios

No testing scenarios

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
