### PR TITLE
chore: removed old apollo gql extension config

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,2 +1,0 @@
-const {config} = require('vscode-apollo-relay').generateConfig()
-module.exports = config


### PR DESCRIPTION
# Description

Now as we use [Official Relay GraphQL exetension](https://marketplace.visualstudio.com/items?itemName=meta.relay), we don't need this old apollo extension config hanging around

## Demo

No demo

## Testing scenarios

No testing scenarios

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
