### PR TITLE
fix(templates): Public templates missing in new environments

### DIFF
--- a/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateListPublic.tsx
@@ -29,10 +29,6 @@ interface Props {
   queryRef: PreloadedQuery<ReflectTemplateListPublicQuery>
 }
 
-// We're not showing public templates created after June 5, 2023, since all of these should *only*
-// be shown in the new activity library, and not in the older new meeting modal.
-const MAX_PUBLIC_CREATED_AT = '2023-06-05T00:00:00Z'
-
 const getValue = (item: {node: {id: string; name: string}}) => {
   return item.node.name.toLowerCase()
 }
@@ -55,6 +51,7 @@ const query = graphql`
                   id
                   name
                   createdAt
+                  category
                 }
               }
             }
@@ -79,7 +76,7 @@ const ReflectTemplateListPublic = (props: Props) => {
   const activeTemplateId = activeTemplate?.id ?? '-tmp'
   const {edges} = publicTemplates!
   const filteredEdges = useFilteredItems(searchQuery, edges, getValue).filter(
-    ({node}) => node.createdAt < MAX_PUBLIC_CREATED_AT
+    ({node}) => !['premortem', 'postmortem'].includes(node.category)
   )
   useActiveTopTemplate(edges, activeTemplateId, teamId, true, 'retrospective')
   if (filteredEdges.length === 0) {


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8372

Don't use data to determine whether to include the new pre-/post-mortem templates in the old new meeting view. Instead, use category.

## Testing scenarios
- [ ] Pre-/post-mortems appear in AL
- [ ] Pre-/post-mortems don't appear in "new meeting" view

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
