### PR TITLE
feat(rid): Add new users to feature flag

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -18,6 +18,8 @@ import getUsersbyDomain from '../../../postgres/queries/getUsersByDomain'
 import sendPromptToJoinOrg from '../../../utils/sendPromptToJoinOrg'
 import {makeDefaultTeamName} from 'parabol-client/utils/makeDefaultTeamName'
 
+const PERCENT_ADDED_TO_RID = 0.05
+
 const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?: string) => {
   const r = await getRethink()
   const {
@@ -57,6 +59,10 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   const params = new URLSearchParams(searchParams)
   if (Boolean(params.get('rid')) || domainUserHasRidFlag) {
     experimentalFlags.push('retrosInDisguise')
+  } else if (usersWithDomain.length === 0) {
+    if (Math.random() < PERCENT_ADDED_TO_RID) {
+      experimentalFlags.push('retrosInDisguise')
+    }
   }
 
   await Promise.all([

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -17,6 +17,7 @@ import isPatientZero from './isPatientZero'
 import getUsersbyDomain from '../../../postgres/queries/getUsersByDomain'
 import sendPromptToJoinOrg from '../../../utils/sendPromptToJoinOrg'
 import {makeDefaultTeamName} from 'parabol-client/utils/makeDefaultTeamName'
+import isCompanyDomain from '../../../utils/isCompanyDomain'
 
 const PERCENT_ADDED_TO_RID = 0.05
 
@@ -35,7 +36,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   const domain = email.split('@')[1]
   const [isPatient0, usersWithDomain, isSAMLVerified] = await Promise.all([
     isPatientZero(domain),
-    getUsersbyDomain(domain),
+    isCompanyDomain(domain) ? getUsersbyDomain(domain) : [],
     r.table('SAML').getAll(domain, {index: 'domains'}).limit(1).count().eq(1).run()
   ])
 


### PR DESCRIPTION
# Description
See [spec](https://www.notion.so/parabol/miniRFC-Adding-new-users-to-RiD-feature-flag-f1d3fa0524664c47aa9cfe12f5426b6a?pvs=4#a7f9fc955dad4c8c8dac816e055e54d7) 🔒 

For new P0 users (users for which no existing users share the domain), add 5% of them to the RiD feature flag.

## Testing scenarios
- [ ] Domain affinity for non-P0s
  - [ ] If some other user in the domain has the flag, always add the flag to the new user (suggest changing the `PERCENT_ADDED_TO_RID` to 0 to test this)
  - [ ] If there are other users in the domain, and no other users have the flag, never add the flag to the new user (suggest changing the `PERCENT_ADDED_TO_RID` to 1 to test this)
- [ ] P0s (no other users in the domain)
  - [ ] For low `PERCENT_ADDED_TO_RID`, most new signups won't be added
  - [ ] For high `PERCENT_ADDED_TO_RID`, most new signups will be added
  - [ ] For `PERCENT_ADDED_TO_RID` of 0.5, ~half of new signups will be added

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
