### PR TITLE
feat(analytics): Track meeting category on meeting start

### DIFF
--- a/packages/server/utils/analytics/helpers.ts
+++ b/packages/server/utils/analytics/helpers.ts
@@ -24,6 +24,7 @@ export const createMeetingProperties = (
     meetingTemplateScope: template?.scope,
     meetingTemplateIsFromParabol: template?.isStarter ?? false,
     meetingTemplateIsFree: template?.isFree ?? false,
+    meetingTemplateCategory: template?.mainCategory,
     meetingSeriesId:
       meetingType === 'teamPrompt' ? (meeting as MeetingTeamPrompt).meetingSeriesId : undefined,
     disableAnonymity:


### PR DESCRIPTION
# Description

See [slack](https://parabol.slack.com/archives/C03C3J42WDU/p1686069496724449)

## Testing scenarios
- [ ] When starting a meeting, confirm that `meetingCategory` is set correctly for retros + poker

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
