### PR TITLE
fix: Fix optimistic update for create task in Sprint Poker

### DIFF
--- a/packages/client/mutations/CreateTaskMutation.ts
+++ b/packages/client/mutations/CreateTaskMutation.ts
@@ -240,7 +240,6 @@ const CreateTaskMutation: StandardMutation<TCreateTaskMutation, OptionalHandlers
       }
       const editorPayload = getOptimisticTaskEditor(store, taskId, isEditing)
       handleEditTask(editorPayload, store)
-      //TODO #7943 Optimistic updates on arrays has a bug in Relay. As a workaround until it's fixed properly, let's just not do optimistic updates
       handleUpsertTasks(task as any, store)
       handleJiraCreateIssue(task, store)
       handleGitHubCreateIssue(task as any, store)

--- a/packages/client/mutations/CreateTaskMutation.ts
+++ b/packages/client/mutations/CreateTaskMutation.ts
@@ -180,6 +180,7 @@ const CreateTaskMutation: StandardMutation<TCreateTaskMutation, OptionalHandlers
         .setLinkedRecord(userId ? store.get(userId)! : null, 'user')
         .setLinkedRecord(viewer, 'createdByUser')
         .setLinkedRecords([], 'replies')
+        .setLinkedRecord(null, 'integration')
       if (integration) {
         const {service, serviceProjectHash} = integration
         if (service === 'jira') {
@@ -240,7 +241,7 @@ const CreateTaskMutation: StandardMutation<TCreateTaskMutation, OptionalHandlers
       const editorPayload = getOptimisticTaskEditor(store, taskId, isEditing)
       handleEditTask(editorPayload, store)
       //TODO #7943 Optimistic updates on arrays has a bug in Relay. As a workaround until it's fixed properly, let's just not do optimistic updates
-      //handleUpsertTasks(task as any, store)
+      handleUpsertTasks(task as any, store)
       handleJiraCreateIssue(task, store)
       handleGitHubCreateIssue(task as any, store)
       handleGitLabCreateIssue(task as any, store)


### PR DESCRIPTION
# Description

Fixes #8094 
Optimistic update was disabled because it threw an error. This happened because one of the fields was undefined while it should have been null.

## Demo

https://www.loom.com/share/8500771c4b3048eaa45724ae553e4350?sid=599ca38f-fc7b-4b06-a775-60bd05e12935

## Testing scenarios

- start a Sprint Poker meeting
- in scoping create a Parabol task

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
