### PR TITLE
feat(AL): Activity subsections for retros

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -316,7 +316,7 @@ export const ActivityLibrary = (props: Props) => {
             </div>
           ) : (
             <>
-              {categoryId === 'retrospective' ? (
+              {categoryId === 'retrospective' && searchQuery.length === 0 ? (
                 <>
                   {(Object.keys(subCategoryMapping) as SubCategory[]).map(
                     (subCategory) =>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -125,17 +125,18 @@ const CategoryIDToColorClass = {
   )
 } as Record<CategoryID | typeof QUICK_START_CATEGORY_ID, string>
 
-const subCategoryMapping: Record<string, string> = {
+type Template = Omit<ActivityLibrary_template$data, ' $fragmentType'>
+
+type SubCategory = 'popular' | 'recentlyUsed' | 'recentlyUsedInOrg' | 'neverTried'
+
+const subCategoryMapping: Record<SubCategory, string> = {
   popular: 'Popular templates',
   recentlyUsed: 'You used these recently',
   recentlyUsedInOrg: 'Others in your organization are using',
   neverTried: 'Try these activities'
 }
 
-const activityGridList = (
-  templatesToRender: Omit<ActivityLibrary_template$data, ' $fragmentType'>[],
-  selectedCategory: string
-) => {
+const activityGridList = (templatesToRender: Template[], selectedCategory: string) => {
   return templatesToRender.map((template) => {
     return (
       <Link
@@ -211,17 +212,17 @@ export const ActivityLibrary = (props: Props) => {
         subCategory,
         templatesToRender
           .filter((template) => template.subCategories?.includes(subCategory))
-          .slice(0, MAX_PER_SUBCATEGORY) as Omit<ActivityLibrary_template$data, ' $fragmentType'>[]
+          .slice(0, MAX_PER_SUBCATEGORY) as Template[]
       ]
     })
-  )
+  ) as Record<SubCategory, Template[]>
 
   const otherTemplates = templatesToRender.filter(
     (template) =>
       !Object.values(subCategoryTemplates)
         .flat()
         .find((catTemplate) => catTemplate.id === template.id)
-  ) as Omit<ActivityLibrary_template$data, ' $fragmentType'>[]
+  ) as Template[]
 
   if (!featureFlags.retrosInDisguise) {
     return <Redirect to='/404' />
@@ -317,30 +318,33 @@ export const ActivityLibrary = (props: Props) => {
             <>
               {categoryId === 'retrospective' ? (
                 <>
-                  {Object.keys(subCategoryMapping).map(
+                  {(Object.keys(subCategoryMapping) as SubCategory[]).map(
                     (subCategory) =>
-                      subCategoryTemplates[subCategory]!.length > 0 && (
+                      subCategoryTemplates[subCategory].length > 0 && (
                         <>
                           <div className='ml-4 mt-8 text-xl font-bold text-slate-700'>
                             {subCategoryMapping[subCategory]}
                           </div>
                           <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 px-4 md:mt-4'>
-                            {activityGridList(subCategoryTemplates[subCategory]!, selectedCategory)}
+                            {activityGridList(subCategoryTemplates[subCategory], selectedCategory)}
                           </div>
                         </>
                       )
                   )}
-                  <div className='ml-4 mt-8 text-xl font-bold text-slate-700'>Other activities</div>
-                  <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 px-4 md:mt-4'>
-                    {activityGridList(otherTemplates, selectedCategory)}
-                  </div>
+                  {otherTemplates.length > 0 && (
+                    <>
+                      <div className='ml-4 mt-8 text-xl font-bold text-slate-700'>
+                        Other activities
+                      </div>
+                      <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 px-4 md:mt-4'>
+                        {activityGridList(otherTemplates, selectedCategory)}
+                      </div>
+                    </>
+                  )}
                 </>
               ) : (
                 <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
-                  {activityGridList(
-                    templatesToRender as Omit<ActivityLibrary_template$data, ' $fragmentType'>[],
-                    selectedCategory
-                  )}
+                  {activityGridList(templatesToRender as Template[], selectedCategory)}
                 </div>
               )}
             </>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -136,37 +136,49 @@ const subCategoryMapping: Record<SubCategory, string> = {
   neverTried: 'Try these activities'
 }
 
-const activityGridList = (templatesToRender: Template[], selectedCategory: string) => {
-  return templatesToRender.map((template) => {
-    return (
-      <Link
-        key={template.id}
-        to={{
-          pathname: `/activity-library/details/${template.id}`,
-          state: {prevCategory: selectedCategory}
-        }}
-        className='flex focus:rounded-md focus:outline-primary'
-      >
-        <ActivityLibraryCard
-          className='group aspect-[256/160] flex-1'
-          key={template.id}
-          theme={CATEGORY_THEMES[template.category as CategoryID]}
-          title={template.name}
-          badge={
-            !template.isFree ? (
-              <ActivityBadge className='m-2 bg-gold-300 text-grape-700'>Premium</ActivityBadge>
-            ) : null
-          }
-        >
-          <ActivityCardImage className='group-hover/card:hidden' src={template.illustrationUrl} />
-          <ActivityLibraryCardDescription
-            className='hidden group-hover/card:flex'
-            templateRef={template}
-          />
-        </ActivityLibraryCard>
-      </Link>
-    )
-  })
+interface ActivityGridProps {
+  templates: Template[]
+  selectedCategory: string
+}
+
+const ActivityGrid = ({templates, selectedCategory}: ActivityGridProps) => {
+  return (
+    <>
+      {templates.map((template) => {
+        return (
+          <Link
+            key={template.id}
+            to={{
+              pathname: `/activity-library/details/${template.id}`,
+              state: {prevCategory: selectedCategory}
+            }}
+            className='flex focus:rounded-md focus:outline-primary'
+          >
+            <ActivityLibraryCard
+              className='group aspect-[256/160] flex-1'
+              key={template.id}
+              theme={CATEGORY_THEMES[template.category as CategoryID]}
+              title={template.name}
+              badge={
+                !template.isFree ? (
+                  <ActivityBadge className='m-2 bg-gold-300 text-grape-700'>Premium</ActivityBadge>
+                ) : null
+              }
+            >
+              <ActivityCardImage
+                className='group-hover/card:hidden'
+                src={template.illustrationUrl}
+              />
+              <ActivityLibraryCardDescription
+                className='hidden group-hover/card:flex'
+                templateRef={template}
+              />
+            </ActivityLibraryCard>
+          </Link>
+        )
+      })}
+    </>
+  )
 }
 
 const MAX_PER_SUBCATEGORY = 6
@@ -326,7 +338,10 @@ export const ActivityLibrary = (props: Props) => {
                             {subCategoryMapping[subCategory]}
                           </div>
                           <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 px-4 md:mt-4'>
-                            {activityGridList(subCategoryTemplates[subCategory], selectedCategory)}
+                            <ActivityGrid
+                              templates={subCategoryTemplates[subCategory]}
+                              selectedCategory={selectedCategory}
+                            />
                           </div>
                         </>
                       )
@@ -337,14 +352,20 @@ export const ActivityLibrary = (props: Props) => {
                         Other activities
                       </div>
                       <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 px-4 md:mt-4'>
-                        {activityGridList(otherTemplates, selectedCategory)}
+                        <ActivityGrid
+                          templates={otherTemplates}
+                          selectedCategory={selectedCategory}
+                        />
                       </div>
                     </>
                   )}
                 </>
               ) : (
                 <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
-                  {activityGridList(templatesToRender as Template[], selectedCategory)}
+                  <ActivityGrid
+                    templates={templatesToRender as Template[]}
+                    selectedCategory={selectedCategory}
+                  />
                 </div>
               )}
             </>

--- a/packages/server/graphql/public/typeDefs/MeetingTemplate.graphql
+++ b/packages/server/graphql/public/typeDefs/MeetingTemplate.graphql
@@ -181,6 +181,12 @@ type ReflectTemplate implements MeetingTemplate {
   The lowest scope of the permissions available to the viewer
   """
   viewerLowestScope: SharingScopeEnum!
+
+  """
+  Experimental: sub-categories that this template is in (e.g. "popular", "recentlyUsed", "unused",
+  etc.)
+  """
+  subCategories: [String!]!
 }
 
 """

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -1,4 +1,26 @@
+import ms from 'ms'
+import errorFilter from '../../errorFilter'
 import {ReflectTemplateResolvers} from '../resolverTypes'
+import {getUserId} from '../../../utils/authorization'
+
+const POPULAR_RETROS = [
+  'workingStuckTemplate',
+  'startStopContinueTemplate',
+  'whatWentWellTemplate',
+  'gladSadMadTemplate',
+  'original4Template',
+  'fourLsTemplate'
+]
+
+const getAllMeetingsForTeamIds = async (teamIds: string[], dataLoader) => {
+  const activeMeetings = (await dataLoader.get('activeMeetingsByTeamId').loadMany(teamIds))
+    .filter(errorFilter)
+    .flat()
+  const completedMeetings = (await dataLoader.get('completedMeetingsByTeamId').loadMany(teamIds))
+    .filter(errorFilter)
+    .flat()
+  return [...activeMeetings, ...completedMeetings]
+}
 
 const ReflectTemplate: ReflectTemplateResolvers = {
   __isTypeOf: ({type}) => type === 'retrospective',
@@ -7,6 +29,51 @@ const ReflectTemplate: ReflectTemplateResolvers = {
     return prompts
       .filter((prompt) => !prompt.removedAt)
       .sort((a, b) => (a.sortOrder < b.sortOrder ? -1 : 1))
+  },
+  team: async ({teamId}, _args, {dataLoader}) => {
+    return dataLoader.get('teams').loadNonNull(teamId)
+  },
+  subCategories: async ({id}, _args, {dataLoader, authToken}) => {
+    const subCategories: string[] = []
+    // Popular
+    if (POPULAR_RETROS.includes(id)) {
+      subCategories.push('popular')
+    }
+
+    // Recently Used
+    const allMeetings = await getAllMeetingsForTeamIds(authToken.tms, dataLoader)
+
+    if (
+      allMeetings
+        .filter((meeting) => meeting.createdAt > new Date(Date.now() - ms('30d')))
+        .find((meeting) => meeting.meetingType === 'retrospective' && meeting.templateId === id)
+    ) {
+      subCategories.push('recentlyUsed')
+    }
+
+    // Others are using in your org
+    const viewerId = getUserId(authToken)
+    const organizationUsers = await dataLoader.get('organizationUsersByUserId').load(viewerId)
+    const orgIds = organizationUsers.map(({orgId}) => orgId)
+    const orgTeamIds = (await dataLoader.get('teamsByOrgIds').loadMany(orgIds))
+      .filter(errorFilter)
+      .flat()
+      .map((team) => team.id)
+    const allOrgMeetings = await getAllMeetingsForTeamIds(orgTeamIds, dataLoader)
+    if (
+      allOrgMeetings
+        .filter((meeting) => meeting.createdAt > new Date(Date.now() - ms('30d')))
+        .find((meeting) => meeting.meetingType === 'retrospective' && meeting.templateId === id)
+    ) {
+      subCategories.push('recentlyUsedInOrg')
+    }
+
+    // Try these activities
+    if (!allMeetings.find((meeting) => meeting.templateId === id)) {
+      subCategories.push('neverTried')
+    }
+
+    return subCategories
   }
 }
 

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -34,6 +34,8 @@ const ReflectTemplate: ReflectTemplateResolvers = {
     return dataLoader.get('teams').loadNonNull(teamId)
   },
   subCategories: async ({id, name}, _args, {dataLoader, authToken}) => {
+    // :TODO: (jmtaber129): Refactor this to be a bit cleaner if decide to use subcategories
+    // long-term.
     if (name === '*New Template') {
       return []
     }

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -33,8 +33,13 @@ const ReflectTemplate: ReflectTemplateResolvers = {
   team: async ({teamId}, _args, {dataLoader}) => {
     return dataLoader.get('teams').loadNonNull(teamId)
   },
-  subCategories: async ({id}, _args, {dataLoader, authToken}) => {
+  subCategories: async ({id, name}, _args, {dataLoader, authToken}) => {
+    if (name === '*New Template') {
+      return []
+    }
+
     const subCategories: string[] = []
+
     // Popular
     if (POPULAR_RETROS.includes(id)) {
       subCategories.push('popular')
@@ -63,6 +68,7 @@ const ReflectTemplate: ReflectTemplateResolvers = {
     if (
       allOrgMeetings
         .filter((meeting) => meeting.createdAt > new Date(Date.now() - ms('30d')))
+        .filter((meeting) => !allMeetings.find((selfMeeting) => selfMeeting.id === meeting.id))
         .find((meeting) => meeting.meetingType === 'retrospective' && meeting.templateId === id)
     ) {
       subCategories.push('recentlyUsedInOrg')


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8365

Splits the "Retrospective" category into sub-categories:
* Popular templates
* You used these recently
* Others in your organization are using
* Try these activities

Since this is still pretty experimental, I didn't invest much time into making this code especially robust - if/when we decide to follow this sub-section pattern long-term, we'll want to clean this up a bit (e.g. make the subsections an enum instead of just a string, clean up DB calls, etc.)

## Demo
https://www.loom.com/share/68dbae64ebfb4a88bd2381c23ce6b9dc

## Testing scenarios
- [ ] Smoke test each of the different subcategories in the retro category
- [ ] Smoke test other categories

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
