### PR TITLE
chore: replace xml-lint due to mem leak

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -80,7 +80,6 @@
     "webpack-s3-plugin": "^1.2.0-rc.0"
   },
   "dependencies": {
-    "@authenio/samlify-node-xmllint": "^2.0.0",
     "@aws-sdk/client-s3": "^3.315.0",
     "@graphql-tools/schema": "^9.0.16",
     "@mattkrick/sanitize-svg": "0.4.0",
@@ -102,6 +101,7 @@
     "draft-js-export-markdown": "^1.3.3",
     "emoji-mart": "^3.0.1",
     "fast-json-stable-stringify": "^2.1.0",
+    "fast-xml-parser": "^4.2.5",
     "graphql": "15.7.2",
     "graphql-jit": "^0.7.4",
     "graphql-middleware": "^6.1.18",

--- a/packages/server/utils/samlXMLValidator.ts
+++ b/packages/server/utils/samlXMLValidator.ts
@@ -1,0 +1,11 @@
+import {XMLValidator} from 'fast-xml-parser'
+
+export const samlXMLValidator = {
+  async validate(xml: string) {
+    const isValid = XMLValidator.validate(xml, {
+      allowBooleanAttributes: true
+    })
+    if (isValid === true) return 'SUCCESS_VALIDATE_XML'
+    throw 'ERR_INVALID_XML'
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,13 +71,6 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
-"@authenio/samlify-node-xmllint@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@authenio/samlify-node-xmllint/-/samlify-node-xmllint-2.0.0.tgz#74bf7dc540506a25e842ae72d492afec627b3a6d"
-  integrity sha512-V9cQ0CHqu3JwOmbSecGPUnzIES5kHxD00FEZKnWh90ksQUJG5/TscV2r9XLbKp7MlRMOSUfWxecM35xPSLFdSg==
-  dependencies:
-    node-xmllint "^1.0.0"
-
 "@authenio/xml-encryption@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@authenio/xml-encryption/-/xml-encryption-1.3.0.tgz#9079f227d5f54daf8bec25245a7a98a46186445d"
@@ -9757,9 +9750,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001359, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449, caniuse-lite@~1.0.0:
-  version "1.0.30001509"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz#2b7ad5265392d6d2de25cd8776d1ab3899570d14"
-  integrity sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==
+  version "1.0.30001514"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz#e2a7e184a23affc9367b7c8d734e7ec4628c1309"
+  integrity sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -12173,6 +12166,13 @@ fast-xml-parser@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
   integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
+  dependencies:
+    strnum "^1.0.5"
+
+fast-xml-parser@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz#a6747a09296a6cb34f2ae634019bf1738f3b421f"
+  integrity sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==
   dependencies:
     strnum "^1.0.5"
 
@@ -16377,11 +16377,6 @@ node-rsa@^1.1.1:
   integrity sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==
   dependencies:
     asn1 "^0.2.4"
-
-node-xmllint@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-xmllint/-/node-xmllint-1.0.0.tgz#f680457eb0166a3d06996f1242d34d47000fe55b"
-  integrity sha1-9oBFfrAWaj0GmW8SQtNNRwAP5Vs=
 
 nodemailer-fetch@1.6.0:
   version "1.6.0"


### PR DESCRIPTION
# Description

fix #8498

## Demo

https://www.loom.com/share/8bb1ace6d4da4c3091daee1ef33046f8

## Testing scenarios

testing performed in demo, probably not necessary to test it yourself, but if you'd like to...

- [ ] create a dev okta account & dev parabol app. locally, call `enableSAMLForDomain` with the dev okta's metadata & your parabol.co email
- [ ] verify that logging in works

To test that the memory leak is gone:

- [ ] login a few times & then run `dumpHeap` in /admin/graphql
- [ ] analyze the heap & notice that there isn't a huge array of 16MB JSArrayBuffers being held onto
