### PR TITLE
fix: canAccess for organization

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -83,6 +83,7 @@
           "RemoveIntegrationSearchQuerySuccess": "./types/RemoveIntegrationSearchQuerySuccess#RemoveIntegrationSearchQuerySuccessSource",
           "RemoveTeamMemberPayload": "./types/RemoveTeamMemberPayload#RemoveTeamMemberPayloadSource",
           "RequestToJoinDomainSuccess": "./types/RequestToJoinDomainSuccess#RequestToJoinDomainSuccessSource",
+          "SetMeetingSettingsPayload": "../types/SetMeetingSettingsPayload#SetMeetingSettingsPayloadSource",
           "SetNotificationStatusPayload": "./types/SetNotificationStatusPayload#SetNotificationStatusPayloadSource",
           "SetOrgUserRoleSuccess": "./types/SetOrgUserRoleSuccess#SetOrgUserRoleSuccessSource",
           "StartTeamPromptSuccess": "./types/StartTeamPromptSuccess#StartTeamPromptSuccessSource",

--- a/codegen.json
+++ b/codegen.json
@@ -56,6 +56,7 @@
           "DomainJoinRequest": "../../database/types/DomainJoinRequest#default as DomainJoinRequestDB",
           "File": "./types/File#TFile",
           "InviteToTeamPayload": "./types/InviteToTeamPayload#InviteToTeamPayloadSource",
+          "JiraIssue": "./types/JiraIssue#JiraIssueSource",
           "JiraRemoteProject": "../types/JiraRemoteProject#JiraRemoteProjectSource",
           "MeetingSeries": "../../postgres/types/MeetingSeries#MeetingSeries",
           "MeetingTemplate": "../../database/types/MeetingTemplate#default",

