### PR TITLE
feat(share-summary): Add share topic button to meeting summary

### DIFF
--- a/packages/client/components/PrivateRoutes.tsx
+++ b/packages/client/components/PrivateRoutes.tsx
@@ -49,6 +49,10 @@ const ReviewRequestToJoinOrgRoot = lazy(
   () => import(/* webpackChunkName: 'ReviewRequestToJoinOrgRoot' */ './ReviewRequestToJoinOrgRoot')
 )
 
+const ShareTopicRoot = lazy(
+  () => import(/* webpackChunkName: 'ShareTopicRoot' */ './ShareTopicRoot')
+)
+
 const NewMeetingRoot = lazy(
   () => import(/* webpackChunkName: 'NewMeetingRoot' */ './NewMeetingRoot')
 )
@@ -81,6 +85,7 @@ const PrivateRoutes = () => {
           path='/organization-join-request/:requestId'
           component={ReviewRequestToJoinOrgRoot}
         />
+        <Route path='/new-summary/:meetingId/share/:stageId' component={ShareTopicRoot} />
         <Route path='/new-meeting/:teamId?' component={NewMeetingRoot} />
       </Switch>
     </>

--- a/packages/client/components/ShareTopicModal.tsx
+++ b/packages/client/components/ShareTopicModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import DialogContainer from './DialogContainer'
+import DialogContent from './DialogContent'
+import DialogTitle from './DialogTitle'
+import PrimaryButton from './PrimaryButton'
+import SecondaryButton from './SecondaryButton'
+
+interface Props {
+  closePortal: () => void
+}
+
+// TODO: Create generic dialog components using tailwind https://github.com/ParabolInc/parabol/issues/8107
+const ShareTopicModal = (props: Props) => {
+  const {closePortal} = props
+
+  const onShare = () => {
+    /* TODO */
+  }
+
+  return (
+    <DialogContainer>
+      <DialogTitle>{'Share topic'}</DialogTitle>
+      <DialogContent>
+        <div className={'mb-4 text-base'}>Where would you like to share the topic to?</div>
+
+        <div className={'mt-6 flex w-full justify-end'}>
+          <div className={'mr-2'}>
+            <SecondaryButton onClick={closePortal} size='small'>
+              Cancel
+            </SecondaryButton>
+          </div>
+          <PrimaryButton size='small' onClick={onShare}>
+            Share
+          </PrimaryButton>
+        </div>
+      </DialogContent>
+    </DialogContainer>
+  )
+}
+
+export default ShareTopicModal

--- a/packages/client/components/ShareTopicModal.tsx
+++ b/packages/client/components/ShareTopicModal.tsx
@@ -7,6 +7,7 @@ import SecondaryButton from './SecondaryButton'
 
 interface Props {
   closePortal: () => void
+  stageId: string
 }
 
 // TODO: Create generic dialog components using tailwind https://github.com/ParabolInc/parabol/issues/8107

--- a/packages/client/components/ShareTopicRoot.tsx
+++ b/packages/client/components/ShareTopicRoot.tsx
@@ -1,0 +1,37 @@
+import React, {Suspense, useCallback, useEffect} from 'react'
+import {useHistory, useLocation} from 'react-router'
+import useRouter from '../hooks/useRouter'
+import useModal from '../hooks/useModal'
+import ShareTopicModal from '~/components/ShareTopicModal'
+const ShareTopicRoot = () => {
+  const {match} = useRouter<{stageId: string; meetingId: string}>()
+  const {params} = match
+
+  const {meetingId} = params
+
+  const location = useLocation<{backgroundLocation?: Location}>()
+  const history = useHistory()
+
+  const onClose = useCallback(() => {
+    const state = location.state
+    history.replace(state?.backgroundLocation ?? `/new-summary/${meetingId}`)
+  }, [location])
+
+  const {openPortal, closePortal, modalPortal} = useModal({
+    id: 'shareTopicModal',
+    onClose
+  })
+
+  useEffect(() => {
+    openPortal()
+    return () => {
+      closePortal()
+    }
+  }, [])
+
+  return (
+    <Suspense fallback={''}>{modalPortal(<ShareTopicModal closePortal={closePortal} />)}</Suspense>
+  )
+}
+
+export default ShareTopicRoot

--- a/packages/client/components/ShareTopicRoot.tsx
+++ b/packages/client/components/ShareTopicRoot.tsx
@@ -3,6 +3,8 @@ import {useHistory, useLocation} from 'react-router'
 import useRouter from '../hooks/useRouter'
 import useModal from '../hooks/useModal'
 import ShareTopicModal from '~/components/ShareTopicModal'
+import {renderLoader} from '../utils/relay/renderLoader'
+
 const ShareTopicRoot = () => {
   const {match} = useRouter<{stageId: string; meetingId: string}>()
   const {params} = match
@@ -30,7 +32,9 @@ const ShareTopicRoot = () => {
   }, [])
 
   return (
-    <Suspense fallback={''}>{modalPortal(<ShareTopicModal closePortal={closePortal} />)}</Suspense>
+    <Suspense fallback={renderLoader()}>
+      {modalPortal(<ShareTopicModal closePortal={closePortal} />)}
+    </Suspense>
   )
 }
 

