### PR TITLE
fix: Missing discussion topics when skipping from Group to Discuss

### DIFF
--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -808,9 +808,6 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
           stage.endAt = new Date().toJSON()
         }
       }
-      if (!phaseInitializeData || Object.keys(phaseInitializeData).length === 0) {
-        phaseInitializeData = {[GROUP]: null, [VOTE]: null, [DISCUSS]: null}
-      }
       if (facilitatorStageId) {
         const facilitatorStageRes = findStageById(phases, facilitatorStageId)
         const {stage: facilitatorStage} = facilitatorStageRes!
@@ -830,6 +827,9 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
 
         // mutative! sets isNavigable and isNavigableByFacilitator
         unlockedStageIds = unlockNextStages(facilitatorStageId, phases!)
+      }
+      if (!phaseInitializeData || Object.keys(phaseInitializeData).length === 0) {
+        phaseInitializeData = {[GROUP]: null, [VOTE]: null, [DISCUSS]: null}
       }
 
       const oldFacilitatorStageId = this.db.newMeeting.facilitatorStageId!

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -812,17 +812,20 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
         const facilitatorStageRes = findStageById(phases, facilitatorStageId)
         const {stage: facilitatorStage} = facilitatorStageRes!
 
-        phaseInitializeData = await handleInitializeDemoStage(this.db, facilitatorStage)
-        const voteData = phaseInitializeData[VOTE]
-        if (voteData) {
-          Object.assign(voteData, {
-            meeting: this.db.newMeeting
-          })
-        } else if (phaseInitializeData[DISCUSS]) {
-          Object.assign(phaseInitializeData[DISCUSS], {
-            meeting: this.db.newMeeting
-          })
+        if (facilitatorStage.phaseType === DISCUSS && !facilitatorStage.reflectionGroupId) {
+          phaseInitializeData = await handleInitializeDemoStage(this.db, facilitatorStage)
+          const voteData = phaseInitializeData[VOTE]
+          if (voteData) {
+            Object.assign(voteData, {
+              meeting: this.db.newMeeting
+            })
+          } else if (phaseInitializeData[DISCUSS]) {
+            Object.assign(phaseInitializeData[DISCUSS], {
+              meeting: this.db.newMeeting
+            })
+          }
         }
+
         startStage_(facilitatorStage)
 
         // mutative! sets isNavigable and isNavigableByFacilitator

--- a/packages/client/modules/demo/handleInitializeDemoStage.ts
+++ b/packages/client/modules/demo/handleInitializeDemoStage.ts
@@ -1,5 +1,5 @@
 import {ReactableEnum} from '~/__generated__/AddReactjiToReactableMutation.graphql'
-import {ACTIVE, GROUP, REFLECT, VOTE} from '../../utils/constants'
+import {ACTIVE, DISCUSS, GROUP, VOTE} from '../../utils/constants'
 import extractTextFromDraftString from '../../utils/draftjs/extractTextFromDraftString'
 import mapGroupsToStages from '../../utils/makeGroupsToStages'
 import clientTempId from '../../utils/relay/clientTempId'
@@ -192,18 +192,18 @@ const addDiscussionTopics = (db: RetroDemoDB) => {
   return {meetingId, discussPhaseStages: nextDiscussStages}
 }
 
-const handleCompletedDemoStage = async (db: RetroDemoDB, stage: {phaseType: string}) => {
-  if (stage.phaseType === REFLECT) {
+const handleInitializeDemoStage = async (db: RetroDemoDB, stage: {phaseType: string}) => {
+  if (stage.phaseType === GROUP) {
     const data = removeEmptyReflections(db)
-    return {[REFLECT]: data, [GROUP]: null, [VOTE]: null}
-  } else if (stage.phaseType === GROUP) {
-    const data = removeEmptyReflections(db)
-    return {[REFLECT]: null, [GROUP]: data, [VOTE]: null}
+    return {[GROUP]: data, [VOTE]: null, [DISCUSS]: null}
   } else if (stage.phaseType === VOTE) {
+    const data = removeEmptyReflections(db)
+    return {[GROUP]: null, [VOTE]: data, [DISCUSS]: null}
+  } else if (stage.phaseType === DISCUSS) {
     const data = addDiscussionTopics(db)
-    return {[REFLECT]: null, [GROUP]: null, [VOTE]: data}
+    return {[GROUP]: null, [VOTE]: null, [DISCUSS]: data}
   }
   return {}
 }
 
-export default handleCompletedDemoStage
+export default handleInitializeDemoStage

--- a/packages/client/mutations/NavigateMeetingMutation.ts
+++ b/packages/client/mutations/NavigateMeetingMutation.ts
@@ -38,14 +38,14 @@ graphql`
       id
       isComplete
     }
-    phaseComplete {
-      reflect {
+    phaseInitialized {
+      group {
         emptyReflectionGroupIds
         reflectionGroups {
           sortOrder
         }
       }
-      group {
+      vote {
         emptyReflectionGroupIds
         meeting {
           phases {
@@ -59,7 +59,7 @@ graphql`
           }
         }
       }
