### PR TITLE
fix: types in meeting tips; prevent rendering undefined

### DIFF
--- a/packages/client/components/BottomControlBarTips.tsx
+++ b/packages/client/components/BottomControlBarTips.tsx
@@ -80,15 +80,15 @@ const EstimateHelpMenu = lazyPreload(
   async () => import(/* webpackChunkName: 'EstimateHelpMenu' */ './MeetingHelp/EstimateHelpMenu')
 )
 
-const demoHelps = {
+const demoHelps: Partial<Record<NewMeetingPhaseTypeEnum, LazyExoticPreload<any>>> = {
   checkin: DemoReflectHelpMenu,
   reflect: DemoReflectHelpMenu,
   group: DemoGroupHelpMenu,
   vote: DemoVoteHelpMenu,
   discuss: DemoDiscussHelpMenu
-} as Record<NewMeetingPhaseTypeEnum, LazyExoticPreload<any>>
+}
 
-const helps = {
+const helps: Partial<Record<NewMeetingPhaseTypeEnum, LazyExoticPreload<any>>> = {
   checkin: CheckInHelpMenu,
   reflect: ReflectHelpMenu,
   group: GroupHelpMenu,
@@ -100,7 +100,7 @@ const helps = {
   lastcall: ActionMeetingLastCallHelpMenu,
   SCOPE: ScopeHelpMenu,
   ESTIMATE: EstimateHelpMenu
-} as Record<NewMeetingPhaseTypeEnum, LazyExoticPreload<any>>
+}
 
 interface Props {
   cancelConfirm: (() => void) | undefined
@@ -108,6 +108,7 @@ interface Props {
   status: TransitionStatus
   onTransitionEnd: () => void
 }
+
 const BottomControlBarTips = (props: Props) => {
   const {cancelConfirm, meeting: meetingRef, status, onTransitionEnd} = props
   const meeting = useFragment(
@@ -148,6 +149,11 @@ const BottomControlBarTips = (props: Props) => {
       }
     }
   }, [demoPauseOpen, openPortal])
+
+  if (!MenuContent) {
+    return null
+  }
+
   return (
     <BottomNavControl
       dataCy={`tip-menu-toggle`}


### PR DESCRIPTION
# Description

Fixes #8442 

## Demo

No demo

## Testing scenarios

- [ ] Go to the team health check and see if there's an error thrown about rendering `undefined`

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
