### PR TITLE
feat: retry invoice after failed payment

### DIFF
--- a/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
+++ b/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
@@ -65,31 +65,29 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
   }
 
   // RESOLUTION
-  await Promise.all(
-    [
-      r({
-        updatedOrg: r
-          .table('Organization')
-          .get(orgId)
-          .update({
-            creditCard: await getCCFromCustomer(customer),
-            tier: 'team',
-            tierLimitExceededAt: null,
-            scheduledLockAt: null,
-            lockedAt: null,
-            updatedAt: now
-          })
-      }).run(),
-      updateTeamByOrgId(
-        {
-          isPaid: true,
-          tier: 'team'
-        },
-        orgId
-      )
-    ],
+  await Promise.all([
+    r({
+      updatedOrg: r
+        .table('Organization')
+        .get(orgId)
+        .update({
+          creditCard: await getCCFromCustomer(customer),
+          tier: 'team',
+          tierLimitExceededAt: null,
+          scheduledLockAt: null,
+          lockedAt: null,
+          updatedAt: now
+        })
+    }).run(),
+    updateTeamByOrgId(
+      {
+        isPaid: true,
+        tier: 'team'
+      },
+      orgId
+    ),
     removeTeamsLimitObjects(orgId, dataLoader)
-  )
+  ])
   organization.tier = 'team'
 
   await Promise.all([setUserTierForOrgId(orgId), setTierForOrgUsers(orgId)])

--- a/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
+++ b/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
@@ -111,6 +111,7 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
     setUserTierForOrgId(orgId),
     setTierForOrgUsers(orgId)
   ])
+
   const activeMeetings = await hideConversionModal(orgId, dataLoader)
   const meetingIds = activeMeetings.map(({id}) => id)
 

--- a/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
+++ b/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
@@ -85,13 +85,32 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
         tier: 'team'
       },
       orgId
-    ),
-    removeTeamsLimitObjects(orgId, dataLoader)
+    )
   ])
   organization.tier = 'team'
 
-  await Promise.all([setUserTierForOrgId(orgId), setTierForOrgUsers(orgId)])
+  // If subscription already exists and has open invoices, try to process them
+  const openInvoices = (await manager.listSubscriptionOpenInvoices(stripeSubscriptionId)).data
 
+  let unpaidInvoice = false
+  if (openInvoices.length) {
+    for (const invoice of openInvoices) {
+      const invoiceResult = await manager.payInvoice(invoice.id)
+      // Unlock teams only if all invoices are paid
+      if (invoiceResult.status !== 'paid') {
+        unpaidInvoice = true
+      }
+    }
+  }
+  if (unpaidInvoice) {
+    return standardError(new Error('Could not pay failed invoices'), {userId: viewerId})
+  }
+
+  await Promise.all([
+    removeTeamsLimitObjects(orgId, dataLoader),
+    setUserTierForOrgId(orgId),
+    setTierForOrgUsers(orgId)
+  ])
   const activeMeetings = await hideConversionModal(orgId, dataLoader)
   const meetingIds = activeMeetings.map(({id}) => id)
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8452

Demo: https://www.loom.com/share/8095302e24ec45ddb4c6df42009eab00

### To test

We need to get a failed invoice and then run `updateCreditCard` to charge the failed invoice. This is a hacky way of testing this; I'm open to any better ways. 

- [ ] Run `stripe listen --forward-to localhost:3000/stripe` in your terminal to listen to webhooks 
- [ ] Use the old checkout flow by updating this line: https://github.com/ParabolInc/parabol/blob/ef51c26e331f693fe993b9ead2433445c11b6cd2/packages/client/modules/userDashboard/components/Organization/Organization.tsx#L130. I'm doing this because the new checkout flow has a 3D Secure check on the client which shows an error when using the `Decline after attaching` Stripe card
- [ ] Comment out the `terminateSubscription` line in `stripeFailPayment` [here](https://github.com/ParabolInc/parabol/blob/e90eb2278e0e87a9149e20e3192c356c5cb4050a/packages/server/graphql/private/mutations/stripeFailPayment.ts#L77). We need to do this because when the first payment fails, we terminate the subscription and remove `stripeSubscriptionId` from the Organization object, which is needed to find the invoices. This wouldn't happen after the first payment has occurred - the status would be `past_due`. 
- [ ] Use the decline after attaching Stripe [card](https://stripe.com/docs/testing?testing-method=card-numbers#declined-payments) `4000000000000341`
- [ ] Switch to the new checkout flow, updating this line: https://github.com/ParabolInc/parabol/blob/ef51c26e331f693fe993b9ead2433445c11b6cd2/packages/client/modules/userDashboard/components/Organization/Organization.tsx#L130
- [ ] Enter a valid credit card and see that the failed payment has now been successfully charged
- [ ] You'll see a `Organization is not on the starter tier` error because the payment has triggered `upgradeToTeamTier`. I have another issue open to change the webhook that we listen to to remove this code smell.  

