### PR TITLE
fix: del instead of hdel

### DIFF
--- a/packages/server/utils/atlassian/jiraImages.ts
+++ b/packages/server/utils/atlassian/jiraImages.ts
@@ -69,7 +69,7 @@ export const downloadAndCacheImage = async (
     .exec()
   const imageResponse = await manager.getImage(imageUrl)
   if (!imageResponse?.contentType) {
-    await redis.hdel(imageKey)
+    await redis.del(imageKey)
     return
   }
 


### PR DESCRIPTION
# Description

fixes #8400

HDEL is for deleting a specific key in a hash. DEL is for deleting the entire hash.