### PR TITLE
fix: Show error message when creating Jira task fails

### DIFF
--- a/packages/client/components/NewJiraIssueInput.tsx
+++ b/packages/client/components/NewJiraIssueInput.tsx
@@ -241,7 +241,7 @@ const NewJiraIssueInput = (props: Props) => {
 
   if (createTaskError) {
     return (
-      <Item onBlur={() => setCreateTaskError(undefined)}>
+      <Item>
         <Checkbox active disabled />
         <Issue>
           <Error>{createTaskError}</Error>

--- a/packages/client/hooks/useTimedState.ts
+++ b/packages/client/hooks/useTimedState.ts
@@ -1,0 +1,23 @@
+import {useRef, useState} from 'react'
+
+/**
+ * State hook that automatically clears itself after a timeout.
+ * This is especially useful for situations like showing an error message which disappears after some timeout
+ * @param timeout in milliseconds, defaults to 5000
+ */
+const useTimedState = <T = string>(timeout = 5000) => {
+  const [state, setState] = useState<T>()
+  const timer = useRef<ReturnType<typeof setTimeout>>()
+  const setTimedState = (value: T | undefined = undefined) => {
+    clearTimeout(timer.current)
+    setState(value)
+    if (value) {
+      timer.current = setTimeout(() => {
+        setState(undefined)
+      }, timeout)
+    }
+  }
+  return [state, setTimedState] as const
+}
+
+export default useTimedState

--- a/packages/server/graphql/public/types/CreateTaskPayload.ts
+++ b/packages/server/graphql/public/types/CreateTaskPayload.ts
@@ -13,6 +13,7 @@ const CreateTaskPayload: CreateTaskPayloadResolvers = {
   error: async ({error}) => {
     if (!error) return null
     return {
+      // although the error already has the correct shape, without this resolver, the error member in source would not be used as source here, but treated as if it was thrown by graphql
       message: error.message
     }
   },

--- a/packages/server/graphql/public/types/CreateTaskPayload.ts
+++ b/packages/server/graphql/public/types/CreateTaskPayload.ts
@@ -4,13 +4,20 @@ import errorFilter from '../../errorFilter'
 import {CreateTaskPayloadResolvers} from '../resolverTypes'
 
 export type CreateTaskPayloadSource = {
-  taskId: string
+  error?: Error
+  taskId?: string
   notificationIds?: string[]
 }
 
 const CreateTaskPayload: CreateTaskPayloadResolvers = {
+  error: async ({error}) => {
+    if (!error) return null
+    return {
+      message: error.message
+    }
+  },
   task: async ({taskId}, _args, {authToken, dataLoader}) => {
-    const taskDoc = await dataLoader.get('tasks').load(taskId)
+    const taskDoc = taskId && (await dataLoader.get('tasks').load(taskId))
     if (!taskDoc) return null
     const {userId, tags, teamId} = taskDoc
     const isViewer = userId === getUserId(authToken)


### PR DESCRIPTION
# Description

Fixes #6320 
When creating a Jira task in Sprint Poker failed, the error message wasn't send properly to the client. It also wouldn't be shown to the client.
If task creation failed, show the error message now for 5s.

This does not fix the underlying issue, but presents it to the user, so they hopefully can react accordingly or report more detailed errors.

## Demo

https://www.loom.com/share/d798bb9765394f2a9097a51a1fea41e4?sid=6da48e5b-40ec-4599-88cc-36f3b51e4b8e

## Testing scenarios

- [ ] Try to create a **Jira** issue which produces an error
- [ ] see the error message
- [ ] repeat for **GitHub**
- [ ] repeat for **GitLab**
- [ ] repeat for **Azure DevOps**

Run `node scripts/toolbox/postDeploy.js` if you're missing some of the integrations.
You can test error scenarios by adding a something like
```ts
return {error: new Error('Georg was here')}
```
in https://github.com/ParabolInc/parabol/blob/063a526dbcfd6340f4daa645c5875c679745519b/packages/server/graphql/mutations/helpers/createTaskInService.ts#L59

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
