### PR TITLE
fix(retros): When skipping phases, mark interim stages as complete

### DIFF
--- a/packages/client/hooks/useGotoStageId.ts
+++ b/packages/client/hooks/useGotoStageId.ts
@@ -88,9 +88,6 @@ const useGotoStageId = (meetingRef: useGotoStageId_meeting$key) => {
             }
           }
         }
-        if (!isComplete && isForwardProgress(phases, facilitatorStageId, stageId)) {
-          variables.completedStageId = facilitatorStageId
-        }
         NavigateMeetingMutation(atmosphere, variables)
       }
     },

--- a/packages/client/hooks/useGotoStageId.ts
+++ b/packages/client/hooks/useGotoStageId.ts
@@ -71,6 +71,9 @@ const useGotoStageId = (meetingRef: useGotoStageId_meeting$key) => {
           if (!isComplete) {
             variables.completedStageId = facilitatorStageId
           } else {
+            // Check if we're skipping a phase, and mark it as completed if we are.
+            // Note: Only one uncompleted phase should be skippable at a time (the one right before
+            // the unlocked stage).
             const oldStagePhaseIndex = phases.findIndex((phase) =>
               phase.stages.find((stage) => stage.id === facilitatorStageId)
             )
@@ -78,7 +81,10 @@ const useGotoStageId = (meetingRef: useGotoStageId_meeting$key) => {
               phase.stages.find((stage) => stage.id === stageId)
             )
             if (newStagePhaseIndex - oldStagePhaseIndex > 1) {
-              variables.completedStageId = phases[newStagePhaseIndex - 1]!.stages[0]!.id
+              const maybeCompletedStage = phases[newStagePhaseIndex - 1]!.stages[0]
+              if (!maybeCompletedStage!.isComplete) {
+                variables.completedStageId = maybeCompletedStage!.id
+              }
             }
           }
         }


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/7265

Our meeting flow allows users to skip between phases, as long as they navigated to the previous phase before. For example, a user could navigate group -> vote -> group -> discuss. However, our current navigation logic only executes "completion" side effects for stages/phases we just navigated from. In the above example, we wouldn't execute side effects for completing the "vote" phase because we navigated from group to discuss.

To fix this, check if we're skipping phases when navigating to a new stage, and execute side effects for any skipped stages.

## Demo
https://www.loom.com/share/a467a9b8add045d28c1417e05c6e0070

## Testing scenarios
- [ ] Navigate like so in a retro: Reflect -> Group -> Reflect -> Vote -> Group (confirm completed) -> Discuss (confirm discussions are present) -> Vote (confirm completed)
- [ ] Smoke test navigation

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
