### PR TITLE
chore(template-limits): remove template limit feature flag

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
@@ -52,7 +52,6 @@ export const TemplateDetails = (props: Props) => {
         organizations {
           id
         }
-        ...useTemplateDescription_viewer
       }
     `,
     viewerRef
@@ -135,7 +134,7 @@ export const TemplateDetails = (props: Props) => {
   const isOwner = teamIds.includes(template.teamId)
 
   const lowestScope = isOwner ? 'TEAM' : orgIds.includes(template.orgId) ? 'ORGANIZATION' : 'PUBLIC'
-  const description = useTemplateDescription(lowestScope, template, viewer, tier)
+  const description = useTemplateDescription(lowestScope, template, tier)
 
   useEffect(() => {
     setIsEditing(!!history.location.state?.edit)

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -102,7 +102,6 @@ const NewMeetingInner = styled('div')({
 const query = graphql`
   query NewMeetingQuery {
     viewer {
-      ...NewMeetingSettings_viewer
       featureFlags {
         insights
       }
@@ -211,11 +210,7 @@ const NewMeeting = (props: Props) => {
             />
           </SettingsFirstRow>
           <SettingsRow>
-            <NewMeetingSettings
-              selectedTeamRef={selectedTeam}
-              meetingType={meetingType}
-              viewerRef={viewer}
-            />
+            <NewMeetingSettings selectedTeamRef={selectedTeam} meetingType={meetingType} />
             {meetingType === 'teamPrompt' && (
               <NewMeetingRecurrenceSettings
                 onRecurrenceSettingsUpdated={setRecurrenceSettings}

--- a/packages/client/components/NewMeetingSettings.tsx
+++ b/packages/client/components/NewMeetingSettings.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {MeetingTypeEnum} from '~/__generated__/NewMeetingQuery.graphql'
 import {NewMeetingSettings_selectedTeam$key} from '~/__generated__/NewMeetingSettings_selectedTeam.graphql'
-import {NewMeetingSettings_viewer$key} from '~/__generated__/NewMeetingSettings_viewer.graphql'
 import NewMeetingSettingsAction from './NewMeetingSettingsAction'
 import NewMeetingSettingsPoker from './NewMeetingSettingsPoker'
 import NewMeetingSettingsRetrospective from './NewMeetingSettingsRetrospective'
@@ -12,7 +11,6 @@ import NewMeetingSettingsTeamPrompt from './NewMeetingSettingsTeamPrompt'
 interface Props {
   meetingType: MeetingTypeEnum
   selectedTeamRef: NewMeetingSettings_selectedTeam$key
-  viewerRef: NewMeetingSettings_viewer$key
 }
 
 const settingsLookup = {
@@ -23,16 +21,7 @@ const settingsLookup = {
 }
 
 const NewMeetingSettings = (props: Props) => {
-  const {meetingType, selectedTeamRef, viewerRef} = props
-  const viewer = useFragment(
-    graphql`
-      fragment NewMeetingSettings_viewer on User {
-        ...NewMeetingSettingsRetrospective_viewer
-        ...NewMeetingSettingsPoker_viewer
-      }
-    `,
-    viewerRef
-  )
+  const {meetingType, selectedTeamRef} = props
   const selectedTeam = useFragment(
     graphql`
       fragment NewMeetingSettings_selectedTeam on Team {
@@ -47,7 +36,7 @@ const NewMeetingSettings = (props: Props) => {
   )
 
   const Settings = settingsLookup[meetingType]
-  return <Settings teamRef={selectedTeam} viewerRef={viewer} />
+  return <Settings teamRef={selectedTeam} />
 }
 
 export default NewMeetingSettings

--- a/packages/client/components/NewMeetingSettingsPoker.tsx
+++ b/packages/client/components/NewMeetingSettingsPoker.tsx
@@ -2,17 +2,15 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {NewMeetingSettingsPoker_team$key} from '~/__generated__/NewMeetingSettingsPoker_team.graphql'
-import {NewMeetingSettingsPoker_viewer$key} from '~/__generated__/NewMeetingSettingsPoker_viewer.graphql'
 import PokerTemplatePicker from '../modules/meeting/components/PokerTemplatePicker'
 import NewMeetingSettingsToggleCheckIn from './NewMeetingSettingsToggleCheckIn'
 
 interface Props {
   teamRef: NewMeetingSettingsPoker_team$key
-  viewerRef: NewMeetingSettingsPoker_viewer$key
 }
 
 const NewMeetingSettingsPoker = (props: Props) => {
-  const {teamRef, viewerRef} = props
+  const {teamRef} = props
   const team = useFragment(
     graphql`
       fragment NewMeetingSettingsPoker_team on Team {
@@ -24,18 +22,10 @@ const NewMeetingSettingsPoker = (props: Props) => {
     `,
     teamRef
   )
-  const viewer = useFragment(
-    graphql`
-      fragment NewMeetingSettingsPoker_viewer on User {
-        ...PokerTemplatePicker_viewer
-      }
-    `,
-    viewerRef
-  )
   const {pokerSettings} = team
   return (
     <>
-      <PokerTemplatePicker settingsRef={pokerSettings} viewerRef={viewer} />
+      <PokerTemplatePicker settingsRef={pokerSettings} />
       <NewMeetingSettingsToggleCheckIn settingsRef={pokerSettings} />
     </>
   )

--- a/packages/client/components/NewMeetingSettingsRetrospective.tsx
+++ b/packages/client/components/NewMeetingSettingsRetrospective.tsx
@@ -2,17 +2,15 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {NewMeetingSettingsRetrospective_team$key} from '~/__generated__/NewMeetingSettingsRetrospective_team.graphql'
-import {NewMeetingSettingsRetrospective_viewer$key} from '~/__generated__/NewMeetingSettingsRetrospective_viewer.graphql'
 import RetroTemplatePicker from '../modules/meeting/components/RetroTemplatePicker'
 import NewMeetingSettingsRetrospectiveSettings from './NewMeetingSettingsRetrospectiveSettings'
 
 interface Props {
   teamRef: NewMeetingSettingsRetrospective_team$key
-  viewerRef: NewMeetingSettingsRetrospective_viewer$key
 }
 
 const NewMeetingSettingsRetrospective = (props: Props) => {
-  const {teamRef, viewerRef} = props
+  const {teamRef} = props
   const team = useFragment(
     graphql`
       fragment NewMeetingSettingsRetrospective_team on Team {
@@ -28,18 +26,10 @@ const NewMeetingSettingsRetrospective = (props: Props) => {
     teamRef
   )
   const {organization} = team
-  const viewer = useFragment(
-    graphql`
-      fragment NewMeetingSettingsRetrospective_viewer on User {
-        ...RetroTemplatePicker_viewer
-      }
-    `,
-    viewerRef
-  )
   const {retroSettings} = team
   return (
     <>
-      <RetroTemplatePicker settingsRef={retroSettings} viewerRef={viewer} />
+      <RetroTemplatePicker settingsRef={retroSettings} />
       <NewMeetingSettingsRetrospectiveSettings
         settingsRef={retroSettings}
         organizationRef={organization}

--- a/packages/client/modules/meeting/components/AddNewPokerTemplate.tsx
+++ b/packages/client/modules/meeting/components/AddNewPokerTemplate.tsx
@@ -10,7 +10,6 @@ import AddPokerTemplateMutation from '../../../mutations/AddPokerTemplateMutatio
 import {Threshold} from '../../../types/constEnums'
 import {AddNewPokerTemplate_pokerTemplates$key} from '../../../__generated__/AddNewPokerTemplate_pokerTemplates.graphql'
 import {AddNewPokerTemplate_team$key} from '../../../__generated__/AddNewPokerTemplate_team.graphql'
-import {AddNewPokerTemplate_viewer$key} from '../../../__generated__/AddNewPokerTemplate_viewer.graphql'
 
 const ErrorLine = styled(TooltipStyled)({
   margin: '0 0 8px'

--- a/packages/client/modules/meeting/components/AddNewPokerTemplate.tsx
+++ b/packages/client/modules/meeting/components/AddNewPokerTemplate.tsx
@@ -31,13 +31,12 @@ const AddPokerTemplateLink = styled(LinkButton)({
 interface Props {
   gotoTeamTemplates: () => void
   pokerTemplatesRef: AddNewPokerTemplate_pokerTemplates$key
-  viewerRef: AddNewPokerTemplate_viewer$key
   teamRef: AddNewPokerTemplate_team$key
   displayUpgradeDetails: () => void
 }
 
 const AddNewPokerTemplate = (props: Props) => {
-  const {gotoTeamTemplates, teamRef, pokerTemplatesRef, viewerRef, displayUpgradeDetails} = props
+  const {gotoTeamTemplates, teamRef, pokerTemplatesRef, displayUpgradeDetails} = props
   const atmosphere = useAtmosphere()
   const pokerTemplates = useFragment(
     graphql`
@@ -46,16 +45,6 @@ const AddNewPokerTemplate = (props: Props) => {
       }
     `,
     pokerTemplatesRef
-  )
-  const {featureFlags} = useFragment(
-    graphql`
-      fragment AddNewPokerTemplate_viewer on User {
-        featureFlags {
-          templateLimit
-        }
-      }
-    `,
-    viewerRef
   )
   const team = useFragment(
     graphql`
@@ -76,7 +65,7 @@ const AddNewPokerTemplate = (props: Props) => {
   }, [])
   const addNewTemplate = () => {
     if (submitting) return
-    if (featureFlags.templateLimit && tier === 'starter') {
+    if (tier === 'starter') {
       displayUpgradeDetails()
       return
     }
@@ -110,7 +99,7 @@ const AddNewPokerTemplate = (props: Props) => {
     <div>
       {error && <ErrorLine>{error.message}</ErrorLine>}
       <AddPokerTemplateLink palette='blue' onClick={addNewTemplate} waiting={submitting}>
-        Create New Template {featureFlags.templateLimit && tier === 'starter' && '🔒'}
+        Create New Template {tier === 'starter' && '🔒'}
       </AddPokerTemplateLink>
     </div>
   )

--- a/packages/client/modules/meeting/components/AddNewReflectTemplate.tsx
+++ b/packages/client/modules/meeting/components/AddNewReflectTemplate.tsx
@@ -10,7 +10,6 @@ import AddReflectTemplateMutation from '../../../mutations/AddReflectTemplateMut
 import {Threshold} from '../../../types/constEnums'
 import {AddNewReflectTemplate_reflectTemplates$key} from '../../../__generated__/AddNewReflectTemplate_reflectTemplates.graphql'
 import {AddNewReflectTemplate_team$key} from '../../../__generated__/AddNewReflectTemplate_team.graphql'
-import {AddNewReflectTemplate_viewer$key} from '../../../__generated__/AddNewReflectTemplate_viewer.graphql'
 
 const ErrorLine = styled(TooltipStyled)({
   margin: '0 0 8px'
@@ -31,13 +30,12 @@ const AddRetroTemplateLink = styled(LinkButton)({
 interface Props {
   gotoTeamTemplates: () => void
   reflectTemplatesRef: AddNewReflectTemplate_reflectTemplates$key
-  viewerRef: AddNewReflectTemplate_viewer$key
   displayUpgradeDetails: () => void
   teamRef: AddNewReflectTemplate_team$key
 }
 
 const AddNewReflectTemplate = (props: Props) => {
-  const {gotoTeamTemplates, reflectTemplatesRef, teamRef, viewerRef, displayUpgradeDetails} = props
+  const {gotoTeamTemplates, reflectTemplatesRef, teamRef, displayUpgradeDetails} = props
   const atmosphere = useAtmosphere()
   const reflectTemplates = useFragment(
     graphql`
@@ -46,16 +44,6 @@ const AddNewReflectTemplate = (props: Props) => {
       }
     `,
     reflectTemplatesRef
-  )
-  const {featureFlags} = useFragment(
-    graphql`
-      fragment AddNewReflectTemplate_viewer on User {
-        featureFlags {
-          templateLimit
-        }
-      }
-    `,
-    viewerRef
   )
   const team = useFragment(
     graphql`
@@ -76,7 +64,7 @@ const AddNewReflectTemplate = (props: Props) => {
   }, [])
   const addNewTemplate = () => {
     if (submitting) return
-    if (featureFlags.templateLimit && tier === 'starter') {
+    if (tier === 'starter') {
       displayUpgradeDetails()
       return
     }
@@ -107,7 +95,7 @@ const AddNewReflectTemplate = (props: Props) => {
     <div>
       {error && <ErrorLine>{error.message}</ErrorLine>}
       <AddRetroTemplateLink palette='blue' onClick={addNewTemplate} waiting={submitting}>
-        Create New Template {featureFlags.templateLimit && tier === 'starter' && '🔒'}
+        Create New Template {tier === 'starter' && '🔒'}
       </AddRetroTemplateLink>
     </div>
   )

--- a/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
@@ -113,16 +113,11 @@ const PokerTemplateDetails = (props: Props) => {
   const viewer = useFragment(
     graphql`
       fragment PokerTemplateDetails_viewer on User {
-        featureFlags {
-          templateLimit
-        }
         ...useTemplateDescription_viewer
       }
     `,
     viewerRef
   )
-  const {featureFlags} = viewer
-  const {templateLimit: templateLimitFlag} = featureFlags
   const {teamTemplates, team} = settings
   const activeTemplate = settings.activeTemplate ?? settings.selectedTemplate
   const {id: templateId, name: templateName, dimensions} = activeTemplate
@@ -147,7 +142,7 @@ const PokerTemplateDetails = (props: Props) => {
   const headerImg =
     pokerIllustrations[templateId as keyof typeof pokerIllustrations] ?? customTemplate
   const isActiveTemplate = activeTemplate.id === settings.selectedTemplate.id
-  const showClone = !isOwner && (templateLimitFlag ? tier !== 'starter' : true)
+  const showClone = !isOwner && tier !== 'starter'
   return (
     <DimensionEditor>
       <Scrollable isActiveTemplate={isActiveTemplate}>

--- a/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateDetails.tsx
@@ -12,7 +12,6 @@ import {Threshold} from '../../../types/constEnums'
 import getTemplateList from '../../../utils/getTemplateList'
 import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {PokerTemplateDetails_settings$key} from '../../../__generated__/PokerTemplateDetails_settings.graphql'
-import {PokerTemplateDetails_viewer$key} from '../../../__generated__/PokerTemplateDetails_viewer.graphql'
 import AddPokerTemplateDimension from './AddPokerTemplateDimension'
 import CloneTemplate from './CloneTemplate'
 import EditableTemplateName from './EditableTemplateName'
@@ -75,17 +74,10 @@ interface Props {
   gotoPublicTemplates: () => void
   closePortal: () => void
   settings: PokerTemplateDetails_settings$key
-  viewer: PokerTemplateDetails_viewer$key
 }
 
 const PokerTemplateDetails = (props: Props) => {
-  const {
-    gotoTeamTemplates,
-    gotoPublicTemplates,
-    closePortal,
-    settings: settingsRef,
-    viewer: viewerRef
-  } = props
+  const {gotoTeamTemplates, gotoPublicTemplates, closePortal, settings: settingsRef} = props
   const settings = useFragment(
     graphql`
       fragment PokerTemplateDetails_settings on PokerMeetingSettings {
@@ -110,21 +102,13 @@ const PokerTemplateDetails = (props: Props) => {
     `,
     settingsRef
   )
-  const viewer = useFragment(
-    graphql`
-      fragment PokerTemplateDetails_viewer on User {
-        ...useTemplateDescription_viewer
-      }
-    `,
-    viewerRef
-  )
   const {teamTemplates, team} = settings
   const activeTemplate = settings.activeTemplate ?? settings.selectedTemplate
   const {id: templateId, name: templateName, dimensions} = activeTemplate
   const {id: teamId, orgId, tier} = team
   const lowestScope = getTemplateList(teamId, orgId, activeTemplate)
   const isOwner = activeTemplate.teamId === teamId
-  const description = useTemplateDescription(lowestScope, activeTemplate, viewer)
+  const description = useTemplateDescription(lowestScope, activeTemplate, tier)
   const templateCount = teamTemplates.length
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()

--- a/packages/client/modules/meeting/components/PokerTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateItem.tsx
@@ -11,7 +11,6 @@ import {PALETTE} from '../../../styles/paletteV3'
 import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
 import {PokerTemplateItem_template$key} from '../../../__generated__/PokerTemplateItem_template.graphql'
-import {PokerTemplateItem_viewer$key} from '../../../__generated__/PokerTemplateItem_viewer.graphql'
 
 const TemplateItem = styled('li')<{isActive: boolean}>(({isActive}) => ({
   backgroundColor: isActive ? PALETTE.SLATE_200 : undefined,
@@ -55,12 +54,11 @@ interface Props {
   isActive: boolean
   teamId: string
   templateRef: PokerTemplateItem_template$key
-  viewerRef?: PokerTemplateItem_viewer$key
   lowestScope: 'TEAM' | 'ORGANIZATION' | 'PUBLIC'
 }
 
 const PokerTemplateItem = (props: Props) => {
-  const {lowestScope, isActive, teamId, templateRef, viewerRef} = props
+  const {lowestScope, isActive, teamId, templateRef} = props
   const template = useFragment(
     graphql`
       fragment PokerTemplateItem_template on PokerTemplate {
@@ -76,16 +74,8 @@ const PokerTemplateItem = (props: Props) => {
     `,
     templateRef
   )
-  const viewer = useFragment(
-    graphql`
-      fragment PokerTemplateItem_viewer on User {
-        ...useTemplateDescription_viewer
-      }
-    `,
-    viewerRef ?? null
-  )
   const {id: templateId, name: templateName, scope, isFree} = template
-  const description = useTemplateDescription(lowestScope, template, viewer ?? undefined)
+  const description = useTemplateDescription(lowestScope, template)
   const atmosphere = useAtmosphere()
   const ref = useRef<HTMLLIElement>(null)
   useScrollIntoView(ref, isActive)

--- a/packages/client/modules/meeting/components/PokerTemplateList.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateList.tsx
@@ -15,7 +15,6 @@ import {desktopSidebarShadow} from '../../../styles/elevation'
 import {PALETTE} from '../../../styles/paletteV3'
 import {Breakpoint} from '../../../types/constEnums'
 import {PokerTemplateList_settings$key} from '../../../__generated__/PokerTemplateList_settings.graphql'
-import {PokerTemplateList_viewer$key} from '../../../__generated__/PokerTemplateList_viewer.graphql'
 import AddNewPokerTemplate from './AddNewPokerTemplate'
 import PokerTemplateListOrgRoot from './PokerTemplateListOrgRoot'
 import PokerTemplateListPublicRoot from './PokerTemplateListPublicRoot'
@@ -78,12 +77,11 @@ interface Props {
   activeIdx: number
   setActiveIdx: (idx: number) => void
   settingsRef: PokerTemplateList_settings$key
-  viewerRef: PokerTemplateList_viewer$key
   displayUpgradeDetails: () => void
 }
 
 const PokerTemplateList = (props: Props) => {
-  const {activeIdx, setActiveIdx, settingsRef, viewerRef, displayUpgradeDetails} = props
+  const {activeIdx, setActiveIdx, settingsRef, displayUpgradeDetails} = props
   const settings = useFragment(
     graphql`
       fragment PokerTemplateList_settings on PokerMeetingSettings {
@@ -105,15 +103,6 @@ const PokerTemplateList = (props: Props) => {
       }
     `,
     settingsRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment PokerTemplateList_viewer on User {
-        ...PokerTemplateListTeam_viewer
-        ...AddNewPokerTemplate_viewer
-      }
-    `,
-    viewerRef
   )
   const {team, teamTemplates} = settings
   const {id: teamId} = team
@@ -174,7 +163,6 @@ const PokerTemplateList = (props: Props) => {
       <AddNewPokerTemplate
         teamRef={team}
         pokerTemplatesRef={teamTemplates}
-        viewerRef={viewer}
         gotoTeamTemplates={gotoTeamTemplates}
         displayUpgradeDetails={displayUpgradeDetails}
       />
@@ -192,7 +180,6 @@ const PokerTemplateList = (props: Props) => {
             teamTemplatesRef={teamTemplates}
             teamRef={team}
             isActive={activeIdx === 0}
-            viewerRef={viewer}
           />
         </TabContents>
         <TabContents>{activeIdx === 1 && <PokerTemplateListOrgRoot teamId={teamId} />}</TabContents>

--- a/packages/client/modules/meeting/components/PokerTemplateListOrg.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateListOrg.tsx
@@ -43,9 +43,6 @@ const query = graphql`
   query PokerTemplateListOrgQuery($teamId: ID!) {
     viewer {
       id
-      featureFlags {
-        templateLimit
-      }
       team(teamId: $teamId) {
         id
         tier
@@ -75,7 +72,6 @@ const PokerTemplateListOrg = (props: Props) => {
   const data = usePreloadedQuery<PokerTemplateListOrgQuery>(query, queryRef)
   const {viewer} = data
   const team = viewer.team!
-  const featureFlags = viewer.featureFlags!
   const {id: teamId, meetingSettings, tier, orgId} = team
   const activeTemplateId = meetingSettings.activeTemplate?.id ?? '-tmp'
   const organizationTemplates = meetingSettings.organizationTemplates!
@@ -85,7 +81,7 @@ const PokerTemplateListOrg = (props: Props) => {
   const history = useHistory()
 
   if (edges.length === 0) {
-    if (tier === 'starter' && featureFlags.templateLimit) {
+    if (tier === 'starter') {
       const goToBilling = () => {
         SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
           upgradeCTALocation: 'orgTemplate',

--- a/packages/client/modules/meeting/components/PokerTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateListPublic.tsx
@@ -18,7 +18,6 @@ interface Props {
 const query = graphql`
   query PokerTemplateListPublicQuery($teamId: ID!) {
     viewer {
-      ...PokerTemplateItem_viewer
       id
       team(teamId: $teamId) {
         id
@@ -62,7 +61,6 @@ const PokerTemplateListPublic = (props: Props) => {
             isActive={template.id === activeTemplateId}
             lowestScope={'PUBLIC'}
             teamId={teamId}
-            viewerRef={viewer}
           />
         )
       })}

--- a/packages/client/modules/meeting/components/PokerTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateListTeam.tsx
@@ -9,7 +9,6 @@ import SendClientSegmentEventMutation from '../../../mutations/SendClientSegment
 import {PALETTE} from '../../../styles/paletteV3'
 import {PokerTemplateListTeam_team$key} from '../../../__generated__/PokerTemplateListTeam_team.graphql'
 import {PokerTemplateListTeam_teamTemplates$key} from '../../../__generated__/PokerTemplateListTeam_teamTemplates.graphql'
-import {PokerTemplateListTeam_viewer$key} from '../../../__generated__/PokerTemplateListTeam_viewer.graphql'
 import PokerTemplateItem from './PokerTemplateItem'
 
 const TemplateList = styled('ul')({

--- a/packages/client/modules/meeting/components/PokerTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateListTeam.tsx
@@ -44,12 +44,10 @@ interface Props {
   showPublicTemplates: () => void
   teamTemplatesRef: PokerTemplateListTeam_teamTemplates$key
   teamRef: PokerTemplateListTeam_team$key
-  viewerRef: PokerTemplateListTeam_viewer$key
 }
 
 const PokerTemplateListTeam = (props: Props) => {
-  const {isActive, activeTemplateId, showPublicTemplates, teamTemplatesRef, viewerRef, teamRef} =
-    props
+  const {isActive, activeTemplateId, showPublicTemplates, teamTemplatesRef, teamRef} = props
   const teamTemplates = useFragment(
     graphql`
       fragment PokerTemplateListTeam_teamTemplates on PokerTemplate @relay(plural: true) {
@@ -58,16 +56,6 @@ const PokerTemplateListTeam = (props: Props) => {
       }
     `,
     teamTemplatesRef
-  )
-  const {featureFlags} = useFragment(
-    graphql`
-      fragment PokerTemplateListTeam_viewer on User {
-        featureFlags {
-          templateLimit
-        }
-      }
-    `,
-    viewerRef
   )
   const team = useFragment(
     graphql`
@@ -85,7 +73,7 @@ const PokerTemplateListTeam = (props: Props) => {
   const atmosphere = useAtmosphere()
   const history = useHistory()
   if (teamTemplates.length === 0) {
-    if (tier === 'starter' && featureFlags.templateLimit) {
+    if (tier === 'starter') {
       const goToBilling = () => {
         SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
           upgradeCTALocation: 'teamTemplate',

--- a/packages/client/modules/meeting/components/PokerTemplateModal.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplateModal.tsx
@@ -7,7 +7,6 @@ import useAtmosphere from '../../../hooks/useAtmosphere'
 import getTemplateList from '../../../utils/getTemplateList'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
 import {PokerTemplateModal_pokerMeetingSettings$key} from '../../../__generated__/PokerTemplateModal_pokerMeetingSettings.graphql'
-import {PokerTemplateModal_viewer$key} from '../../../__generated__/PokerTemplateModal_viewer.graphql'
 import CustomTemplateUpgradeMsg from './CustomTemplateUpgradeMsg'
 import PokerTemplateDetails from './PokerTemplateDetails'
 import PokerTemplateList from './PokerTemplateList'
@@ -16,7 +15,6 @@ import PokerTemplateScaleDetails from './PokerTemplateScaleDetails'
 interface Props {
   closePortal: () => void
   pokerMeetingSettingsRef: PokerTemplateModal_pokerMeetingSettings$key
-  viewerRef: PokerTemplateModal_viewer$key
 }
 
 const StyledDialogContainer = styled(DialogContainer)({
@@ -29,7 +27,7 @@ const StyledDialogContainer = styled(DialogContainer)({
 const SCOPES = ['TEAM', 'ORGANIZATION', 'PUBLIC']
 
 const PokerTemplateModal = (props: Props) => {
-  const {closePortal, pokerMeetingSettingsRef, viewerRef} = props
+  const {closePortal, pokerMeetingSettingsRef} = props
   const pokerMeetingSettings = useFragment(
     graphql`
       fragment PokerTemplateModal_pokerMeetingSettings on PokerMeetingSettings {
@@ -52,15 +50,6 @@ const PokerTemplateModal = (props: Props) => {
       }
     `,
     pokerMeetingSettingsRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment PokerTemplateModal_viewer on User {
-        ...PokerTemplateDetails_viewer
-        ...PokerTemplateList_viewer
-      }
-    `,
-    viewerRef
   )
 
   const {selectedTemplate, team, activeTemplate, meetingType} = pokerMeetingSettings
@@ -99,7 +88,6 @@ const PokerTemplateModal = (props: Props) => {
         settingsRef={pokerMeetingSettings}
         activeIdx={activeIdx}
         setActiveIdx={setActiveIdx}
-        viewerRef={viewer}
         displayUpgradeDetails={displayUpgradeDetails}
       />
       {showUpgradeDetails ? (
@@ -112,7 +100,6 @@ const PokerTemplateModal = (props: Props) => {
           gotoTeamTemplates={gotoTeamTemplates}
           gotoPublicTemplates={gotoPublicTemplates}
           closePortal={closePortal}
-          viewer={viewer}
         />
       )}
     </StyledDialogContainer>

--- a/packages/client/modules/meeting/components/PokerTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/PokerTemplatePicker.tsx
@@ -7,11 +7,9 @@ import useModal from '../../../hooks/useModal'
 import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 import lazyPreload from '../../../utils/lazyPreload'
 import {PokerTemplatePicker_settings$key} from '../../../__generated__/PokerTemplatePicker_settings.graphql'
-import {PokerTemplatePicker_viewer$key} from '../../../__generated__/PokerTemplatePicker_viewer.graphql'
 
 interface Props {
   settingsRef: PokerTemplatePicker_settings$key
-  viewerRef: PokerTemplatePicker_viewer$key
 }
 
 const PokerTemplateModal = lazyPreload(
@@ -23,7 +21,7 @@ const PokerTemplateModal = lazyPreload(
 )
 
 const PokerTemplatePicker = (props: Props) => {
-  const {settingsRef, viewerRef} = props
+  const {settingsRef} = props
   const settings = useFragment(
     graphql`
       fragment PokerTemplatePicker_settings on PokerMeetingSettings {
@@ -37,14 +35,6 @@ const PokerTemplatePicker = (props: Props) => {
       }
     `,
     settingsRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment PokerTemplatePicker_viewer on User {
-        ...PokerTemplateModal_viewer
-      }
-    `,
-    viewerRef
   )
   const {selectedTemplate} = settings
   const {name: templateName, scope} = selectedTemplate
@@ -71,11 +61,7 @@ const PokerTemplatePicker = (props: Props) => {
         title={'Template'}
       />
       {modalPortal(
-        <PokerTemplateModal
-          closePortal={closePortal}
-          pokerMeetingSettingsRef={settings}
-          viewerRef={viewer}
-        />
+        <PokerTemplateModal closePortal={closePortal} pokerMeetingSettingsRef={settings} />
       )}
     </>
   )

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -113,16 +113,11 @@ const ReflectTemplateDetails = (props: Props) => {
   const viewer = useFragment(
     graphql`
       fragment ReflectTemplateDetails_viewer on User {
-        featureFlags {
-          templateLimit
-        }
         ...useTemplateDescription_viewer
       }
     `,
     viewerRef
   )
-  const {featureFlags} = viewer
-  const {templateLimit: templateLimitFlag} = featureFlags
   const {teamTemplates, team} = settings
   const activeTemplate = settings.activeTemplate ?? settings.selectedTemplate
   const {id: templateId, name: templateName, prompts} = activeTemplate
@@ -147,7 +142,7 @@ const ReflectTemplateDetails = (props: Props) => {
   const headerImg =
     retroIllustrations[templateId as keyof typeof retroIllustrations] ?? customTemplate
   const isActiveTemplate = templateId === settings.selectedTemplate.id
-  const showClone = !isOwner && (templateLimitFlag ? tier !== 'starter' : true)
+  const showClone = !isOwner && tier !== 'starter'
   return (
     <PromptEditor>
       <Scrollable isActiveTemplate={isActiveTemplate}>
@@ -183,7 +178,6 @@ const ReflectTemplateDetails = (props: Props) => {
           closePortal={closePortal}
           template={activeTemplate}
           teamId={teamId}
-          hasFeatureFlag={templateLimitFlag}
           tier={tier}
           orgId={orgId}
         />

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -11,7 +11,6 @@ import {Threshold} from '../../../types/constEnums'
 import getTemplateList from '../../../utils/getTemplateList'
 import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {ReflectTemplateDetails_settings$key} from '../../../__generated__/ReflectTemplateDetails_settings.graphql'
-import {ReflectTemplateDetails_viewer$key} from '../../../__generated__/ReflectTemplateDetails_viewer.graphql'
 import AddTemplatePrompt from './AddTemplatePrompt'
 import CloneTemplate from './CloneTemplate'
 import EditableTemplateName from './EditableTemplateName'
@@ -75,17 +74,10 @@ interface Props {
   gotoPublicTemplates: () => void
   closePortal: () => void
   settings: ReflectTemplateDetails_settings$key
-  viewer: ReflectTemplateDetails_viewer$key
 }
 
 const ReflectTemplateDetails = (props: Props) => {
-  const {
-    gotoTeamTemplates,
-    gotoPublicTemplates,
-    closePortal,
-    settings: settingsRef,
-    viewer: viewerRef
-  } = props
+  const {gotoTeamTemplates, gotoPublicTemplates, closePortal, settings: settingsRef} = props
   const settings = useFragment(
     graphql`
       fragment ReflectTemplateDetails_settings on RetrospectiveMeetingSettings {
@@ -110,21 +102,13 @@ const ReflectTemplateDetails = (props: Props) => {
     `,
     settingsRef
   )
-  const viewer = useFragment(
-    graphql`
-      fragment ReflectTemplateDetails_viewer on User {
-        ...useTemplateDescription_viewer
-      }
-    `,
-    viewerRef
-  )
   const {teamTemplates, team} = settings
   const activeTemplate = settings.activeTemplate ?? settings.selectedTemplate
   const {id: templateId, name: templateName, prompts} = activeTemplate
   const {id: teamId, orgId, tier} = team
   const lowestScope = getTemplateList(teamId, orgId, activeTemplate)
   const isOwner = activeTemplate.teamId === teamId
-  const description = useTemplateDescription(lowestScope, activeTemplate, viewer, tier)
+  const description = useTemplateDescription(lowestScope, activeTemplate, tier)
   const templateCount = teamTemplates.length
   const atmosphere = useAtmosphere()
   const {onError, onCompleted, submitting, submitMutation} = useMutationProps()

--- a/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateItem.tsx
@@ -12,7 +12,6 @@ import {PALETTE} from '../../../styles/paletteV3'
 import useTemplateDescription from '../../../utils/useTemplateDescription'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
 import {ReflectTemplateItem_template$key} from '../../../__generated__/ReflectTemplateItem_template.graphql'
-import {ReflectTemplateItem_viewer$key} from '../../../__generated__/ReflectTemplateItem_viewer.graphql'
 import {TierEnum} from '../../../__generated__/SendClientSegmentEventMutation.graphql'
 
 const TemplateItem = styled('li')<{isActive: boolean}>(({isActive}) => ({
@@ -60,19 +59,10 @@ interface Props {
   lowestScope: 'TEAM' | 'ORGANIZATION' | 'PUBLIC'
   templateSearchQuery: string
   tier?: TierEnum
-  viewer?: ReflectTemplateItem_viewer$key
 }
 
 const ReflectTemplateItem = (props: Props) => {
-  const {
-    lowestScope,
-    isActive,
-    teamId,
-    template: templateRef,
-    templateSearchQuery,
-    tier,
-    viewer: viewerRef
-  } = props
+  const {lowestScope, isActive, teamId, template: templateRef, templateSearchQuery, tier} = props
   const template = useFragment(
     graphql`
       fragment ReflectTemplateItem_template on ReflectTemplate {
@@ -88,16 +78,8 @@ const ReflectTemplateItem = (props: Props) => {
     `,
     templateRef
   )
-  const viewer = useFragment(
-    graphql`
-      fragment ReflectTemplateItem_viewer on User {
-        ...useTemplateDescription_viewer
-      }
-    `,
-    viewerRef ?? null
-  )
   const {id: templateId, name: templateName, scope, isFree} = template
-  const description = useTemplateDescription(lowestScope, template, viewer, tier)
+  const description = useTemplateDescription(lowestScope, template, tier)
   const atmosphere = useAtmosphere()
   const ref = useRef<HTMLLIElement>(null)
   useScrollIntoView(ref, isActive, true)

--- a/packages/client/modules/meeting/components/ReflectTemplateList.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateList.tsx
@@ -17,7 +17,6 @@ import {desktopSidebarShadow} from '../../../styles/elevation'
 import {PALETTE} from '../../../styles/paletteV3'
 import {Breakpoint} from '../../../types/constEnums'
 import {ReflectTemplateList_settings$key} from '../../../__generated__/ReflectTemplateList_settings.graphql'
-import {ReflectTemplateList_viewer$key} from '../../../__generated__/ReflectTemplateList_viewer.graphql'
 import AddNewReflectTemplate from './AddNewReflectTemplate'
 import ReflectTemplateListOrgRoot from './ReflectTemplateListOrgRoot'
 import ReflectTemplateListPublicRoot from './ReflectTemplateListPublicRoot'
@@ -83,7 +82,6 @@ interface Props {
   setActiveIdx: (idx: number) => void
   displayUpgradeDetails: () => void
   settingsRef: ReflectTemplateList_settings$key
-  viewerRef: ReflectTemplateList_viewer$key
 }
 
 const useReadyToSmoothScroll = (activeTemplateId: string) => {
@@ -103,7 +101,7 @@ export const templateIdxs = {
 } as const
 
 const ReflectTemplateList = (props: Props) => {
-  const {activeIdx, setActiveIdx, settingsRef, viewerRef, displayUpgradeDetails} = props
+  const {activeIdx, setActiveIdx, settingsRef, displayUpgradeDetails} = props
   const settings = useFragment(
     graphql`
       fragment ReflectTemplateList_settings on RetrospectiveMeetingSettings {
@@ -127,15 +125,6 @@ const ReflectTemplateList = (props: Props) => {
       }
     `,
     settingsRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment ReflectTemplateList_viewer on User {
-        ...ReflectTemplateListTeam_viewer
-        ...AddNewReflectTemplate_viewer
-      }
-    `,
-    viewerRef
   )
   const {id: settingsId, team, teamTemplates, templateSearchQuery} = settings
   const {id: teamId} = team
@@ -216,7 +205,6 @@ const ReflectTemplateList = (props: Props) => {
         reflectTemplatesRef={teamTemplates}
         teamRef={team}
         displayUpgradeDetails={displayUpgradeDetails}
-        viewerRef={viewer}
         gotoTeamTemplates={() => goToTab('TEAM')}
       />
       <SwipeableViews
@@ -235,7 +223,6 @@ const ReflectTemplateList = (props: Props) => {
             teamRef={team}
             teamTemplatesRef={teamTemplates}
             isActive={activeIdx === 0}
-            viewerRef={viewer}
           />
         </TabContents>
         <TabContents>

--- a/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListOrg.tsx
@@ -48,9 +48,6 @@ const query = graphql`
   query ReflectTemplateListOrgQuery($teamId: ID!) {
     viewer {
       id
-      featureFlags {
-        templateLimit
-      }
       team(teamId: $teamId) {
         id
         orgId
@@ -85,7 +82,6 @@ const ReflectTemplateListOrg = (props: Props) => {
   const history = useHistory()
   const {viewer} = data
   const team = viewer.team!
-  const featureFlags = viewer.featureFlags
   const {id: teamId, meetingSettings, orgId, tier} = team
   const {templateSearchQuery, organizationTemplates, activeTemplate} = meetingSettings
   const searchQuery = templateSearchQuery ?? ''
@@ -95,7 +91,7 @@ const ReflectTemplateListOrg = (props: Props) => {
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
 
   if (edges.length === 0) {
-    if (tier === 'starter' && featureFlags.templateLimit) {
+    if (tier === 'starter') {
       const goToBilling = () => {
         SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
           upgradeCTALocation: 'orgTemplate',

--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -40,7 +40,6 @@ const getValue = (item: {node: {id: string; name: string}}) => {
 const query = graphql`
   query ReflectTemplateListPublicQuery($teamId: ID!) {
     viewer {
-      ...ReflectTemplateItem_viewer
       id
       team(teamId: $teamId) {
         id
@@ -98,7 +97,6 @@ const ReflectTemplateListPublic = (props: Props) => {
             teamId={teamId}
             tier={tier}
             templateSearchQuery={searchQuery}
-            viewer={viewer}
           />
         )
       })}

--- a/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
@@ -48,7 +48,6 @@ interface Props {
   showPublicTemplates: () => void
   teamTemplatesRef: ReflectTemplateListTeam_teamTemplates$key
   teamRef: ReflectTemplateListTeam_team$key
-  viewerRef: ReflectTemplateListTeam_viewer$key
   templateSearchQuery: string
 }
 
@@ -63,8 +62,7 @@ const ReflectTemplateListTeam = (props: Props) => {
     showPublicTemplates,
     templateSearchQuery,
     teamTemplatesRef,
-    teamRef,
-    viewerRef
+    teamRef
   } = props
   const teamTemplates = useFragment(
     graphql`
@@ -75,16 +73,6 @@ const ReflectTemplateListTeam = (props: Props) => {
       }
     `,
     teamTemplatesRef
-  )
-  const {featureFlags} = useFragment(
-    graphql`
-      fragment ReflectTemplateListTeam_viewer on User {
-        featureFlags {
-          templateLimit
-        }
-      }
-    `,
-    viewerRef
   )
   const team = useFragment(
     graphql`
@@ -104,7 +92,7 @@ const ReflectTemplateListTeam = (props: Props) => {
   useActiveTopTemplate(edges, activeTemplateId, teamId, isActive, 'retrospective')
   const filteredTemplates = useFilteredItems(searchQuery, teamTemplates, getValue)
   if (teamTemplates.length === 0) {
-    if (tier === 'starter' && featureFlags.templateLimit) {
+    if (tier === 'starter') {
       const goToBilling = () => {
         SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
           upgradeCTALocation: 'teamTemplate',

--- a/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListTeam.tsx
@@ -8,7 +8,6 @@ import useActiveTopTemplate from '../../../hooks/useActiveTopTemplate'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 import {PALETTE} from '../../../styles/paletteV3'
-import {ReflectTemplateListTeam_viewer$key} from '../../../__generated__/ReflectTemplateListTeam_viewer.graphql'
 import {
   ReflectTemplateListTeam_teamTemplates$key,
   ReflectTemplateListTeam_teamTemplates$data

--- a/packages/client/modules/meeting/components/ReflectTemplateModal.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateModal.tsx
@@ -7,7 +7,6 @@ import useAtmosphere from '../../../hooks/useAtmosphere'
 import getTemplateList from '../../../utils/getTemplateList'
 import {setActiveTemplate} from '../../../utils/relay/setActiveTemplate'
 import {ReflectTemplateModal_retroMeetingSettings$key} from '../../../__generated__/ReflectTemplateModal_retroMeetingSettings.graphql'
-import {ReflectTemplateModal_viewer$key} from '../../../__generated__/ReflectTemplateModal_viewer.graphql'
 import CustomTemplateUpgradeMsg from './CustomTemplateUpgradeMsg'
 import ReflectTemplateDetails from './ReflectTemplateDetails'
 import ReflectTemplateList from './ReflectTemplateList'
@@ -15,7 +14,6 @@ import ReflectTemplateList from './ReflectTemplateList'
 interface Props {
   closePortal: () => void
   retroMeetingSettingsRef: ReflectTemplateModal_retroMeetingSettings$key
-  viewerRef: ReflectTemplateModal_viewer$key
 }
 
 const StyledDialogContainer = styled(DialogContainer)({
@@ -28,7 +26,7 @@ const StyledDialogContainer = styled(DialogContainer)({
 const SCOPES = ['TEAM', 'ORGANIZATION', 'PUBLIC']
 
 const ReflectTemplateModal = (props: Props) => {
-  const {closePortal, retroMeetingSettingsRef, viewerRef} = props
+  const {closePortal, retroMeetingSettingsRef} = props
   const retroMeetingSettings = useFragment(
     graphql`
       fragment ReflectTemplateModal_retroMeetingSettings on RetrospectiveMeetingSettings {
@@ -49,15 +47,6 @@ const ReflectTemplateModal = (props: Props) => {
       }
     `,
     retroMeetingSettingsRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment ReflectTemplateModal_viewer on User {
-        ...ReflectTemplateDetails_viewer
-        ...ReflectTemplateList_viewer
-      }
-    `,
-    viewerRef
   )
   const {selectedTemplate, team, activeTemplate, meetingType} = retroMeetingSettings
   const {id: teamId, orgId} = team
@@ -96,7 +85,6 @@ const ReflectTemplateModal = (props: Props) => {
         activeIdx={activeIdx}
         setActiveIdx={setActiveIdx}
         displayUpgradeDetails={displayUpgradeDetails}
-        viewerRef={viewer}
       />
       {showUpgradeDetails ? (
         <CustomTemplateUpgradeMsg orgId={orgId} meetingType={meetingType} />
@@ -106,7 +94,6 @@ const ReflectTemplateModal = (props: Props) => {
           gotoTeamTemplates={gotoTeamTemplates}
           gotoPublicTemplates={gotoPublicTemplates}
           closePortal={closePortal}
-          viewer={viewer}
         />
       )}
     </StyledDialogContainer>

--- a/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
+++ b/packages/client/modules/meeting/components/RetroTemplatePicker.tsx
@@ -7,11 +7,9 @@ import useModal from '../../../hooks/useModal'
 import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 import lazyPreload from '../../../utils/lazyPreload'
 import {RetroTemplatePicker_settings$key} from '../../../__generated__/RetroTemplatePicker_settings.graphql'
-import {RetroTemplatePicker_viewer$key} from '../../../__generated__/RetroTemplatePicker_viewer.graphql'
 
 interface Props {
   settingsRef: RetroTemplatePicker_settings$key
-  viewerRef: RetroTemplatePicker_viewer$key
 }
 
 const ReflectTemplateModal = lazyPreload(
@@ -23,7 +21,7 @@ const ReflectTemplateModal = lazyPreload(
 )
 
 const RetroTemplatePicker = (props: Props) => {
-  const {settingsRef, viewerRef} = props
+  const {settingsRef} = props
   const settings = useFragment(
     graphql`
       fragment RetroTemplatePicker_settings on RetrospectiveMeetingSettings {
@@ -37,14 +35,6 @@ const RetroTemplatePicker = (props: Props) => {
       }
     `,
     settingsRef
-  )
-  const viewer = useFragment(
-    graphql`
-      fragment RetroTemplatePicker_viewer on User {
-        ...ReflectTemplateModal_viewer
-      }
-    `,
-    viewerRef
   )
 
   const {selectedTemplate} = settings
@@ -72,11 +62,7 @@ const RetroTemplatePicker = (props: Props) => {
         title={'Template'}
       />
       {modalPortal(
-        <ReflectTemplateModal
-          closePortal={closePortal}
-          retroMeetingSettingsRef={settings}
-          viewerRef={viewer}
-        />
+        <ReflectTemplateModal closePortal={closePortal} retroMeetingSettingsRef={settings} />
       )}
     </>
   )

--- a/packages/client/modules/meeting/components/SelectTemplate.tsx
+++ b/packages/client/modules/meeting/components/SelectTemplate.tsx
@@ -53,13 +53,12 @@ interface Props {
   closePortal: () => void
   template: SelectTemplate_template$key
   teamId: string
-  hasFeatureFlag?: boolean
   tier?: TierEnum
   orgId?: string
 }
 
 const SelectTemplate = (props: Props) => {
-  const {template: templateRef, closePortal, teamId, hasFeatureFlag, tier, orgId} = props
+  const {template: templateRef, closePortal, teamId, tier, orgId} = props
   const template = useFragment(
     graphql`
       fragment SelectTemplate_template on MeetingTemplate {
@@ -91,7 +90,7 @@ const SelectTemplate = (props: Props) => {
     })
     history.push(`/me/organizations/${orgId}`)
   }
-  const showUpgradeCTA = hasFeatureFlag && !isFree && tier === 'starter' && scope === 'PUBLIC'
+  const showUpgradeCTA = !isFree && tier === 'starter' && scope === 'PUBLIC'
   if (showUpgradeCTA) {
     return (
       <ButtonBlock>

--- a/packages/client/utils/useTemplateDescription.ts
+++ b/packages/client/utils/useTemplateDescription.ts
@@ -1,27 +1,14 @@
 import graphql from 'babel-plugin-relay/macro'
-import {readInlineData, useFragment} from 'react-relay'
+import {readInlineData} from 'react-relay'
 import {useTemplateDescription_template$key} from '../__generated__/useTemplateDescription_template.graphql'
-import {useTemplateDescription_viewer$key} from '../__generated__/useTemplateDescription_viewer.graphql'
 import {TierEnum} from '../__generated__/SendClientSegmentEventMutation.graphql'
 import relativeDate from './date/relativeDate'
 
 const useTemplateDescription = (
   lowestScope: string,
   templateRef?: useTemplateDescription_template$key,
-  viewerRef?: useTemplateDescription_viewer$key | null,
   tier?: TierEnum
 ) => {
-  const viewer = useFragment(
-    graphql`
-      fragment useTemplateDescription_viewer on User {
-        featureFlags {
-          templateLimit
-        }
-      }
-    `,
-    viewerRef ?? null
-  )
-
   if (!templateRef) {
     return null
   }
@@ -40,10 +27,9 @@ const useTemplateDescription = (
     templateRef
   )
 
-  const showTemplateLimit = viewer?.featureFlags.templateLimit
   const {lastUsedAt, team, isFree} = template
   const {name: teamName} = team
-  if (lowestScope === 'PUBLIC' && showTemplateLimit) {
+  if (lowestScope === 'PUBLIC') {
     return isFree ? 'Free template' : `Premium template ${tier === 'starter' ? '🔒' : '✨'}`
   }
   if (lowestScope === 'TEAM')

--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -50,9 +50,7 @@ const addPokerTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    const viewer = await dataLoader.get('users').loadNonNull(viewerId)
-    const hasTemplateLimitFlag = viewer.featureFlags.includes('templateLimit')
-    if (viewerTeam.tier === 'starter' && hasTemplateLimitFlag) {
+    if (viewerTeam.tier === 'starter') {
       return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
     }
     let data

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -51,9 +51,7 @@ const addReflectTemplate = {
     if (!viewerTeam) {
       return standardError(new Error('Team not found'), {userId: viewerId})
     }
-    const viewer = await dataLoader.get('users').loadNonNull(viewerId)
-    const hasTemplateLimitFlag = viewer.featureFlags.includes('templateLimit')
-    if (viewerTeam.tier === 'starter' && hasTemplateLimitFlag) {
+    if (viewerTeam.tier === 'starter') {
       return standardError(new Error('Creating templates is a premium feature'), {userId: viewerId})
     }
     let data

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -23,16 +23,7 @@ const PERCENT_ADDED_TO_RID = 0.05
 
 const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?: string) => {
   const r = await getRethink()
-  const {
-    id: userId,
-    createdAt,
-    preferredName,
-    email,
-    featureFlags,
-    tier,
-    segmentId,
-    identities
-  } = newUser
+  const {id: userId, createdAt, preferredName, email, featureFlags, tier, segmentId} = newUser
   const domain = email.split('@')[1]
   const [isPatient0, usersWithDomain, isSAMLVerified] = await Promise.all([
     isPatientZero(domain),
@@ -43,16 +34,6 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   const joinEvent = new TimelineEventJoinedParabol({userId})
 
   const experimentalFlags = [...featureFlags]
-
-  // TODO: remove the following after templateLimit experiment is complete: https://github.com/ParabolInc/parabol/issues/7712
-  const stopTemplateLimitsP0Experiment = !!process.env.STOP_TEMPLATE_LIMITS_P0_EXPERIMENT
-  const domainUserHasTemplateFlag = usersWithDomain.some((user) =>
-    user.featureFlags.includes('templateLimit')
-  )
-
-  if (!stopTemplateLimitsP0Experiment && (isPatient0 || domainUserHasTemplateFlag)) {
-    experimentalFlags.push('templateLimit')
-  }
 
   const domainUserHasRidFlag = usersWithDomain.some((user) =>
     user.featureFlags.includes('retrosInDisguise')

--- a/packages/server/graphql/mutations/selectTemplate.ts
+++ b/packages/server/graphql/mutations/selectTemplate.ts
@@ -28,8 +28,6 @@ const selectTemplate = {
     const operationId = dataLoader.share()
     const subOptions = {operationId, mutatorId}
     const viewerId = getUserId(authToken)
-    const user = await dataLoader.get('users').loadNonNull(viewerId)
-    const {featureFlags} = user
 
     // AUTH
     const template = (await dataLoader
@@ -52,7 +50,7 @@ const selectTemplate = {
         return standardError(new Error('Template is scoped to organization'), {userId: viewerId})
       }
     } else if (scope === 'PUBLIC') {
-      if (featureFlags.includes('templateLimit') && !isFree && viewerTeam.tier === 'starter') {
+      if (!isFree && viewerTeam.tier === 'starter') {
         return standardError(new Error('User does not have access to this premium template'), {
           userId: viewerId
         })

--- a/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
+++ b/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
@@ -7,7 +7,6 @@ enum UserFlagEnum {
   msTeams
   insights
   recurrence
-  templateLimit
   noAISummary
   noMeetingHistoryLimit
   checkoutFlow
@@ -23,7 +22,6 @@ type UserFeatureFlags {
   msTeams: Boolean!
   insights: Boolean!
   recurrence: Boolean!
-  templateLimit: Boolean!
   noAISummary: Boolean!
   noMeetingHistoryLimit: Boolean!
   checkoutFlow: Boolean!

--- a/packages/server/graphql/public/types/UserFeatureFlags.ts
+++ b/packages/server/graphql/public/types/UserFeatureFlags.ts
@@ -4,7 +4,6 @@ const UserFeatureFlags: UserFeatureFlagsResolvers = {
   azureDevOps: ({azureDevOps}) => !!azureDevOps,
   msTeams: ({msTeams}) => !!msTeams,
   insights: ({insights}) => !!insights,
-  templateLimit: ({templateLimit}) => !!templateLimit,
   noAISummary: ({noAISummary}) => !!noAISummary,
   noMeetingHistoryLimit: ({noMeetingHistoryLimit}) => !!noMeetingHistoryLimit,
   checkoutFlow: ({checkoutFlow}) => !!checkoutFlow,

--- a/packages/server/graphql/types/UserFlagEnum.ts
+++ b/packages/server/graphql/types/UserFlagEnum.ts
@@ -6,7 +6,6 @@ const UserFlagEnum = new GraphQLEnumType({
   values: {
     azureDevOps: {},
     msTeams: {},
-    templateLimit: {},
     noAISummary: {},
     noMeetingHistoryLimit: {},
     checkoutFlow: {}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/7413

Demo part 1 (was unable to restart the Loom after pausing it so I created two): https://www.loom.com/share/78c6c3200e704249a06ba2c065e30169

Demo part 2: https://www.loom.com/share/a7e1640a7de2420faa17669f20e6c1dd

### To test

- [ ] Create a new user and see that they can't access the premium retro templates
- [ ] Upgrade their org and see that they can
- [ ] Sprint poker templates are always available on the Starter and Team tier
- [ ] Users on the Starter tier that previously created a custom template can still access their old templates