### PR TITLE
Remove default_incomplete payment behaviour for old subscription flow

### DIFF
--- a/packages/server/graphql/mutations/helpers/oldUpgradeToTeamTier.ts
+++ b/packages/server/graphql/mutations/helpers/oldUpgradeToTeamTier.ts
@@ -35,7 +35,7 @@ const oldUpgradeToTeamTier = async (
 
   let subscriptionFields = {}
   if (!stripeSubscriptionId) {
-    const subscription = await manager.createTeamSubscription(customer.id, orgId, quantity)
+    const subscription = await manager.createTeamSubscriptionOld(customer.id, orgId, quantity)
     subscriptionFields = {
       periodEnd: fromEpochSeconds(subscription.current_period_end),
       periodStart: fromEpochSeconds(subscription.current_period_start),

--- a/packages/server/utils/stripe/StripeManager.ts
+++ b/packages/server/utils/stripe/StripeManager.ts
@@ -74,7 +74,6 @@ export default class StripeManager {
       ]
     })
   }
-
   async createTeamSubscription(customerId: string, orgId: string, quantity: number) {
     return this.stripe.subscriptions.create({
       // USE THIS FOR TESTING A FAILING PAYMENT
@@ -84,6 +83,29 @@ export default class StripeManager {
       proration_behavior: 'none',
       payment_behavior: 'default_incomplete',
       expand: ['latest_invoice.payment_intent'], // expand the payment intent so we can get the client_secret
+      // Use this for testing invoice.created hooks
+      // run `yarn ultrahook` and subscribe
+      // the `invoice.created` hook will be run once the billing_cycle_anchor is reached with some slack
+      // billing_cycle_anchor: toEpochSeconds(Date.now() + ms('2m')),
+      metadata: {
+        orgId
+      },
+      items: [
+        {
+          plan: StripeManager.PARABOL_TEAM_600,
+          quantity
+        }
+      ]
+    })
+  }
+
+  async createTeamSubscriptionOld(customerId: string, orgId: string, quantity: number) {
+    return this.stripe.subscriptions.create({
+      // USE THIS FOR TESTING A FAILING PAYMENT
+      // https://stripe.com/docs/billing/testing
+      // trial_end: toEpochSeconds(new Date(Date.now() + 1000 * 10)),
+      customer: customerId,
+      proration_behavior: 'none',
       // Use this for testing invoice.created hooks
       // run `yarn ultrahook` and subscribe
       // the `invoice.created` hook will be run once the billing_cycle_anchor is reached with some slack

--- a/packages/server/utils/stripe/StripeManager.ts
+++ b/packages/server/utils/stripe/StripeManager.ts
@@ -74,6 +74,7 @@ export default class StripeManager {
       ]
     })
   }
+
   async createTeamSubscription(customerId: string, orgId: string, quantity: number) {
     return this.stripe.subscriptions.create({
       // USE THIS FOR TESTING A FAILING PAYMENT


### PR DESCRIPTION
To handle 3D Secure cards, we're setting the payment behaviour to `default_incomplete` so that it's authorised on the client. While this works for the new payment flow, for the old flow, it results in subscriptions being incomplete. 

Merging this PR right away as it's using the old code, and I want to get this in before the ship. 