### PR TITLE
chore: cleanup connect rethink db in migrations

### DIFF
--- a/packages/server/postgres/getPgp.ts
+++ b/packages/server/postgres/getPgp.ts
@@ -1,0 +1,15 @@
+import pgpInit, {IDatabase, IMain} from 'pg-promise'
+import getPgConfig from './getPgConfig'
+
+let pgp: IMain | null = null
+let pg: IDatabase<unknown> | null = null
+
+const getPgp = () => {
+  if (!pgp || !pg) {
+    pgp = pgpInit()
+    pg = pgp(getPgConfig())
+  }
+  return {pg, pgp}
+}
+
+export default getPgp

--- a/packages/server/postgres/migrations/1625576993065_addAtlassianAuthTable.ts
+++ b/packages/server/postgres/migrations/1625576993065_addAtlassianAuthTable.ts
@@ -6,15 +6,7 @@ import {RDatum} from '../../database/stricterR'
 import {insertAtlassianAuthsQuery} from '../generatedMigrationHelpers'
 import getPgConfig from '../getPgConfig'
 export const shorthands: ColumnDefinitions | undefined = undefined
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up(): Promise<void> {
   await connectRethinkDB()

--- a/packages/server/postgres/migrations/1631553388387_add-template-teams-users.ts
+++ b/packages/server/postgres/migrations/1631553388387_add-template-teams-users.ts
@@ -2,15 +2,7 @@ import {Client} from 'pg'
 import {r} from 'rethinkdb-ts'
 import {backupTeamQuery, backupUserQuery} from '../generatedMigrationHelpers'
 import getPgConfig from '../getPgConfig'
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
   const client = new Client(getPgConfig())

--- a/packages/server/postgres/migrations/1640229261909_mattermostToIntegrationsTables.ts
+++ b/packages/server/postgres/migrations/1640229261909_mattermostToIntegrationsTables.ts
@@ -1,6 +1,7 @@
 import {Client} from 'pg'
 import {r} from 'rethinkdb-ts'
 import getPgConfig from '../getPgConfig'
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 interface MattermostAuth {
   createdAt: Date
@@ -9,15 +10,6 @@ interface MattermostAuth {
   webhookUrl: string
   userId: string
   teamId: string
-}
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
 }
 
 export async function up() {

--- a/packages/server/postgres/migrations/1654861495450_migrateSecureDomain.ts
+++ b/packages/server/postgres/migrations/1654861495450_migrateSecureDomain.ts
@@ -1,17 +1,7 @@
 import {Client} from 'pg'
 import {r} from 'rethinkdb-ts'
-import {ParabolR} from '../../database/rethinkDriver'
 import getPgConfig from '../getPgConfig'
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
   await connectRethinkDB()

--- a/packages/server/postgres/migrations/1674074684762_deleteEmptyGroups.ts
+++ b/packages/server/postgres/migrations/1674074684762_deleteEmptyGroups.ts
@@ -1,15 +1,5 @@
 import {r} from 'rethinkdb-ts'
-import {ParabolR} from '../../database/rethinkDriver'
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
   await connectRethinkDB()

--- a/packages/server/postgres/migrations/1676299334703_addSeasonalTemplates.ts
+++ b/packages/server/postgres/migrations/1676299334703_addSeasonalTemplates.ts
@@ -1,6 +1,6 @@
 import {r} from 'rethinkdb-ts'
 import {PALETTE} from '../../../client/styles/paletteV3'
-import {ParabolR} from '../../database/rethinkDriver'
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 const createdAt = new Date()
 
@@ -173,16 +173,6 @@ const promptsInfo = [
 
 const templates = templateNames.map((templateName) => makeTemplate(templateName))
 const reflectPrompts = promptsInfo.map((promptInfo, idx) => makePrompt(promptInfo, idx))
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
 
 export const up = async function () {
   try {

--- a/packages/server/postgres/migrations/1677272969994_meetingTemplatesMove.ts
+++ b/packages/server/postgres/migrations/1677272969994_meetingTemplatesMove.ts
@@ -1,14 +1,13 @@
 import {FirstParam} from 'parabol-client/types/generics'
 import {Client} from 'pg'
-import pgpInit from 'pg-promise'
 import {r} from 'rethinkdb-ts'
 import getPgConfig from '../getPgConfig'
 import connectRethinkDB from '../../database/connectRethinkDB'
+import getPgp from '../getPgp'
 
 export async function up() {
   await connectRethinkDB()
-  const pgp = pgpInit()
-  const pg = pgp(getPgConfig())
+  const {pgp, pg} = getPgp()
   const batchSize = 1000
   // Create an index we can paginate on
   try {

--- a/packages/server/postgres/migrations/1677272969994_meetingTemplatesMove.ts
+++ b/packages/server/postgres/migrations/1677272969994_meetingTemplatesMove.ts
@@ -2,18 +2,9 @@ import {FirstParam} from 'parabol-client/types/generics'
 import {Client} from 'pg'
 import pgpInit from 'pg-promise'
 import {r} from 'rethinkdb-ts'
-import {ParabolR} from '../../database/rethinkDriver'
 import getPgConfig from '../getPgConfig'
+import connectRethinkDB from '../../database/connectRethinkDB'
 
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
 export async function up() {
   await connectRethinkDB()
   const pgp = pgpInit()

--- a/packages/server/postgres/migrations/1682541572157_deleteUserRethink.ts
+++ b/packages/server/postgres/migrations/1682541572157_deleteUserRethink.ts
@@ -1,15 +1,5 @@
 import {r} from 'rethinkdb-ts'
-import {ParabolR} from '../../database/rethinkDriver'
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
   await connectRethinkDB()

--- a/packages/server/postgres/migrations/1684250022646_teamHealthPhase.ts
+++ b/packages/server/postgres/migrations/1684250022646_teamHealthPhase.ts
@@ -1,15 +1,5 @@
 import {r, RValue} from 'rethinkdb-ts'
-import {ParabolR} from '../../database/rethinkDriver'
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
   // Noop, using the feature will however create data which is not backwards compatible, thus only a down migration

--- a/packages/server/postgres/migrations/1685721573097_addPrePostMortemTemplates.ts
+++ b/packages/server/postgres/migrations/1685721573097_addPrePostMortemTemplates.ts
@@ -2,11 +2,10 @@ import {r} from 'rethinkdb-ts'
 import {Client} from 'pg'
 import getPgConfig from '../getPgConfig'
 import {PALETTE} from 'parabol-client/styles/paletteV3'
-import getPg from '../getPg'
 import pgpInit from 'pg-promise'
-import {ParabolR} from '../../database/rethinkDriver'
 import ReflectTemplate from '../../database/types/ReflectTemplate'
 import RetrospectivePrompt from '../../database/types/RetrospectivePrompt'
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 interface Prompt {
   question: string
@@ -1065,16 +1064,6 @@ const reflectPrompts = NEW_TEMPLATE_CONFIGS.map((templateConfig) => {
     )
   })
 }).flat()
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
 
 export async function up() {
   const pgp = pgpInit()

--- a/packages/server/postgres/migrations/1685721573097_addPrePostMortemTemplates.ts
+++ b/packages/server/postgres/migrations/1685721573097_addPrePostMortemTemplates.ts
@@ -2,10 +2,10 @@ import {r} from 'rethinkdb-ts'
 import {Client} from 'pg'
 import getPgConfig from '../getPgConfig'
 import {PALETTE} from 'parabol-client/styles/paletteV3'
-import pgpInit from 'pg-promise'
 import ReflectTemplate from '../../database/types/ReflectTemplate'
 import RetrospectivePrompt from '../../database/types/RetrospectivePrompt'
 import connectRethinkDB from '../../database/connectRethinkDB'
+import getPgp from '../getPgp'
 
 interface Prompt {
   question: string
@@ -1066,8 +1066,7 @@ const reflectPrompts = NEW_TEMPLATE_CONFIGS.map((templateConfig) => {
 }).flat()
 
 export async function up() {
-  const pgp = pgpInit()
-  const pg = pgp(getPgConfig())
+  const {pgp, pg} = getPgp()
   const columnSet = new pgp.helpers.ColumnSet(
     [
       'id',

--- a/packages/server/postgres/migrations/1686226640890_addTeamHealthToAllMeetingSettingsRetrospective.ts
+++ b/packages/server/postgres/migrations/1686226640890_addTeamHealthToAllMeetingSettingsRetrospective.ts
@@ -1,15 +1,5 @@
 import {r, RValue} from 'rethinkdb-ts'
-import {ParabolR} from '../../database/rethinkDriver'
-
-const connectRethinkDB = async () => {
-  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
-  await r.connectPool({
-    host,
-    port: parseInt(port, 10),
-    db: pathname.split('/')[1]
-  })
-  return r as any as ParabolR
-}
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
   await connectRethinkDB()


### PR DESCRIPTION
# Description

Some migrations cleanup. We should not use application logic in migrations, however initializing the database is an exception to that, because if we change our infrastructure, connecting to the db needs to change everywhere.

## Testing scenarios

* clean your db and run migrations

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