--- a/packages/client/modules/email/components/EmailNotifications/EmailDiscussionMentioned.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailDiscussionMentioned.tsx
@@ -68,7 +68,7 @@ const EmailDiscussionMentioned = (props: Props) => {
   const {meeting, author, comment, discussion} = notification
   const {rasterPicture: authorPicture, preferredName: authorName} = author
   const {stage} = discussion
-  const {id: meetingId, name: meetingName, facilitatorStageId} = meeting
+  const {id: meetingId, name: meetingName} = meeting
   const {id: stageId, response} = stage ?? {}
 
   const directUrl = stageId ? fromStageIdToUrl(stageId, meeting) : `/meet/${meetingId}`

--- a/packages/client/modules/email/components/EmailNotifications/EmailNotificationPicker.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailNotificationPicker.tsx
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import {ValueOf} from 'parabol-client/types/generics'
+import enumLookup from 'parabol-client/types/enumLookup'
 import {EmailNotificationPicker_notification$key} from 'parabol-client/__generated__/EmailNotificationPicker_notification.graphql'
 import React from 'react'
 import {useFragment} from 'react-relay'
@@ -54,9 +54,7 @@ const EmailNotificationPicker = (props: Props) => {
     notificationRef
   )
   const {type} = notification
-  const SpecificNotification = NOTIFICATION_TEMPLATE_TYPE[type] as ValueOf<
-    typeof NOTIFICATION_TEMPLATE_TYPE
-  > | null
+  const SpecificNotification = enumLookup(NOTIFICATION_TEMPLATE_TYPE, type)
   return SpecificNotification ? (
     <SpecificNotification appOrigin={appOrigin} notificationRef={notification} />
   ) : null

--- a/packages/client/modules/email/components/EmailNotifications/EmailNotificationPicker.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailNotificationPicker.tsx
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import enumLookup from 'parabol-client/types/enumLookup'
+import typedLookup from 'parabol-client/types/typedLookup'
 import {EmailNotificationPicker_notification$key} from 'parabol-client/__generated__/EmailNotificationPicker_notification.graphql'
 import React from 'react'
 import {useFragment} from 'react-relay'
@@ -54,7 +54,7 @@ const EmailNotificationPicker = (props: Props) => {
     notificationRef
   )
   const {type} = notification
-  const SpecificNotification = enumLookup(NOTIFICATION_TEMPLATE_TYPE, type)
+  const SpecificNotification = typedLookup(NOTIFICATION_TEMPLATE_TYPE, type)
   return SpecificNotification ? (
     <SpecificNotification appOrigin={appOrigin} notificationRef={notification} />
   ) : null

--- a/packages/client/types/enumLookup.ts
+++ b/packages/client/types/enumLookup.ts
@@ -1,0 +1,15 @@
+type ValueType<T> = T extends Record<any, infer U> ? U : never
+type NoExtraKeys<O, K extends string | symbol | number> = {
+  [P in keyof O]: P extends K ? O[P] : never
+}
+
+// lookup values from an object of structure Record<Enum, ValueType> without loosing the ValuType specificity
+// also check that the record does not contain extra keys not present in Enum
+function enumLookup<
+  K extends string | number | symbol | keyof T,
+  T extends Partial<NoExtraKeys<T, K>>
+>(lookup: T, key: K): ValueType<T> | undefined {
+  return lookup[key as keyof T] as ValueType<T> | undefined
+}
+
+export default enumLookup

--- a/packages/client/types/typedLookup.ts
+++ b/packages/client/types/typedLookup.ts
@@ -3,13 +3,15 @@ type NoExtraKeys<O, K extends string | symbol | number> = {
   [P in keyof O]: P extends K ? O[P] : never
 }
 
-// lookup values from an object of structure Record<Enum, ValueType> without loosing the ValuType specificity
-// also check that the record does not contain extra keys not present in Enum
-function enumLookup<
+/**
+ * lookup values from an object of structure Record<Enum, ValueType> without loosing the ValuType specificity
+ * also check that the record does not contain extra keys not present in Enum
+ */
+function typedLookup<
   K extends string | number | symbol | keyof T,
   T extends Partial<NoExtraKeys<T, K>>
 >(lookup: T, key: K): ValueType<T> | undefined {
   return lookup[key as keyof T] as ValueType<T> | undefined
 }
 
-export default enumLookup
+export default typedLookup

--- a/packages/server/database/types/NotificationPromptToJoinOrg.ts
+++ b/packages/server/database/types/NotificationPromptToJoinOrg.ts
@@ -6,7 +6,7 @@ interface Input {
 }
 
 export default class NotificationPromptToJoinOrg extends Notification {
-  orgId: string
+  orgId?: string
   activeDomain: string
   constructor(input: Input) {
     const {userId, activeDomain} = input

--- a/packages/server/database/types/NotificationPromptToJoinOrg.ts
+++ b/packages/server/database/types/NotificationPromptToJoinOrg.ts
@@ -6,7 +6,6 @@ interface Input {
 }
 
 export default class NotificationPromptToJoinOrg extends Notification {
-  orgId?: string
   activeDomain: string
   constructor(input: Input) {
     const {userId, activeDomain} = input

--- a/packages/server/email/getMailManager.ts
+++ b/packages/server/email/getMailManager.ts
@@ -1,4 +1,4 @@
-import enumLookup from '../../client/types/enumLookup'
+import typedLookup from '../../client/types/typedLookup'
 import MailManager from './MailManager'
 import MailManagerDebug from './MailManagerDebug'
 import MailManagerGoogle from './MailManagerGoogle'
@@ -17,7 +17,7 @@ const managers = {
 const getMailManager = () => {
   if (!mailManager) {
     const mailProvider = process.env.MAIL_PROVIDER!
-    const Manager = enumLookup(managers, mailProvider) ?? MailManagerDebug
+    const Manager = typedLookup(managers, mailProvider) ?? MailManagerDebug
     mailManager = new Manager()
   }
   return mailManager

--- a/packages/server/email/getMailManager.ts
+++ b/packages/server/email/getMailManager.ts
@@ -1,3 +1,4 @@
+import enumLookup from '../../client/types/enumLookup'
 import MailManager from './MailManager'
 import MailManagerDebug from './MailManagerDebug'
 import MailManagerGoogle from './MailManagerGoogle'
@@ -16,7 +17,7 @@ const managers = {
 const getMailManager = () => {
   if (!mailManager) {
     const mailProvider = process.env.MAIL_PROVIDER!
-    const Manager = managers[mailProvider as keyof typeof managers] ?? MailManagerDebug
+    const Manager = enumLookup(managers, mailProvider) ?? MailManagerDebug//managers[mailProvider as keyof typeof managers] ?? MailManagerDebug
     mailManager = new Manager()
   }
   return mailManager

--- a/packages/server/email/getMailManager.ts
+++ b/packages/server/email/getMailManager.ts
@@ -17,7 +17,7 @@ const managers = {
 const getMailManager = () => {
   if (!mailManager) {
     const mailProvider = process.env.MAIL_PROVIDER!
-    const Manager = enumLookup(managers, mailProvider) ?? MailManagerDebug//managers[mailProvider as keyof typeof managers] ?? MailManagerDebug
+    const Manager = enumLookup(managers, mailProvider) ?? MailManagerDebug
     mailManager = new Manager()
   }
   return mailManager

--- a/packages/server/graphql/__tests__/getRateLimiter.test.ts
+++ b/packages/server/graphql/__tests__/getRateLimiter.test.ts
@@ -6,7 +6,7 @@ const originalRateLimiterEnvVariable = process.env.CI
 describe('getRateLimiter', () => {
   beforeEach(() => {
     delete process.env.CI
-    jest.useFakeTimers('modern')
+    jest.useFakeTimers()
   })
 
   afterEach(() => {

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -24,7 +24,8 @@ const PERCENT_ADDED_TO_RID = 0.05
 const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?: string) => {
   const r = await getRethink()
   const {id: userId, createdAt, preferredName, email, featureFlags, tier, segmentId} = newUser
-  const domain = email.split('@')[1]
+  // email is checked by the caller
+  const domain = email.split('@')[1]!
   const [isPatient0, usersWithDomain, isSAMLVerified] = await Promise.all([
     isPatientZero(domain),
     isCompanyDomain(domain) ? getUsersbyDomain(domain) : [],

--- a/packages/server/graphql/private/mutations/autopauseUsers.ts
+++ b/packages/server/graphql/private/mutations/autopauseUsers.ts
@@ -4,11 +4,7 @@ import getRethink from '../../../database/rethinkDriver'
 import getUserIdsToPause from '../../../postgres/queries/getUserIdsToPause'
 import {MutationResolvers} from '../resolverTypes'
 
-const autopauseUsers: MutationResolvers['autopauseUsers'] = async (
-  _source,
-  _args,
-  {dataLoader}
-) => {
+const autopauseUsers: MutationResolvers['autopauseUsers'] = async () => {
   const r = await getRethink()
 
   // RESOLUTION

--- a/packages/server/graphql/private/mutations/backupOrganization.ts
+++ b/packages/server/graphql/private/mutations/backupOrganization.ts
@@ -115,10 +115,7 @@ const backupPgOrganization = async (orgIds: string[]) => {
   await pg.query(`DROP SCHEMA IF EXISTS "orgBackup" CASCADE;`)
 }
 
-const backupOrganization: MutationResolvers['backupOrganization'] = async (
-  _source,
-  {orgIds},
-) => {
+const backupOrganization: MutationResolvers['backupOrganization'] = async (_source, {orgIds}) => {
   // RESOLUTION
   await backupPgOrganization(orgIds)
 
@@ -204,7 +201,9 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('ReflectPrompt').insert(items)),
     templateDimension: (
-      r.table('TemplateDimension').filter((row: RDatum) => r(teamIds).contains(row('teamId'))) as any
+      r
+        .table('TemplateDimension')
+        .filter((row: RDatum) => r(teamIds).contains(row('teamId'))) as any
     )
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('TemplateDimension').insert(items)),
@@ -259,7 +258,9 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (
             .coerceTo('array')
             .do((items: RValue) => r.db(DESTINATION).table('SuggestedAction').insert(items)),
           timelineEvent: (
-            r.table('TimelineEvent').filter((row: RDatum) => r(userIds).contains(row('userId'))) as any
+            r
+              .table('TimelineEvent')
+              .filter((row: RDatum) => r(userIds).contains(row('userId'))) as any
           )
             .filter((row: RValue) =>
               r.branch(row('teamId'), r(teamIds).contains(row('teamId')), true)

--- a/packages/server/graphql/private/mutations/backupOrganization.ts
+++ b/packages/server/graphql/private/mutations/backupOrganization.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import util from 'util'
 import getProjectRoot from '../../../../../scripts/webpack/utils/getProjectRoot'
 import getRethink from '../../../database/rethinkDriver'
-import {RValue} from '../../../database/stricterR'
+import {RDatum, RValue} from '../../../database/stricterR'
 import getPg from '../../../postgres/getPg'
 import getPgConfig from '../../../postgres/getPgConfig'
 import getTeamsByOrgIds from '../../../postgres/queries/getTeamsByOrgIds'
@@ -32,7 +32,7 @@ const dumpPgDataToOrgBackupSchema = async (orgIds: string[]) => {
       r
         .table('NewMeeting')
         .getAll(r.args(teamIds), {index: 'teamId'})
-        .filter((row) => row.hasFields('templateRefId')) as any
+        .filter((row: RDatum) => row.hasFields('templateRefId')) as any
     )('templateRefId')
       .coerceTo('array')
       .distinct()
@@ -118,7 +118,6 @@ const backupPgOrganization = async (orgIds: string[]) => {
 const backupOrganization: MutationResolvers['backupOrganization'] = async (
   _source,
   {orgIds},
-  {authToken}
 ) => {
   // RESOLUTION
   await backupPgOrganization(orgIds)
@@ -178,11 +177,11 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (
     atlassianAuth: (r.table('AtlassianAuth').getAll(r.args(teamIds), {index: 'teamId'}) as any)
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('AtlassianAuth').insert(items)),
-    invoice: (r.table('Invoice').filter((row) => r(orgIds).contains(row('orgId'))) as any)
+    invoice: (r.table('Invoice').filter((row: RDatum) => r(orgIds).contains(row('orgId'))) as any)
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('Invoice').insert(items)),
     invoiceItemHook: (
-      r.table('InvoiceItemHook').filter((row) => r(orgIds).contains(row('orgId'))) as any
+      r.table('InvoiceItemHook').filter((row: RDatum) => r(orgIds).contains(row('orgId'))) as any
     )
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('InvoiceItemHook').insert(items)),
@@ -205,12 +204,12 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('ReflectPrompt').insert(items)),
     templateDimension: (
-      r.table('TemplateDimension').filter((row) => r(teamIds).contains(row('teamId'))) as any
+      r.table('TemplateDimension').filter((row: RDatum) => r(teamIds).contains(row('teamId'))) as any
     )
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('TemplateDimension').insert(items)),
     templateScale: (
-      r.table('TemplateScale').filter((row) => r(teamIds).contains(row('teamId'))) as any
+      r.table('TemplateScale').filter((row: RDatum) => r(teamIds).contains(row('teamId'))) as any
     )
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('TemplateScale').insert(items)),
@@ -260,7 +259,7 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (
             .coerceTo('array')
             .do((items: RValue) => r.db(DESTINATION).table('SuggestedAction').insert(items)),
           timelineEvent: (
-            r.table('TimelineEvent').filter((row) => r(userIds).contains(row('userId'))) as any
+            r.table('TimelineEvent').filter((row: RDatum) => r(userIds).contains(row('userId'))) as any
           )
             .filter((row: RValue) =>
               r.branch(row('teamId'), r(teamIds).contains(row('teamId')), true)

--- a/packages/server/graphql/private/mutations/changeEmailDomain.ts
+++ b/packages/server/graphql/private/mutations/changeEmailDomain.ts
@@ -54,7 +54,9 @@ const changeEmailDomain: MutationResolvers['changeEmailDomain'] = async (
     r
       .table('TeamMember')
       .filter((row: RDatum) => row('email').match(`@${normalizedOldDomain}$`))
-      .update((row: RDatum) => ({email: row('email').split('@').nth(0).add(`@${normalizedNewDomain}`)}))
+      .update((row: RDatum) => ({
+        email: row('email').split('@').nth(0).add(`@${normalizedNewDomain}`)
+      }))
       .run(),
     r
       .table('SAML')

--- a/packages/server/graphql/private/mutations/disconnectSocket.ts
+++ b/packages/server/graphql/private/mutations/disconnectSocket.ts
@@ -15,7 +15,7 @@ const disconnectSocket: MutationResolvers['disconnectSocket'] = async (
   const redis = getRedis()
 
   // AUTH
-  if (!socketId) return undefined
+  if (!socketId) return null
 
   // RESOLUTION
   const [user, userPresence] = await Promise.all([

--- a/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
@@ -103,7 +103,12 @@ const draftEnterpriseInvoice: MutationResolvers['draftEnterpriseInvoice'] = asyn
     customerId = stripeId
   }
 
-  const subscription = await manager.createEnterpriseSubscription(customerId, orgId, quantity, plan ?? undefined)
+  const subscription = await manager.createEnterpriseSubscription(
+    customerId,
+    orgId,
+    quantity,
+    plan ?? undefined
+  )
 
   await Promise.all([
     r({

--- a/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
@@ -103,7 +103,7 @@ const draftEnterpriseInvoice: MutationResolvers['draftEnterpriseInvoice'] = asyn
     customerId = stripeId
   }
 
-  const subscription = await manager.createEnterpriseSubscription(customerId, orgId, quantity, plan)
+  const subscription = await manager.createEnterpriseSubscription(customerId, orgId, quantity, plan ?? undefined)
 
   await Promise.all([
     r({
@@ -124,8 +124,7 @@ const draftEnterpriseInvoice: MutationResolvers['draftEnterpriseInvoice'] = asyn
     updateTeamByOrgId(
       {
         isPaid: true,
-        tier: 'enterprise',
-        updatedAt: now
+        tier: 'enterprise'
       },
       orgId
     ),

--- a/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
+++ b/packages/server/graphql/private/mutations/enableSAMLForDomain.ts
@@ -1,4 +1,5 @@
 import getRethink from '../../../database/rethinkDriver'
+import {RValue} from '../../../database/stricterR'
 import getSignOnURL from '../../public/mutations/helpers/SAMLHelpers/getSignOnURL'
 import {MutationResolvers} from '../resolverTypes'
 import normalizeSlugName from './helpers/normalizeSlugName'
@@ -11,7 +12,7 @@ const validateDomains = async (domains: string[] | null | undefined, slugName: s
   const domainOwner = await r
     .table('SAML')
     .getAll(r.args(normalizedDomains), {index: 'domains'})
-    .filter((row) => row('id').ne(slugName))
+    .filter((row: RValue) => row('id').ne(slugName))
     .limit(1)
     .nth(0)
     .default(null)

--- a/packages/server/graphql/private/mutations/hardDeleteUser.ts
+++ b/packages/server/graphql/private/mutations/hardDeleteUser.ts
@@ -72,7 +72,7 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
       r
         .table('NewMeeting')
         .getAll(r.args(teamIds), {index: 'teamId'})
-        .filter((row) => row('meetingType').eq('retro'))
+        .filter((row: RValue) => row('meetingType').eq('retro'))
         .eqJoin('id', r.table('RetroReflection'), {index: 'meetingId'})
         .zip() as any
     )
@@ -84,12 +84,12 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
     r
       .table('NewMeeting')
       .getAll(r.args(teamIds), {index: 'teamId'})
-      .filter((row) => row('facilitatorUserId').eq(userIdToDelete))
+      .filter((row: RValue) => row('facilitatorUserId').eq(userIdToDelete))
       .merge((meeting: RValue) => ({
         otherTeamMember: r
           .table('TeamMember')
           .getAll(meeting('teamId'), {index: 'teamId'})
-          .filter((row) => row('userId').ne(userIdToDelete))
+          .filter((row: RValue) => row('userId').ne(userIdToDelete))
           .nth(0)
           .getField('userId')
           .default(null)
@@ -100,12 +100,12 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
     r
       .table('NewMeeting')
       .getAll(r.args(teamIds), {index: 'teamId'})
-      .filter((row) => row('createdBy').eq(userIdToDelete))
+      .filter((row: RValue) => row('createdBy').eq(userIdToDelete))
       .merge((meeting: RValue) => ({
         otherTeamMember: r
           .table('TeamMember')
           .getAll(meeting('teamId'), {index: 'teamId'})
-          .filter((row) => row('userId').ne(userIdToDelete))
+          .filter((row: RValue) => row('userId').ne(userIdToDelete))
           .nth(0)
           .getField('userId')
           .default(null)
@@ -133,7 +133,7 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
     createdTasks: r
       .table('Task')
       .getAll(r.args(teamIds), {index: 'teamId'})
-      .filter((row) => row('createdBy').eq(userIdToDelete))
+      .filter((row: RValue) => row('createdBy').eq(userIdToDelete))
       .delete(),
     timelineEvent: r
       .table('TimelineEvent')
@@ -144,7 +144,7 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
     agendaItem: r
       .table('AgendaItem')
       .getAll(r.args(teamIds), {index: 'teamId'})
-      .filter((row) => r(teamMemberIds).contains(row('teamMemberId')))
+      .filter((row: RValue) => r(teamMemberIds).contains(row('teamMemberId')))
       .delete(),
     pushInvitation: r.table('PushInvitation').getAll(userIdToDelete, {index: 'userId'}).delete(),
     retroReflection: r
@@ -158,17 +158,17 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
     invitedByTeamInvitation: r
       .table('TeamInvitation')
       .getAll(r.args(teamIds), {index: 'teamId'})
-      .filter((row) => row('invitedBy').eq(userIdToDelete))
+      .filter((row: RValue) => row('invitedBy').eq(userIdToDelete))
       .delete(),
     createdByTeamInvitations: r
       .table('TeamInvitation')
       .getAll(r.args(teamIds), {index: 'teamId'})
-      .filter((row) => row('acceptedBy').eq(userIdToDelete))
+      .filter((row: RValue) => row('acceptedBy').eq(userIdToDelete))
       .update({acceptedBy: ''}),
     comment: r
       .table('Comment')
       .getAll(r.args(teamDiscussionIds), {index: 'discussionId'})
-      .filter((row) => row('createdBy').eq(userIdToDelete))
+      .filter((row: RValue) => row('createdBy').eq(userIdToDelete))
       .update({
         createdBy: tombstoneId,
         isAnonymous: true
@@ -210,7 +210,7 @@ const hardDeleteUser: MutationResolvers['hardDeleteUser'] = async (
   ])
 
   // Send metrics to HubSpot before the user is really deleted in DB
-  await sendAccountRemovedToSegment(userIdToDelete, user.email, reasonText)
+  await sendAccountRemovedToSegment(userIdToDelete, user.email, reasonText ?? '')
 
   // User needs to be deleted after children
   await pg.query(`DELETE FROM "User" WHERE "id" = $1`, [userIdToDelete])

--- a/packages/server/graphql/private/mutations/lockTeams.ts
+++ b/packages/server/graphql/private/mutations/lockTeams.ts
@@ -1,10 +1,7 @@
-import getRethink from '../../../database/rethinkDriver'
 import updateTeamByTeamId from '../../../postgres/queries/updateTeamByTeamId'
 import {MutationResolvers} from '../resolverTypes'
 
 const lockTeams: MutationResolvers['lockTeams'] = async (_source, {message, teamIds, isPaid}) => {
-  const r = await getRethink()
-
   const lockMessageHTML = isPaid ? null : message ?? null
 
   // RESOLUTION

--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -31,7 +31,6 @@ const getRelayState = (body: any) => {
 const loginSAML: MutationResolvers['loginSAML'] = async (
   _source,
   {samlName, queryString},
-  {dataLoader}
 ) => {
   const r = await getRethink()
   const body = querystring.parse(queryString)
@@ -40,7 +39,7 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
 
   if (!doc) return {error: {message: `${normalizedName} has not been created in Parabol yet`}}
   const {domains, metadata} = doc
-  const idp = samlify.IdentityProvider({metadata})
+  const idp = samlify.IdentityProvider({metadata: metadata ?? undefined})
   let loginResponse
   try {
     loginResponse = await serviceProvider.parseLoginResponse(idp, 'post', {body})
@@ -55,13 +54,13 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
   const {isInvited} = relayState
   const {extract} = loginResponse
   const {attributes, nameID: name} = extract
-  const caseInsensitiveAtttributes = {} as Record<Lowercase<string>, string | undefined>
+  const caseInsensitiveAttributes = {} as Record<string, string | undefined>
   Object.keys(attributes).forEach((key) => {
     const lowercaseKey = key.toLowerCase()
     const value = attributes[key]
-    caseInsensitiveAtttributes[lowercaseKey] = String(value)
+    caseInsensitiveAttributes[lowercaseKey] = String(value)
   })
-  const {email: inputEmail, emailaddress, displayname} = caseInsensitiveAtttributes
+  const {email: inputEmail, emailaddress, displayname} = caseInsensitiveAttributes
   const preferredName = displayname || name
   const email = inputEmail?.toLowerCase() || emailaddress?.toLowerCase()
   if (!email) {

--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -28,10 +28,7 @@ const getRelayState = (body: any) => {
   return relayState
 }
 
-const loginSAML: MutationResolvers['loginSAML'] = async (
-  _source,
-  {samlName, queryString},
-) => {
+const loginSAML: MutationResolvers['loginSAML'] = async (_source, {samlName, queryString}) => {
   const r = await getRethink()
   const body = querystring.parse(queryString)
   const normalizedName = samlName.trim().toLowerCase()

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -1,7 +1,7 @@
 import ms from 'ms'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {getRRuleDateFromJSDate, getJSDateFromRRuleDate} from 'parabol-client/shared/rruleUtil'
-import {RRule, datetime} from 'rrule'
+import {RRule} from 'rrule'
 import getRethink, {ParabolR} from '../../../database/rethinkDriver'
 import MeetingTeamPrompt, {createTeamPromptTitle} from '../../../database/types/MeetingTeamPrompt'
 import {getActiveMeetingSeries} from '../../../postgres/queries/getActiveMeetingSeries'
@@ -49,6 +49,7 @@ const startRecurringTeamPrompt = async (
   analytics.meetingStarted(facilitatorId, meeting)
   const data = {teamId, meetingId: meeting.id}
   publish(SubscriptionChannel.TEAM, teamId, 'StartTeamPromptSuccess', data, subOptions)
+  return undefined
 }
 
 const processRecurrence: MutationResolvers['processRecurrence'] = async (_source, {}, context) => {

--- a/packages/server/graphql/private/mutations/profileCPU.ts
+++ b/packages/server/graphql/private/mutations/profileCPU.ts
@@ -34,7 +34,7 @@ const stop = () => {
   })
 }
 
-const profileCPU: MutationResolvers['profileCPU'] = async (_source, _args, {authToken}) => {
+const profileCPU: MutationResolvers['profileCPU'] = async () => {
   if (!session) {
     session = new inspector.Session()
     session.connect()

--- a/packages/server/graphql/private/mutations/sendBatchNotificationEmails.ts
+++ b/packages/server/graphql/private/mutations/sendBatchNotificationEmails.ts
@@ -25,7 +25,7 @@ const sendBatchNotificationEmails: MutationResolvers['sendBatchNotificationEmail
     r
       .table('Notification')
       // Only include notifications which occurred within the last day
-      .filter((row) => row('createdAt').gt(yesterday))
+      .filter((row: RValue) => row('createdAt').gt(yesterday))
       .filter({status: 'UNREAD'})
       // de-dup users
       .group('userId') as any

--- a/packages/server/graphql/private/mutations/sendUpcomingInvoiceEmails.ts
+++ b/packages/server/graphql/private/mutations/sendUpcomingInvoiceEmails.ts
@@ -71,7 +71,7 @@ const sendUpcomingInvoiceEmails: MutationResolvers['sendUpcomingInvoiceEmails'] 
   const organizations = (await r
     .table('Organization')
     .getAll('team', {index: 'tier'})
-    .filter((organization) =>
+    .filter((organization: RValue) =>
       r.and(
         organization('periodEnd').le(periodEndThresh).default(false),
         organization('upcomingInvoiceEmailSentAt').le(lastSentThresh).default(true)
@@ -82,11 +82,11 @@ const sendUpcomingInvoiceEmails: MutationResolvers['sendUpcomingInvoiceEmails'] 
       newUserIds: r
         .table('OrganizationUser')
         .getAll(organization('id'), {index: 'orgId'})
-        .filter((organizationUser) => organizationUser('newUserUntil').ge(now))
+        .filter((organizationUser: RValue) => organizationUser('newUserUntil').ge(now))
         .filter({removedAt: null, role: null})('userId')
         .coerceTo('array')
     }))
-    .filter((organization) => organization('newUserIds').count().ge(1))
+    .filter((organization: RValue) => organization('newUserIds').count().ge(1))
     .merge((organization: RValue) => ({
       billingLeaderIds: r
         .table('OrganizationUser')

--- a/packages/server/graphql/private/mutations/setIsFreeMeetingTemplate.ts
+++ b/packages/server/graphql/private/mutations/setIsFreeMeetingTemplate.ts
@@ -1,4 +1,3 @@
-import getRethink from '../../../database/rethinkDriver'
 import updateMeetingTemplateFreeStatusById from '../../../postgres/queries/updateMeetingTemplateFreeStatusById'
 import updateMeetingTemplateFreeStatusByName from '../../../postgres/queries/updateMeetingTemplateFreeStatusByName'
 import {MutationResolvers} from '../resolverTypes'
@@ -7,7 +6,6 @@ const setIsFreeMeetingTemplate: MutationResolvers['setIsFreeMeetingTemplate'] = 
   _source,
   {isFree, templateIds, templateNames}
 ) => {
-  const r = await getRethink()
   // VALIDATION
   if (!templateIds?.length && !templateNames?.length) {
     return {error: {message: 'Must provide template ids or names'}}

--- a/packages/server/graphql/private/mutations/stripeInvoiceFinalized.ts
+++ b/packages/server/graphql/private/mutations/stripeInvoiceFinalized.ts
@@ -1,3 +1,4 @@
+import Stripe from 'stripe'
 import getRethink from '../../../database/rethinkDriver'
 import {isSuperUser} from '../../../utils/authorization'
 import {getStripeManager} from '../../../utils/stripe'
@@ -24,7 +25,7 @@ const stripeInvoiceFinalized: MutationResolvers['stripeInvoiceFinalized'] = asyn
   const {
     livemode,
     metadata: {orgId}
-  } = await manager.retrieveCustomer(customerId)
+  } = (await manager.retrieveCustomer(customerId)) as Stripe.Customer
   const org = await r.table('Organization').get(orgId).run()
   if (!org) {
     if (livemode) {

--- a/packages/server/graphql/private/mutations/stripeInvoiceFinalized.ts
+++ b/packages/server/graphql/private/mutations/stripeInvoiceFinalized.ts
@@ -1,4 +1,3 @@
-import Stripe from 'stripe'
 import getRethink from '../../../database/rethinkDriver'
 import {isSuperUser} from '../../../utils/authorization'
 import {getStripeManager} from '../../../utils/stripe'
@@ -22,10 +21,14 @@ const stripeInvoiceFinalized: MutationResolvers['stripeInvoiceFinalized'] = asyn
   const invoice = await manager.retrieveInvoice(invoiceId)
   const customerId = invoice.customer as string
 
+  const customer = await manager.retrieveCustomer(customerId)
+  if (customer.deleted) {
+    return false
+  }
   const {
     livemode,
     metadata: {orgId}
-  } = (await manager.retrieveCustomer(customerId)) as Stripe.Customer
+  } = customer
   const org = await r.table('Organization').get(orgId).run()
   if (!org) {
     if (livemode) {

--- a/packages/server/graphql/private/mutations/stripeSucceedPayment.ts
+++ b/packages/server/graphql/private/mutations/stripeSucceedPayment.ts
@@ -1,3 +1,4 @@
+import Stripe from 'stripe'
 import getRethink from '../../../database/rethinkDriver'
 import updateTeamByOrgId from '../../../postgres/queries/updateTeamByOrgId'
 import {isSuperUser} from '../../../utils/authorization'
@@ -25,7 +26,7 @@ const stripeSucceedPayment: MutationResolvers['stripeSucceedPayment'] = async (
   const {
     livemode,
     metadata: {orgId}
-  } = await manager.retrieveCustomer(customerId)
+  } = (await manager.retrieveCustomer(customerId)) as Stripe.Customer
   const org = await r.table('Organization').get(orgId).run()
   if (!org || !orgId) {
     if (livemode) {

--- a/packages/server/graphql/private/mutations/stripeUpdateInvoiceItem.ts
+++ b/packages/server/graphql/private/mutations/stripeUpdateInvoiceItem.ts
@@ -9,7 +9,7 @@ import {MutationResolvers} from '../resolverTypes'
 
 const MAX_STRIPE_DELAY = 3 // seconds
 
-const getPossibleHooks = async (invoiceItem: Stripe.invoiceItems.InvoiceItem) => {
+const getPossibleHooks = async (invoiceItem: Stripe.InvoiceItem) => {
   const r = await getRethink()
   const {
     subscription,
@@ -49,9 +49,7 @@ const getBestHook = (possibleHooks: InvoiceItemHook[]) => {
   return firstHook
 }
 
-const tagInvoiceItemWithHook = async (
-  invoiceItem: Stripe.invoiceItems.InvoiceItem
-): Promise<boolean> => {
+const tagInvoiceItemWithHook = async (invoiceItem: Stripe.InvoiceItem): Promise<boolean> => {
   const r = await getRethink()
   const {id: invoiceItemId, amount} = invoiceItem
   const isRefund = amount < 0

--- a/packages/server/graphql/private/mutations/stripeUpdateInvoiceItem.ts
+++ b/packages/server/graphql/private/mutations/stripeUpdateInvoiceItem.ts
@@ -28,7 +28,7 @@ const getPossibleHooks = async (invoiceItem: Stripe.invoiceItems.InvoiceItem) =>
       [quantityName]: quantity,
       stripeSubscriptionId: subscription as string
     })
-    .filter((row) => row(invoiceItemName).default(null).eq(null))
+    .filter((row: RValue) => row(invoiceItemName).default(null).eq(null))
     .orderBy(r.desc('prorationDate'))
     .run()
   if (proratedHooks.length) return proratedHooks
@@ -36,7 +36,7 @@ const getPossibleHooks = async (invoiceItem: Stripe.invoiceItems.InvoiceItem) =>
     .table('InvoiceItemHook')
     .getAll(subscription as string, {index: 'stripeSubscriptionId'})
     .filter({[quantityName]: quantity, isProrated: false})
-    .filter((row) => row(invoiceItemName).default(null).eq(null))
+    .filter((row: RValue) => row(invoiceItemName).default(null).eq(null))
     .orderBy(r.desc('createdAt'))
     .run()
 }

--- a/packages/server/graphql/private/mutations/toggleAllowInsights.ts
+++ b/packages/server/graphql/private/mutations/toggleAllowInsights.ts
@@ -1,4 +1,4 @@
-import {r} from 'rethinkdb-ts'
+import {r, RValue} from 'rethinkdb-ts'
 import {getUsersByEmails} from '../../../postgres/queries/getUsersByEmails'
 import {MutationResolvers} from '../resolverTypes'
 
@@ -30,7 +30,7 @@ const toggleAllowInsights: MutationResolvers['toggleAllowInsights'] = async (
         .filter({
           userId
         })
-        .filter((row) => row('removedAt').default(null).eq(null))
+        .filter((row: RValue) => row('removedAt').default(null).eq(null))
         .update({suggestedTier})('replaced')
         .run()
     })

--- a/packages/server/graphql/private/mutations/updateOrgFeatureFlag.ts
+++ b/packages/server/graphql/private/mutations/updateOrgFeatureFlag.ts
@@ -1,3 +1,4 @@
+import {RValue} from 'rethinkdb-ts'
 import getRethink from '../../../database/rethinkDriver'
 import {MutationResolvers} from '../resolverTypes'
 
@@ -20,13 +21,13 @@ const updateOrgFeatureFlag: MutationResolvers['updateOrgFeatureFlag'] = async (
     .table('Organization')
     .getAll(r.args(orgIds))
     .update(
-      (row) => ({
+      (row: RValue) => ({
         featureFlags: r.branch(
           addFlag,
           row('featureFlags').default([]).setInsert(flag),
           row('featureFlags')
             .default([])
-            .filter((featureFlag) => featureFlag.ne(flag))
+            .filter((featureFlag: RValue) => featureFlag.ne(flag))
         )
       }),
       {returnChanges: true}

--- a/packages/server/graphql/private/mutations/updateWatchlist.ts
+++ b/packages/server/graphql/private/mutations/updateWatchlist.ts
@@ -6,8 +6,7 @@ import {MutationResolvers} from '../resolverTypes'
 
 const updateWatchlist: MutationResolvers['updateWatchlist'] = async (
   _source,
-  {includeInWatchlist, emails, domain},
-  {authToken}
+  {includeInWatchlist, emails, domain}
 ) => {
   // RESOLUTION
   const users = [] as User[]

--- a/packages/server/graphql/private/queries/dailyPulse.ts
+++ b/packages/server/graphql/private/queries/dailyPulse.ts
@@ -1,3 +1,4 @@
+import {RValue} from '../../../database/stricterR'
 import getRethink from '../../../database/rethinkDriver'
 import getPg from '../../../postgres/getPg'
 import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
@@ -80,7 +81,7 @@ const dailyPulse: QueryResolvers['dailyPulse'] = async (_source, {after, email, 
   const slackAuth = await r
     .table('SlackAuth')
     .getAll(userId, {index: 'userId'})
-    .filter((row) => row('botAccessToken').default(null).ne(null))
+    .filter((row: RValue) => row('botAccessToken').default(null).ne(null))
     .nth(0)
     .default(null)
     .run()

--- a/packages/server/graphql/private/queries/pingActionTick.ts
+++ b/packages/server/graphql/private/queries/pingActionTick.ts
@@ -1,6 +1,6 @@
 import {QueryResolvers} from '../resolverTypes'
 
-const pingActionTick: QueryResolvers['pingActionTick'] = async (_source, _args, {authToken}) => {
+const pingActionTick: QueryResolvers['pingActionTick'] = async () => {
   return 'pong!'
 }
 

--- a/packages/server/graphql/private/queries/suProOrgInfo.ts
+++ b/packages/server/graphql/private/queries/suProOrgInfo.ts
@@ -12,7 +12,7 @@ const suProOrgInfo: QueryResolvers['suProOrgInfo'] = async (_source, {includeIna
         .table('OrganizationUser')
         .getAll(organization('id'), {index: 'orgId'})
         .filter({removedAt: null})
-        .filter((user) => r.branch(includeInactive, true, user('inactive').not()))
+        .filter((user: RValue) => r.branch(includeInactive, true, user('inactive').not()))
         .count()
     }))
     .filter((org: RValue) => r.branch(includeInactive, true, org('users').ge(1)))

--- a/packages/server/graphql/private/queries/user.ts
+++ b/packages/server/graphql/private/queries/user.ts
@@ -5,7 +5,7 @@ const user: QueryResolvers['user'] = async (_source, {email, userId}, {dataLoade
   if (email) {
     return getUserByEmail(email)
   }
-  return dataLoader.get('users').load(userId)
+  return (userId && (await dataLoader.get('users').load(userId))) || null
 }
 
 export default user

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -259,7 +259,7 @@ type Mutation {
     """
     the userId to disconnect
     """
-    userId: ID
+    userId: ID!
   ): DisconnectSocketPayload
 
   """
@@ -344,7 +344,7 @@ type Mutation {
     """
     List of teams to target
     """
-    teamIds: [ID]!
+    teamIds: [ID!]!
 
     """
     true to unlock the teams, false to lock

--- a/packages/server/graphql/public/mutations/acceptRequestToJoinDomain.ts
+++ b/packages/server/graphql/public/mutations/acceptRequestToJoinDomain.ts
@@ -82,6 +82,9 @@ const acceptRequestToJoinDomain: MutationResolvers['acceptRequestToJoinDomain'] 
   }
 
   const user = await getUserById(createdBy)
+  if (!user) {
+    return standardError(new Error('User not found'))
+  }
 
   const {id: userId} = user
 
@@ -113,6 +116,9 @@ const acceptRequestToJoinDomain: MutationResolvers['acceptRequestToJoinDomain'] 
 
   // Send the new team member a welcome & a new token
   const updatedUser = await getUserById(createdBy)
+  if (!updatedUser) {
+    return standardError(new Error('User not found'))
+  }
   publish(SubscriptionChannel.NOTIFICATION, userId, 'AuthTokenPayload', {tms: updatedUser.tms})
 
   validTeams.forEach((team) => {

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -23,11 +23,6 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   {invitationToken, notificationId},
   {authToken, dataLoader, socketId: mutatorId}
 ) => {
-  // AUTH WORKAROUND
-  if (!isAuthenticated(authToken) || !invitationToken) {
-    // Workaround for https://github.com/zalando-incubator/graphql-jit/issues/171
-    return {}
-  }
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
   const viewerId = getUserId(authToken)
@@ -43,7 +38,7 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   if (invitationRes.error) {
     const {error: message, teamId, meetingId} = invitationRes
     if (message === InvitationTokenError.ALREADY_ACCEPTED) {
-      return {error: {message}, teamId, meetingId, teamMemberId: toTeamMemberId(teamId, viewerId)}
+      return {error: {message}, teamId, meetingId, teamMemberId: toTeamMemberId(teamId!, viewerId)}
     }
     return {error: {message}}
   }

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -7,7 +7,7 @@ import {
 import AuthToken from '../../../database/types/AuthToken'
 import acceptTeamInvitationSafe from '../../../safeMutations/acceptTeamInvitation'
 import {analytics} from '../../../utils/analytics/analytics'
-import {getUserId, isAuthenticated} from '../../../utils/authorization'
+import {getUserId} from '../../../utils/authorization'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
 import publish from '../../../utils/publish'
 import RedisLock from '../../../utils/RedisLock'

--- a/packages/server/graphql/public/mutations/addApprovedOrganizationDomains.ts
+++ b/packages/server/graphql/public/mutations/addApprovedOrganizationDomains.ts
@@ -12,9 +12,9 @@ const addApprovedOrganizationDomains: MutationResolvers['addApprovedOrganization
 
   // VALIDATION
   const normalizedEmailDomains = emailDomains.map((domain) => domain.toLowerCase().trim())
-  const invalidEmailDomain = normalizedEmailDomains.find((domain) => {
-    if (!emailRegex.test(domain) && !domainRegex.test(domain)) return true
-  })
+  const invalidEmailDomain = normalizedEmailDomains.find(
+    (domain) => !emailRegex.test(domain) && !domainRegex.test(domain)
+  )
   if (invalidEmailDomain) {
     return {error: {message: `${invalidEmailDomain} is not a valid domain or email`}}
   }

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -1,3 +1,4 @@
+import MeetingRetrospective from '../../../database/types/MeetingRetrospective'
 import {getUserId, isTeamMember} from '../../../utils/authorization'
 import standardError from '../../../utils/standardError'
 import {GQLContext} from '../../graphql'
@@ -19,7 +20,7 @@ const autogroup: MutationResolvers['autogroup'] = async (
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
 
-  const {meetingType, autogroupReflectionGroups, teamId} = meeting
+  const {meetingType, autogroupReflectionGroups, teamId} = meeting as MeetingRetrospective
   if (!autogroupReflectionGroups) {
     return standardError(new Error('No autogroup reflection groups found'), {userId: viewerId})
   }
@@ -37,6 +38,9 @@ const autogroup: MutationResolvers['autogroup'] = async (
       const {groupTitle, reflectionIds} = group
       const reflectionsInGroup = reflections.filter(({id}) => reflectionIds.includes(id))
       const firstReflectionInGroup = reflectionsInGroup[0]
+      if (!firstReflectionInGroup) {
+        return []
+      }
       return reflectionsInGroup.map((reflection) =>
         addReflectionToGroup(
           reflection.id,

--- a/packages/server/graphql/public/mutations/createStripeSubscription.ts
+++ b/packages/server/graphql/public/mutations/createStripeSubscription.ts
@@ -16,7 +16,7 @@ const createStripeSubscription: MutationResolvers['createStripeSubscription'] = 
   const r = await getRethink()
 
   const [viewer, organization, orgUsersCount, organizationUser] = await Promise.all([
-    dataLoader.get('users').load(viewerId),
+    dataLoader.get('users').loadNonNull(viewerId),
     dataLoader.get('organizations').load(orgId),
     r
       .table('OrganizationUser')

--- a/packages/server/graphql/public/mutations/requestToJoinDomain.ts
+++ b/packages/server/graphql/public/mutations/requestToJoinDomain.ts
@@ -15,7 +15,7 @@ const REQUEST_EXPIRATION_DAYS = 30
 const requestToJoinDomain: MutationResolvers['requestToJoinDomain'] = async (
   _source,
   {},
-  {authToken, dataLoader, socketId: mutatorId}
+  {authToken, dataLoader}
 ) => {
   const r = await getRethink()
   const operationId = dataLoader.share()
@@ -50,7 +50,7 @@ const requestToJoinDomain: MutationResolvers['requestToJoinDomain'] = async (
 
   const teamIds = await getTeamIdsByOrgIds(orgIds)
 
-  const leadUserIds = await r
+  const leadUserIds = (await r
     .table('TeamMember')
     .getAll(r.args(teamIds), {index: 'teamId'})
     .filter({
@@ -59,7 +59,7 @@ const requestToJoinDomain: MutationResolvers['requestToJoinDomain'] = async (
     })
     .pluck('userId')
     .distinct()('userId')
-    .run()
+    .run()) as string[]
 
   const notificationsToInsert = leadUserIds.map((userId) => {
     return new NotificationRequestToJoinOrg({

--- a/packages/server/graphql/public/mutations/setMeetingSettings.ts
+++ b/packages/server/graphql/public/mutations/setMeetingSettings.ts
@@ -7,6 +7,7 @@ import {getUserId} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import RecallAIServerManager from '../../../utils/RecallAIServerManager'
 import standardError from '../../../utils/standardError'
+import {MutationResolvers} from '../resolverTypes'
 
 const getBotId = async (videoMeetingURL?: string | null) => {
   if (!videoMeetingURL) return null

--- a/packages/server/graphql/public/mutations/setOrgUserRole.ts
+++ b/packages/server/graphql/public/mutations/setOrgUserRole.ts
@@ -59,8 +59,14 @@ const setOrgUserRole: MutationResolvers['setOrgUserRole'] = async (
     .filter({orgId, removedAt: null})
     .nth(0)
     .run()
-  if (organizationUser.role === role) return null
   const {id: organizationUserId} = organizationUser
+  if (organizationUser.role === role) {
+    return {
+      orgId,
+      organizationUserId,
+      notificationIdsAdded: []
+    }
+  }
   await r.table('OrganizationUser').get(organizationUserId).update({role}).run()
 
   const modificationType = role === 'BILLING_LEADER' ? 'add' : 'remove'

--- a/packages/server/graphql/public/mutations/updateGitLabDimensionField.ts
+++ b/packages/server/graphql/public/mutations/updateGitLabDimensionField.ts
@@ -31,7 +31,7 @@ const updateGitLabDimensionField: MutationResolvers['updateGitLabDimensionField'
   }
   const viewerId = getUserId(authToken)
   const gitlabAuth = await dataLoader.get('freshGitlabAuth').load({teamId, userId: viewerId})
-  if (!gitlabAuth.providerId) return {error: {message: 'Invalid dimension name'}}
+  if (!gitlabAuth?.providerId) return {error: {message: 'Invalid dimension name'}}
 
   // TODO validate labelTemplate
 

--- a/packages/server/graphql/public/mutations/updateJiraDimensionField.ts
+++ b/packages/server/graphql/public/mutations/updateJiraDimensionField.ts
@@ -53,7 +53,7 @@ const updateJiraDimensionField: MutationResolvers['updateJiraDimensionField'] = 
   }
   const {integration} = task
   const service = integration?.service
-  if (service !== 'jira') {
+  if (!integration || service !== 'jira') {
     return {error: {message: 'Not a Jira task'}}
   }
 

--- a/packages/server/graphql/public/mutations/updateJiraServerDimensionField.ts
+++ b/packages/server/graphql/public/mutations/updateJiraServerDimensionField.ts
@@ -1,5 +1,4 @@
 import {SprintPokerDefaults, SubscriptionChannel} from 'parabol-client/types/constEnums'
-import getRethink from '../../../database/rethinkDriver'
 import MeetingPoker from '../../../database/types/MeetingPoker'
 import JiraServerRestManager from '../../../integrations/jiraServer/JiraServerRestManager'
 import {IntegrationProviderJiraServer} from '../../../postgres/queries/getIntegrationProvidersByIds'
@@ -13,7 +12,6 @@ const updateJiraServerDimensionField: MutationResolvers['updateJiraServerDimensi
   {dimensionName, issueType, fieldName, projectId, meetingId},
   {authToken, dataLoader, socketId: mutatorId}
 ) => {
-  const r = await getRethink()
   const operationId = dataLoader.share()
   const viewerId = getUserId(authToken)
   const subOptions = {mutatorId, operationId}

--- a/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
+++ b/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
@@ -1,6 +1,6 @@
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {getRRuleDateFromJSDate, getJSDateFromRRuleDate} from 'parabol-client/shared/rruleUtil'
-import {RRule, datetime} from 'rrule'
+import {RRule} from 'rrule'
 import getRethink from '../../../database/rethinkDriver'
 import {insertMeetingSeries as insertMeetingSeriesQuery} from '../../../postgres/queries/insertMeetingSeries'
 import restartMeetingSeries from '../../../postgres/queries/restartMeetingSeries'
@@ -25,7 +25,7 @@ export const startNewMeetingSeries = async (
 
   const newMeetingSeriesParams = {
     meetingType: 'teamPrompt',
-    title: meetingSeriesName || meetingName.split('-')[0].trim(), // if no name is provided, we use the name of the first meeting without the date
+    title: meetingSeriesName || meetingName.split('-')[0]!.trim(), // if no name is provided, we use the name of the first meeting without the date
     recurrenceRule: recurrenceRule.toString(),
     // TODO: once we have to UI ready, we should set and handle it properly, for now meeting will last till the new meeting starts
     duration: 0,

--- a/packages/server/graphql/public/permissions.ts
+++ b/packages/server/graphql/public/permissions.ts
@@ -28,9 +28,7 @@ export type PermissionMap<T> = {
 const permissionMap: PermissionMap<Resolvers> = {
   Mutation: {
     '*': isAuthenticated,
-    // Bug in graphql-jit means it will always get called
-    // https://github.com/zalando-incubator/graphql-jit/issues/171
-    acceptTeamInvitation: and(/* isAuthenticated, */ rateLimit({perMinute: 50, perHour: 100})),
+    acceptTeamInvitation: and(isAuthenticated, rateLimit({perMinute: 50, perHour: 100})),
     createImposterToken: isSuperUser,
     loginWithGoogle: and(
       not(isEnvVarTrue('AUTH_GOOGLE_DISABLED')),

--- a/packages/server/graphql/public/typeDefs/updateGitLabDimensionField.graphql
+++ b/packages/server/graphql/public/typeDefs/updateGitLabDimensionField.graphql
@@ -6,19 +6,19 @@ extend type Mutation {
     """
     The Poker dimension that we're updating, e.g. story points
     """
-    dimensionName: String
+    dimensionName: String!
     """
     The template string to map to a label, e.g. __comment
     """
-    labelTemplate: String
+    labelTemplate: String!
     """
     The meeting the update happend in. Returns a meeting object with updated serviceField.
     """
-    meetingId: ID
+    meetingId: ID!
     """
     The id of the project the issue belongs to
     """
-    projectId: Int
+    projectId: Int!
   ): UpdateGitLabDimensionFieldPayload!
 }
 

--- a/packages/server/graphql/public/types/AcceptTeamInvitationPayload.ts
+++ b/packages/server/graphql/public/types/AcceptTeamInvitationPayload.ts
@@ -6,20 +6,20 @@ import isValid from '../../isValid'
 import {AcceptTeamInvitationPayloadResolvers} from '../resolverTypes'
 
 export type AcceptTeamInvitationPayloadSource = {
-  meetingId: string | undefined | null
-  teamId: string
-  teamMemberId: string
-  invitationNotificationIds: string[]
+  meetingId?: string
+  teamId?: string
+  teamMemberId?: string
+  invitationNotificationIds?: string[]
   authToken?: string
   teamLeadId?: string
 }
 
 const AcceptTeamInvitationPayload: AcceptTeamInvitationPayloadResolvers = {
   team: ({teamId}, _args, {dataLoader}: GQLContext) => {
-    return dataLoader.get('teams').loadNonNull(teamId)
+    return teamId ? dataLoader.get('teams').loadNonNull(teamId) : null
   },
   teamMember: async ({teamMemberId}, _args, {dataLoader}: GQLContext) => {
-    return dataLoader.get('teamMembers').load(teamMemberId)
+    return teamMemberId ? dataLoader.get('teamMembers').load(teamMemberId) : null
   },
   meeting: async ({meetingId}, _args, {dataLoader, authToken}) => {
     if (!meetingId) {
@@ -40,6 +40,9 @@ const AcceptTeamInvitationPayload: AcceptTeamInvitationPayloadResolvers = {
   },
 
   notifications: async ({invitationNotificationIds}, _args, {dataLoader}) => {
+    if (!invitationNotificationIds) {
+      return null
+    }
     const teamInvitationNotifications = (
       await dataLoader.get('notifications').loadMany(invitationNotificationIds)
     ).filter(isValid) as NotificationTeamInvitation[]

--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -9,7 +9,7 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
   issues: async ({teamId, userId, accessToken, cloudIds}, args, {authToken}) => {
     const {first, queryString, isJQL, projectKeyFilters} = args
     const viewerId = getUserId(authToken)
-    if (viewerId !== userId) {
+    if (viewerId !== userId || !accessToken) {
       const err = new Error('Cannot access another team members issues')
       standardError(err, {tags: {teamId, userId}, userId: viewerId})
       return connectionFromTasks([], 0, err)
@@ -28,7 +28,7 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
         projectKeyFiltersByCloudId[cloudId] = []
       })
     }
-    const issueRes = await manager.getIssues(queryString, isJQL, projectKeyFiltersByCloudId)
+    const issueRes = await manager.getIssues(queryString ?? null, isJQL, projectKeyFiltersByCloudId)
     const {error, issues} = issueRes
     const mappedIssues = issues.map((issue) => {
       const {updatedDescription, imageUrlToHash} = updateJiraImageUrls(

--- a/packages/server/graphql/public/types/DomainJoinRequest.ts
+++ b/packages/server/graphql/public/types/DomainJoinRequest.ts
@@ -3,6 +3,7 @@ import {getUserId} from '../../../utils/authorization'
 import DomainJoinRequestId from 'parabol-client/shared/gqlIds/DomainJoinRequestId'
 import {GQLContext} from '../../graphql'
 import getRethink from '../../../database/rethinkDriver'
+import isValid from '../../isValid'
 
 const DomainJoinRequest: DomainJoinRequestResolvers = {
   id: ({id}) => {
@@ -29,7 +30,7 @@ const DomainJoinRequest: DomainJoinRequestResolvers = {
       .run()
 
     const leadTeamIds = leadTeamMembers.map((teamMember) => teamMember.teamId)
-    const leadTeams = await dataLoader.get('teams').loadMany(leadTeamIds)
+    const leadTeams = (await dataLoader.get('teams').loadMany(leadTeamIds)).filter(isValid)
     const validOrgIds = await r
       .table('Organization')
       .getAll(r.args(leadTeams.map((team) => team.orgId)))

--- a/packages/server/graphql/public/types/JiraIssue.ts
+++ b/packages/server/graphql/public/types/JiraIssue.ts
@@ -2,6 +2,14 @@ import JiraIssueId from '../../../../client/shared/gqlIds/JiraIssueId'
 import JiraProjectKeyId from '../../../../client/shared/gqlIds/JiraProjectKeyId'
 import {JiraIssueResolvers} from '../resolverTypes'
 
+export type JiraIssueSource = {
+  cloudId: string
+  issueKey: string
+  teamId: string
+  userId: string
+  description?: string
+}
+
 const JiraIssue: JiraIssueResolvers = {
   __isTypeOf: ({cloudId, issueKey}) => !!(cloudId && issueKey),
   id: ({cloudId, issueKey}) => {
@@ -20,13 +28,15 @@ const JiraIssue: JiraIssueResolvers = {
     const jiraRemoteProjectRes = await dataLoader
       .get('jiraRemoteProject')
       .load({cloudId, projectKey, teamId, userId})
-    return {
-      ...jiraRemoteProjectRes,
-      service: 'jira',
-      cloudId,
-      userId,
-      teamId
-    }
+    return jiraRemoteProjectRes
+      ? {
+          ...jiraRemoteProjectRes,
+          service: 'jira',
+          cloudId,
+          userId,
+          teamId
+        }
+      : null
   },
   description: ({description}) => (description ? JSON.stringify(description) : '')
 }

--- a/packages/server/graphql/public/types/MeetingSeries.ts
+++ b/packages/server/graphql/public/types/MeetingSeries.ts
@@ -18,7 +18,7 @@ const MeetingSeries: MeetingSeriesResolvers = {
       .orderBy((doc) => (doc('endedAt') ? 0 : 1), r.desc('createdAt'))
       .limit(1)
       .run()
-    return meetings[0]
+    return meetings[0]!
   }
 }
 

--- a/packages/server/graphql/public/types/NotifyResponseReplied.ts
+++ b/packages/server/graphql/public/types/NotifyResponseReplied.ts
@@ -8,7 +8,7 @@ const NotifyResponseReplied: NotifyResponseRepliedResolvers = {
     const meeting = await dataLoader.get('newMeetings').load(meetingId)
     return meeting as MeetingTeamPrompt
   },
-  response: async ({userId, meetingId}, _args: unknown, {dataLoader}) => {
+  response: async ({userId, meetingId}) => {
     // TODO: implement getTeamPromptResponsesByMeetingIdAndUserId
     const responses = await getTeamPromptResponsesByMeetingId(meetingId)
     return responses.find(({userId: responseUserId}) => responseUserId === userId)!

--- a/packages/server/graphql/public/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/public/types/TeamPromptMeeting.ts
@@ -4,7 +4,7 @@ import getRethink from '../../../database/rethinkDriver'
 import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 import {getUserId} from '../../../utils/authorization'
 import filterTasksByMeeting from '../../../utils/filterTasksByMeeting'
-import {RValue} from 'rethinkdb-ts'
+import {RValue} from '../../../database/stricterR'
 
 const TeamPromptMeeting: TeamPromptMeetingResolvers = {
   meetingSeriesId: ({meetingSeriesId}, _args, _context) => {

--- a/packages/server/graphql/public/types/TeamPromptMeeting.ts
+++ b/packages/server/graphql/public/types/TeamPromptMeeting.ts
@@ -4,6 +4,7 @@ import getRethink from '../../../database/rethinkDriver'
 import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 import {getUserId} from '../../../utils/authorization'
 import filterTasksByMeeting from '../../../utils/filterTasksByMeeting'
+import {RValue} from 'rethinkdb-ts'
 
 const TeamPromptMeeting: TeamPromptMeetingResolvers = {
   meetingSeriesId: ({meetingSeriesId}, _args, _context) => {
@@ -36,7 +37,7 @@ const TeamPromptMeeting: TeamPromptMeetingResolvers = {
       .table('NewMeeting')
       .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
       .filter({meetingType: 'teamPrompt'})
-      .filter((row) => row('createdAt').lt(createdAt))
+      .filter((row: RValue) => row('createdAt').lt(createdAt))
       .orderBy(r.desc('createdAt'))
       .limit(1)
       .run()
@@ -56,7 +57,7 @@ const TeamPromptMeeting: TeamPromptMeetingResolvers = {
       .table('NewMeeting')
       .getAll(meetingSeriesId, {index: 'meetingSeriesId'})
       .filter({meetingType: 'teamPrompt'})
-      .filter((doc) => doc('createdAt').gt(createdAt))
+      .filter((doc: RValue) => doc('createdAt').gt(createdAt))
       .orderBy(r.asc('createdAt'))
       .limit(1)
       .run()

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -120,7 +120,7 @@ const User: UserResolvers = {
     )
     const allUserActivities = userActivities.flat()
     if (!__PRODUCTION__) {
-      if (parabolActivities.length + allUserActivities.length > first) {
+      if (parabolActivities!.length + allUserActivities.length > first) {
         throw new Error(
           'Please implement pagination for User.activities or increase `first` for the query'
         )
@@ -149,7 +149,7 @@ const User: UserResolvers = {
 
       return score
     }
-    const allActivities = [...parabolActivities, ...allUserActivities]
+    const allActivities = [...parabolActivities!, ...allUserActivities]
       .map((activity) => ({
         ...activity,
         sortOrder: getScore(activity, teamIds)

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -42,7 +42,7 @@ const User: UserResolvers = {
       case 'Organization':
         const organizationUser = await dataLoader
           .get('organizationUsersByUserIdOrgId')
-          .load({userId: viewerId, id})
+          .load({userId: viewerId, orgId: id})
         return !!organizationUser
       default:
         return false

--- a/packages/server/graphql/queries/archivedTasks.ts
+++ b/packages/server/graphql/queries/archivedTasks.ts
@@ -1,5 +1,6 @@
 import {GraphQLID, GraphQLInt, GraphQLNonNull} from 'graphql'
 import getRethink from '../../database/rethinkDriver'
+import {RValue} from '../../database/stricterR'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import standardError from '../../utils/standardError'
 import GraphQLISO8601Type from '../types/GraphQLISO8601Type'
@@ -44,7 +45,7 @@ export default {
       .between([teamId, r.minval], [teamId, dbAfter], {
         index: 'teamIdUpdatedAt'
       })
-      .filter((task) =>
+      .filter((task: RValue) =>
         task('tags')
           .contains('archived')
           .and(

--- a/packages/server/graphql/queries/archivedTasksCount.ts
+++ b/packages/server/graphql/queries/archivedTasksCount.ts
@@ -1,7 +1,9 @@
 import {GraphQLID, GraphQLInt, GraphQLNonNull} from 'graphql'
 import getRethink from '../../database/rethinkDriver'
+import {RValue} from '../../database/stricterR'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import standardError from '../../utils/standardError'
+import {GQLContext} from '../graphql'
 
 export default {
   type: GraphQLInt,
@@ -11,7 +13,7 @@ export default {
       description: 'The unique team ID'
     }
   },
-  async resolve(_source: unknown, {teamId}, {authToken}) {
+  async resolve(_source: unknown, {teamId}: {teamId: string}, {authToken}: GQLContext) {
     const r = await getRethink()
     const viewerId = getUserId(authToken)
 
@@ -29,7 +31,7 @@ export default {
       .between([teamId, r.minval], [teamId, r.maxval], {
         index: 'teamIdUpdatedAt'
       })
-      .filter((task) =>
+      .filter((task: RValue) =>
         task('tags')
           .contains('archived')
           .and(

--- a/packages/server/graphql/queries/notifications.ts
+++ b/packages/server/graphql/queries/notifications.ts
@@ -2,8 +2,9 @@ import {GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphq
 import getRethink from '../../database/rethinkDriver'
 import {RDatum} from '../../database/stricterR'
 import {getUserId} from '../../utils/authorization'
+import {GQLContext} from '../graphql'
 import GraphQLISO8601Type from '../types/GraphQLISO8601Type'
-import NotificationEnum from '../types/NotificationEnum'
+import NotificationEnum, {NotificationEnumType} from '../types/NotificationEnum'
 
 export default {
   type: new GraphQLNonNull(new GraphQLObjectType({name: 'NotificationConnection', fields: {}})),
@@ -20,7 +21,11 @@ export default {
     }
   },
   description: 'all the notifications for a single user',
-  resolve: async (_source: unknown, {first, after, types}, {authToken}) => {
+  resolve: async (
+    _source: unknown,
+    {first, after, types}: {first: number; after: Date; types: NotificationEnumType},
+    {authToken}: GQLContext
+  ) => {
     const r = await getRethink()
     // AUTH
     const userId = getUserId(authToken)

--- a/packages/server/graphql/queries/team.ts
+++ b/packages/server/graphql/queries/team.ts
@@ -1,5 +1,5 @@
 import {GraphQLID, GraphQLNonNull, GraphQLResolveInfo} from 'graphql'
-import {getUserId, isPrivateSchema, isSuperUser, isTeamMember} from '../../utils/authorization'
+import {getUserId, isSuperUser, isTeamMember} from '../../utils/authorization'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import Team from '../types/Team'
@@ -18,13 +18,13 @@ export default {
   },
   async resolve(
     _source: unknown,
-    {teamId},
+    {teamId}: {teamId: string},
     {authToken, dataLoader}: GQLContext,
     {operation}: GraphQLResolveInfo
   ) {
     if (!isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
       const viewerId = getUserId(authToken)
-      if (!HANDLED_OPS.includes(operation.name.value)) {
+      if (!HANDLED_OPS.includes(operation?.name?.value ?? '')) {
         standardError(new Error('Team not found'), {userId: viewerId})
       }
       return null

--- a/packages/server/graphql/types/SetMeetingSettingsPayload.ts
+++ b/packages/server/graphql/types/SetMeetingSettingsPayload.ts
@@ -3,7 +3,18 @@ import {GQLContext} from '../graphql'
 import StandardMutationError from './StandardMutationError'
 import TeamMeetingSettings from './TeamMeetingSettings'
 
-const SetMeetingSettingsPayload = new GraphQLObjectType<any, GQLContext>({
+export type SetMeetingSettingsPayloadSource = {
+  error?: {
+    title?: string
+    message: string
+  }
+  settingsId?: string
+}
+
+const SetMeetingSettingsPayload = new GraphQLObjectType<
+  SetMeetingSettingsPayloadSource,
+  GQLContext
+>({
   name: 'SetMeetingSettingsPayload',
   fields: () => ({
     error: {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -103,7 +103,7 @@
     "emoji-mart": "^3.0.1",
     "fast-json-stable-stringify": "^2.1.0",
     "graphql": "15.7.2",
-    "graphql-jit": "^0.7.2",
+    "graphql-jit": "^0.7.4",
     "graphql-middleware": "^6.1.18",
     "graphql-relay": "^0.10.0",
     "graphql-shield": "^7.5.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -44,7 +44,6 @@
     "@types/relay-runtime": "^14.1.9",
     "@types/sharp": "^0.30.1",
     "@types/string-similarity": "^3.0.0",
-    "@types/stripe": "^6.32.0",
     "@types/uuid": "^8.3.3",
     "babel-plugin-relay": "^12.0.0",
     "clean-webpack-plugin": "^3.0.0",

--- a/packages/server/postgres/queries/updateMeetingTemplateFreeStatusById.ts
+++ b/packages/server/postgres/queries/updateMeetingTemplateFreeStatusById.ts
@@ -2,10 +2,11 @@ import getPg from '../getPg'
 
 const updateMeetingTemplateFreeStatusById = async (templateIds: string[], isFree: boolean) => {
   const pg = getPg()
-  return pg.query<string[]>(
+  const result = await pg.query<{id: string}>(
     `UPDATE "MeetingTemplate" SET "isFree" = $1 WHERE id in $2 RETURNING id;`,
     [isFree, templateIds]
   )
+  return result.rows.map(({id}) => id)
 }
 
 export default updateMeetingTemplateFreeStatusById

--- a/packages/server/postgres/queries/updateMeetingTemplateFreeStatusByName.ts
+++ b/packages/server/postgres/queries/updateMeetingTemplateFreeStatusByName.ts
@@ -2,10 +2,11 @@ import getPg from '../getPg'
 
 const updateMeetingTemplateFreeStatusByName = async (templateNames: string[], isFree: boolean) => {
   const pg = getPg()
-  return pg.query<string[]>(
+  const result = await pg.query<{id: string}>(
     `UPDATE "MeetingTemplate" SET "isFree" = $1 WHERE "teamId" = 'aGhostTeam' AND name LIKE ANY($2) RETURNING id;`,
     [isFree, templateNames]
   )
+  return result.rows.map(({id}) => id)
 }
 
 export default updateMeetingTemplateFreeStatusByName

--- a/packages/server/postgres/utils/checkEqBase.ts
+++ b/packages/server/postgres/utils/checkEqBase.ts
@@ -26,7 +26,7 @@ export const checkRowCount = async (tableName: string) => {
       .run(),
     pg.query<{count: number}>(`SELECT COUNT(*) FROM "${tableName}";`)
   ])
-  const pgCount = Number(pgRes.rows[0].count)
+  const pgCount = Number(pgRes?.rows[0]?.count)
   return rCount === pgCount
     ? `Row count matches. ${rCount} in both DBs.`
     : `Row count mismatch. RethinkDB: ${rCount}. PG: ${pgCount}`
@@ -66,7 +66,7 @@ export async function checkTableEq(
         const eqFn = equalityMap[prop]
         const rVal = rethinkRow[prop]
         const pgVal = pgRow[prop]
-        const isEqual = eqFn(rVal, pgVal)
+        const isEqual = eqFn?.(rVal, pgVal)
         if (!isEqual) {
           errors.push({id, prop, rVal, pgVal})
           if (errors.length >= maxErrors) return errors

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -33,7 +33,9 @@
   ],
   "include": [
     // TODO: make this into "graphql/**/*.ts" after fixing all the type errors
-    "graphql/public/types/*.ts"
+    "graphql/public/types/*.ts",
+    "graphql/private/types/*.ts",
+    "graphql/private/queries/*.ts"
   ]
 
   // if "include" or "files" is added, even if they are empty arrays, then strictNullChecks breaks

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -33,10 +33,8 @@
   ],
   "include": [
     // TODO: make this into "graphql/**/*.ts" after fixing all the type errors
-    "graphql/public/types/*.ts",
-    "graphql/private/types/*.ts",
-    "graphql/private/queries/*.ts",
-    "graphql/private/mutations/*.ts"
+    "graphql/public/**/*.ts",
+    "graphql/private/**/*.ts"
   ]
 
   // if "include" or "files" is added, even if they are empty arrays, then strictNullChecks breaks

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -33,8 +33,7 @@
   ],
   "include": [
     // TODO: make this into "graphql/**/*.ts" after fixing all the type errors
-    "graphql/public/**/*.ts",
-    "graphql/private/**/*.ts"
+    "graphql/**/*.ts",
   ]
 
   // if "include" or "files" is added, even if they are empty arrays, then strictNullChecks breaks

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -32,7 +32,6 @@
     "../client/modules/email/components/SummaryEmail/MeetingSummaryEmail/MeetingSummaryEmail.tsx"
   ],
   "include": [
-    // TODO: make this into "graphql/**/*.ts" after fixing all the type errors
     "graphql/**/*.ts",
   ]
 

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -30,6 +30,10 @@
     "types/modules.d.ts",
     "server.ts",
     "../client/modules/email/components/SummaryEmail/MeetingSummaryEmail/MeetingSummaryEmail.tsx"
+  ],
+  "include": [
+    // TODO: make this into "graphql/**/*.ts" after fixing all the type errors
+    "graphql/public/types/*.ts"
   ]
 
   // if "include" or "files" is added, even if they are empty arrays, then strictNullChecks breaks

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -35,7 +35,8 @@
     // TODO: make this into "graphql/**/*.ts" after fixing all the type errors
     "graphql/public/types/*.ts",
     "graphql/private/types/*.ts",
-    "graphql/private/queries/*.ts"
+    "graphql/private/queries/*.ts",
+    "graphql/private/mutations/*.ts"
   ]
 
   // if "include" or "files" is added, even if they are empty arrays, then strictNullChecks breaks

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -30,6 +30,7 @@ export type OrgTierChangeEventProperties = {
   newTier: string
   reasonsForLeaving?: ReasonToDowngradeEnum[]
   otherTool?: string
+  billingLeaderEmail?: string
 }
 
 export type TaskProperties = {

--- a/packages/server/utils/isRequestToJoinDomainAllowed.ts
+++ b/packages/server/utils/isRequestToJoinDomainAllowed.ts
@@ -18,8 +18,8 @@ export const getEligibleOrgIdsByDomain = async (
   return r
     .table('Organization')
     .getAll(activeDomain, {index: 'activeDomain'})
-    .filter((org) => org('featureFlags').contains('promptToJoinOrg'))
-    .filter((org) =>
+    .filter((org: RDatum) => org('featureFlags').contains('promptToJoinOrg'))
+    .filter((org: RDatum) =>
       r
         .table('OrganizationUser')
         .getAll(org('id'), {index: 'orgId'})
@@ -29,7 +29,7 @@ export const getEligibleOrgIdsByDomain = async (
           orgUsers
             .count()
             .gt(1)
-            .and(orgUsers.filter((ou) => ou('userId').eq(viewerId)).isEmpty())
+            .and(orgUsers.filter((ou: RDatum) => ou('userId').eq(viewerId)).isEmpty())
         )
     )
     .limit(limit ?? BIG_ENOUGH_LIMIT)('id')

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,13 +7709,6 @@
   resolved "https://registry.yarnpkg.com/@types/stripe-v2/-/stripe-v2-2.0.2.tgz#b174b75342f537f36c8ba0e91164b719c14397b5"
   integrity sha512-YhXpV+x01wAmI44mBAKLGmeJ6q8iY9+cmwAXwfeXuNATSMgIwoB8ZsCgX4SvgQ3GiYot68ekiGnMrxDjY4beYg==
 
-"@types/stripe@^6.32.0":
-  version "6.32.13"
-  resolved "https://registry.yarnpkg.com/@types/stripe/-/stripe-6.32.13.tgz#d292ce2e7f4b9530fc144d00d3746a19a2fe9fc8"
-  integrity sha512-qMcM3ecF/4a0dtfMN2rm1w5TjSDzUqIIADI7BwXpkSUdXfekc4JjL2s7oAp9htB44nPsTYw5mxCCz9j1zTAXwA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/tapable@^1":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
@@ -9338,9 +9331,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001359, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449, caniuse-lite@~1.0.0:
-  version "1.0.30001502"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz#f7e4a76eb1d2d585340f773767be1fefc118dca8"
-  integrity sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==
+  version "1.0.30001506"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz#35bd814b310a487970c585430e9e80ee23faf14b"
+  integrity sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==
 
 capital-case@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4417,11 +4417,6 @@
     tslib "^2.4.0"
     value-or-promise "1.0.12"
 
-"@graphql-typed-document-node/core@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
-
 "@graphql-typed-document-node/core@3.1.1", "@graphql-typed-document-node/core@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
@@ -11701,7 +11696,7 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-sta
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-json-stringify@^1.13.0:
+fast-json-stringify@^1.21.0:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-1.21.0.tgz#51bc8c6d77d8c7b2cc7e5fa754f7f909f9e1262f"
   integrity sha512-xY6gyjmHN3AK1Y15BCbMpeO9+dea5ePVsp3BouHCdukcx0hOHbXwFhRodhcI0NpZIgDChSeAKkHW9YjKvhwKBA==
@@ -12498,13 +12493,13 @@ graphql-executor@0.0.22:
   resolved "https://registry.yarnpkg.com/graphql-executor/-/graphql-executor-0.0.22.tgz#14bc466bb27ab38346998e0b375cba55685eed94"
   integrity sha512-WbKSnSHFn6REKKH4T6UAwDM3mLUnYMQlQLNG0Fw+Lkb3ilCnL3m5lkJ7411LAI9sF7BvPbthovVZhsEUh9Xfag==
 
-graphql-jit@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/graphql-jit/-/graphql-jit-0.7.2.tgz#8cf08863c22377ea4a0c4b3c12a258f3c94934ca"
-  integrity sha512-u+FuMCBZfoB0v8Iw6blh+D3Feke2m6hS1TFhStJcLTCOyH+KmJPo3XCFJC5QLHxqT+PJEfyf0S+zKJUZjZrhsg==
+graphql-jit@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/graphql-jit/-/graphql-jit-0.7.4.tgz#bc8ccf79596d13dff3835902a466f9a5ecc3a8c1"
+  integrity sha512-kWyHmsQtKMD6xcKDgf4dgPLyIZhviqA6IWGdnA0ElL9wgrIOTxf3eI4c0/U3tnoAU3t09zliVCfDkfIptzYjIA==
   dependencies:
-    "@graphql-typed-document-node/core" "3.1.0"
-    fast-json-stringify "^1.13.0"
+    "@graphql-typed-document-node/core" "^3.1.1"
+    fast-json-stringify "^1.21.0"
     generate-function "^2.3.1"
     json-schema "^0.4.0"
     lodash.memoize "^4.1.2"


### PR DESCRIPTION
# Description

There was an error in the `canAccess` field which should have been caught by `yarn typecheck`. Looking into this, it turned out that we did not run any typecheck on the `server/graphql` sources.

## Testing scenarios

- Full release test

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
