### PR TITLE
chore: bump pg to v12.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
     docker:
       - image: cimg/node:18.16.0
       - image: rethinkdb:2.4.0
-      - image: cimg/postgres:12.9 # TODO: update to 12.10 when https://github.com/CircleCI-Public/cimg-postgres/pull/42 is merged
+      - image: cimg/postgres:12.15
         environment:
           # These env values need to be synced up with the `test` environment file
           POSTGRES_PASSWORD: "p9_p455w02d_f02_73575"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: "write"
     services:
       postgres:
-        image: postgres:12.10-alpine
+        image: postgres:12.15-alpine
         # This env variables must be the same in the file PARABOL_BUILD_ENV_PATH
         env:
           POSTGRES_PASSWORD: "temppassword"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     networks:
       - parabol-network
   postgres:
-    image: postgres:12.10
+    image: postgres:12.15
     restart: always
     env_file: .env
     ports:

--- a/docker/parabol-ubi/docker-host-st/docker-compose.yaml
+++ b/docker/parabol-ubi/docker-host-st/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     networks:
       - parabol-network
   postgres:
-    image: postgres:12.10
+    image: postgres:12.15
     restart: always
     env_file: .env
     ports:

--- a/packages/server/postgres/Dockerfile
+++ b/packages/server/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:12.10
+FROM postgres:12.15
 
 ADD extensions /extensions
 


### PR DESCRIPTION
# Description

pg v12 has some vulns when version is < 12.15.
this bumps pg to 12.15 for all deploys.

@adaniels-parabol can you confirm if 12.15 works for gov clients?
