### PR TITLE
chore: hide invoices for enterprise users

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
@@ -46,6 +46,7 @@ const OrgBilling = (props: Props) => {
     organizationRef
   )
   const {tier} = organization
+
   return (
     <div>
       <OrgBillingUpgrade organization={organization} invoiceListRefetch={refetch} />

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBilling.tsx
@@ -40,15 +40,21 @@ const OrgBilling = (props: Props) => {
         ...OrgBillingUpgrade_organization
         ...OrgBillingDangerZone_organization
         id
+        tier
       }
     `,
     organizationRef
   )
+  const {tier} = organization
   return (
     <div>
       <OrgBillingUpgrade organization={organization} invoiceListRefetch={refetch} />
-      <OrgBillingCreditCardInfoOld organization={organization} />
-      <OrgBillingInvoices queryRef={queryData} />
+      {tier === 'team' && (
+        <>
+          <OrgBillingCreditCardInfoOld organization={organization} />
+          <OrgBillingInvoices queryRef={queryData} />
+        </>
+      )}
       <OrgBillingDangerZone organization={organization} />
     </div>
   )

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlansAndBilling.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlansAndBilling.tsx
@@ -75,7 +75,7 @@ const OrgPlansAndBilling = (props: Props) => {
     <Suspense fallback={''}>
       <div className='pb-20'>
         <OrgPlansAndBillingHeading organizationRef={organization} />
-        {isBillingLeader && (
+        {isBillingLeader && tier === 'team' && (
           <>
             <OrgBillingInvoices queryRef={queryData} isWide />
             <OrgBillingCreditCardInfo organizationRef={organization} />


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8268

### To test

- [ ] Upgrade a team to the Team-tier and see their upcoming invoices
- [ ] Now upgrade them to Enterprise (I did this by updating pgadmin's Team table and rethinkdb's Organization table)
- [ ] See that Enterprise users no longer see the credit card info or the upcoming invoices
- [ ] This is the case with the new and the old checkout flow