### PR TITLE
fix: show all slack channels in dropdown

### DIFF
--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -191,7 +191,6 @@ abstract class SlackManager {
 
   getConversationList(types: ConversationType[] = ['public_channel']) {
     const typeStr = types.join(',')
-
     return this.get<ConversationListResponse>(
       `https://slack.com/api/conversations.list?token=${this.token}&exclude_archived=true&types=${typeStr}&limit=1000`
     )

--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -191,8 +191,9 @@ abstract class SlackManager {
 
   getConversationList(types: ConversationType[] = ['public_channel']) {
     const typeStr = types.join(',')
+
     return this.get<ConversationListResponse>(
-      `https://slack.com/api/conversations.list?token=${this.token}&exclude_archived=true&types=${typeStr}`
+      `https://slack.com/api/conversations.list?token=${this.token}&exclude_archived=true&types=${typeStr}&limit=1000`
     )
   }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8328

Slack has a default limit of 100 channels on the `conversations.list` API. By setting the limit to 1000, we can see all the channels.

### To test

- [ ] On `master`, add the Slack integration
- [ ] Open the dropdown and see that some channels are missing, e.g. `nick-test-playground`
- [ ] Checkout this branch
- [ ] Open dropdown and see that all channels now show-up, including `nick-test-playground`