--- a/packages/client/components/ShareTopicRoot.tsx
+++ b/packages/client/components/ShareTopicRoot.tsx
@@ -9,7 +9,7 @@ const ShareTopicRoot = () => {
   const {match} = useRouter<{stageId: string; meetingId: string}>()
   const {params} = match
 
-  const {meetingId} = params
+  const {meetingId, stageId} = params
 
   const location = useLocation<{backgroundLocation?: Location}>()
   const history = useHistory()
@@ -33,7 +33,7 @@ const ShareTopicRoot = () => {
 
   return (
     <Suspense fallback={renderLoader()}>
-      {modalPortal(<ShareTopicModal closePortal={closePortal} />)}
+      {modalPortal(<ShareTopicModal closePortal={closePortal} stageId={stageId} />)}
     </Suspense>
   )
 }

--- a/packages/client/hooks/useModal.ts
+++ b/packages/client/hooks/useModal.ts
@@ -19,7 +19,8 @@ const useModal = (options: Options = {}) => {
     id,
     parentId,
     onOpen,
-    onClose
+    onClose,
+    allowScroll: false
   })
   const {loadingDelay, loadingDelayRef} = useLoadingDelay()
   const modalPortal = useModalPortal(

--- a/packages/client/hooks/useModalPortal.tsx
+++ b/packages/client/hooks/useModalPortal.tsx
@@ -16,7 +16,7 @@ const ModalBlock = styled('div')({
   justifyContent: 'center',
   left: 0,
   // no margins or paddings since they could force it too low & cause a scrollbar to appear
-  position: 'absolute',
+  position: 'fixed',
   top: 0,
   width: '100%',
   zIndex: ZIndex.DIALOG,
@@ -81,7 +81,7 @@ const ModalContents = styled('div')<{portalStatus: PortalStatus}>(({portalStatus
   display: 'flex',
   flex: '0 1 auto',
   flexDirection: 'column',
-  position: 'fixed',
+  position: 'relative',
   marginTop: 'auto',
   marginBottom: 'auto',
   ...modalStyles[portalStatus as keyof typeof backdropStyles]

--- a/packages/client/hooks/useModalPortal.tsx
+++ b/packages/client/hooks/useModalPortal.tsx
@@ -81,7 +81,7 @@ const ModalContents = styled('div')<{portalStatus: PortalStatus}>(({portalStatus
   display: 'flex',
   flex: '0 1 auto',
   flexDirection: 'column',
-  position: 'relative',
+  position: 'fixed',
   marginTop: 'auto',
   marginBottom: 'auto',
   ...modalStyles[portalStatus as keyof typeof backdropStyles]

--- a/packages/client/hooks/usePortal.tsx
+++ b/packages/client/hooks/usePortal.tsx
@@ -41,6 +41,7 @@ export type PortalId =
   | 'topBarNotificationsMenu'
   | 'pokerTemplateScaleDetailsModal'
   | 'activityDetailsRecurrenceSettings'
+  | 'shareTopicModal'
 
 export interface UsePortalOptions {
   onOpen?: (el: HTMLElement) => void

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
@@ -60,6 +60,7 @@ const RetroTopics = (props: Props) => {
             }
           }
         }
+        ...RetroTopic_meeting
       }
     `,
     meetingRef
@@ -106,7 +107,9 @@ const RetroTopics = (props: Props) => {
                 isDemo={isDemo}
                 isEmail={isEmail}
                 stageRef={stage}
+                meetingRef={meeting}
                 to={topicUrl}
+                appOrigin={appOrigin}
               />
             )
           })

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
@@ -31,22 +31,25 @@ const style = {
 
 const ShareTopic = (props: Props) => {
   const {isDemo, isEmail, meetingId, stageId, appOrigin} = props
-  const {history} = useRouter()
-  const location = useLocation()
 
   const path = `new-summary/${meetingId}/share/${stageId}`
-
   const href = makeAppURL(appOrigin, path)
 
-  if (isEmail || isDemo) {
+  if (isEmail) {
     return (
-      <AnchorIfEmail isEmail={true} isDemo={isDemo} href={href} style={style} title={label}>
+      <AnchorIfEmail isEmail={true} href={href} style={style} title={label}>
         {label}
       </AnchorIfEmail>
     )
   }
 
+  // Avoid calling hooks when doing SSR
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const {history} = useRouter()
+  const location = useLocation()
+
   const onClick = () => {
+    if (isDemo) return
     history.replace(`/${path}`, {
       backgroundLocation: location
     })

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
@@ -1,10 +1,11 @@
 import {PALETTE} from 'parabol-client/styles/paletteV3'
 import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
-import React from 'react'
-import {useLocation} from 'react-router'
+import React, {Suspense} from 'react'
 import AnchorIfEmail from './AnchorIfEmail'
-import useRouter from '../../../../../hooks/useRouter'
 import makeAppURL from '../../../../../utils/makeAppURL'
+import useModal from '../../../../../hooks/useModal'
+import {renderLoader} from '../../../../../utils/relay/renderLoader'
+import ShareTopicModal from '../../../../../components/ShareTopicModal'
 
 interface Props {
   isEmail: boolean
@@ -43,22 +44,24 @@ const ShareTopic = (props: Props) => {
     )
   }
 
-  // Avoid calling hooks when doing SSR
-  /* eslint-disable react-hooks/rules-of-hooks */
-  const {history} = useRouter()
-  const location = useLocation()
-
   const onClick = () => {
     if (isDemo) return
-    history.replace(`/${path}`, {
-      backgroundLocation: location
-    })
+    openPortal()
   }
 
+  const {openPortal, closePortal, modalPortal} = useModal({
+    id: 'shareTopicModal'
+  })
+
   return (
-    <span style={style} onClick={onClick}>
-      {label}
-    </span>
+    <>
+      <span style={style} onClick={onClick}>
+        {label}
+      </span>
+      <Suspense fallback={renderLoader()}>
+        {modalPortal(<ShareTopicModal closePortal={closePortal} stageId={stageId} />)}
+      </Suspense>
+    </>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
@@ -1,0 +1,62 @@
+import {PALETTE} from 'parabol-client/styles/paletteV3'
+import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
+import React from 'react'
+import {useLocation} from 'react-router'
+import AnchorIfEmail from './AnchorIfEmail'
+import useRouter from '../../../../../hooks/useRouter'
+import makeAppURL from '../../../../../utils/makeAppURL'
+
+interface Props {
+  isEmail: boolean
+  isDemo: boolean
+  meetingId: string
+  stageId: string
+  appOrigin: string
+}
+
+const label = 'Share Topic'
+
+const style = {
+  backgroundColor: PALETTE.WHITE,
+  color: PALETTE.SKY_500,
+  borderRadius: 64,
+  border: `1px solid ${PALETTE.SKY_500}`,
+  cursor: 'pointer',
+  fontFamily: FONT_FAMILY.SANS_SERIF,
+  fontSize: 13,
+  fontWeight: 600,
+  padding: '7px 21px',
+  textDecoration: 'none'
+}
+
+const ShareTopic = (props: Props) => {
+  const {isDemo, isEmail, meetingId, stageId, appOrigin} = props
+  const {history} = useRouter()
+  const location = useLocation()
+
+  const path = `new-summary/${meetingId}/share/${stageId}`
+
+  const href = makeAppURL(appOrigin, path)
+
+  if (isEmail || isDemo) {
+    return (
+      <AnchorIfEmail isEmail={true} isDemo={isDemo} href={href} style={style} title={label}>
+        {label}
+      </AnchorIfEmail>
+    )
+  }
+
+  const onClick = () => {
+    history.replace(`/${path}`, {
+      backgroundLocation: location
+    })
+  }
+
+  return (
+    <span style={style} onClick={onClick}>
+      {label}
+    </span>
+  )
+}
+
+export default ShareTopic


### PR DESCRIPTION
Partially solves: #8232 #8234

**Demo**

https://www.loom.com/share/1302d78b31494ff8a02a20d6f8790a4d

<img width="623" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/702ff896-0b19-49d1-b2ce-c06fa0655b15">


**In this PR**

- Added `share topic` to the email summary (works both in the email and the website)
- Button opens a modal (Added routing and modal placeholder)

**Not included**

- Modal UI
- I have some scroll issue when modal is opened, going to look into it in next PR (Please let me know if you know what is going on)

**How to test**

- Add `shareSummary` org-level feature flag
- Run a retro and have some topics
- Click on `Share topic` button, see modal is opened and routing works fine
- Click on `Share topic` button from email, see modal is opened and routing works fine

