### PR TITLE
fix: show correct drawer info after upgrade

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -134,6 +134,7 @@ const BillingForm = (props: Props) => {
       commitLocalUpdate(atmosphere, (store) => {
         const org = store.get(orgId)
         if (!org) return
+        // stripe webhooks will trigger upgradeToTeamTier which will update the tier, but we want to show the confetti and correct drawer info immediately
         org.setValue('team', 'tier')
         org.setValue(true, 'showConfetti')
         org.setValue(true, 'showDrawer')

--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -16,7 +16,6 @@ import SendClientSegmentEventMutation from '../../../../mutations/SendClientSegm
 import {StripeElementChangeEvent} from '@stripe/stripe-js'
 import CreateStripeSubscriptionMutation from '../../../../mutations/CreateStripeSubscriptionMutation'
 import {CreateStripeSubscriptionMutation$data} from '../../../../__generated__/CreateStripeSubscriptionMutation.graphql'
-import {commitLocalUpdate} from 'relay-runtime'
 
 const ButtonBlock = styled('div')({
   display: 'flex',
@@ -126,19 +125,11 @@ const BillingForm = (props: Props) => {
         return
       }
       const {error} = await stripe.confirmCardPayment(stripeSubscriptionClientSecret)
-      setIsLoading(false)
       if (error) {
         setErrorMsg(error.message)
+        setIsLoading(false)
         return
       }
-      commitLocalUpdate(atmosphere, (store) => {
-        const org = store.get(orgId)
-        if (!org) return
-        // stripe webhooks will trigger upgradeToTeamTier which will update the tier, but we want to show the confetti and correct drawer info immediately
-        org.setValue('team', 'tier')
-        org.setValue(true, 'showConfetti')
-        org.setValue(true, 'showDrawer')
-      })
       onCompleted()
     }
 

--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -9,7 +9,6 @@ import {
 } from '@stripe/react-stripe-js'
 import PrimaryButton from '../../../../components/PrimaryButton'
 import {PALETTE} from '../../../../styles/paletteV3'
-import Confetti from '../../../../components/Confetti'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
 import StyledError from '../../../../components/StyledError'
@@ -41,13 +40,6 @@ const UpgradeButton = styled(PrimaryButton)<{isDisabled: boolean}>(({isDisabled}
   }
 }))
 
-const ConfettiWrapper = styled('div')({
-  position: 'fixed',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)'
-})
-
 const ErrorMsg = styled(StyledError)({
   paddingTop: 8,
   textTransform: 'none'
@@ -76,7 +68,6 @@ const BillingForm = (props: Props) => {
   const stripe = useStripe()
   const elements = useElements()
   const [isLoading, setIsLoading] = useState(false)
-  const [isPaymentSuccessful, setIsPaymentSuccessful] = useState(false)
   const atmosphere = useAtmosphere()
   const {onError, onCompleted} = useMutationProps()
   const [errorMsg, setErrorMsg] = useState<null | string>()
@@ -143,9 +134,10 @@ const BillingForm = (props: Props) => {
       commitLocalUpdate(atmosphere, (store) => {
         const org = store.get(orgId)
         if (!org) return
+        org.setValue('team', 'tier')
+        org.setValue(true, 'showConfetti')
         org.setValue(true, 'showDrawer')
       })
-      setIsPaymentSuccessful(true)
       onCompleted()
     }
 
@@ -245,9 +237,6 @@ const BillingForm = (props: Props) => {
           {'Upgrade'}
         </UpgradeButton>
       </ButtonBlock>
-      <ConfettiWrapper>
-        <Confetti active={isPaymentSuccessful} />
-      </ConfettiWrapper>
     </form>
   )
 }

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
@@ -14,6 +14,7 @@ import PlainButton from '../../../../components/PlainButton/PlainButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import {ICON_SIZE} from '../../../../styles/typographyV2'
 import OrgPlanDrawerContent from './OrgPlanDrawerContent'
+import Confetti from '../../../../components/Confetti'
 
 const DrawerHeader = styled('div')({
   alignItems: 'center',
@@ -21,6 +22,13 @@ const DrawerHeader = styled('div')({
   justifyContent: 'space-between',
   padding: '16px 8px 16px 16px',
   width: '100%'
+})
+
+const ConfettiWrapper = styled('div')({
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)'
 })
 
 const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
@@ -78,11 +86,12 @@ const OrgPlanDrawer = (props: Props) => {
         id
         showDrawer
         tier
+        showConfetti
       }
     `,
     organizationRef
   )
-  const {id: orgId, tier, showDrawer} = organization
+  const {id: orgId, tier, showDrawer, showConfetti} = organization
   const atmosphere = useAtmosphere()
   const isDesktop = useBreakpoint(Breakpoint.ORG_DRAWER)
 
@@ -96,23 +105,28 @@ const OrgPlanDrawer = (props: Props) => {
   }
 
   return (
-    <ResponsiveDashSidebar
-      isOpen={showDrawer}
-      isDesktop={isDesktop}
-      onToggle={toggleSidebar}
-      isRightDrawer
-      sidebarWidth={DiscussionThreadEnum.WIDTH}
-    >
-      <Drawer isDesktop={isDesktop} isOpen={showDrawer}>
-        <DrawerHeader>
-          <StyledLabelHeading>{'Plan Details'}</StyledLabelHeading>
-          <StyledCloseButton onClick={toggleSidebar}>
-            <CloseIcon />
-          </StyledCloseButton>
-        </DrawerHeader>
-        <OrgPlanDrawerContent tier={tier} />
-      </Drawer>
-    </ResponsiveDashSidebar>
+    <>
+      <ResponsiveDashSidebar
+        isOpen={showDrawer}
+        isDesktop={isDesktop}
+        onToggle={toggleSidebar}
+        isRightDrawer
+        sidebarWidth={DiscussionThreadEnum.WIDTH}
+      >
+        <Drawer isDesktop={isDesktop} isOpen={showDrawer}>
+          <DrawerHeader>
+            <StyledLabelHeading>{'Plan Details'}</StyledLabelHeading>
+            <StyledCloseButton onClick={toggleSidebar}>
+              <CloseIcon />
+            </StyledCloseButton>
+          </DrawerHeader>
+          <OrgPlanDrawerContent tier={tier} />
+        </Drawer>
+      </ResponsiveDashSidebar>
+      <ConfettiWrapper>
+        <Confetti active={showConfetti} />
+      </ConfettiWrapper>
+    </>
   )
 }
 

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlanDrawer.tsx
@@ -24,13 +24,6 @@ const DrawerHeader = styled('div')({
   width: '100%'
 })
 
-const ConfettiWrapper = styled('div')({
-  position: 'fixed',
-  top: '50%',
-  left: '50%',
-  transform: 'translate(-50%, -50%)'
-})
-
 const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
   boxShadow: isDesktop ? desktopSidebarShadow : undefined,
   backgroundColor: '#FFFFFF',
@@ -123,9 +116,9 @@ const OrgPlanDrawer = (props: Props) => {
           <OrgPlanDrawerContent tier={tier} />
         </Drawer>
       </ResponsiveDashSidebar>
-      <ConfettiWrapper>
+      <div className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform'>
         <Confetti active={showConfetti} />
-      </ConfettiWrapper>
+      </div>
     </>
   )
 }

--- a/packages/client/mutations/handlers/upgradeToTeamTierSuccessUpdater.ts
+++ b/packages/client/mutations/handlers/upgradeToTeamTierSuccessUpdater.ts
@@ -1,0 +1,10 @@
+import {RecordProxy} from 'relay-runtime'
+
+const upgradeToTeamTierSuccessUpdater = (payload: RecordProxy) => {
+  const organization = payload.getLinkedRecord('organization')
+  if (organization) {
+    organization.setValue(true, 'showConfetti')
+    organization.setValue(true, 'showDrawer')
+  }
+}
+export default upgradeToTeamTierSuccessUpdater

--- a/packages/client/schemaExtensions/clientSchema.graphql
+++ b/packages/client/schemaExtensions/clientSchema.graphql
@@ -125,4 +125,5 @@ extend type Discussion {
 
 extend type Organization {
   showDrawer: Boolean!
+  showConfetti: Boolean!
 }

--- a/packages/client/subscriptions/OrganizationSubscription.ts
+++ b/packages/client/subscriptions/OrganizationSubscription.ts
@@ -22,6 +22,7 @@ import {
 import {updateTemplateScopeOrganizationUpdater} from '../mutations/UpdateReflectTemplateScopeMutation'
 import subscriptionOnNext from './subscriptionOnNext'
 import subscriptionUpdater from './subscriptionUpdater'
+import upgradeToTeamTierSuccessUpdater from '../mutations/handlers/upgradeToTeamTierSuccessUpdater'
 
 const subscription = graphql`
   subscription OrganizationSubscription {
@@ -73,7 +74,8 @@ const updateHandlers = {
   ArchiveOrganizationPayload: archiveOrganizationOrganizationUpdater,
   SetOrgUserRoleSuccess: setOrgUserRoleAddedOrganizationUpdater,
   RemoveOrgUserPayload: removeOrgUserOrganizationUpdater,
-  UpdateTemplateScopeSuccess: updateTemplateScopeOrganizationUpdater
+  UpdateTemplateScopeSuccess: updateTemplateScopeOrganizationUpdater,
+  UpgradeToTeamTierSuccess: upgradeToTeamTierSuccessUpdater
 } as const
 
 const OrganizationSubscription = (


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8484

Loom demo: https://www.loom.com/share/c6099d36128a4cd593cd1a49126612b7

The problem in master:
- To handle 3D Secure cards, we have to separate the Stripe subscription logic from the upgrade logic. This is because the client need to authenticate the 3D Secure payment after the subscription has been created.
- After the subscription has been created, Stripe webhooks triggers `upgradeToTeamTier` which upgrades the org 
- After `createStripeSubscription` has complete, we show the right draw and confetti before `upgradeToTeamTier` has finished to give the user faster feedback (it's already pretty slow)
- When the right drawer initially shows, it shows the Starter tier info, not the Team tier info

Solution:
- Add a `upgradeToTeamTierSuccessUpdater` to the `OrganizationSubscription`
- In the updater, set `showDrawer` and `showConfetti` to true
- Wait until `upgradeToTeamTier` has been executed before updating the UI

Downside:
- We're now waiting for the `upgradeToTeamTier` subscription before updating the UI. This can be a long wait
- I've got an issue to give the user feedback while they're upgrading: https://github.com/ParabolInc/parabol/issues/8497

### To test

- [ ] Run `stripe listen --forward-to localhost:3000/stripe` to listen to webhooks
- [ ] Upgrade to the Team tier using a 3D Secure card (see [here](https://stripe.com/docs/payments/3d-secure?locale=en-GB#three-ds-cards)), and see that the right drawer and the confetti show after the user has upgraded
- [ ] Use a 3D Secure card and fail the authentication. See that the right drawer and confetti doesn't show
- [ ] Use a non-3D Secure card and see the expected behaviour 