-      vote {
+      discuss {
         meeting {
           phases {
             id
@@ -137,14 +137,14 @@ export const navigateMeetingTeamUpdater: SharedUpdater<NavigateMeetingMutation_t
   }
 
   const emptyReflectionGroupIds = safeProxy(payload)
-    .getLinkedRecord('phaseComplete')
-    .getLinkedRecord('reflect')
+    .getLinkedRecord('phaseInitialized')
+    .getLinkedRecord('group')
     .getValue('emptyReflectionGroupIds')!
   handleRemoveReflectionGroups(emptyReflectionGroupIds, meetingId, store)
 
   const emptyGroupReflectionGroupIds = safeProxy(payload)
-    .getLinkedRecord('phaseComplete')
-    .getLinkedRecord('group')
+    .getLinkedRecord('phaseInitialized')
+    .getLinkedRecord('vote')
     .getValue('emptyReflectionGroupIds')!
   handleRemoveReflectionGroups(emptyGroupReflectionGroupIds, meetingId, store)
 

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -22,10 +22,11 @@ import EndRetrospectivePayload from '../types/EndRetrospectivePayload'
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import generateWholeMeetingSentimentScore from './helpers/generateWholeMeetingSentimentScore'
 import generateWholeMeetingSummary from './helpers/generateWholeMeetingSummary'
-import handleCompletedStage from './helpers/handleCompletedStage'
 import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
 import updateQualAIMeetingsCount from './helpers/updateQualAIMeetingsCount'
+import DiscussStage from '../../database/types/DiscussStage'
+import generateDiscussionSummary from './helpers/generateDiscussionSummary'
 
 const getTranscription = async (recallBotId?: string | null) => {
   if (!recallBotId) return
@@ -157,7 +158,11 @@ export default {
     const currentStageRes = findStageById(phases, facilitatorStageId)
     if (currentStageRes) {
       const {stage} = currentStageRes
-      await handleCompletedStage(stage, meeting, dataLoader)
+      if (stage.phaseType === 'discuss') {
+        const {discussionId} = stage as DiscussStage
+        // dont await for the OpenAI API response
+        generateDiscussionSummary(discussionId, meeting, dataLoader)
+      }
       stage.isComplete = true
       stage.endAt = now
     }

--- a/packages/server/graphql/mutations/navigateMeeting.ts
+++ b/packages/server/graphql/mutations/navigateMeeting.ts
@@ -59,7 +59,7 @@ export default {
     }
 
     // VALIDATION
-    let phaseCompleteData
+    let phaseInitializeData
     let unlockedStageIds
     if (completedStageId) {
       const completedStageRes = findStageById(phases, completedStageId)
@@ -98,7 +98,7 @@ export default {
       }
 
       // handle any side effects, this could mutate the meeting object!
-      phaseCompleteData = await handleInitializeStage(facilitatorStage, meeting, dataLoader)
+      phaseInitializeData = await handleInitializeStage(facilitatorStage, meeting, dataLoader)
 
       // mutative
       // NOTE: it is possible to start a stage then move backwards & complete another phase, which would make it seem like this phase took a long time
@@ -133,7 +133,7 @@ export default {
       oldFacilitatorStageId,
       facilitatorStageId,
       unlockedStageIds,
-      ...phaseCompleteData
+      ...phaseInitializeData
     }
     publish(SubscriptionChannel.TEAM, teamId, 'NavigateMeetingPayload', data, subOptions)
     return data

--- a/packages/server/graphql/mutations/navigateMeeting.ts
+++ b/packages/server/graphql/mutations/navigateMeeting.ts
@@ -97,8 +97,10 @@ export default {
         return standardError(new Error('Stage has not started'), {userId: viewerId})
       }
 
-      // handle any side effects, this could mutate the meeting object!
-      phaseInitializeData = await handleInitializeStage(facilitatorStage, meeting, dataLoader)
+      if (!facilitatorStageRes.phase.stages.some((stage) => stage.startAt)) {
+        // handle any side effects, this could mutate the meeting object!
+        phaseInitializeData = await handleInitializeStage(facilitatorStage, meeting, dataLoader)
+      }
 
       // mutative
       // NOTE: it is possible to start a stage then move backwards & complete another phase, which would make it seem like this phase took a long time

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -8359,7 +8359,7 @@ type NavigateMeetingPayload {
   """
   Additional details triggered by completing certain phases
   """
-  phaseComplete: PhaseCompletePayload
+  phaseInitialized: PhaseInitializedPayload
 
   """
   The stages that were unlocked by navigating
@@ -8367,24 +8367,24 @@ type NavigateMeetingPayload {
   unlockedStages: [NewMeetingStage!]
 }
 
-type PhaseCompletePayload {
-  """
-  payload provided if the retro reflect phase was completed
-  """
-  reflect: ReflectPhaseCompletePayload
-
+type PhaseInitializedPayload {
   """
   payload provided if the retro grouping phase was completed
   """
-  group: GroupPhaseCompletePayload
+  group: GroupPhaseInitializedPayload
 
   """
   payload provided if the retro voting phase was completed
   """
-  vote: VotePhaseCompletePayload
+  vote: VotePhaseInitializedPayload
+
+  """
+  payload provided if the retro voting phase was completed
+  """
+  discuss: DiscussPhaseInitializedPayload
 }
 
-type ReflectPhaseCompletePayload {
+type GroupPhaseInitializedPayload {
   """
   a list of empty reflection groups to remove
   """
@@ -8396,7 +8396,7 @@ type ReflectPhaseCompletePayload {
   reflectionGroups: [RetroReflectionGroup!]!
 }
 
-type GroupPhaseCompletePayload {
+type VotePhaseInitializedPayload {
   """
   a list of empty reflection groups to remove
   """
@@ -8413,7 +8413,7 @@ type GroupPhaseCompletePayload {
   reflectionGroups: [RetroReflectionGroup]
 }
 
-type VotePhaseCompletePayload {
+type DiscussPhaseInitializedPayload {
   """
   the current meeting
   """

--- a/packages/server/graphql/types/DiscussPhaseInitializedPayload.ts
+++ b/packages/server/graphql/types/DiscussPhaseInitializedPayload.ts
@@ -3,8 +3,8 @@ import {GQLContext} from '../graphql'
 import {resolveNewMeeting} from '../resolvers'
 import RetrospectiveMeeting from './RetrospectiveMeeting'
 
-const VotePhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
-  name: 'VotePhaseCompletePayload',
+const DiscussPhaseInitializedPayload = new GraphQLObjectType<any, GQLContext>({
+  name: 'DiscussPhaseInitializedPayload',
   fields: () => ({
     meeting: {
       type: RetrospectiveMeeting,
@@ -14,4 +14,4 @@ const VotePhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
   })
 })
 
-export default VotePhaseCompletePayload
+export default DiscussPhaseInitializedPayload

--- a/packages/server/graphql/types/GroupPhaseInitializedPayload.ts
+++ b/packages/server/graphql/types/GroupPhaseInitializedPayload.ts
@@ -2,8 +2,8 @@ import {GraphQLID, GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql
 import {GQLContext} from '../graphql'
 import RetroReflectionGroup from './RetroReflectionGroup'
 
-const ReflectPhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
-  name: 'ReflectPhaseCompletePayload',
+const GroupPhaseInitializedPayload = new GraphQLObjectType<any, GQLContext>({
+  name: 'GroupPhaseInitializedPayload',
   fields: () => ({
     emptyReflectionGroupIds: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLID))),
@@ -16,4 +16,4 @@ const ReflectPhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
   })
 })
 
-export default ReflectPhaseCompletePayload
+export default GroupPhaseInitializedPayload

--- a/packages/server/graphql/types/NavigateMeetingPayload.ts
+++ b/packages/server/graphql/types/NavigateMeetingPayload.ts
@@ -4,7 +4,7 @@ import {GQLContext} from '../graphql'
 import {resolveNewMeeting, resolveUnlockedStages} from '../resolvers'
 import NewMeeting from './NewMeeting'
 import NewMeetingStage from './NewMeetingStage'
-import PhaseCompletePayload from './PhaseCompletePayload'
+import PhaseInitializedPayload from './PhaseCompletePayload'
 import StandardMutationError from './StandardMutationError'
 
 const NavigateMeetingPayload = new GraphQLObjectType<any, GQLContext>({
@@ -37,9 +37,9 @@ const NavigateMeetingPayload = new GraphQLObjectType<any, GQLContext>({
         return stageRes && stageRes.stage
       }
     },
-    phaseComplete: {
-      type: PhaseCompletePayload,
-      description: 'Additional details triggered by completing certain phases',
+    phaseInitialized: {
+      type: PhaseInitializedPayload,
+      description: 'Additional details triggered by initializing certain phases',
       resolve: (source) => source
     },
     unlockedStages: {

--- a/packages/server/graphql/types/NavigateMeetingPayload.ts
+++ b/packages/server/graphql/types/NavigateMeetingPayload.ts
@@ -4,7 +4,7 @@ import {GQLContext} from '../graphql'
 import {resolveNewMeeting, resolveUnlockedStages} from '../resolvers'
 import NewMeeting from './NewMeeting'
 import NewMeetingStage from './NewMeetingStage'
-import PhaseInitializedPayload from './PhaseCompletePayload'
+import PhaseInitializedPayload from './PhaseInitializedPayload'
 import StandardMutationError from './StandardMutationError'
 
 const NavigateMeetingPayload = new GraphQLObjectType<any, GQLContext>({

--- a/packages/server/graphql/types/PhaseCompletePayload.ts
+++ b/packages/server/graphql/types/PhaseCompletePayload.ts
@@ -1,29 +1,29 @@
 import {GraphQLObjectType} from 'graphql'
-import {GROUP, REFLECT, VOTE} from 'parabol-client/utils/constants'
+import {GROUP, VOTE, DISCUSS} from 'parabol-client/utils/constants'
 import {GQLContext} from '../graphql'
-import GroupPhaseCompletePayload from './GroupPhaseCompletePayload'
-import ReflectPhaseCompletePayload from './ReflectPhaseCompletePayload'
-import VotePhaseCompletePayload from './VotePhaseCompletePayload'
+import GroupPhaseInitializedPayload from './GroupPhaseInitializedPayload'
+import DiscussPhaseInitializedPayload from './DiscussPhaseInitializedPayload'
+import VotePhaseInitializedPayload from './VotePhaseInitializedPayload'
 
-const PhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
-  name: 'PhaseCompletePayload',
+const PhaseInitializedPayload = new GraphQLObjectType<any, GQLContext>({
+  name: 'PhaseInitializedPayload',
   fields: () => ({
-    [REFLECT]: {
-      type: ReflectPhaseCompletePayload,
-      description: 'payload provided if the retro reflect phase was completed',
-      resolve: (source) => source[REFLECT]
-    },
     [GROUP]: {
-      type: GroupPhaseCompletePayload,
+      type: GroupPhaseInitializedPayload,
       description: 'payload provided if the retro grouping phase was completed',
       resolve: (source) => source[GROUP]
     },
     [VOTE]: {
-      type: VotePhaseCompletePayload,
+      type: VotePhaseInitializedPayload,
       description: 'payload provided if the retro voting phase was completed',
       resolve: (source) => source[VOTE]
+    },
+    [DISCUSS]: {
+      type: DiscussPhaseInitializedPayload,
+      description: 'payload provided if the retro reflect phase was completed',
+      resolve: (source) => source[DISCUSS]
     }
   })
 })
 
-export default PhaseCompletePayload
+export default PhaseInitializedPayload

--- a/packages/server/graphql/types/PhaseInitializedPayload.ts
+++ b/packages/server/graphql/types/PhaseInitializedPayload.ts
@@ -10,17 +10,17 @@ const PhaseInitializedPayload = new GraphQLObjectType<any, GQLContext>({
   fields: () => ({
     [GROUP]: {
       type: GroupPhaseInitializedPayload,
-      description: 'payload provided if the retro grouping phase was completed',
+      description: 'payload provided if the retro grouping phase was initialized',
       resolve: (source) => source[GROUP]
     },
     [VOTE]: {
       type: VotePhaseInitializedPayload,
-      description: 'payload provided if the retro voting phase was completed',
+      description: 'payload provided if the retro voting phase was initialized',
       resolve: (source) => source[VOTE]
     },
     [DISCUSS]: {
       type: DiscussPhaseInitializedPayload,
-      description: 'payload provided if the retro reflect phase was completed',
+      description: 'payload provided if the retro discuss phase was initialized',
       resolve: (source) => source[DISCUSS]
     }
   })

--- a/packages/server/graphql/types/VotePhaseInitializedPayload.ts
+++ b/packages/server/graphql/types/VotePhaseInitializedPayload.ts
@@ -4,8 +4,8 @@ import {resolveNewMeeting} from '../resolvers'
 import RetroReflectionGroup from './RetroReflectionGroup'
 import RetrospectiveMeeting from './RetrospectiveMeeting'
 
-const GroupPhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
-  name: 'GroupPhaseCompletePayload',
+const VotePhaseInitializedPayload = new GraphQLObjectType<any, GQLContext>({
+  name: 'VotePhaseInitializedPayload',
   fields: () => ({
     emptyReflectionGroupIds: {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLID))),
@@ -28,4 +28,4 @@ const GroupPhaseCompletePayload = new GraphQLObjectType<any, GQLContext>({
   })
 })
 
-export default GroupPhaseCompletePayload
+export default VotePhaseInitializedPayload


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7265

Change the model of executing side effects from "we just completed this stage" to "we're about to start this stage". This will ensure things like discussion topics are inserted when entering the discuss phase, even if the user is navigating out of order.

## Demo
https://www.loom.com/share/b6d29d98584d4cdd83896c745dd43fc5

## Testing scenarios
- [ ] Test the case outlined in the issue
- [ ] Smoke test navigation within a retro meeting
- [ ] Smoke test navigation within the demo retro.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
