### PR TITLE
fix: Drain rethinkdb pool after running all migrations

### DIFF
--- a/scripts/toolboxSrc/standaloneMigrations.ts
+++ b/scripts/toolboxSrc/standaloneMigrations.ts
@@ -1,13 +1,13 @@
 // Should roughly match runMigrations.js except it isn't run in PM2 in dev
 // This file is bundled by webpack into a small migrate.js file which includes all migration files & their deps
 // It is used by PPMIs who are only provided with the bundles
-import Redis from 'ioredis'
 import path from 'path'
 import {parse} from 'url'
 import cliPgmConfig from '../../packages/server/postgres/pgmConfig'
 import '../webpack/utils/dotenv'
 import pgMigrate from './pgMigrateRunner'
 import * as rethinkMigrate from './rethinkMigrateRunner'
+import {r} from 'rethinkdb-ts'
 
 const migrateRethinkDB = async () => {
   const {hostname, port, path: urlPath} = parse(process.env.RETHINKDB_URL!)
@@ -61,7 +61,8 @@ const migrateDBs = async () => {
   // RethinkDB must be run first because
   // Some PG migrations depemd on the latest state of RethinkDB
   await migrateRethinkDB()
-  return migratePG()
+  await migratePG()
+  await r.getPoolMaster()?.drain()
 }
 
 migrateDBs()


### PR DESCRIPTION
# Description

Fixes #8314

Drain RethinkDB pool as it blocks the process from exiting otherwise.

## Demo

-

## Testing scenarios

* run `yarn build --no-deps`
* clear local db `yarn db:stop && docker volume rm docker_postgres-data docker_rethink-data && yarn db:start`
* run `./dist/migrate.js`
* [ ] check the script terminates properly and does not hang

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
