### PR TITLE
fix(rid): Long team names truncate instead of wrapping

### DIFF
--- a/packages/client/components/DropdownToggleInner.tsx
+++ b/packages/client/components/DropdownToggleInner.tsx
@@ -6,7 +6,6 @@ const Container = styled('div')({
   alignItems: 'center',
   display: 'flex',
   flex: 1,
-  flexWrap: 'wrap',
   minWidth: 0
 })
 
@@ -15,8 +14,7 @@ const IconContainer = styled('div')({
 })
 
 const MenuToggleLabelContainer = styled('div')({
-  // Squeeze in an extra 1% to fit the largest public template "Always Be Learning Retrospective 🌱"
-  maxWidth: '101%'
+  overflow: 'hidden'
 })
 
 const MenuToggleLabel = styled('div')({

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -59,7 +59,7 @@ const SettingsRow = styled('div')({
 })
 
 const NewMeetingDialog = styled(DialogContainer)({
-  width: '860px',
+  width: '865px',
   borderRadius: Radius.FIELD,
 
   [MEDIA_QUERY_FUZZY_TABLET]: {


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8296

These dropdowns shouldn't wrap, so remove that style. Also needed to increase the new meeting modal width by a few pixels to get around removing `maxWidth` while still fitting the public template "Always Be Learning Retrospective 🌱" without wrapping.

## Demo
<img width="417" alt="Screen Shot 2023-06-01 at 12 38 59 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/6beb5d2d-ffa3-47bd-9153-b74b253aa282">

## Testing scenarios
- [ ] Long team name in activity lib truncates properly
- [ ] Smoke test new meeting modal dropdown styles.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
