### PR TITLE
chore: add task and comment to release checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_test.md
+++ b/.github/ISSUE_TEMPLATE/release_test.md
@@ -33,6 +33,8 @@ Run through this list at least once at [staging](https://action-staging.parabol.
 - [ ] Upgraded to Team (Credit card number: `4242 4242 4242 4242`, expiration date: any month in the future, CVC: `123`)
 - [ ] Smoke tested the app on a mobile device (e.g. navigate between views, smoke test a Retro meeting, etc.)
 - [ ] Test previously existed meetings to make sure that existing data is not corrupted
+- [ ] Create a comment in the discussion thread of a meeting
+- [ ] Create a task in the discussion thread of a meeting
 
 ## What’s changed
 

--- a/.github/ISSUE_TEMPLATE/release_test.md
+++ b/.github/ISSUE_TEMPLATE/release_test.md
@@ -33,8 +33,8 @@ Run through this list at least once at [staging](https://action-staging.parabol.
 - [ ] Upgraded to Team (Credit card number: `4242 4242 4242 4242`, expiration date: any month in the future, CVC: `123`)
 - [ ] Smoke tested the app on a mobile device (e.g. navigate between views, smoke test a Retro meeting, etc.)
 - [ ] Test previously existed meetings to make sure that existing data is not corrupted
-- [ ] Create a comment in the discussion thread of a meeting
 - [ ] Create a task in the discussion thread of a meeting
+- [ ] Create a comment in the discussion thread of a meeting
 
 ## What’s changed
 


### PR DESCRIPTION
On master, I noticed that we can't create tasks: https://github.com/ParabolInc/parabol/pull/8472

We should add this to the release tests to catch this in the future (see [Slack thread](https://parabol.slack.com/archives/C836NA350/p1688407245901649?thread_ts=1687971553.304529&cid=C836NA350)).

