### PR TITLE
feat(Team Health): Add setting to new activity library

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -9,7 +9,9 @@ import {ActivityDetailsSidebar_teams$key} from '~/__generated__/ActivityDetailsS
 import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
 import {MenuPosition} from '../../hooks/useCoords'
 import sortByTier from '../../utils/sortByTier'
+import isTeamHealthAvailable from '../../utils/features/isTeamHealthAvailable'
 import NewMeetingSettingsToggleCheckIn from '../NewMeetingSettingsToggleCheckIn'
+import NewMeetingSettingsToggleTeamHealth from '../NewMeetingSettingsToggleTeamHealth'
 import NewMeetingSettingsToggleAnonymity from '../NewMeetingSettingsToggleAnonymity'
 import NewMeetingActionsCurrentMeetings from '../NewMeetingActionsCurrentMeetings'
 import FlatPrimaryButton from '../FlatPrimaryButton'
@@ -62,6 +64,7 @@ const ActivityDetailsSidebar = (props: Props) => {
         }
         retroSettings: meetingSettings(meetingType: retrospective) {
           ...NewMeetingSettingsToggleCheckIn_settings
+          ...NewMeetingSettingsToggleTeamHealth_settings
           ...NewMeetingSettingsToggleAnonymity_settings
         }
         pokerSettings: meetingSettings(meetingType: poker) {
@@ -204,6 +207,9 @@ const ActivityDetailsSidebar = (props: Props) => {
           {type === 'retrospective' && (
             <>
               <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
+              {isTeamHealthAvailable(selectedTeam.tier) && (
+                <NewMeetingSettingsToggleTeamHealth settingsRef={selectedTeam.retroSettings} />
+              )}
               <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
             </>
           )}


### PR DESCRIPTION
# Description

Add team health settings to new activity library.

## Demo

![Peek 2023-06-14 20-21](https://github.com/ParabolInc/parabol/assets/7331043/7cb2eae3-752f-4c82-ac36-8edb4b146d4f)

## Testing scenarios

* enable 'retrosInDisguise' feature flag
* start a retro
* see the team health setting

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
