### PR TITLE
fix(templates): Many public templates not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows conventions [outlined here](http://keepachangelog.com/).
 
+## 6.107.1 2023-June-8
+
+### Fixed:
+
+- fix: Many public templates not displayed
+
 ## 6.107.0 2023-June-7
 
 ### Added

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -48,7 +48,7 @@ const query = graphql`
         meetingSettings(meetingType: retrospective) {
           ... on RetrospectiveMeetingSettings {
             templateSearchQuery
-            publicTemplates(first: 50)
+            publicTemplates(first: 100)
               @connection(key: "ReflectTemplateListPublic_publicTemplates") {
               edges {
                 node {


### PR DESCRIPTION
# Description
See [slack](https://parabol.slack.com/archives/C836NA350/p1686249487077819?thread_ts=1686161803.697149&cid=C836NA350) 🔒 
