### PR TITLE
feat(rid): Enhance search

### DIFF
--- a/packages/client/hooks/useSearchFilter.ts
+++ b/packages/client/hooks/useSearchFilter.ts
@@ -2,7 +2,10 @@ import useFilteredItems from '~/hooks/useFilteredItems'
 import useForm from '~/hooks/useForm'
 
 // Matches 'items' based on the item's 'getValue' result and the value passed to 'onQueryChange'.
-const useSearchFilter = <T>(items: readonly T[], getValue: (item: T) => string) => {
+const useSearchFilter = <T extends U, U = T>(
+  items: readonly T[],
+  getValue: (item: U) => string
+) => {
   const {fields, onChange, setValue} = useForm({
     search: {
       getDefault: () => ''


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8323

Enhance search functionality in the activity library by expanding what the search query matches against. In this PR, the search query will match:
* Team name
* Meeting type
* Category
* Category-related keywords
* Dimension names + descriptions + scale names for poker templates
* Prompt questions + descriptions for retro templates

## Demo
https://www.loom.com/share/0fa984491b7d457398536585630b1cbc

## Testing scenarios
- [ ] Test each of the match cases

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
