### PR TITLE
feat(DX): Infer parent portal IDs through React context

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
@@ -190,7 +190,6 @@ export const TemplateDetails = (props: Props) => {
                 )}
               >
                 <UnstyledTemplateSharing
-                  noModal={true}
                   isOwner={isOwner}
                   template={template}
                   readOnly={!isEditing}

--- a/packages/client/components/ActivityLibrary/ActivityDetailsRecurrenceSettings.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsRecurrenceSettings.tsx
@@ -30,7 +30,6 @@ export const ActivityDetailsRecurrenceSettings = (props: Props) => {
       {modalPortal(
         <DialogContainer className='bg-white'>
           <RecurrenceSettings
-            parentId='newMeetingRecurrenceSettings'
             onRecurrenceSettingsUpdated={onRecurrenceSettingsUpdated}
             recurrenceSettings={recurrenceSettings}
           />

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -221,7 +221,7 @@ const ActivityDetailsSidebar = (props: Props) => {
           )}
           <div className='flex grow flex-col justify-end gap-2'>
             {error && <StyledError>{error.message}</StyledError>}
-            <NewMeetingActionsCurrentMeetings noModal={true} team={selectedTeam} />
+            <NewMeetingActionsCurrentMeetings team={selectedTeam} />
             <FlatPrimaryButton onClick={handleStartActivity} waiting={submitting} className='h-14'>
               <div className='text-lg'>Start Activity</div>
             </FlatPrimaryButton>

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -138,7 +138,6 @@ const TeamPickerModal = (props: Props) => {
           <b>Select the team</b> to manage this cloned template
         </div>
         <NewMeetingTeamPicker
-          parentId='templateTeamPickerModal'
           positionOverride={MenuPosition.UPPER_LEFT}
           onSelectTeam={(teamId) => {
             const newTeam = teams.find((team) => team.id === teamId)

--- a/packages/client/components/GitHubFieldMenu.tsx
+++ b/packages/client/components/GitHubFieldMenu.tsx
@@ -115,8 +115,7 @@ const GitHubFieldMenu = (props: Props) => {
     openPortal,
     closePortal: closeModal
   } = useModal({
-    id: 'editGitHubLabel',
-    parentId: 'githubFieldMenu'
+    id: 'editGitHubLabel'
   })
 
   if (task?.integration?.__typename !== '_xGitHubIssue') return null

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -208,7 +208,6 @@ const NewMeeting = (props: Props) => {
               onSelectTeam={(teamId) => history.replace(`/new-meeting/${teamId}`)}
               selectedTeamRef={selectedTeam}
               teamsRef={teams}
-              parentId='newMeetingRoot'
             />
           </SettingsFirstRow>
           <SettingsRow>

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -26,11 +26,10 @@ const ForumIcon = styled(Forum)({
 
 interface Props {
   team: NewMeetingActionsCurrentMeetings_team$key
-  noModal?: boolean
 }
 
 const NewMeetingActionsCurrentMeetings = (props: Props) => {
-  const {team: teamRef, noModal} = props
+  const {team: teamRef} = props
   const team = useFragment(
     graphql`
       fragment NewMeetingActionsCurrentMeetings_team on Team {
@@ -47,7 +46,6 @@ const NewMeetingActionsCurrentMeetings = (props: Props) => {
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu<HTMLButtonElement>(
     MenuPosition.LOWER_RIGHT,
     {
-      parentId: noModal ? undefined : 'newMeetingRoot',
       isDropdown: true
     }
   )

--- a/packages/client/components/NewMeetingRecurrenceSettings.tsx
+++ b/packages/client/components/NewMeetingRecurrenceSettings.tsx
@@ -17,7 +17,6 @@ export const NewMeetingRecurrenceSettings = (props: Props) => {
     MenuPosition.LOWER_RIGHT,
     {
       id: 'newMeetingRecurrenceSettings',
-      parentId: 'newMeetingRoot',
       isDropdown: true
     }
   )

--- a/packages/client/components/NewMeetingRecurrenceSettings.tsx
+++ b/packages/client/components/NewMeetingRecurrenceSettings.tsx
@@ -40,7 +40,6 @@ export const NewMeetingRecurrenceSettings = (props: Props) => {
       />
       {menuPortal(
         <RecurrenceSettings
-          parentId='newMeetingRecurrenceSettings'
           onRecurrenceSettingsUpdated={onRecurrenceSettingsUpdated}
           recurrenceSettings={recurrenceSettings}
         />

--- a/packages/client/components/NewMeetingSettingsRetrospectiveSettings.tsx
+++ b/packages/client/components/NewMeetingSettingsRetrospectiveSettings.tsx
@@ -35,7 +35,6 @@ const NewMeetingSettingsRetrospectiveSettings = (props: Props) => {
   const {togglePortal, menuPortal, originRef, menuProps, portalStatus} = useMenu<HTMLDivElement>(
     MenuPosition.LOWER_RIGHT,
     {
-      parentId: 'newMeetingRoot',
       isDropdown: true
     }
   )

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -5,7 +5,7 @@ import {NewMeetingTeamPicker_selectedTeam$key} from '~/__generated__/NewMeetingT
 import {NewMeetingTeamPicker_teams$key} from '~/__generated__/NewMeetingTeamPicker_teams.graphql'
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
-import {PortalId, PortalStatus} from '../hooks/usePortal'
+import {PortalStatus} from '../hooks/usePortal'
 import lazyPreload from '../utils/lazyPreload'
 import NewMeetingDropdown from './NewMeetingDropdown'
 import NewMeetingTeamPickerAvatars from './NewMeetingTeamPickerAvatars'
@@ -22,17 +22,15 @@ interface Props {
   selectedTeamRef: NewMeetingTeamPicker_selectedTeam$key
   teamsRef: NewMeetingTeamPicker_teams$key
   onSelectTeam: (teamId: string) => void
-  parentId?: PortalId
   positionOverride?: MenuPosition
   customPortal?: React.ReactNode
 }
 
 const NewMeetingTeamPicker = (props: Props) => {
-  const {selectedTeamRef, teamsRef, onSelectTeam, parentId, positionOverride, customPortal} = props
+  const {selectedTeamRef, teamsRef, onSelectTeam, positionOverride, customPortal} = props
   const {togglePortal, menuPortal, originRef, menuProps, portalStatus} = useMenu<HTMLDivElement>(
     positionOverride ?? MenuPosition.LOWER_RIGHT,
     {
-      parentId: parentId,
       isDropdown: true
     }
   )

--- a/packages/client/components/ReflectionGroup/ReflectionGroup.tsx
+++ b/packages/client/components/ReflectionGroup/ReflectionGroup.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {RefObject, useEffect, useMemo, useRef, useState} from 'react'
 import {commitLocalUpdate, useFragment} from 'react-relay'
-import {PortalId} from '~/hooks/usePortal'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import useEventCallback from '../../hooks/useEventCallback'
 import useExpandedReflections from '../../hooks/useExpandedReflections'
@@ -73,7 +72,6 @@ interface Props {
   reflectionGroupRef: ReflectionGroup_reflectionGroup$key
   swipeColumn?: SwipeColumn
   dataCy?: string
-  expandedReflectionGroupPortalParentId?: PortalId
   reflectionIdsToHide?: string[] | null
   isSpotlightEntering?: boolean
   showDragHintAnimation?: boolean
@@ -87,7 +85,6 @@ const ReflectionGroup = (props: Props) => {
     reflectionGroupRef,
     swipeColumn,
     dataCy,
-    expandedReflectionGroupPortalParentId,
     reflectionIdsToHide,
     isSpotlightEntering,
     showDragHintAnimation
@@ -173,13 +170,7 @@ const ReflectionGroup = (props: Props) => {
   }, [visibleReflections])
   const stackRef = useRef<HTMLDivElement>(null)
   const {setItemsRef, scrollRef, bgRef, modalHeaderRef, portal, portalStatus, collapse, expand} =
-    useExpandedReflections(
-      groupRef,
-      stackRef,
-      visibleReflections.length,
-      headerRef,
-      expandedReflectionGroupPortalParentId
-    )
+    useExpandedReflections(groupRef, stackRef, visibleReflections.length, headerRef)
   const atmosphere = useAtmosphere()
   const [isEditing, thisSetIsEditing] = useState(false)
   const isDragPhase = phaseType === 'group' && !isComplete

--- a/packages/client/components/SpotlightResults.tsx
+++ b/packages/client/components/SpotlightResults.tsx
@@ -104,7 +104,6 @@ const SpotlightResults = (props: Props) => {
                   meetingRef={meeting!}
                   phaseRef={phaseRef}
                   reflectionGroupRef={group}
-                  expandedReflectionGroupPortalParentId='spotlight'
                   isSpotlightEntering={isSpotlightEntering}
                 />
               ))}

--- a/packages/client/components/StageTimerModalEndTimeDate.tsx
+++ b/packages/client/components/StageTimerModalEndTimeDate.tsx
@@ -47,7 +47,6 @@ const StageTimerModalEndTimeDate = (props: Props) => {
     originRef
   } = useMenu<HTMLDivElement>(MenuPosition.LOWER_LEFT, {
     id: 'StageTimerEndTimePicker',
-    parentId: 'StageTimerModal',
     isDropdown: true
   })
   const handleDayClick = (day: Date, {disabled, selected}: DayModifiers) => {

--- a/packages/client/components/StageTimerModalEndTimeHour.tsx
+++ b/packages/client/components/StageTimerModalEndTimeHour.tsx
@@ -24,7 +24,6 @@ const StageTimerModalEndTimeHour = (props: Props) => {
     MenuPosition.LOWER_LEFT,
     {
       id: 'StageTimerEndTimePicker',
-      parentId: 'StageTimerModal',
       isDropdown: true
     }
   )

--- a/packages/client/components/StageTimerModalTimeLimit.tsx
+++ b/packages/client/components/StageTimerModalTimeLimit.tsx
@@ -78,7 +78,6 @@ const StageTimerModalTimeLimit = (props: Props) => {
     originRef
   } = useMenu<HTMLDivElement>(MenuPosition.LOWER_LEFT, {
     id: 'StageTimerMinutePicker',
-    parentId: 'StageTimerModal',
     isDropdown: true
   })
   const {submitting, onError, onCompleted, submitMutation, error} = useMutationProps()

--- a/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
@@ -5,7 +5,6 @@ import React, {PropsWithChildren, useEffect} from 'react'
 import {Frequency, RRule} from 'rrule'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useMenu from '../../../hooks/useMenu'
-import {PortalId} from '../../../hooks/usePortal'
 import plural from '../../../utils/plural'
 import DropdownMenuToggle from '../../DropdownMenuToggle'
 import {toHumanReadable} from './HumanReadableRecurrenceRule'
@@ -171,7 +170,6 @@ export interface RecurrenceSettings {
 }
 
 interface Props {
-  parentId: PortalId
   onRecurrenceSettingsUpdated: (
     recurrenceSettings: RecurrenceSettings,
     validationErrors: string[] | undefined
@@ -180,7 +178,7 @@ interface Props {
 }
 
 export const RecurrenceSettings = (props: Props) => {
-  const {parentId, onRecurrenceSettingsUpdated, recurrenceSettings} = props
+  const {onRecurrenceSettingsUpdated, recurrenceSettings} = props
   const {name: meetingSeriesName, rrule: recurrenceRule} = recurrenceSettings
   const [name, setName] = React.useState(meetingSeriesName)
   const [nameError, setNameError] = React.useState<string | undefined>()
@@ -212,7 +210,6 @@ export const RecurrenceSettings = (props: Props) => {
     MenuPosition.LOWER_LEFT,
     {
       id: 'recurrenceStartTimePicker',
-      parentId,
       isDropdown: true
     }
   )

--- a/packages/client/components/TeamPrompt/Recurrence/UpdateRecurrenceSettingsModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/UpdateRecurrenceSettingsModal.tsx
@@ -189,7 +189,6 @@ export const UpdateRecurrenceSettingsModal = (props: Props) => {
   return (
     <UpdateRecurrenceSettingsModalRoot>
       <RecurrenceSettings
-        parentId='updateRecurrenceSettingsModal'
         recurrenceSettings={newRecurrenceSettings}
         onRecurrenceSettingsUpdated={handleNewRecurrenceSettings}
       />

--- a/packages/client/hooks/useExpandedReflections.ts
+++ b/packages/client/hooks/useExpandedReflections.ts
@@ -2,7 +2,7 @@ import {MutableRefObject, RefObject, useEffect} from 'react'
 import {ElementWidth, Times} from '../types/constEnums'
 import useFlip from './useFlip'
 import useFlipDeal from './useFlipDeal'
-import usePortal, {PortalId, PortalStatus} from './usePortal'
+import usePortal, {PortalStatus} from './usePortal'
 
 const shrinkGroupOnExpand = (groupEl: HTMLDivElement) => {
   const {style, scrollHeight} = groupEl
@@ -18,8 +18,7 @@ const useExpandedReflections = (
   groupRef: MutableRefObject<any>,
   stackRef: RefObject<HTMLDivElement>,
   count: number,
-  headerRef?: RefObject<HTMLDivElement>,
-  portalParentId?: PortalId
+  headerRef?: RefObject<HTMLDivElement>
 ) => {
   const offsetLeft = ElementWidth.REFLECTION_CARD_PADDING * 2
   const offsetTop = ElementWidth.REFLECTION_CARD_PADDING * 2
@@ -38,7 +37,6 @@ const useExpandedReflections = (
   const [modalHeaderRef, headerReverse] = useFlip({firstRef: headerRef, isGroup})
   const [setItemsRef, itemsReverse] = useFlipDeal(count)
   const {terminatePortal, openPortal, portal, portalStatus, setPortalStatus} = usePortal({
-    parentId: portalParentId,
     id: 'expandedReflectionGroup',
     noClose: true
   })

--- a/packages/client/hooks/usePortal.tsx
+++ b/packages/client/hooks/usePortal.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode, useCallback, useEffect, useRef} from 'react'
+import React, {ReactNode, createContext, useCallback, useContext, useEffect, useRef} from 'react'
 import {createPortal} from 'react-dom'
 import requestDoubleAnimationFrame from '../components/RetroReflectPhase/requestDoubleAnimationFrame'
 import hideBodyScroll from '../utils/hideBodyScroll'
@@ -54,6 +54,8 @@ export interface UsePortalOptions {
   noClose?: boolean
 }
 
+const PortalContext = createContext<PortalId | undefined>(undefined)
+
 const getParent = (parentId: string | undefined) => {
   const parent = parentId ? document.getElementById(parentId) : document.body
   if (!parent) throw new Error('Could not find parent ' + parentId)
@@ -70,6 +72,8 @@ const usePortal = (options: UsePortalOptions = {}) => {
   const timeoutRef = useRef<number | null>(null)
   const showBodyScroll = useRef<() => void>()
   const [portalStatusRef, setPortalStatus] = useRefState(PortalStatus.Exited)
+  const contextParentId = useContext(PortalContext)
+  const parentId = options.parentId ?? contextParentId
 
   const terminatePortal = useEventCallback(() => {
     if (!portalRef.current) return
@@ -78,7 +82,7 @@ const usePortal = (options: UsePortalOptions = {}) => {
     document.removeEventListener('touchstart', handleDocumentClick)
     setPortalStatus(PortalStatus.Exited)
     try {
-      getParent(options.parentId).removeChild(portalRef.current)
+      getParent(parentId).removeChild(portalRef.current)
     } catch (e) {
       /* portal already removed (possible when parent is not document.body) */
     }
@@ -167,7 +171,7 @@ const usePortal = (options: UsePortalOptions = {}) => {
 
       portalRef.current = document.createElement('div')
       portalRef.current.id = options.id || 'portal'
-      getParent(options.parentId).appendChild(portalRef.current)
+      getParent(parentId).appendChild(portalRef.current)
       if (e?.currentTarget) {
         originRef.current = e.currentTarget as HTMLElement
       }
@@ -184,7 +188,10 @@ const usePortal = (options: UsePortalOptions = {}) => {
       const targetEl = portalRef.current
       return !targetEl || portalStatusRef.current === PortalStatus.Exited
         ? null
-        : createPortal(reactEl, targetEl)
+        : createPortal(
+            <PortalContext.Provider value={options.id}>{reactEl} </PortalContext.Provider>,
+            targetEl
+          )
     },
     [portalRef, portalStatusRef]
   )

--- a/packages/client/modules/meeting/components/EditableTemplatePromptColor.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplatePromptColor.tsx
@@ -11,13 +11,11 @@ import PalettePicker from '../../../components/PalettePicker/PalettePicker'
 import {MenuPosition} from '../../../hooks/useCoords'
 import useMenu from '../../../hooks/useMenu'
 import {PALETTE} from '../../../styles/paletteV3'
-import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
   prompt: EditableTemplatePromptColor_prompt$key
   prompts: EditableTemplatePromptColor_prompts$key
-  parentId?: PortalId
 }
 
 const PromptColor = styled(PlainButton)<{isOwner: boolean}>(({isOwner}) => ({
@@ -59,7 +57,7 @@ const DropdownIcon = styled('div')({
 })
 
 const EditableTemplatePromptColor = (props: Props) => {
-  const {isOwner, prompt: promptRef, prompts: promptsRef, parentId} = props
+  const {isOwner, prompt: promptRef, prompts: promptsRef} = props
   const prompts = useFragment(
     graphql`
       fragment EditableTemplatePromptColor_prompts on ReflectPrompt @relay(plural: true) {
@@ -80,7 +78,7 @@ const EditableTemplatePromptColor = (props: Props) => {
   const {groupColor} = prompt
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu<HTMLButtonElement>(
     MenuPosition.UPPER_LEFT,
-    {parentId: parentId}
+    {parentId: 'templateModal'}
   )
   return (
     <PromptColor ref={originRef} isOwner={isOwner} onClick={isOwner ? togglePortal : undefined}>

--- a/packages/client/modules/meeting/components/EditableTemplatePromptColor.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplatePromptColor.tsx
@@ -77,8 +77,7 @@ const EditableTemplatePromptColor = (props: Props) => {
   )
   const {groupColor} = prompt
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu<HTMLButtonElement>(
-    MenuPosition.UPPER_LEFT,
-    {parentId: 'templateModal'}
+    MenuPosition.UPPER_LEFT
   )
   return (
     <PromptColor ref={originRef} isOwner={isOwner} onClick={isOwner ? togglePortal : undefined}>

--- a/packages/client/modules/meeting/components/EditableTemplateScaleValueColor.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplateScaleValueColor.tsx
@@ -67,8 +67,7 @@ const EditableTemplateScaleValueColor = (props: Props) => {
     scaleRef
   )
   const {menuProps, menuPortal, originRef, togglePortal} = useMenu<HTMLButtonElement>(
-    MenuPosition.UPPER_LEFT,
-    {parentId: 'templateModal'}
+    MenuPosition.UPPER_LEFT
   )
   return (
     <ScaleValueColor ref={originRef} onClick={togglePortal}>

--- a/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
@@ -174,12 +174,7 @@ const PokerTemplateDetails = (props: Props) => {
           </FirstLine>
           <Description>{description}</Description>
         </TemplateHeader>
-        <TemplateDimensionList
-          isOwner={isOwner}
-          dimensions={dimensions}
-          templateId={templateId}
-          parentId='templateModal'
-        />
+        <TemplateDimensionList isOwner={isOwner} dimensions={dimensions} templateId={templateId} />
         {isOwner && <AddPokerTemplateDimension templateId={templateId} dimensions={dimensions} />}
         <TemplateSharing isOwner={isOwner} template={activeTemplate} />
       </Scrollable>

--- a/packages/client/modules/meeting/components/PokerTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplatePicker.tsx
@@ -49,8 +49,7 @@ const PokerTemplatePicker = (props: Props) => {
   const {selectedTemplate} = settings
   const {name: templateName, scope} = selectedTemplate
   const {togglePortal, modalPortal, closePortal} = useModal({
-    id: 'templateModal',
-    parentId: 'newMeetingRoot'
+    id: 'templateModal'
   })
   const atmosphere = useAtmosphere()
 

--- a/packages/client/modules/meeting/components/PokerTemplateScalePicker.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateScalePicker.tsx
@@ -11,7 +11,6 @@ import {PALETTE} from '../../../styles/paletteV3'
 import {FONT_FAMILY} from '../../../styles/typographyV2'
 import lazyPreload from '../../../utils/lazyPreload'
 import {PokerTemplateScalePicker_dimension$key} from '../../../__generated__/PokerTemplateScalePicker_dimension.graphql'
-import {PortalId} from '../../../hooks/usePortal'
 
 const SelectScaleDropdown = lazyPreload(
   () =>
@@ -65,12 +64,11 @@ const MenuToggleLabel = styled('div')({
 interface Props {
   dimension: PokerTemplateScalePicker_dimension$key
   isOwner: boolean
-  parentId?: PortalId
   readOnly?: boolean
 }
 
 const PokerTemplateScalePicker = (props: Props) => {
-  const {dimension: dimensionRef, isOwner, parentId, readOnly} = props
+  const {dimension: dimensionRef, isOwner, readOnly} = props
   const dimension = useFragment(
     graphql`
       fragment PokerTemplateScalePicker_dimension on TemplateDimension {
@@ -89,7 +87,6 @@ const PokerTemplateScalePicker = (props: Props) => {
     {
       isDropdown: true,
       id: 'scaleDropdown',
-      parentId,
       loadingWidth: 300
     }
   )

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -174,12 +174,7 @@ const ReflectTemplateDetails = (props: Props) => {
           </FirstLine>
           <Description>{description}</Description>
         </TemplateHeader>
-        <TemplatePromptList
-          isOwner={isOwner}
-          prompts={prompts}
-          templateId={templateId}
-          parentId='templateModal'
-        />
+        <TemplatePromptList isOwner={isOwner} prompts={prompts} templateId={templateId} />
         {isOwner && <AddTemplatePrompt templateId={templateId} prompts={prompts} />}
         <TemplateSharing isOwner={isOwner} template={activeTemplate} />
       </Scrollable>

--- a/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
@@ -50,8 +50,7 @@ const RetroTemplatePicker = (props: Props) => {
   const {selectedTemplate} = settings
   const {name: templateName, scope} = selectedTemplate
   const {togglePortal, modalPortal, closePortal} = useModal({
-    id: 'templateModal',
-    parentId: 'newMeetingRoot'
+    id: 'templateModal'
   })
   const atmosphere = useAtmosphere()
 

--- a/packages/client/modules/meeting/components/TemplateDimensionItem.tsx
+++ b/packages/client/modules/meeting/components/TemplateDimensionItem.tsx
@@ -12,7 +12,6 @@ import {PALETTE} from '../../../styles/paletteV3'
 import {TemplateDimensionItem_dimension$key} from '../../../__generated__/TemplateDimensionItem_dimension.graphql'
 import EditableTemplateDimension from './EditableTemplateDimension'
 import PokerTemplateScalePicker from './PokerTemplateScalePicker'
-import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
@@ -20,7 +19,6 @@ interface Props {
   dimension: TemplateDimensionItem_dimension$key
   dimensions: TemplateDimensionItem_dimensions$key
   dragProvided: DraggableProvided
-  parentId?: PortalId
   readOnly?: boolean
 }
 
@@ -74,7 +72,6 @@ const TemplateDimensionItem = (props: Props) => {
     isOwner,
     dimension: dimensionRef,
     dimensions: dimensionsRef,
-    parentId,
     readOnly
   } = props
   const dimensions = useFragment(
@@ -142,12 +139,7 @@ const TemplateDimensionItem = (props: Props) => {
           dimensions={dimensions}
         />
       </DimensionAndDescription>
-      <PokerTemplateScalePicker
-        dimension={dimension}
-        isOwner={isOwner}
-        readOnly={readOnly}
-        parentId={parentId}
-      />
+      <PokerTemplateScalePicker dimension={dimension} isOwner={isOwner} readOnly={readOnly} />
     </DimensionItem>
   )
 }

--- a/packages/client/modules/meeting/components/TemplateDimensionList.tsx
+++ b/packages/client/modules/meeting/components/TemplateDimensionList.tsx
@@ -9,14 +9,12 @@ import {TEMPLATE_DIMENSION} from '../../../utils/constants'
 import dndNoise from '../../../utils/dndNoise'
 import {TemplateDimensionList_dimensions$key} from '../../../__generated__/TemplateDimensionList_dimensions.graphql'
 import TemplateDimensionItem from './TemplateDimensionItem'
-import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
   dimensions: TemplateDimensionList_dimensions$key
   templateId: string
   readOnly?: boolean
-  parentId?: PortalId
 }
 
 const DimensionList = styled('div')({
@@ -26,7 +24,7 @@ const DimensionList = styled('div')({
 })
 
 const TemplateDimensionList = (props: Props) => {
-  const {isOwner, dimensions: dimensionsRef, templateId, parentId, readOnly} = props
+  const {isOwner, dimensions: dimensionsRef, templateId, readOnly} = props
   const dimensions = useFragment(
     graphql`
       fragment TemplateDimensionList_dimensions on TemplateDimension @relay(plural: true) {
@@ -98,7 +96,6 @@ const TemplateDimensionList = (props: Props) => {
                             dimensions={dimensions}
                             isDragging={dragSnapshot.isDragging}
                             dragProvided={dragProvided}
-                            parentId={parentId}
                           />
                         )
                       }}

--- a/packages/client/modules/meeting/components/TemplatePromptItem.tsx
+++ b/packages/client/modules/meeting/components/TemplatePromptItem.tsx
@@ -13,7 +13,6 @@ import {TemplatePromptItem_prompt$key} from '../../../__generated__/TemplateProm
 import EditableTemplateDescription from './EditableTemplateDescription'
 import EditableTemplatePrompt from './EditableTemplatePrompt'
 import EditableTemplatePromptColor from './EditableTemplatePromptColor'
-import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
@@ -21,7 +20,6 @@ interface Props {
   prompt: TemplatePromptItem_prompt$key
   prompts: TemplatePromptItem_prompts$key
   dragProvided: DraggableProvided
-  parentId?: PortalId
 }
 
 interface StyledProps {
@@ -66,14 +64,7 @@ const PromptAndDescription = styled('div')({
 })
 
 const TemplatePromptItem = (props: Props) => {
-  const {
-    dragProvided,
-    isDragging,
-    isOwner,
-    prompt: promptRef,
-    prompts: promptsRef,
-    parentId
-  } = props
+  const {dragProvided, isDragging, isOwner, prompt: promptRef, prompts: promptsRef} = props
   const prompts = useFragment(
     graphql`
       fragment TemplatePromptItem_prompts on ReflectPrompt @relay(plural: true) {
@@ -127,12 +118,7 @@ const TemplatePromptItem = (props: Props) => {
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
-      <EditableTemplatePromptColor
-        isOwner={isOwner}
-        prompt={prompt}
-        prompts={prompts}
-        parentId={parentId}
-      />
+      <EditableTemplatePromptColor isOwner={isOwner} prompt={prompt} prompts={prompts} />
       <PromptAndDescription>
         <EditableTemplatePrompt
           isOwner={isOwner}

--- a/packages/client/modules/meeting/components/TemplatePromptList.tsx
+++ b/packages/client/modules/meeting/components/TemplatePromptList.tsx
@@ -9,13 +9,11 @@ import {TEMPLATE_PROMPT} from '../../../utils/constants'
 import dndNoise from '../../../utils/dndNoise'
 import {TemplatePromptList_prompts$key} from '../../../__generated__/TemplatePromptList_prompts.graphql'
 import TemplatePromptItem from './TemplatePromptItem'
-import {PortalId} from '../../../hooks/usePortal'
 
 interface Props {
   isOwner: boolean
   prompts: TemplatePromptList_prompts$key
   templateId: string
-  parentId?: PortalId
 }
 
 const PromptList = styled('div')({
@@ -25,7 +23,7 @@ const PromptList = styled('div')({
 })
 
 const TemplatePromptList = (props: Props) => {
-  const {isOwner, prompts: promptsRef, templateId, parentId} = props
+  const {isOwner, prompts: promptsRef, templateId} = props
   const prompts = useFragment(
     graphql`
       fragment TemplatePromptList_prompts on ReflectPrompt @relay(plural: true) {
@@ -96,7 +94,6 @@ const TemplatePromptList = (props: Props) => {
                             prompts={prompts}
                             isDragging={dragSnapshot.isDragging}
                             dragProvided={dragProvided}
-                            parentId={parentId}
                           />
                         )
                       }}

--- a/packages/client/modules/meeting/components/TemplateSharing.tsx
+++ b/packages/client/modules/meeting/components/TemplateSharing.tsx
@@ -68,7 +68,6 @@ const DropdownBlock = styled('div')<{readOnly?: boolean}>(({readOnly}) => ({
 interface Props {
   isOwner: boolean
   template: TemplateSharing_template$key
-  noModal?: boolean
   readOnly?: boolean
 }
 
@@ -88,7 +87,7 @@ const TemplateSharing = (props: Props) => {
 }
 
 export const UnstyledTemplateSharing = (props: Props) => {
-  const {template: templateRef, isOwner, noModal, readOnly} = props
+  const {template: templateRef, isOwner, readOnly} = props
   const template = useFragment(
     graphql`
       fragment TemplateSharing_template on MeetingTemplate {
@@ -113,7 +112,6 @@ export const UnstyledTemplateSharing = (props: Props) => {
     {
       isDropdown: true,
       id: 'sharingScopeDropdown',
-      parentId: noModal ? undefined : 'templateModal',
       menuContentStyles: {
         minWidth: 320
       }

--- a/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardAssignMenu/TaskFooterTeamAssigneeMenu.tsx
@@ -117,8 +117,7 @@ const TaskFooterTeamAssigneeMenu = (props: Props) => {
     closePortal: closeAddIntegrationPortal
   } = useModal({
     onClose: onDialogClose,
-    id: 'taskFooterTeamAssigneeAddIntegration',
-    parentId: 'taskFooterTeamAssigneeMenu'
+    id: 'taskFooterTeamAssigneeAddIntegration'
   })
   const [newTeam, setNewTeam] = useState({id: '', name: ''})
 


### PR DESCRIPTION
# Description
POC for inferring parent portal IDs through a React context.

Currently, we manually configure portals with a `parentId` if they're nested, and then we use that parent ID to attach the new portal to the parent portal. This is tricky, since many components rendering portals are decoupled from the rendered parent portal, which leads to bugs like https://github.com/ParabolInc/parabol/issues/8272 when a component is reused without updating child portals' `parentId`s (which can often be deep inside the component tree).

Instead, track the parent portal ID through a React context managed within the `usePortal` hook. This should eliminate almost all needs for passing `parentId` to `usePortal`-like hooks (e.g. `useMenu`, etc.), and either eliminate this class of bug or (at minimum) make fixes for these bugs much simpler.

## Demo
Nested portal without `parentId` passed:
https://www.loom.com/share/b9669e2ca9e6484f8145014131d14d2c

Nested portal with incorrect `parentId` passed:
https://www.loom.com/share/e5766720bff04c398bd0a743607556ed

New POC - no `parentId` needed:
https://www.loom.com/share/37ec71d5c5114c6ea587ef3417ec039f

## Testing scenarios
Smoke test modals throughout the app

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
