### PR TITLE
chore(metrics): Add hasTeamHealth to meeting properties for meeting related events

### DIFF
--- a/packages/server/utils/analytics/helpers.ts
+++ b/packages/server/utils/analytics/helpers.ts
@@ -11,13 +11,15 @@ export const createMeetingProperties = (
   template?: MeetingTemplate
 ) => {
   const {id: meetingId, teamId, facilitatorUserId, meetingType, phases} = meeting
-  const hasIcebreaker = phases[0]?.phaseType === CHECKIN
+  const hasIcebreaker = phases.some(({phaseType}) => phaseType === CHECKIN)
+  const hasTeamHealth = phases.some(({phaseType}) => phaseType === 'TEAM_HEALTH')
   return {
     meetingId,
     teamId,
     facilitatorUserId,
     meetingType,
     hasIcebreaker,
+    hasTeamHealth,
     teamMembersPresentCount: meetingMembers?.length,
     meetingTemplateId: template?.id,
     meetingTemplateName: template?.name,


### PR DESCRIPTION
## Demo
<img width="475" alt="Screenshot 2023-06-19 at 14 43 13" src="https://github.com/ParabolInc/parabol/assets/1879975/512b79f7-decf-4e56-b6e8-db39c8d6bcb9">

## Testing scenarios

- [ ] 
  - Start/Join/Complete a meeting with/without team health phase
  - See in [Segment Debugger](https://app.segment.com/parabol-jordan/sources/action_local/debugger) to verify the `hasTeamHealth` property is added to the events

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
