### PR TITLE
fix: better description for failed to execute removeChild on Node error

### DIFF
--- a/packages/client/components/ErrorComponent/ErrorComponent.tsx
+++ b/packages/client/components/ErrorComponent/ErrorComponent.tsx
@@ -5,6 +5,8 @@ import ReportErrorFeedback from '~/components/ReportErrorFeedback'
 import useModal from '~/hooks/useModal'
 import {isOldBrowserError} from '~/utils/isOldBrowserError'
 
+const isNotFoundError = (error: Error) => error.name === 'NotFoundError'
+
 const ErrorBlock = styled('div')({
   alignItems: 'center',
   display: 'flex',
@@ -32,8 +34,21 @@ const ErrorComponent = (props: Props) => {
   const {error, eventId} = props
   console.error(error)
   const {modalPortal, openPortal, closePortal} = useModal()
-  const isOldBrowserErr = isOldBrowserError(error.message)
 
+  if (isNotFoundError(error)) {
+    return (
+      <ErrorBlock>
+        <div>
+          Oh no! Seems like you're using Google Translate or a similar extension, which has a bug in
+          it that can crash apps like ours.
+        </div>
+        <div>If this continues, please disable the extension</div>
+        <Button onClick={() => window.location.reload()}>Refresh the page</Button>
+      </ErrorBlock>
+    )
+  }
+
+  const isOldBrowserErr = isOldBrowserError(error.message)
   if (isOldBrowserErr) {
     const url = 'https://browser-update.org/update-browser.html'
     return (


### PR DESCRIPTION
# Description

Fixes #4482 . Details in the issue itself.

## Demo

<img width="1860" alt="Screenshot 2023-06-07 at 07 02 06" src="https://github.com/ParabolInc/parabol/assets/1017620/38047229-4003-4b46-928c-f8351821f428">


## Testing scenarios

- [ ] Check the error message when the error happens
       - build production version of an app by running `yarn build`
       - run it via `yarn start`
       - open retro meeting, go to discuss phase
       - right click anywhere, translate the page to a different language than English
       - write a comment, add a task and shortly after you'll see our error boundary catching this error
       - check the message


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
