### PR TITLE
feat(Team Health): enable team health by default for paid tiers

### DIFF
--- a/packages/client/components/NewMeetingSettingsRetrospectiveSettings.tsx
+++ b/packages/client/components/NewMeetingSettingsRetrospectiveSettings.tsx
@@ -57,15 +57,17 @@ const NewMeetingSettingsRetrospectiveSettings = (props: Props) => {
   const organization = useFragment(
     graphql`
       fragment NewMeetingSettingsRetrospectiveSettings_organization on Organization {
+        tier
         featureFlags {
           zoomTranscription
-          teamHealth
         }
       }
     `,
     organizationRef
   )
-  const {zoomTranscription, teamHealth} = organization.featureFlags
+  const {tier} = organization
+  const teamHealthAvailable = tier !== 'starter'
+  const {zoomTranscription} = organization.featureFlags
 
   return (
     <>
@@ -79,7 +81,9 @@ const NewMeetingSettingsRetrospectiveSettings = (props: Props) => {
       {menuPortal(
         <div {...menuProps}>
           <NewMeetingSettingsToggleCheckInMenuEntry settingsRef={settings} />
-          {teamHealth && <NewMeetingSettingsToggleTeamHealthMenuEntry settingsRef={settings} />}
+          {teamHealthAvailable && (
+            <NewMeetingSettingsToggleTeamHealthMenuEntry settingsRef={settings} />
+          )}
           <NewMeetingSettingsToggleAnonymityMenuEntry settingsRef={settings} />
           {zoomTranscription && <NewMeetingSettingsToggleTranscription settingsRef={settings} />}
         </div>

--- a/packages/client/components/NewMeetingSettingsRetrospectiveSettings.tsx
+++ b/packages/client/components/NewMeetingSettingsRetrospectiveSettings.tsx
@@ -7,6 +7,7 @@ import {NewMeetingSettingsRetrospectiveSettings_organization$key} from '~/__gene
 import {MenuPosition} from '../hooks/useCoords'
 import useMenu from '../hooks/useMenu'
 import {PortalStatus} from '../hooks/usePortal'
+import isTeamHealthAvailable from '../utils/features/isTeamHealthAvailable'
 import NewMeetingDropdown from './NewMeetingDropdown'
 import NewMeetingSettingsToggleAnonymity from './NewMeetingSettingsToggleAnonymity'
 import NewMeetingSettingsToggleCheckIn from './NewMeetingSettingsToggleCheckIn'
@@ -66,7 +67,7 @@ const NewMeetingSettingsRetrospectiveSettings = (props: Props) => {
     organizationRef
   )
   const {tier} = organization
-  const teamHealthAvailable = tier !== 'starter'
+  const teamHealthAvailable = isTeamHealthAvailable(tier)
   const {zoomTranscription} = organization.featureFlags
 
   return (

--- a/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
@@ -37,14 +37,16 @@ const Label = styled('div')({
 })
 
 const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
-  color: active ? PALETTE.SKY_500 : PALETTE.SLATE_700,
-  svg: {
-    fontSize: 28
-  },
-  width: 28,
-  height: 28,
-  textAlign: 'center',
-  userSelect: 'none'
+  '&&': {
+    color: active ? PALETTE.SKY_500 : PALETTE.SLATE_700,
+    svg: {
+      fontSize: 28
+    },
+    width: 28,
+    height: 28,
+    textAlign: 'center',
+    userSelect: 'none'
+  }
 }))
 
 interface Props {

--- a/packages/client/components/TeamHealth.tsx
+++ b/packages/client/components/TeamHealth.tsx
@@ -84,18 +84,18 @@ const TeamHealth = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <div className='flex h-[300px] flex-col items-center'>
-            <div className='text-2xl text-center'>{question}</div>
+            <div className='text-center text-2xl'>{question}</div>
             {isRevealed && votes ? (
               <>
                 <div className='flex flex-row'>
                   {labels?.map((label, index) => (
                     <div
                       key={label}
-                      className='flex flex-col justify-start w-20 h-32 m-3 rounded'
+                      className='m-3 flex h-32 w-20 flex-col justify-start rounded'
                       style={{backgroundColor: getTeamHealthVoteColor(votes, votes[index]!)}}
                     >
-                      <div className='flex items-center justify-center h-24 text-4xl'>{label}</div>
-                      <label className='text-xl font-semibold text-center text-white'>
+                      <div className='flex h-24 items-center justify-center text-4xl'>{label}</div>
+                      <label className='text-center text-xl font-semibold text-white'>
                         {votes[index]}
                       </label>
                     </div>
@@ -138,7 +138,7 @@ const TeamHealth = (props: Props) => {
                   <RaisedButton
                     palette='white'
                     onClick={onRevealVotes}
-                    className='mt-4 rounded-full h-14 w-44 text-slate-600 disabled:bg-slate-300 disabled:text-slate-600'
+                    className='mt-4 h-14 w-44 rounded-full text-slate-600 disabled:bg-slate-300 disabled:text-slate-600'
                     disabled={!canReveal}
                   >
                     Reveal Results

--- a/packages/client/components/TeamHealth.tsx
+++ b/packages/client/components/TeamHealth.tsx
@@ -84,18 +84,18 @@ const TeamHealth = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <div className='flex h-[300px] flex-col items-center'>
-            <div className='text-center text-2xl'>{question}</div>
+            <div className='text-2xl text-center'>{question}</div>
             {isRevealed && votes ? (
               <>
                 <div className='flex flex-row'>
                   {labels?.map((label, index) => (
                     <div
                       key={label}
-                      className='m-3 flex h-32 w-20 flex-col justify-start rounded'
+                      className='flex flex-col justify-start w-20 h-32 m-3 rounded'
                       style={{backgroundColor: getTeamHealthVoteColor(votes, votes[index]!)}}
                     >
-                      <div className='flex h-24 items-center justify-center text-4xl'>{label}</div>
-                      <label className='text-center text-xl font-semibold text-white'>
+                      <div className='flex items-center justify-center h-24 text-4xl'>{label}</div>
+                      <label className='text-xl font-semibold text-center text-white'>
                         {votes[index]}
                       </label>
                     </div>
@@ -138,7 +138,7 @@ const TeamHealth = (props: Props) => {
                   <RaisedButton
                     palette='white'
                     onClick={onRevealVotes}
-                    className='mt-4 h-14 w-44 rounded-full text-slate-600 disabled:bg-slate-300 disabled:text-slate-600'
+                    className='mt-4 rounded-full h-14 w-44 text-slate-600 disabled:bg-slate-300 disabled:text-slate-600'
                     disabled={!canReveal}
                   >
                     Reveal Results

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -118,11 +118,18 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
       const hasTopicSummary = reflectionGroups.some((group) => group.summary)
       const hasDiscussionSummary = !!stages?.some((stage) => stage.discussion?.summary)
       const hasOpenAISummary = hasTopicSummary || hasDiscussionSummary
+      const hasTeamHealth = phases.some((phase) => phase.phaseType === 'TEAM_HEALTH')
       const pathname = `/new-summary/${meetingId}`
-      const search = hasOpenAISummary ? '?ai=true' : ''
+      const search = new URLSearchParams()
+      if (hasOpenAISummary) {
+        search.append('ai', 'true')
+      }
+      if (hasTeamHealth) {
+        search.append('team-health', 'true')
+      }
       history.push({
         pathname,
-        search
+        search: search.toString()
       })
     }
   }

--- a/packages/client/utils/features/isTeamHealthAvailable.ts
+++ b/packages/client/utils/features/isTeamHealthAvailable.ts
@@ -1,0 +1,9 @@
+import {TierEnum} from '~/../server/database/types/Invoice'
+
+function isTeamHealthAvailable(_tier: TierEnum) {
+  // we're making it free for all for the beginning
+  //return tier !== 'starter'
+  return true
+}
+
+export default isTeamHealthAvailable

--- a/packages/client/utils/meetings/lookups.ts
+++ b/packages/client/utils/meetings/lookups.ts
@@ -51,6 +51,7 @@ export const meetingTypeToIcon = {
 
 export const phaseTypeToSlug = {
   checkin: 'checkin',
+  TEAM_HEALTH: 'teamhealth',
   reflect: 'reflect',
   group: 'group',
   vote: 'vote',

--- a/packages/server/database/types/MeetingSettingsRetrospective.ts
+++ b/packages/server/database/types/MeetingSettingsRetrospective.ts
@@ -32,6 +32,8 @@ export default class MeetingSettingsRetrospective extends MeetingSettings {
   disableAnonymity: boolean
   videoMeetingURL?: string | null
   recallBotId?: string | null
+  // store if we've added the team health phase to the meeting
+  addTeamHealth?: boolean
   constructor(input: Input) {
     const {
       teamId,
@@ -53,5 +55,6 @@ export default class MeetingSettingsRetrospective extends MeetingSettings {
     this.disableAnonymity = disableAnonymity ?? false
     this.videoMeetingURL = videoMeetingURL
     this.recallBotId = recallBotId
+    this.addTeamHealth = addTeamHealth
   }
 }

--- a/packages/server/database/types/MeetingSettingsRetrospective.ts
+++ b/packages/server/database/types/MeetingSettingsRetrospective.ts
@@ -11,12 +11,9 @@ interface Input {
   disableAnonymity?: boolean
   videoMeetingURL?: string
   recallBotId?: string
-  addTeamHealth?: boolean
 }
 
-const phaseTypes = ['checkin', 'reflect', 'group', 'vote', 'discuss'] as NewMeetingPhaseTypeEnum[]
-
-const teamHealthPhaseTypes = [
+const phaseTypes = [
   'checkin',
   'TEAM_HEALTH',
   'reflect',
@@ -32,8 +29,7 @@ export default class MeetingSettingsRetrospective extends MeetingSettings {
   disableAnonymity: boolean
   videoMeetingURL?: string | null
   recallBotId?: string | null
-  // store if we've added the team health phase to the meeting
-  addTeamHealth?: boolean
+
   constructor(input: Input) {
     const {
       teamId,
@@ -43,11 +39,9 @@ export default class MeetingSettingsRetrospective extends MeetingSettings {
       totalVotes,
       disableAnonymity,
       videoMeetingURL,
-      recallBotId,
-      addTeamHealth
+      recallBotId
     } = input
-    const featurePhaseTypes = addTeamHealth ? teamHealthPhaseTypes : phaseTypes
-    super({teamId, id, meetingType: 'retrospective', phaseTypes: featurePhaseTypes})
+    super({teamId, id, meetingType: 'retrospective', phaseTypes})
     this.maxVotesPerGroup =
       maxVotesPerGroup ?? MeetingSettingsThreshold.RETROSPECTIVE_MAX_VOTES_PER_GROUP_DEFAULT
     this.totalVotes = totalVotes ?? MeetingSettingsThreshold.RETROSPECTIVE_TOTAL_VOTES_DEFAULT
@@ -55,6 +49,5 @@ export default class MeetingSettingsRetrospective extends MeetingSettings {
     this.disableAnonymity = disableAnonymity ?? false
     this.videoMeetingURL = videoMeetingURL
     this.recallBotId = recallBotId
-    this.addTeamHealth = addTeamHealth
   }
 }

--- a/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
+++ b/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
@@ -25,10 +25,9 @@ export default async function createTeamAndLeader(user: IUser, newTeam: ValidNew
   const {id: teamId, orgId} = newTeam
   const organization = await r.table('Organization').get(orgId).run()
   const {tier} = organization
-  const teamHealth = tier !== 'starter'
   const verifiedTeam = new Team({...newTeam, createdBy: userId, tier})
   const meetingSettings = [
-    new MeetingSettingsRetrospective({teamId, addTeamHealth: teamHealth}),
+    new MeetingSettingsRetrospective({teamId}),
     new MeetingSettingsAction({teamId}),
     new MeetingSettingsPoker({teamId})
   ]

--- a/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
+++ b/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
@@ -24,8 +24,8 @@ export default async function createTeamAndLeader(user: IUser, newTeam: ValidNew
   const {id: userId} = user
   const {id: teamId, orgId} = newTeam
   const organization = await r.table('Organization').get(orgId).run()
-  const {tier, featureFlags} = organization
-  const teamHealth = featureFlags?.includes('teamHealth')
+  const {tier} = organization
+  const teamHealth = tier !== 'starter'
   const verifiedTeam = new Team({...newTeam, createdBy: userId, tier})
   const meetingSettings = [
     new MeetingSettingsRetrospective({teamId, addTeamHealth: teamHealth}),

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -8,7 +8,6 @@ enum OrganizationFeatureFlagsEnum {
   suggestGroups
   zoomTranscription
   shareSummary
-  teamHealth
   teamsLimit
 }
 

--- a/packages/server/graphql/public/mutations/setMeetingSettings.ts
+++ b/packages/server/graphql/public/mutations/setMeetingSettings.ts
@@ -30,6 +30,8 @@ const setMeetingSettings: MutationResolvers['setMeetingSettings'] = async (
   if (!settings) {
     return standardError(new Error('Settings not found'), {userId: viewerId})
   }
+
+  // RESOLUTION
   const {teamId, meetingType} = settings
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   const organization = await dataLoader.get('organizations').load(team.orgId)
@@ -37,7 +39,6 @@ const setMeetingSettings: MutationResolvers['setMeetingSettings'] = async (
   const hasTranscriptFlag = featureFlags?.includes('zoomTranscription')
   const recallBotId = hasTranscriptFlag ? await getBotId(videoMeetingURL) : null
 
-  // RESOLUTION
   const meetingSettings = {} as MeetingSettings
   await r
     .table('MeetingSettings')

--- a/packages/server/graphql/public/mutations/setMeetingSettings.ts
+++ b/packages/server/graphql/public/mutations/setMeetingSettings.ts
@@ -61,6 +61,7 @@ const setMeetingSettings: MutationResolvers['setMeetingSettings'] = async (
           teamHealthEnabled ? row('phaseTypes').insertAt(1, 'TEAM_HEALTH') : row('phaseTypes'),
           teamHealthEnabled ? row('phaseTypes').prepend('TEAM_HEALTH') : row('phaseTypes')
         )
+        meetingSettings.hasTeamHealth = teamHealthEnabled
       }
 
       if (isNotNull(disableAnonymity)) {

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -174,6 +174,5 @@ type OrganizationFeatureFlags {
   suggestGroups: Boolean!
   zoomTranscription: Boolean!
   shareSummary: Boolean!
-  teamHealth: Boolean!
   teamsLimit: Boolean!
 }

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -7,7 +7,6 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   zoomTranscription: ({zoomTranscription}) => !!zoomTranscription,
   shareSummary: ({shareSummary}) => !!shareSummary,
   suggestGroups: ({suggestGroups}) => !!suggestGroups,
-  teamHealth: ({teamHealth}) => !!teamHealth,
   teamsLimit: ({teamsLimit}) => !!teamsLimit
 }
 

--- a/packages/server/postgres/migrations/1686226640890_addTeamHealthToAllMeetingSettingsRetrospective.ts
+++ b/packages/server/postgres/migrations/1686226640890_addTeamHealthToAllMeetingSettingsRetrospective.ts
@@ -1,0 +1,42 @@
+import {r, RValue} from 'rethinkdb-ts'
+import {ParabolR} from '../../database/rethinkDriver'
+
+const connectRethinkDB = async () => {
+  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
+  await r.connectPool({
+    host,
+    port: parseInt(port, 10),
+    db: pathname.split('/')[1]
+  })
+  return r as any as ParabolR
+}
+
+export async function up() {
+  await connectRethinkDB()
+  await r
+    .table('MeetingSettings')
+    .filter({meetingType: 'retrospective'})
+    .update((row: RValue) => ({
+      phaseTypes: r.branch(
+        row('phaseTypes').contains('TEAM_HEALTH'),
+        row('phaseTypes'),
+        row('phaseTypes').contains('checkin'),
+        row('phaseTypes').insertAt(1, 'TEAM_HEALTH'),
+        row('phaseTypes').prepend('TEAM_HEALTH')
+      )
+    }))
+    .run()
+  await r.getPoolMaster()?.drain()
+}
+
+export async function down() {
+  await connectRethinkDB()
+  await r
+    .table('MeetingSettings')
+    .filter({meetingType: 'retrospective'})
+    .update((row: RValue) => ({
+      phaseTypes: row('phaseTypes').difference(['TEAM_HEALTH'])
+    }))
+    .run()
+  await r.getPoolMaster()?.drain()
+}

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -51,6 +51,7 @@ export type TaskEstimateProperties = {
 
 export type MeetingSettings = {
   hasIcebreaker?: boolean
+  hasTeamHealth?: boolean
   disableAnonymity?: boolean
   videoMeetingURL?: string | null
   recallBotId?: string | null

--- a/packages/server/utils/isPhaseAvailable.ts
+++ b/packages/server/utils/isPhaseAvailable.ts
@@ -1,9 +1,10 @@
 import {TierEnum} from '../database/types/Invoice'
 import {NewMeetingPhaseTypeEnum} from '../database/types/GenericMeetingPhase'
+import isTeamHealthAvailable from 'parabol-client/utils/features/isTeamHealthAvailable'
 
 const isPhaseAvailable = (tier: TierEnum) => (phaseType: NewMeetingPhaseTypeEnum) => {
   if (phaseType === 'TEAM_HEALTH') {
-    return tier !== 'starter'
+    return isTeamHealthAvailable(tier)
   }
   return true
 }

--- a/packages/server/utils/isPhaseAvailable.ts
+++ b/packages/server/utils/isPhaseAvailable.ts
@@ -1,0 +1,11 @@
+import {TierEnum} from '../database/types/Invoice'
+import {NewMeetingPhaseTypeEnum} from '../database/types/GenericMeetingPhase'
+
+const isPhaseAvailable = (tier: TierEnum) => (phaseType: NewMeetingPhaseTypeEnum) => {
+  if (phaseType === 'TEAM_HEALTH') {
+    return tier !== 'starter'
+  }
+  return true
+}
+
+export default isPhaseAvailable


### PR DESCRIPTION
# Description

Fixes #8288 #8324
It's much less error prone to add the new phase to all retrospective
settings by default and filtering the paid phases from the settings.
The alternative of adding it only to paid teams is more tricky as it
would need to be added in all upgrade paths and we'd need to keep track
if it was disabled.

## Demo

https://www.loom.com/share/2468e37aeae24cc4bb7345f7a9a7aa53

## Testing scenarios

* start on **master**
* create 2 orgs, 1 starter, 1 team
* checkout **PR**
* both teams should now have `TEAM_HEALTH` meeting phase in their `MeetingSettingsRetrospective` in R
* only the team org has the team health setting
* the starter org will not have the team health phase when starting a retro meeting
* create a new org, check it has `TEAM_HEALTH` meeting phase in their settings

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
