### PR TITLE
chore(prompt-to-join): allow non-verified emails

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -116,9 +116,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   }
   analytics.accountCreated(userId, !isOrganic, isPatient0)
 
-  const emailIsVerified = identities[0]?.isEmailVerified
-
-  if (emailIsVerified && isOrganic && !isSAMLVerified) {
+  if (isOrganic && !isSAMLVerified) {
     sendPromptToJoinOrg(email, userId)
   }
 


### PR DESCRIPTION
We [decided](https://parabol.slack.com/archives/C836NA350/p1685572418054199) to allow unverified emails to access the "prompt to join org functionality

**How to test:**

- Make sure no verification enabled for the domain you use 
- Do not use login with google
- Trigger prompt to join org flow using non-verified emails, see everything works as expected