### PR TITLE
chore(suggest-groups): add suggest groups metrics

### DIFF
--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -69,7 +69,6 @@ const generateGroups = async (
   const data = {meetingId}
   const operationId = dataLoader.share()
   const subOptions = {operationId, mutatorId: SERVER_ID}
-
   analytics.suggestGroupsGenerated(facilitatorUserId, meetingId, teamId)
   publish(SubscriptionChannel.MEETING, meetingId, 'GenerateGroupsSuccess', data, subOptions)
   return autogroupReflectionGroups

--- a/packages/server/graphql/public/mutations/autogroup.ts
+++ b/packages/server/graphql/public/mutations/autogroup.ts
@@ -1,5 +1,6 @@
 import {SubscriptionChannel} from '../../../../client/types/constEnums'
 import getRethink from '../../../database/rethinkDriver'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId, isTeamMember} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
@@ -71,7 +72,7 @@ const autogroup: MutationResolvers['autogroup'] = async (
     r.table('NewMeeting').get(meetingId).update({resetReflectionGroups}).run()
   ])
   meeting.resetReflectionGroups = resetReflectionGroups
-
+  analytics.suggestGroupsClicked(viewerId, meetingId, teamId)
   const data = {meetingId}
   publish(SubscriptionChannel.MEETING, meetingId, 'AutogroupSuccess', data, subOptions)
   return data

--- a/packages/server/graphql/public/mutations/resetReflectionGroups.ts
+++ b/packages/server/graphql/public/mutations/resetReflectionGroups.ts
@@ -1,5 +1,6 @@
 import {SubscriptionChannel} from '../../../../client/types/constEnums'
 import getRethink from '../../../database/rethinkDriver'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId, isTeamMember} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
@@ -71,7 +72,7 @@ const resetReflectionGroups: MutationResolvers['resetReflectionGroups'] = async 
     .replace(r.row.without('resetReflectionGroups') as any)
     .run()
   meeting.resetReflectionGroups = undefined
-
+  analytics.resetGroupsClicked(viewerId, meetingId, teamId)
   const data = {meetingId}
   publish(SubscriptionChannel.MEETING, meetingId, 'ResetReflectionGroupsSuccess', data, subOptions)
   return data

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -109,6 +109,10 @@ export type AnalyticsEvent =
   | 'Snackbar Viewed'
   // Join request
   | 'Join Request Reviewed'
+  // Suggest Groups
+  | 'Suggest Groups Generated'
+  | 'Suggest Groups Clicked'
+  | 'Reset Groups Clicked'
 
 /**
  * Provides a unified inteface for sending all the analytics events
@@ -425,6 +429,18 @@ class Analytics {
 
   notificationEmailSent = (userId: string, orgId: string, type: TeamLimitsEmailType) => {
     this.track(userId, 'Notification Email Sent', {type, orgId})
+  }
+
+  suggestGroupsGenerated = (userId: string, meetingId: string, teamId: string) => {
+    this.track(userId, 'Suggest Groups Generated', {meetingId, teamId})
+  }
+
+  suggestGroupsClicked = (userId: string, meetingId: string, teamId: string) => {
+    this.track(userId, 'Suggest Groups Clicked', {meetingId, teamId})
+  }
+
+  resetGroupsClicked = (userId: string, meetingId: string, teamId: string) => {
+    this.track(userId, 'Reset Groups Clicked', {meetingId, teamId})
   }
 
   private track = (userId: string, event: AnalyticsEvent, properties?: Record<string, any>) =>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8447

### To test

- [ ] Sends an event to Segment when clicking the suggest groups and reset groups button
- [ ] Sends an event to Segment when generating groups
