### PR TITLE
fix: allow pasting a link into reflection card

### DIFF
--- a/packages/client/components/ReflectionEditorWrapper.tsx
+++ b/packages/client/components/ReflectionEditorWrapper.tsx
@@ -20,6 +20,8 @@ import './TaskEditor/Draft.css'
 import withEmojis from './TaskEditor/withEmojis'
 import withKeyboardShortcuts from './TaskEditor/withKeyboardShortcuts'
 import withMarkdown from './TaskEditor/withMarkdown'
+import completeEntity from '../utils/draftjs/completeEntity'
+import linkify from '../utils/linkify'
 
 interface Props {
   ariaLabel: string
@@ -209,6 +211,18 @@ class ReflectionEditorWrapper extends PureComponent<Props> {
         }
       }
     }
+    const {setEditorState, editorState} = this.props
+    const links = linkify.match(text)
+    const url = links && links[0]!.url.trim()
+    const trimmedText = text.trim()
+    if (url === trimmedText) {
+      const nextEditorState = completeEntity(editorState, 'LINK', {href: url}, trimmedText, {
+        keepSelection: true
+      })
+      setEditorState(nextEditorState)
+      return 'handled'
+    }
+
     return 'not-handled' as const
   }
 


### PR DESCRIPTION
# Description

Fixes no issue, just personal tension
This PR adds the ability to paste a link into a reflection card. It works just like in the comments editor. Writing link by hand is not supported (ie. it won't recognize link that was written by hand), and it's out of scope (we don't support that in comments either)

## Demo


https://github.com/ParabolInc/parabol/assets/1017620/56790e77-ecdd-4874-8a8b-57b0a810b356


## Testing scenarios

- [ ] Link is recognized after pasting it and submitting a reflection card
- [ ] Card with link should be draggable

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
