### PR TITLE
fix(teams-limit): remove teams limit when upgrading to enterprise

### DIFF
--- a/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
@@ -11,6 +11,7 @@ import {DataLoaderWorker} from '../../graphql'
 import isValid from '../../isValid'
 import hideConversionModal from '../../mutations/helpers/hideConversionModal'
 import {MutationResolvers} from '../resolverTypes'
+import removeTeamsLimitObjects from '../../../billing/helpers/removeTeamsLimitObjects'
 
 const getBillingLeaderUser = async (
   email: string | null | undefined,
@@ -114,6 +115,9 @@ const draftEnterpriseInvoice: MutationResolvers['draftEnterpriseInvoice'] = asyn
           periodStart: fromEpochSeconds(subscription.current_period_start),
           stripeSubscriptionId: subscription.id,
           tier: 'enterprise',
+          tierLimitExceededAt: null,
+          scheduledLockAt: null,
+          lockedAt: null,
           updatedAt: now
         })
     }).run(),
@@ -124,7 +128,8 @@ const draftEnterpriseInvoice: MutationResolvers['draftEnterpriseInvoice'] = asyn
         updatedAt: now
       },
       orgId
-    )
+    ),
+    removeTeamsLimitObjects(orgId, dataLoader)
   ])
 
   await Promise.all([


### PR DESCRIPTION
**How to test:**

- Create a starter org
- You can manually lock the org with the limits


```
r.db('actionDevelopment')
  .table("Organization")       
  .get('nWsBsQtzm8')
  .update({
    scheduledLockAt: new Date(),
    lockedAt: new Date(),
    tierLimitExceededAt: new Date()
  })
```


- Upgrade to enterprise, see limits were removed

```
mutation {
  draftEnterpriseInvoice(
    orgId: "nWsBsQtzm8", 
    quantity: 10,
    email: "test@example.com"
    apEmail: "test@example.com"
  ) {
    organization {
      tier
    }
    error {
	message
    }
  }
}

```