### PR TITLE
fix: dumpHeap to /tmp directory

### DIFF
--- a/packages/server/graphql/private/mutations/dumpHeap.ts
+++ b/packages/server/graphql/private/mutations/dumpHeap.ts
@@ -1,11 +1,12 @@
 import fs from 'fs'
 import inspector from 'inspector'
+import os from 'os'
 import path from 'path'
 import {MutationResolvers} from '../resolverTypes'
 
-declare const __PROJECT_ROOT__: string
+const {SERVER_ID} = process.env
 
-const dumpHeap: MutationResolvers['dumpHeap'] = async (_source, {isDangerous}, {authToken}) => {
+const dumpHeap: MutationResolvers['dumpHeap'] = async (_source, {isDangerous}) => {
   if (!isDangerous)
     return 'This action will block the server for about 1 minute, Must ack the danger!'
   return new Promise((resolve) => {
@@ -16,8 +17,8 @@ const dumpHeap: MutationResolvers['dumpHeap'] = async (_source, {isDangerous}, {
     const MB = 2 ** 20
     const usedMB = Math.floor(rss / MB)
     const now = new Date().toJSON()
-    const fileName = `Dumpy_${now}-${usedMB}.heapsnapshot`
-    const pathName = path.join(__PROJECT_ROOT__, fileName)
+    const fileName = `Dumpy_${now}_GQLExecutor-${SERVER_ID}_${usedMB}.heapsnapshot`
+    const pathName = path.join(os.tmpdir(), fileName)
     const fd = fs.openSync(pathName, 'w')
     session.connect()
     session.on('HeapProfiler.addHeapSnapshotChunk', (m) => {
@@ -26,7 +27,7 @@ const dumpHeap: MutationResolvers['dumpHeap'] = async (_source, {isDangerous}, {
     session.post('HeapProfiler.takeHeapSnapshot', undefined, (err) => {
       session.disconnect()
       fs.closeSync(fd)
-      resolve(err || pathName)
+      resolve(err?.toString() || pathName)
     })
   })
 }


### PR DESCRIPTION
The node process drops all user rights and thus needs to write to a directory writable by all.

## Testing scenarios

run `mutation Dump { dumpHeap(isDangerous: true) }` locally and check the file exists

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
