### PR TITLE
chore: Prefill OrganizationApprovedDomain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ MAIL_SMTP_USE_TLS='1' # set to '0' for false
 MAIL_SMTP_CIPHERS='HIGH:MEDIUM:!aNULL:!eNULL:@STRENGTH:!DH:!kEDH'
 MIN_LOG_DURATION='200'
 OAUTH2_REDIRECT=''
+# domains added here will be added to the domains requiring email verification during the first run of the migrations
+ORGANIZATION_APPROVED_DOMAINS=example.com,example.net
 PGADMIN_DEFAULT_EMAIL='pgadmin4@pgadmin.org'
 PGADMIN_DEFAULT_PASSWORD='admin'
 PORT='3000'

--- a/packages/server/postgres/migrations/1686845459075_fillOrganizationApprovedDomain.ts
+++ b/packages/server/postgres/migrations/1686845459075_fillOrganizationApprovedDomain.ts
@@ -1,0 +1,28 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+const organizationApprovedDomains = process.env.ORGANIZATION_APPROVED_DOMAINS?.split(',')
+
+export async function up() {
+  if (!organizationApprovedDomains) return
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await Promise.all(
+    organizationApprovedDomains.map((domain) =>
+      client.query(
+        `INSERT INTO "OrganizationApprovedDomain" (domain, "orgId", "addedByUserId") VALUES ($1, 'aGhostOrg', 'aGhostUser')`,
+        [domain]
+      )
+    )
+  )
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(
+    `DELETE FROM "OrganizationApprovedDomain" WHERE "orgId" = 'aGhostOrg' AND "addedByUserId" = 'aGhostUser'`
+  )
+  await client.end()
+}


### PR DESCRIPTION
This is mainly useful for automatic setup for newly spawned instances.

## Testing scenarios

* Set environment variable and run up migration
  `ORGANIZATION_APPROVED_DOMAINS=parabol.co,example.com yarn pg:migrate up`
* Check that creating a new account with these domains will require email verification
* Run down migration  `yarn pg:migrate down` and check it's gone from PG

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
