### PR TITLE
fix: Limit number of teams that can be moved in one moveTeamToOrg call

### DIFF
--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -154,11 +154,7 @@ export default {
     if (teamIds.length > MAX_NUM_TEAMS) {
       // Running this mutation with more than ~50 team IDs usually times out on prod. Splitting into
       // batches is the workaround, so fail quickly with a descriptive error when this is the case.
-      return standardError(
-        new Error(
-          `Can only move ${MAX_NUM_TEAMS} teams at once. Please split team IDs into batches.`
-        )
-      )
+      return `Error: Can only move ${MAX_NUM_TEAMS} teams at once. Please split team IDs into batches.`
     }
     const results = [] as (string | any)[]
     for (let i = 0; i < teamIds.length; i++) {

--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -14,6 +14,8 @@ import {DataLoaderWorker, GQLContext} from '../graphql'
 import isValid from '../isValid'
 import getKysely from '../../postgres/getKysely'
 
+const MAX_NUM_TEAMS = 40
+
 const moveToOrg = async (
   teamId: string,
   orgId: string,
@@ -149,6 +151,13 @@ export default {
     {teamIds, orgId}: {teamIds: string[]; orgId: string},
     {authToken, dataLoader}: GQLContext
   ) {
+    if (teamIds.length > MAX_NUM_TEAMS) {
+      return standardError(
+        new Error(
+          `Can only move ${MAX_NUM_TEAMS} teams at once. Please split team IDs into batches.`
+        )
+      )
+    }
     const results = [] as (string | any)[]
     for (let i = 0; i < teamIds.length; i++) {
       const teamId = teamIds[i]!

--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -152,6 +152,8 @@ export default {
     {authToken, dataLoader}: GQLContext
   ) {
     if (teamIds.length > MAX_NUM_TEAMS) {
+      // Running this mutation with more than ~50 team IDs usually times out on prod. Splitting into
+      // batches is the workaround, so fail quickly with a descriptive error when this is the case.
       return standardError(
         new Error(
           `Can only move ${MAX_NUM_TEAMS} teams at once. Please split team IDs into batches.`


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8216

Set a hard limit on the `moveTeamToOrg` mutation to short-circuit to an error when the mutation is likely to time out.

This doesn't solve the underlying issue, but since this is an internal-only mutation, these guardrails should be sufficient. Once this lands, we could optionally convert the GH issue from a "bug" to "enhancement" (or create a new issue), with the AC being to solve the underlying issue and remove this guardrail, but such a task would probably be so low priority it'd likely be marked as "Closed - won't do" pretty quickly.

## Demo
<img width="678" alt="Screen Shot 2023-07-06 at 4 12 45 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/13d038ec-c3ae-4887-ae42-ffcf72713727">

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
