### PR TITLE
fix: reset retro groups with team health

### DIFF
--- a/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
+++ b/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
@@ -65,6 +65,7 @@ const resetRetroMeetingToGroupStage = {
     const newPhases = phases.map((phase, index) => {
       switch (phase.phaseType) {
         case CHECKIN:
+        case 'TEAM_HEALTH':
         case REFLECT:
           return phase
         case GROUP: {


### PR DESCRIPTION
# Description

Fixes #8390

## Demo

![Peek 2023-06-19 08-31](https://github.com/ParabolInc/parabol/assets/7331043/abed5f74-14c0-4a07-b2b2-010fb0369788)

## Testing scenarios

* start retro with team health
* advance to voting
* go back to grouping and press "Edit Groups"

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
