### PR TITLE
fix: avoid pronoun assumptions in ai summary

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -18,14 +18,15 @@ class OpenAIServerManager {
 
   async getSummary(text: string | string[], summaryLocation?: 'discussion thread') {
     if (!this.openAIApi) return null
+    const textStr = Array.isArray(text) ? text.join('\n') : text
     try {
       const location = summaryLocation ?? 'retro meeting'
       const response = await this.openAIApi.createCompletion({
         model: 'text-davinci-003',
-        prompt: `Below is a comma-separated list of text from a ${location}. Summarize the text for a second-grade student in one or two sentences.
+        prompt: `Below is a comma-separated list of text from a ${location}. Summarize the text for a second-grade student in one or two sentences. When referring to people in the summary, do not assume their gender and default to using the pronouns "they" and "them".
 
         Text: """
-        ${text}
+        ${textStr}
         """`,
         temperature: 0.7,
         max_tokens: 80,
@@ -33,6 +34,8 @@ class OpenAIServerManager {
         frequency_penalty: 0,
         presence_penalty: 0
       })
+      const res = response.data.choices[0]?.text?.trim()
+      console.log('🚀 ~ res:', res)
       return (response.data.choices[0]?.text?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -34,8 +34,6 @@ class OpenAIServerManager {
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      const res = response.data.choices[0]?.text?.trim()
-      console.log('🚀 ~ res:', res)
       return (response.data.choices[0]?.text?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8491

I used a newline delimiter as @jordanh suggested [here](https://parabol.slack.com/archives/C042HTVBH8D/p1688755623776749). 

I didn't include the text `If you can't provide a summary, simply write the word "No".` which is mentioned in the issue because I got the following response when summarising reflections which mentioned a bunch of random artists (something it can usually do without problems): 

![Screenshot 2023-07-13 at 15 19 19](https://github.com/ParabolInc/parabol/assets/39854876/6a531d00-26fe-4453-94f2-6545f16f1871)


### To test

- [ ] Create a retro, and see AI Summaries are working as expected
- [ ] Copy & paste the reflections in the issue and see that the summary does not assume gender