### PR TITLE
feat(activity-library): Show activity description when hovering over activity card

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -6,10 +6,21 @@ export interface CardTheme {
   secondary: string
 }
 
-const ActivityCardImage = (props: PropsWithChildren<React.ImgHTMLAttributes<HTMLImageElement>>) => {
+export const ActivityCardImage = (
+  props: PropsWithChildren<React.ImgHTMLAttributes<HTMLImageElement>>
+) => {
   const {className, src} = props
 
-  return <img className={clsx('h-16 w-auto object-contain sm:h-24', className)} src={src} />
+  return (
+    <div
+      className={clsx(
+        'my-1 flex flex-1 items-center justify-center overflow-hidden px-4',
+        className
+      )}
+    >
+      <img className={'h-full w-full object-contain'} src={src} />
+    </div>
+  )
 }
 
 const ActivityCardTitle = (props: ComponentPropsWithoutRef<'div'>) => {
@@ -33,13 +44,12 @@ export interface ActivityCardProps {
   theme: CardTheme
   titleAs?: React.ElementType
   title?: string
-  imageSrc?: string
   badge?: React.ReactNode
   children?: React.ReactNode
 }
 
 export const ActivityCard = (props: ActivityCardProps) => {
-  const {className, theme, title, titleAs, imageSrc, badge, children} = props
+  const {className, theme, title, titleAs, badge, children} = props
   const Title = titleAs ?? ActivityCardTitle
 
   return (
@@ -48,13 +58,8 @@ export const ActivityCard = (props: ActivityCardProps) => {
         <Title>{title}</Title>
         <div className={clsx('ml-auto h-8 w-8 flex-shrink-0 rounded-bl-full', theme.primary)} />
       </div>
-      {imageSrc && (
-        <div className='my-1 flex flex-1 items-center justify-center px-4'>
-          <ActivityCardImage src={imageSrc} />
-        </div>
-      )}
       {children}
-      <div className='flex flex-shrink-0'>
+      <div className='flex flex-shrink-0 group-hover/card:hidden'>
         <div className={clsx('mt-auto h-8 w-8 flex-shrink-0 rounded-tr-full', theme.primary)} />
         <div className='ml-auto'>{badge}</div>
       </div>

--- a/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetails.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import {Redirect, useHistory} from 'react-router'
 import {Link} from 'react-router-dom'
 import IconLabel from '../../IconLabel'
-import {ActivityCard} from '../ActivityCard'
+import {ActivityCard, ActivityCardImage} from '../ActivityCard'
 import {useActivityDetails} from './hooks/useActivityDetails'
 import EditableTemplateName from '../../../modules/meeting/components/EditableTemplateName'
 import ActivityDetailsSidebar from '../ActivityDetailsSidebar'
@@ -118,9 +118,10 @@ const ActivityDetails = (props: Props) => {
               <ActivityCard
                 className='ml-14 mb-8 h-[200px] w-80 xl:ml-0 xl:mb-0'
                 theme={CATEGORY_THEMES[activity.category]}
-                imageSrc={activity.illustration}
                 badge={null}
-              />
+              >
+                <ActivityCardImage src={activity.illustration} />
+              </ActivityCard>
               <div className='pb-20'>
                 <div className='mb-10 space-y-2 pl-14'>
                   <div className='flex min-h-[40px] items-center'>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -24,7 +24,7 @@ import {
 import CreateActivityCard from './CreateActivityCard'
 import SearchBar from './SearchBar'
 import {ActivityCardImage} from './ActivityCard'
-import {Comment, LinearScale, Update} from '@mui/icons-material'
+import {ActivityLibraryCardDescription} from './ActivityLibraryCardDescription'
 
 graphql`
   fragment ActivityLibrary_templateSearchDocument on MeetingTemplate {
@@ -66,6 +66,7 @@ graphql`
     isRecommended
     isFree
     ...ActivityLibrary_templateSearchDocument @relay(mask: false)
+    ...ActivityLibraryCardDescription_template
   }
 `
 
@@ -279,46 +280,10 @@ export const ActivityLibrary = (props: Props) => {
                         className='group-hover/card:hidden'
                         src={activityIllustration}
                       />
-                      <ScrollArea.Root className='hidden flex-1 overflow-auto group-hover/card:flex'>
-                        <ScrollArea.Viewport>
-                          <div className='flex flex-1 flex-col gap-y-1 px-2 py-1 text-slate-900'>
-                            {'prompts' in template &&
-                              template.prompts?.map((prompt, index) => (
-                                <div key={index} className='flex items-center gap-x-2'>
-                                  <div
-                                    className='mt-1 h-3 w-3 shrink-0 self-start rounded-full'
-                                    style={{backgroundColor: prompt.groupColor}}
-                                  />
-                                  <div className='text-sm font-medium'>{prompt.question}</div>
-                                </div>
-                              ))}
-                            {'dimensions' in template &&
-                              template.dimensions?.map((dimension, index) => (
-                                <div key={index} className='flex items-center gap-x-2'>
-                                  <div className='mt-1 shrink-0 self-start rounded-full'>
-                                    <LinearScale className='h-4 w-4' />
-                                  </div>
-                                  <div className='text-sm font-medium'>
-                                    {dimension.name}:{' '}
-                                    <span className='font-semibold'>
-                                      {dimension.selectedScale.name}
-                                    </span>
-                                  </div>
-                                </div>
-                              ))}
-                            {'phases' in template &&
-                              template.phases?.map((phase, index) => (
-                                <div key={index} className='flex items-center gap-x-2'>
-                                  <div className='mt-1 shrink-0 self-start rounded-full'>
-                                    {phase.icon}
-                                  </div>
-                                  <div className='text-sm font-medium'>{phase.description}</div>
-                                </div>
-                              ))}
-                          </div>
-                        </ScrollArea.Viewport>
-                        <ScrollArea.Scrollbar orientation='vertical' className='hidden' />
-                      </ScrollArea.Root>
+                      <ActivityLibraryCardDescription
+                        className='hidden group-hover/card:flex'
+                        templateRef={template}
+                      />
                     </ActivityLibraryCard>
                   </Link>
                 )

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -47,7 +47,6 @@ graphql`
       prompts {
         question
         description
-        groupColor
       }
     }
   }

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -23,6 +23,8 @@ import {
 } from './Categories'
 import CreateActivityCard from './CreateActivityCard'
 import SearchBar from './SearchBar'
+import {ActivityCardImage} from './ActivityCard'
+import {Comment, LinearScale, Update} from '@mui/icons-material'
 
 graphql`
   fragment ActivityLibrary_templateSearchDocument on MeetingTemplate {
@@ -45,6 +47,7 @@ graphql`
       prompts {
         question
         description
+        groupColor
       }
     }
   }
@@ -246,7 +249,7 @@ export const ActivityLibrary = (props: Props) => {
               </div>
             </div>
           ) : (
-            <div className='mx-auto mt-1 grid auto-rows-[1fr] grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
+            <div className='mx-auto mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
               {templatesToRender.map((template) => {
                 const activityIllustration = getActivityIllustration(template.id as ActivityId)
 
@@ -260,11 +263,10 @@ export const ActivityLibrary = (props: Props) => {
                     className='flex focus:rounded-md focus:outline-primary'
                   >
                     <ActivityLibraryCard
-                      className='flex-1'
+                      className='group aspect-[256/160] flex-1'
                       key={template.id}
                       theme={CATEGORY_THEMES[template.category as CategoryID]}
                       title={template.name}
-                      imageSrc={activityIllustration}
                       badge={
                         !template.isFree ? (
                           <ActivityBadge className='m-2 bg-gold-300 text-grape-700'>
@@ -272,7 +274,52 @@ export const ActivityLibrary = (props: Props) => {
                           </ActivityBadge>
                         ) : null
                       }
-                    />
+                    >
+                      <ActivityCardImage
+                        className='group-hover/card:hidden'
+                        src={activityIllustration}
+                      />
+                      <ScrollArea.Root className='hidden flex-1 overflow-auto group-hover/card:flex'>
+                        <ScrollArea.Viewport>
+                          <div className='flex flex-1 flex-col gap-y-1 px-2 py-1 text-slate-900'>
+                            {'prompts' in template &&
+                              template.prompts?.map((prompt, index) => (
+                                <div key={index} className='flex items-center gap-x-2'>
+                                  <div
+                                    className='mt-1 h-3 w-3 shrink-0 self-start rounded-full'
+                                    style={{backgroundColor: prompt.groupColor}}
+                                  />
+                                  <div className='text-sm font-medium'>{prompt.question}</div>
+                                </div>
+                              ))}
+                            {'dimensions' in template &&
+                              template.dimensions?.map((dimension, index) => (
+                                <div key={index} className='flex items-center gap-x-2'>
+                                  <div className='mt-1 shrink-0 self-start rounded-full'>
+                                    <LinearScale className='h-4 w-4' />
+                                  </div>
+                                  <div className='text-sm font-medium'>
+                                    {dimension.name}:{' '}
+                                    <span className='font-semibold'>
+                                      {dimension.selectedScale.name}
+                                    </span>
+                                  </div>
+                                </div>
+                              ))}
+                            {'phases' in template &&
+                              template.phases?.map((phase, index) => (
+                                <div key={index} className='flex items-center gap-x-2'>
+                                  <div className='mt-1 shrink-0 self-start rounded-full'>
+                                    {phase.icon}
+                                  </div>
+                                  <div className='text-sm font-medium'>{phase.description}</div>
+                                </div>
+                              ))}
+                          </div>
+                        </ScrollArea.Viewport>
+                        <ScrollArea.Scrollbar orientation='vertical' className='hidden' />
+                      </ScrollArea.Root>
+                    </ActivityLibraryCard>
                   </Link>
                 )
               })}

--- a/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCard.tsx
@@ -8,7 +8,7 @@ export const ActivityLibraryCard = (props: ActivityCardProps) => {
   return (
     <ActivityCard
       className={clsx(
-        'group transition-shadow focus-within:ring-2 focus-within:ring-primary hover:shadow-md motion-reduce:transition-none',
+        'group/card transition-shadow focus-within:ring-2 focus-within:ring-primary hover:shadow-md motion-reduce:transition-none',
         className
       )}
       {...rest}

--- a/packages/client/components/ActivityLibrary/ActivityLibraryCardDescription.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCardDescription.tsx
@@ -132,7 +132,7 @@ export const ActivityLibraryCardDescription = (props: Props) => {
   )
 
   return (
-    <ScrollArea.Root className={clsx('hidden flex-1 overflow-auto', className)}>
+    <ScrollArea.Root className={clsx('flex-1 overflow-auto', className)}>
       <ScrollArea.Viewport>
         <div className='flex flex-1 flex-col gap-y-1 px-2 py-1 text-slate-900'>
           {template.type === 'retrospective' && <RetroDescription prompts={template.prompts} />}

--- a/packages/client/components/ActivityLibrary/ActivityLibraryCardDescription.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryCardDescription.tsx
@@ -1,0 +1,147 @@
+import graphql from 'babel-plugin-relay/macro'
+import clsx from 'clsx'
+import * as ScrollArea from '@radix-ui/react-scroll-area'
+import React from 'react'
+import {
+  ActivityLibraryCardDescription_template$key,
+  ActivityLibraryCardDescription_template$data
+} from '~/__generated__/ActivityLibraryCardDescription_template.graphql'
+
+import {Comment, LinearScale, Update} from '@mui/icons-material'
+import {useFragment} from 'react-relay'
+
+interface RetroDescriptionProps {
+  prompts: ActivityLibraryCardDescription_template$data['prompts']
+}
+
+const RetroDescription = (props: RetroDescriptionProps) => {
+  const {prompts} = props
+
+  return (
+    <>
+      {prompts!.map((prompt, index) => (
+        <div key={index} className='flex items-center gap-x-2'>
+          <div
+            className='mt-1 h-3 w-3 shrink-0 self-start rounded-full'
+            style={{backgroundColor: prompt.groupColor}}
+          />
+          <div className='text-sm font-medium'>{prompt.question}</div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+interface PokerDescriptionProps {
+  dimensions: ActivityLibraryCardDescription_template$data['dimensions']
+}
+
+const PokerDescription = (props: PokerDescriptionProps) => {
+  const {dimensions} = props
+
+  return (
+    <>
+      {dimensions!.map((dimension, index) => (
+        <div key={index} className='flex items-center gap-x-2'>
+          <div className='mt-1 shrink-0 self-start'>
+            <LinearScale className='h-4 w-4' />
+          </div>
+          <div className='text-sm font-medium'>
+            {dimension.name}: <span className='font-semibold'>{dimension.selectedScale.name}</span>
+          </div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+const ActionDescription = () => {
+  const items = [
+    {
+      icon: <Update className='h-5 w-5' />,
+      description: 'Solo Updates'
+    },
+    {
+      icon: <Comment className='h-5 w-5' />,
+      description: 'Team Agenda'
+    }
+  ]
+
+  return (
+    <>
+      {items.map((item, index) => (
+        <div key={index} className='flex items-center gap-x-2'>
+          <div className='mt-1 shrink-0 self-start'>{item.icon}</div>
+          <div className='text-sm font-medium'>{item.description}</div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+const TeamPromptDescription = () => {
+  const items = [
+    {
+      icon: <Comment className='h-5 w-5' />,
+      description: 'What are you working on today? Stuck on anything?'
+    }
+  ]
+
+  return (
+    <>
+      {items.map((item, index) => (
+        <div key={index} className='flex items-center gap-x-2'>
+          <div className='mt-1 shrink-0 self-start'>{item.icon}</div>
+          <div className='text-sm font-medium'>{item.description}</div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+interface Props {
+  className?: string
+  templateRef: ActivityLibraryCardDescription_template$key
+}
+
+export const ActivityLibraryCardDescription = (props: Props) => {
+  const {className, templateRef} = props
+
+  const template = useFragment(
+    graphql`
+      fragment ActivityLibraryCardDescription_template on MeetingTemplate {
+        type
+        ... on PokerTemplate {
+          dimensions {
+            name
+            description
+            selectedScale {
+              name
+            }
+          }
+        }
+        ... on ReflectTemplate {
+          prompts {
+            question
+            groupColor
+          }
+        }
+      }
+    `,
+    templateRef
+  )
+
+  return (
+    <ScrollArea.Root className={clsx('hidden flex-1 overflow-auto', className)}>
+      <ScrollArea.Viewport>
+        <div className='flex flex-1 flex-col gap-y-1 px-2 py-1 text-slate-900'>
+          {template.type === 'retrospective' && <RetroDescription prompts={template.prompts} />}
+          {template.type === 'poker' && <PokerDescription dimensions={template.dimensions} />}
+          {template.type === 'action' && <ActionDescription />}
+          {template.type === 'teamPrompt' && <TeamPromptDescription />}
+        </div>
+      </ScrollArea.Viewport>
+      <ScrollArea.Scrollbar orientation='vertical' className='hidden' />
+    </ScrollArea.Root>
+  )
+}

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -9,7 +9,7 @@ import newTemplate from '../../../../../static/images/illustrations/newTemplate.
 import estimatedEffortTemplate from '../../../../../static/images/illustrations/estimatedEffortTemplate.png'
 
 import {CreateNewActivityQuery} from '~/__generated__/CreateNewActivityQuery.graphql'
-import {ActivityCard} from '../ActivityCard'
+import {ActivityCard, ActivityCardImage} from '../ActivityCard'
 import {ActivityBadge} from '../ActivityBadge'
 
 import IconLabel from '../../IconLabel'
@@ -291,12 +291,13 @@ export const CreateNewActivity = (props: Props) => {
                 value={activity.type}
               >
                 <ActivityCard
-                  className='w-80 group-data-[state=checked]:ring-4 group-data-[state=checked]:ring-sky-500 group-data-[state=checked]:ring-offset-4'
+                  className='aspect-[320/190] w-80 group-data-[state=checked]:ring-4 group-data-[state=checked]:ring-sky-500 group-data-[state=checked]:ring-offset-4'
                   theme={DEFAULT_CARD_THEME}
                   title={activity.title}
                   titleAs={CategoryTitle}
-                  imageSrc={activity.image}
-                />
+                >
+                  <ActivityCardImage src={activity.image} />
+                </ActivityCard>
                 <div className='flex gap-x-3 p-3'>
                   {activity.includedCategories.map((badge) => (
                     <ActivityBadge


### PR DESCRIPTION
# Description

Fixes #8385 

One thing worth noting - cards now have fixed aspect ratio so we're actually able to scroll the content. Also, I made all the spacing and sizing in various hover elements (for different categories) the same, it looked really odd with different icon sizes and spacing between icons and sizes. 

Depends on #8388 

## Demo

https://github.com/ParabolInc/parabol/assets/1017620/d15b85e3-0ff1-4585-9c9a-fdc388633f09

## Testing scenarios

- [ ] Open activity library, hover over random cards and see if the content is visible, and scrollable id needed

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
