### PR TITLE
feat(rid): After navigating to or selecting a team, use that team by default

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetails.tsx
@@ -42,7 +42,7 @@ export const query = graphql`
   query ActivityDetailsQuery {
     viewer {
       tier
-      defaultTeamId
+      preferredTeamId
       availableTemplates(first: 200) @connection(key: "ActivityDetails_availableTemplates") {
         edges {
           node {
@@ -73,7 +73,7 @@ const ActivityDetails = (props: Props) => {
   const {queryRef, activityId: activityIdParam} = props
   const data = usePreloadedQuery<ActivityDetailsQuery>(query, queryRef)
   const {viewer} = data
-  const {availableTemplates, teams, defaultTeamId} = viewer
+  const {availableTemplates, teams, preferredTeamId} = viewer
 
   const history = useHistory<{prevCategory?: string}>()
   const [isEditing, setIsEditing] = useState(false)
@@ -159,7 +159,7 @@ const ActivityDetails = (props: Props) => {
           teamsRef={teams}
           isOpen={!isEditing}
           type={activity.type}
-          defaultTeamId={defaultTeamId}
+          preferredTeamId={preferredTeamId}
         />
       </div>
     </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetails.tsx
@@ -42,6 +42,7 @@ export const query = graphql`
   query ActivityDetailsQuery {
     viewer {
       tier
+      defaultTeamId
       availableTemplates(first: 200) @connection(key: "ActivityDetails_availableTemplates") {
         edges {
           node {
@@ -72,7 +73,7 @@ const ActivityDetails = (props: Props) => {
   const {queryRef, activityId: activityIdParam} = props
   const data = usePreloadedQuery<ActivityDetailsQuery>(query, queryRef)
   const {viewer} = data
-  const {availableTemplates, teams} = viewer
+  const {availableTemplates, teams, defaultTeamId} = viewer
 
   const history = useHistory<{prevCategory?: string}>()
   const [isEditing, setIsEditing] = useState(false)
@@ -158,6 +159,7 @@ const ActivityDetails = (props: Props) => {
           teamsRef={teams}
           isOpen={!isEditing}
           type={activity.type}
+          defaultTeamId={defaultTeamId}
         />
       </div>
     </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
@@ -45,7 +45,7 @@ export const TemplateDetails = (props: Props) => {
     graphql`
       fragment TemplateDetails_user on User {
         tier
-        defaultTeamId
+        preferredTeamId
         teams {
           id
           ...TeamPickerModal_teams
@@ -70,7 +70,7 @@ export const TemplateDetails = (props: Props) => {
     templatesRef
   )
 
-  const {teams, organizations, tier, defaultTeamId} = viewer
+  const {teams, organizations, tier, preferredTeamId} = viewer
   const history = useHistory<{prevCategory?: string; edit?: boolean}>()
   const prevCategory = history.location.state?.prevCategory
 
@@ -258,7 +258,7 @@ export const TemplateDetails = (props: Props) => {
         <TeamPickerModal
           category={category}
           teamsRef={teams}
-          defaultTeamId={defaultTeamId}
+          preferredTeamId={preferredTeamId}
           templatesRef={templates}
           closePortal={closeTeamPickerPortal}
           parentTemplateId={template.id}

--- a/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
@@ -45,6 +45,7 @@ export const TemplateDetails = (props: Props) => {
     graphql`
       fragment TemplateDetails_user on User {
         tier
+        defaultTeamId
         teams {
           id
           ...TeamPickerModal_teams
@@ -69,7 +70,7 @@ export const TemplateDetails = (props: Props) => {
     templatesRef
   )
 
-  const {teams, organizations, tier} = viewer
+  const {teams, organizations, tier, defaultTeamId} = viewer
   const history = useHistory<{prevCategory?: string; edit?: boolean}>()
   const prevCategory = history.location.state?.prevCategory
 
@@ -257,6 +258,7 @@ export const TemplateDetails = (props: Props) => {
         <TeamPickerModal
           category={category}
           teamsRef={teams}
+          defaultTeamId={defaultTeamId}
           templatesRef={templates}
           closePortal={closeTeamPickerPortal}
           parentTemplateId={template.id}

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -32,11 +32,11 @@ interface Props {
   teamsRef: ActivityDetailsSidebar_teams$key
   type: MeetingTypeEnum
   isOpen: boolean
-  defaultTeamId: string | null
+  preferredTeamId: string | null
 }
 
 const ActivityDetailsSidebar = (props: Props) => {
-  const {selectedTemplateRef, teamsRef, type, isOpen, defaultTeamId} = props
+  const {selectedTemplateRef, teamsRef, type, isOpen, preferredTeamId} = props
   const selectedTemplate = useFragment(
     graphql`
       fragment ActivityDetailsSidebar_template on MeetingTemplate {
@@ -93,7 +93,7 @@ const ActivityDetailsSidebar = (props: Props) => {
       : []
 
   const [selectedTeam, setSelectedTeam] = useState(
-    availableTeams.find((team) => team.id === defaultTeamId) ??
+    availableTeams.find((team) => team.id === preferredTeamId) ??
       templateTeam ??
       sortByTier(availableTeams)[0]!
   )

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -32,10 +32,11 @@ interface Props {
   teamsRef: ActivityDetailsSidebar_teams$key
   type: MeetingTypeEnum
   isOpen: boolean
+  defaultTeamId: string | null
 }
 
 const ActivityDetailsSidebar = (props: Props) => {
-  const {selectedTemplateRef, teamsRef, type, isOpen} = props
+  const {selectedTemplateRef, teamsRef, type, isOpen, defaultTeamId} = props
   const selectedTemplate = useFragment(
     graphql`
       fragment ActivityDetailsSidebar_template on MeetingTemplate {
@@ -91,7 +92,11 @@ const ActivityDetailsSidebar = (props: Props) => {
       ? [templateTeam]
       : []
 
-  const [selectedTeam, setSelectedTeam] = useState(templateTeam ?? sortByTier(availableTeams)[0]!)
+  const [selectedTeam, setSelectedTeam] = useState(
+    availableTeams.find((team) => team.id === defaultTeamId) ??
+      templateTeam ??
+      sortByTier(availableTeams)[0]!
+  )
   const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
   const history = useHistory()
 

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -111,6 +111,7 @@ const SUPPORTED_CUSTOM_ACTIVITIES: SupportedActivity[] = [
 const query = graphql`
   query CreateNewActivityQuery {
     viewer {
+      defaultTeamId
       featureFlags {
         retrosInDisguise
       }
@@ -157,7 +158,10 @@ export const CreateNewActivity = (props: Props) => {
     if (!selectedActivity) return defaultActivity
     return selectedActivity
   })
-  const [selectedTeam, setSelectedTeam] = useState(sortByTier(data.viewer.teams)[0]!)
+  const [selectedTeam, setSelectedTeam] = useState(
+    data.viewer.teams.find((team) => team.id === data.viewer.defaultTeamId) ??
+      sortByTier(data.viewer.teams)[0]!
+  )
   const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()
   const history = useHistory()
 

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -111,7 +111,7 @@ const SUPPORTED_CUSTOM_ACTIVITIES: SupportedActivity[] = [
 const query = graphql`
   query CreateNewActivityQuery {
     viewer {
-      defaultTeamId
+      preferredTeamId
       featureFlags {
         retrosInDisguise
       }
@@ -159,7 +159,7 @@ export const CreateNewActivity = (props: Props) => {
     return selectedActivity
   })
   const [selectedTeam, setSelectedTeam] = useState(
-    data.viewer.teams.find((team) => team.id === data.viewer.defaultTeamId) ??
+    data.viewer.teams.find((team) => team.id === data.viewer.preferredTeamId) ??
       sortByTier(data.viewer.teams)[0]!
   )
   const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -25,6 +25,7 @@ const ACTION_BUTTON_CLASSES =
 
 interface Props {
   teamsRef: TeamPickerModal_teams$key
+  defaultTeamId: string | null
   templatesRef: TeamPickerModal_templates$key
   closePortal: () => void
   category: string
@@ -33,7 +34,8 @@ interface Props {
 }
 
 const TeamPickerModal = (props: Props) => {
-  const {teamsRef, templatesRef, closePortal, category, parentTemplateId, type} = props
+  const {teamsRef, templatesRef, closePortal, category, parentTemplateId, type, defaultTeamId} =
+    props
   const teams = useFragment(
     graphql`
       fragment TeamPickerModal_teams on Team @relay(plural: true) {
@@ -58,7 +60,9 @@ const TeamPickerModal = (props: Props) => {
     templatesRef
   )
 
-  const [selectedTeam, setSelectedTeam] = useState(sortByTier(teams)[0]!)
+  const [selectedTeam, setSelectedTeam] = useState(
+    teams.find((team) => team.id === defaultTeamId) ?? sortByTier(teams)[0]!
+  )
 
   const atmosphere = useAtmosphere()
   const {submitting, error, submitMutation, onError, onCompleted} = useMutationProps()

--- a/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
+++ b/packages/client/components/ActivityLibrary/TeamPickerModal.tsx
@@ -25,7 +25,7 @@ const ACTION_BUTTON_CLASSES =
 
 interface Props {
   teamsRef: TeamPickerModal_teams$key
-  defaultTeamId: string | null
+  preferredTeamId: string | null
   templatesRef: TeamPickerModal_templates$key
   closePortal: () => void
   category: string
@@ -34,7 +34,7 @@ interface Props {
 }
 
 const TeamPickerModal = (props: Props) => {
-  const {teamsRef, templatesRef, closePortal, category, parentTemplateId, type, defaultTeamId} =
+  const {teamsRef, templatesRef, closePortal, category, parentTemplateId, type, preferredTeamId} =
     props
   const teams = useFragment(
     graphql`
@@ -61,7 +61,7 @@ const TeamPickerModal = (props: Props) => {
   )
 
   const [selectedTeam, setSelectedTeam] = useState(
-    teams.find((team) => team.id === defaultTeamId) ?? sortByTier(teams)[0]!
+    teams.find((team) => team.id === preferredTeamId) ?? sortByTier(teams)[0]!
   )
 
   const atmosphere = useAtmosphere()

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -9,6 +9,8 @@ import {PortalStatus} from '../hooks/usePortal'
 import lazyPreload from '../utils/lazyPreload'
 import NewMeetingDropdown from './NewMeetingDropdown'
 import NewMeetingTeamPickerAvatars from './NewMeetingTeamPickerAvatars'
+import useAtmosphere from '../hooks/useAtmosphere'
+import setDefaultTeamId from '../utils/relay/setDefaultTeamId'
 
 const SelectTeamDropdown = lazyPreload(
   () =>
@@ -34,6 +36,13 @@ const NewMeetingTeamPicker = (props: Props) => {
       isDropdown: true
     }
   )
+
+  const atmosphere = useAtmosphere()
+
+  const handleSelectTeam = (teamId: string) => {
+    setDefaultTeamId(atmosphere, teamId)
+    onSelectTeam(teamId)
+  }
 
   const selectedTeam = useFragment(
     graphql`
@@ -73,7 +82,11 @@ const NewMeetingTeamPicker = (props: Props) => {
         customPortal ? (
           customPortal
         ) : (
-          <SelectTeamDropdown menuProps={menuProps} teams={teams} teamHandleClick={onSelectTeam} />
+          <SelectTeamDropdown
+            menuProps={menuProps}
+            teams={teams}
+            teamHandleClick={handleSelectTeam}
+          />
         )
       )}
     </>

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -10,7 +10,7 @@ import lazyPreload from '../utils/lazyPreload'
 import NewMeetingDropdown from './NewMeetingDropdown'
 import NewMeetingTeamPickerAvatars from './NewMeetingTeamPickerAvatars'
 import useAtmosphere from '../hooks/useAtmosphere'
-import setDefaultTeamId from '../utils/relay/setDefaultTeamId'
+import setPreferredTeamId from '../utils/relay/setPreferredTeamId'
 
 const SelectTeamDropdown = lazyPreload(
   () =>
@@ -40,7 +40,7 @@ const NewMeetingTeamPicker = (props: Props) => {
   const atmosphere = useAtmosphere()
 
   const handleSelectTeam = (teamId: string) => {
-    setDefaultTeamId(atmosphere, teamId)
+    setPreferredTeamId(atmosphere, teamId)
     onSelectTeam(teamId)
   }
 

--- a/packages/client/modules/teamDashboard/components/TeamDashMainRoot.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMainRoot.tsx
@@ -5,11 +5,15 @@ import teamDashMainQuery, {
   TeamDashMainQuery
 } from '../../../__generated__/TeamDashMainQuery.graphql'
 import TeamDashMain from './TeamDashMain/TeamDashMain'
+import setDefaultTeamId from '~/utils/relay/setDefaultTeamId'
+import useAtmosphere from '../../../hooks/useAtmosphere'
 
 const TeamDashMainRoot = () => {
   const {match} = useRouter<{teamId: string}>()
   const {params} = match
   const {teamId} = params
+  const atmosphere = useAtmosphere()
+  setDefaultTeamId(atmosphere, teamId)
   const queryRef = useQueryLoaderNow<TeamDashMainQuery>(teamDashMainQuery, {teamId})
   return <Suspense fallback={''}>{queryRef && <TeamDashMain queryRef={queryRef} />}</Suspense>
 }

--- a/packages/client/modules/teamDashboard/components/TeamDashMainRoot.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMainRoot.tsx
@@ -5,7 +5,7 @@ import teamDashMainQuery, {
   TeamDashMainQuery
 } from '../../../__generated__/TeamDashMainQuery.graphql'
 import TeamDashMain from './TeamDashMain/TeamDashMain'
-import setDefaultTeamId from '~/utils/relay/setDefaultTeamId'
+import setPreferredTeamId from '~/utils/relay/setPreferredTeamId'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 
 const TeamDashMainRoot = () => {
@@ -13,7 +13,7 @@ const TeamDashMainRoot = () => {
   const {params} = match
   const {teamId} = params
   const atmosphere = useAtmosphere()
-  setDefaultTeamId(atmosphere, teamId)
+  setPreferredTeamId(atmosphere, teamId)
   const queryRef = useQueryLoaderNow<TeamDashMainQuery>(teamDashMainQuery, {teamId})
   return <Suspense fallback={''}>{queryRef && <TeamDashMain queryRef={queryRef} />}</Suspense>
 }

--- a/packages/client/schemaExtensions/clientSchema.graphql
+++ b/packages/client/schemaExtensions/clientSchema.graphql
@@ -70,7 +70,7 @@ extend type User {
   dashSearch: String
   pageName: String
   # The team we should default to in team pickers, etc.
-  defaultTeamId: ID
+  preferredTeamId: ID
 }
 
 extend type Task {

--- a/packages/client/schemaExtensions/clientSchema.graphql
+++ b/packages/client/schemaExtensions/clientSchema.graphql
@@ -69,6 +69,8 @@ extend type User {
   clientClockOffset: Int
   dashSearch: String
   pageName: String
+  # The team we should default to in team pickers, etc.
+  defaultTeamId: ID
 }
 
 extend type Task {

--- a/packages/client/utils/relay/setDefaultTeamId.ts
+++ b/packages/client/utils/relay/setDefaultTeamId.ts
@@ -1,0 +1,12 @@
+import {commitLocalUpdate} from 'relay-runtime'
+import Atmosphere from '../../Atmosphere'
+
+const setDefaultTeamId = (atmosphere: Atmosphere, teamId: string) => {
+  return commitLocalUpdate(atmosphere, (store) => {
+    const viewer = store.getRoot().getLinkedRecord('viewer')
+    if (!viewer) return
+    viewer.setValue(teamId, 'defaultTeamId')
+  })
+}
+
+export default setDefaultTeamId

--- a/packages/client/utils/relay/setPreferredTeamId.ts
+++ b/packages/client/utils/relay/setPreferredTeamId.ts
@@ -1,12 +1,12 @@
 import {commitLocalUpdate} from 'relay-runtime'
 import Atmosphere from '../../Atmosphere'
 
-const setDefaultTeamId = (atmosphere: Atmosphere, teamId: string) => {
+const setPreferredTeamId = (atmosphere: Atmosphere, teamId: string) => {
   return commitLocalUpdate(atmosphere, (store) => {
     const viewer = store.getRoot().getLinkedRecord('viewer')
     if (!viewer) return
-    viewer.setValue(teamId, 'defaultTeamId')
+    viewer.setValue(teamId, 'preferredTeamId')
   })
 }
 
-export default setDefaultTeamId
+export default setPreferredTeamId


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8312

In the activity library, we default to the first alphabetically-ordered team, with preference to premium teams. This is different from the existing flow, in which if a user navigates to a team dashboard, that team is the default.

Add a new global client-side relay field called `defaultTeamId` that gets updated any time the user navigates to a team dashboard or selects a team from a dropdown. This team ID is then the default for other team dropdowns.

## Demo
https://www.loom.com/share/c795617873d9437ca1e374dce17fdfee

## Testing scenarios
- [ ] Navigate to a team dashboard, then go to a template details page, and confirm that team is the default (as long as it's in the dropdown)
- [ ] Pick a team from a dropdown, then navigate to a different page, then to an AL page. Confirm that the team is the default

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
