### PR TITLE
feat: teams view

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -5,7 +5,7 @@ import {useFragment} from 'react-relay'
 import {useLocation, useRouteMatch} from 'react-router'
 import {PALETTE} from '../../styles/paletteV3'
 import {NavSidebar} from '../../types/constEnums'
-import {BILLING_PAGE, MEMBERS_PAGE, ORG_SETTINGS_PAGE} from '../../utils/constants'
+import {BILLING_PAGE, MEMBERS_PAGE, ORG_SETTINGS_PAGE, TEAMS_PAGE} from '../../utils/constants'
 import {DashSidebar_viewer$key} from '../../__generated__/DashSidebar_viewer.graphql'
 import DashNavList from '../DashNavList/DashNavList'
 import SideBarStartMeetingButton from '../SideBarStartMeetingButton'
@@ -113,6 +113,11 @@ const DashSidebar = (props: Props) => {
                 icon={'creditScore'}
                 href={`/me/organizations/${orgId}/${BILLING_PAGE}`}
                 label={'Plans & Billing'}
+              />
+              <NavItem
+                icon={'groups'}
+                href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}
+                label={'Teams'}
               />
               <NavItem
                 icon={'group'}

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -7,6 +7,7 @@ import {
   ExitToApp,
   Forum,
   Group,
+  Groups,
   History,
   PlaylistAddCheck,
   Warning,
@@ -66,6 +67,7 @@ const iconLookup = {
   add: <Add />,
   exit_to_app: <ExitToApp />,
   group: <Group />,
+  groups: <Groups />,
   warning: <Warning />,
   work: <WorkOutline />
 }

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -5,7 +5,7 @@ import {useFragment} from 'react-relay'
 import {useRouteMatch} from 'react-router'
 import {PALETTE} from '../../styles/paletteV3'
 import {NavSidebar} from '../../types/constEnums'
-import {BILLING_PAGE, MEMBERS_PAGE, ORG_SETTINGS_PAGE} from '../../utils/constants'
+import {BILLING_PAGE, MEMBERS_PAGE, ORG_SETTINGS_PAGE, TEAMS_PAGE} from '../../utils/constants'
 import {DashSidebar_viewer$key} from '../../__generated__/DashSidebar_viewer.graphql'
 import DashNavList from '../DashNavList/DashNavList'
 import StandardHub from '../StandardHub/StandardHub'
@@ -127,6 +127,12 @@ const MobileDashSidebar = (props: Props) => {
                 icon={'creditScore'}
                 href={`/me/organizations/${orgId}/${BILLING_PAGE}`}
                 label={'Plans & Billing'}
+              />
+              <LeftDashNavItem
+                onClick={handleMenuClick}
+                icon={'groups'}
+                href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}
+                label={'Teams'}
               />
               <LeftDashNavItem
                 onClick={handleMenuClick}

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPage.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPage.tsx
@@ -35,6 +35,7 @@ const OrgPage = (props: Props) => {
         ...OrgNav_organization
         ...OrgPlansAndBillingRoot_organization
         ...OrgDetails_organization
+        ...OrgTeams_organization
       }
     `,
     organizationRef
@@ -56,7 +57,11 @@ const OrgPage = (props: Props) => {
           path={`${match.url}/${BILLING_PAGE}`}
           render={() => <OrgPlansAndBillingRoot organizationRef={organization} />}
         />
-        <Route exact path={`${match.url}/${TEAMS_PAGE}`} render={() => <OrgTeams />} />
+        <Route
+          exact
+          path={`${match.url}/${TEAMS_PAGE}`}
+          render={() => <OrgTeams organizationRef={organization} />}
+        />
         <Route
           exact
           path={`${match.url}/${MEMBERS_PAGE}`}

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPage.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPage.tsx
@@ -2,9 +2,15 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {lazy} from 'react'
 import {useFragment} from 'react-relay'
 import {Redirect, Route, Switch, useRouteMatch} from 'react-router'
-import {BILLING_PAGE, MEMBERS_PAGE, ORG_SETTINGS_PAGE} from '../../../../utils/constants'
+import {
+  BILLING_PAGE,
+  MEMBERS_PAGE,
+  ORG_SETTINGS_PAGE,
+  TEAMS_PAGE
+} from '../../../../utils/constants'
 import {OrgPage_organization$key} from '../../../../__generated__/OrgPage_organization.graphql'
 import OrgNav from '../Organization/OrgNav'
+import OrgTeams from '../OrgTeams/OrgTeams'
 
 const OrgPlansAndBillingRoot = lazy(
   () => import(/* webpackChunkName: 'OrgBillingRoot' */ './OrgPlansAndBillingRoot')
@@ -50,6 +56,7 @@ const OrgPage = (props: Props) => {
           path={`${match.url}/${BILLING_PAGE}`}
           render={() => <OrgPlansAndBillingRoot organizationRef={organization} />}
         />
+        <Route exact path={`${match.url}/${TEAMS_PAGE}`} render={() => <OrgTeams />} />
         <Route
           exact
           path={`${match.url}/${MEMBERS_PAGE}`}

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -4,41 +4,12 @@ import styled from '@emotion/styled'
 import Row from '../../../../components/Row/Row'
 import Panel from '../../../../components/Panel/Panel'
 import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
-import RowInfo from '../../../../components/Row/RowInfo'
-import {PALETTE} from '../../../../styles/paletteV3'
-import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
 import {useFragment} from 'react-relay'
+import OrgTeamsRow from './OrgTeamsRow'
 import plural from '../../../../utils/plural'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH
-})
-
-const StyledRowInfo = styled(RowInfo)({
-  paddingLeft: 0
-})
-const RowInfoHeader = styled('div')({
-  alignItems: 'center',
-  display: 'flex'
-})
-
-const RowInfoHeading = styled('div')({
-  color: PALETTE.SLATE_700,
-  fontSize: 16,
-  fontWeight: 600,
-  lineHeight: '24px'
-})
-
-const color = PALETTE.SLATE_600
-
-const LinkComponent = RowInfoCopy.withComponent('a')
-
-const RowInfoLink = styled(LinkComponent)({
-  color,
-  ':hover, :focus, :active': {
-    color,
-    textDecoration: 'underline'
-  }
 })
 
 const StyledRow = styled(Row)({
@@ -59,10 +30,7 @@ const OrgTeams = (props: Props) => {
       fragment OrgTeams_organization on Organization {
         id
         teams {
-          name
-          teamMembers {
-            id
-          }
+          ...OrgTeamsRow_team
         }
       }
     `,
@@ -70,37 +38,16 @@ const OrgTeams = (props: Props) => {
   )
   const {teams} = organization
   const teamsCount = teams.length
-  const teamMembersCount = teams.reduce((acc, team) => acc + team.teamMembers.length, 0)
-  console.log('🚀 ~ organization:', {organization, teamMembersCount})
   return (
     <StyledPanel label={`${teamsCount} ${plural(teamsCount, 'team')}`}>
       <Row>
-        <div className='flex w-full justify-between px-6 '>
-          <div className='flex items-center '>Team Name</div>
-          <div className='flex items-center '>Lead</div>
+        <div className='flex w-full justify-between px-6'>
+          <div className='flex items-center font-bold'>Team Name</div>
+          <div className='flex items-center font-bold'>Lead</div>
         </div>
       </Row>
       {teams.map((team) => (
-        <StyledRow>
-          <div className='flex w-full flex-col px-6'>
-            <div className='text-gray-700 text-lg font-bold'>{team.name}</div>
-            <div className='flex items-center justify-between'>
-              <a href='mailto' title='Send an email' className='text-gray-600 hover:underline'>
-                {`${teamMembersCount}  ${plural(
-                  teamMembersCount,
-                  'member'
-                )} • Last met on July 3rd 2023`}
-              </a>
-              <a
-                href='mailto:test@example.com'
-                title='Email'
-                className='text-gray-600 hover:underline'
-              >
-                test@example.com
-              </a>
-            </div>
-          </div>
-        </StyledRow>
+        <OrgTeamsRow key={team.id} teamRef={team} />
       ))}
     </StyledPanel>
   )

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -1,23 +1,76 @@
 import React from 'react'
 import styled from '@emotion/styled'
 import Row from '../../../../components/Row/Row'
-import RowInfo from '../../../../components/Row/RowInfo'
-import RowInfoHeader from '../../../../components/Row/RowInfoHeader'
 import Panel from '../../../../components/Panel/Panel'
-import {ElementWidth} from '../../../../types/constEnums'
+import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
+import RowInfo from '../../../../components/Row/RowInfo'
+import {PALETTE} from '../../../../styles/paletteV3'
+import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH
+})
+
+const StyledRowInfo = styled(RowInfo)({
+  paddingLeft: 0
+})
+const RowInfoHeader = styled('div')({
+  alignItems: 'center',
+  display: 'flex'
+})
+
+const RowInfoHeading = styled('div')({
+  color: PALETTE.SLATE_700,
+  fontSize: 16,
+  fontWeight: 600,
+  lineHeight: '24px'
+})
+
+const color = PALETTE.SLATE_600
+
+const LinkComponent = RowInfoCopy.withComponent('a')
+
+const RowInfoLink = styled(LinkComponent)({
+  color,
+  ':hover, :focus, :active': {
+    color,
+    textDecoration: 'underline'
+  }
+})
+
+const StyledRow = styled(Row)({
+  padding: '12px 8px 12px 16px',
+  [`@media screen and (min-width: ${Breakpoint.SIDEBAR_LEFT}px)`]: {
+    padding: '16px 8px 16px 16px'
+  }
 })
 
 const OrgTeams = () => {
   return (
     <StyledPanel label='6 Teams'>
       <Row>
-        <RowInfo>
-          <RowInfoHeader>Team Name</RowInfoHeader>
-        </RowInfo>
+        <div className='flex w-full justify-between px-6 '>
+          <div className='flex items-center '>Team Name</div>
+          <div className='flex items-center '>Lead</div>
+        </div>
       </Row>
+      <StyledRow>
+        <div className='flex w-full flex-col px-6'>
+          <div className='text-gray-700 text-lg font-bold'>bavin</div>
+          <div className='flex items-center justify-between'>
+            <a href='mailto' title='Send an email' className='text-gray-600 hover:underline'>
+              6 members • Last met on 2/2/2021
+            </a>
+            <a
+              href='mailto:test@example.com'
+              title='Email'
+              className='text-gray-600 hover:underline'
+            >
+              test@example.com
+            </a>
+          </div>
+        </div>
+      </StyledRow>
     </StyledPanel>
   )
 }

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -3,20 +3,12 @@ import graphql from 'babel-plugin-relay/macro'
 import styled from '@emotion/styled'
 import Row from '../../../../components/Row/Row'
 import Panel from '../../../../components/Panel/Panel'
-import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
+import {ElementWidth} from '../../../../types/constEnums'
 import {useFragment} from 'react-relay'
 import OrgTeamsRow from './OrgTeamsRow'
-import plural from '../../../../utils/plural'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH
-})
-
-const StyledRow = styled(Row)({
-  padding: '12px 8px 12px 16px',
-  [`@media screen and (min-width: ${Breakpoint.SIDEBAR_LEFT}px)`]: {
-    padding: '16px 8px 16px 16px'
-  }
 })
 
 type Props = {
@@ -37,19 +29,21 @@ const OrgTeams = (props: Props) => {
     organizationRef
   )
   const {teams} = organization
-  const teamsCount = teams.length
   return (
-    <StyledPanel label={`${teamsCount} ${plural(teamsCount, 'team')}`}>
-      <Row>
-        <div className='flex w-full justify-between px-6'>
-          <div className='flex items-center font-bold'>Team Name</div>
-          <div className='flex items-center font-bold'>Lead</div>
-        </div>
-      </Row>
-      {teams.map((team) => (
-        <OrgTeamsRow key={team.id} teamRef={team} />
-      ))}
-    </StyledPanel>
+    <>
+      <h1>{'Teams'}</h1>
+      <StyledPanel>
+        <Row>
+          <div className='flex w-full justify-between px-6'>
+            <div className='flex items-center font-bold'>Team Name</div>
+            <div className='flex items-center font-bold'>Lead</div>
+          </div>
+        </Row>
+        {teams.map((team) => (
+          <OrgTeamsRow key={team.id} teamRef={team} />
+        ))}
+      </StyledPanel>
+    </>
   )
 }
 

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -6,13 +6,14 @@ import Panel from '../../../../components/Panel/Panel'
 import {ElementWidth} from '../../../../types/constEnums'
 import {useFragment} from 'react-relay'
 import OrgTeamsRow from './OrgTeamsRow'
+import {OrgTeams_organization$key} from '../../../../__generated__/OrgTeams_organization.graphql'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH
 })
 
 type Props = {
-  organizationRef: any // OrgPage_organization$key
+  organizationRef: OrgTeams_organization$key
 }
 
 const OrgTeams = (props: Props) => {
@@ -22,6 +23,7 @@ const OrgTeams = (props: Props) => {
       fragment OrgTeams_organization on Organization {
         id
         teams {
+          id
           ...OrgTeamsRow_team
         }
       }

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import graphql from 'babel-plugin-relay/macro'
 import styled from '@emotion/styled'
 import Row from '../../../../components/Row/Row'
 import Panel from '../../../../components/Panel/Panel'
@@ -6,6 +7,8 @@ import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
 import RowInfo from '../../../../components/Row/RowInfo'
 import {PALETTE} from '../../../../styles/paletteV3'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
+import {useFragment} from 'react-relay'
+import plural from '../../../../utils/plural'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH
@@ -45,32 +48,60 @@ const StyledRow = styled(Row)({
   }
 })
 
-const OrgTeams = () => {
+type Props = {
+  organizationRef: any // OrgPage_organization$key
+}
+
+const OrgTeams = (props: Props) => {
+  const {organizationRef} = props
+  const organization = useFragment(
+    graphql`
+      fragment OrgTeams_organization on Organization {
+        id
+        teams {
+          name
+          teamMembers {
+            id
+          }
+        }
+      }
+    `,
+    organizationRef
+  )
+  const {teams} = organization
+  const teamsCount = teams.length
+  const teamMembersCount = teams.reduce((acc, team) => acc + team.teamMembers.length, 0)
+  console.log('🚀 ~ organization:', {organization, teamMembersCount})
   return (
-    <StyledPanel label='6 Teams'>
+    <StyledPanel label={`${teamsCount} ${plural(teamsCount, 'team')}`}>
       <Row>
         <div className='flex w-full justify-between px-6 '>
           <div className='flex items-center '>Team Name</div>
           <div className='flex items-center '>Lead</div>
         </div>
       </Row>
-      <StyledRow>
-        <div className='flex w-full flex-col px-6'>
-          <div className='text-gray-700 text-lg font-bold'>bavin</div>
-          <div className='flex items-center justify-between'>
-            <a href='mailto' title='Send an email' className='text-gray-600 hover:underline'>
-              6 members • Last met on 2/2/2021
-            </a>
-            <a
-              href='mailto:test@example.com'
-              title='Email'
-              className='text-gray-600 hover:underline'
-            >
-              test@example.com
-            </a>
+      {teams.map((team) => (
+        <StyledRow>
+          <div className='flex w-full flex-col px-6'>
+            <div className='text-gray-700 text-lg font-bold'>{team.name}</div>
+            <div className='flex items-center justify-between'>
+              <a href='mailto' title='Send an email' className='text-gray-600 hover:underline'>
+                {`${teamMembersCount}  ${plural(
+                  teamMembersCount,
+                  'member'
+                )} • Last met on July 3rd 2023`}
+              </a>
+              <a
+                href='mailto:test@example.com'
+                title='Email'
+                className='text-gray-600 hover:underline'
+              >
+                test@example.com
+              </a>
+            </div>
           </div>
-        </div>
-      </StyledRow>
+        </StyledRow>
+      ))}
     </StyledPanel>
   )
 }

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import Row from '../../../../components/Row/Row'
+import RowInfo from '../../../../components/Row/RowInfo'
+import RowInfoHeader from '../../../../components/Row/RowInfoHeader'
+import Panel from '../../../../components/Panel/Panel'
+import {ElementWidth} from '../../../../types/constEnums'
+
+const StyledPanel = styled(Panel)({
+  maxWidth: ElementWidth.PANEL_WIDTH
+})
+
+const OrgTeams = () => {
+  return (
+    <StyledPanel label='6 Teams'>
+      <Row>
+        <RowInfo>
+          <RowInfoHeader>Team Name</RowInfoHeader>
+        </RowInfo>
+      </Row>
+    </StyledPanel>
+  )
+}
+
+export default OrgTeams

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import styled from '@emotion/styled'
+import Row from '../../../../components/Row/Row'
+import Panel from '../../../../components/Panel/Panel'
+import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
+import {useFragment} from 'react-relay'
+import plural from '../../../../utils/plural'
+
+const StyledPanel = styled(Panel)({
+  maxWidth: ElementWidth.PANEL_WIDTH
+})
+
+const StyledRow = styled(Row)({
+  padding: '12px 8px 12px 16px',
+  [`@media screen and (min-width: ${Breakpoint.SIDEBAR_LEFT}px)`]: {
+    padding: '16px 8px 16px 16px'
+  }
+})
+
+type Props = {
+  teamRef: any // OrgPage_team$key
+}
+
+const OrgTeamsRow = (props: Props) => {
+  const {teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment OrgTeamsRow_team on Team {
+        name
+        teamMembers {
+          id
+          isLead
+          isSelf
+          email
+        }
+      }
+    `,
+    teamRef
+  )
+  console.log('🚀 ~ team:', team)
+  const {teamMembers, name} = team
+  const teamsCount = 2
+  const teamMembersCount = teamMembers.length
+  const teamLeadEmail = teamMembers.find((member) => member.isLead).email
+  const isViewerTeamLead = teamMembers.some((member) => member.isSelf && member.isLead)
+  console.log('🚀 ~ teamLeadEmail:', teamLeadEmail)
+  // const teamMembersCount = teams.reduce((acc, team) => acc + team.teamMembers.length, 0)
+  // const teamLeadEmail = teams.console.log('🚀 ~ organization:', {organization, teamMembersCount})
+  return (
+    <StyledRow>
+      <div className='flex w-full flex-col px-6 py-2'>
+        <div className='text-gray-700 text-lg font-bold'>{name}</div>
+        <div className='flex items-center justify-between'>
+          <a href='mailto' title='Send an email' className='text-gray-600 hover:underline'>
+            {`${teamMembersCount}  ${plural(
+              teamMembersCount,
+              'member'
+            )} • Last met on July 3rd 2023`}
+          </a>
+          <a
+            href={`mailto:${teamLeadEmail}`}
+            title='Email'
+            className='text-gray-600 hover:underline'
+          >
+            {`${teamLeadEmail} ${isViewerTeamLead ? '(You)' : ''}`}
+          </a>
+        </div>
+      </div>
+    </StyledRow>
+  )
+}
+
+export default OrgTeamsRow

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {Link} from 'react-router-dom'
 import graphql from 'babel-plugin-relay/macro'
 import styled from '@emotion/styled'
 import Row from '../../../../components/Row/Row'
@@ -6,10 +7,6 @@ import Panel from '../../../../components/Panel/Panel'
 import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
 import {useFragment} from 'react-relay'
 import plural from '../../../../utils/plural'
-
-const StyledPanel = styled(Panel)({
-  maxWidth: ElementWidth.PANEL_WIDTH
-})
 
 const StyledRow = styled(Row)({
   padding: '12px 8px 12px 16px',
@@ -27,6 +24,7 @@ const OrgTeamsRow = (props: Props) => {
   const team = useFragment(
     graphql`
       fragment OrgTeamsRow_team on Team {
+        id
         name
         teamMembers {
           id
@@ -38,26 +36,32 @@ const OrgTeamsRow = (props: Props) => {
     `,
     teamRef
   )
-  console.log('🚀 ~ team:', team)
-  const {teamMembers, name} = team
-  const teamsCount = 2
+  const {id: teamId, teamMembers, name} = team
   const teamMembersCount = teamMembers.length
   const teamLeadEmail = teamMembers.find((member) => member.isLead).email
   const isViewerTeamLead = teamMembers.some((member) => member.isSelf && member.isLead)
-  console.log('🚀 ~ teamLeadEmail:', teamLeadEmail)
-  // const teamMembersCount = teams.reduce((acc, team) => acc + team.teamMembers.length, 0)
-  // const teamLeadEmail = teams.console.log('🚀 ~ organization:', {organization, teamMembersCount})
   return (
     <StyledRow>
-      <div className='flex w-full flex-col px-6 py-2'>
+      <div className='flex w-full flex-col px-6 py-1'>
         <div className='text-gray-700 text-lg font-bold'>{name}</div>
         <div className='flex items-center justify-between'>
-          <a href='mailto' title='Send an email' className='text-gray-600 hover:underline'>
-            {`${teamMembersCount}  ${plural(
-              teamMembersCount,
-              'member'
-            )} • Last met on July 3rd 2023`}
-          </a>
+          <div className='text-gray-600'>
+            {`${teamMembersCount} ${plural(teamMembersCount, 'member')}`}
+            <span className='mx-2'>•</span>
+            {`Last met on July 3rd 2023`}
+            {isViewerTeamLead && (
+              <>
+                <span className='mx-2'>•</span>
+                <Link
+                  to={`/team/${teamId}/settings`}
+                  className='cursor-pointer font-bold text-sky-500 hover:underline'
+                >
+                  {'Manage Team'}
+                </Link>
+              </>
+            )}
+          </div>
+
           <a
             href={`mailto:${teamLeadEmail}`}
             title='Email'

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -1,19 +1,9 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
 import graphql from 'babel-plugin-relay/macro'
-import styled from '@emotion/styled'
 import Row from '../../../../components/Row/Row'
-import Panel from '../../../../components/Panel/Panel'
-import {Breakpoint, ElementWidth} from '../../../../types/constEnums'
 import {useFragment} from 'react-relay'
 import plural from '../../../../utils/plural'
-
-const StyledRow = styled(Row)({
-  padding: '12px 8px 12px 16px',
-  [`@media screen and (min-width: ${Breakpoint.SIDEBAR_LEFT}px)`]: {
-    padding: '16px 8px 16px 16px'
-  }
-})
 
 type Props = {
   teamRef: any // OrgPage_team$key
@@ -41,14 +31,12 @@ const OrgTeamsRow = (props: Props) => {
   const teamLeadEmail = teamMembers.find((member) => member.isLead).email
   const isViewerTeamLead = teamMembers.some((member) => member.isSelf && member.isLead)
   return (
-    <StyledRow>
+    <Row>
       <div className='flex w-full flex-col px-6 py-1'>
         <div className='text-gray-700 text-lg font-bold'>{name}</div>
         <div className='flex items-center justify-between'>
           <div className='text-gray-600'>
             {`${teamMembersCount} ${plural(teamMembersCount, 'member')}`}
-            <span className='mx-2'>•</span>
-            {`Last met on July 3rd 2023`}
             {isViewerTeamLead && (
               <>
                 <span className='mx-2'>•</span>
@@ -71,7 +59,7 @@ const OrgTeamsRow = (props: Props) => {
           </a>
         </div>
       </div>
-    </StyledRow>
+    </Row>
   )
 }
 

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -4,9 +4,10 @@ import graphql from 'babel-plugin-relay/macro'
 import Row from '../../../../components/Row/Row'
 import {useFragment} from 'react-relay'
 import plural from '../../../../utils/plural'
+import {OrgTeamsRow_team$key} from '../../../../__generated__/OrgTeamsRow_team.graphql'
 
 type Props = {
-  teamRef: any // OrgPage_team$key
+  teamRef: OrgTeamsRow_team$key
 }
 
 const OrgTeamsRow = (props: Props) => {
@@ -28,7 +29,7 @@ const OrgTeamsRow = (props: Props) => {
   )
   const {id: teamId, teamMembers, name} = team
   const teamMembersCount = teamMembers.length
-  const teamLeadEmail = teamMembers.find((member) => member.isLead).email
+  const teamLeadEmail = teamMembers.find((member) => member.isLead)?.email ?? ''
   const isViewerTeamLead = teamMembers.some((member) => member.isSelf && member.isLead)
   return (
     <Row>

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -92,6 +92,7 @@ export const NOTIFICATIONS = 'notifications'
 /* Org Settings */
 export const BILLING_PAGE = 'billing'
 export const MEMBERS_PAGE = 'members'
+export const TEAMS_PAGE = 'teams'
 export const ORG_SETTINGS_PAGE = 'settings'
 export const AUTHENTICATION_PAGE = 'authentication'
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,11 +22,16 @@ module.exports = {
         'icon-md-48': '48px'
       },
       boxShadow: {
-        'card-1': '0px 6px 10px rgba(68, 66, 88, 0.14), 0px 1px 18px rgba(68, 66, 88, 0.12), 0px 3px 5px rgba(68, 66, 88, 0.2)',
-        'dialog': '0px 11px 15px -7px rgba(0,0,0,.2), 0px 24px 38px 3px rgba(0,0,0,.14), 0px 9px 46px 8px rgba(0,0,0,.12)'
+        'card-1':
+          '0px 6px 10px rgba(68, 66, 88, 0.14), 0px 1px 18px rgba(68, 66, 88, 0.12), 0px 3px 5px rgba(68, 66, 88, 0.2)',
+        dialog:
+          '0px 11px 15px -7px rgba(0,0,0,.2), 0px 24px 38px 3px rgba(0,0,0,.14), 0px 9px 46px 8px rgba(0,0,0,.12)'
       },
       borderRadius: {
         card: '4px'
+      },
+      borderWidth: {
+        0.5: '0.5px'
       },
       screens: {
         // => @media (min-width: 512px) { ... }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,9 +30,6 @@ module.exports = {
       borderRadius: {
         card: '4px'
       },
-      borderWidth: {
-        0.5: '0.5px'
-      },
       screens: {
         // => @media (min-width: 512px) { ... }
         invoice: '512px',


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8503

Demo: https://www.loom.com/share/62299583ec2d40b886e38c79c6092411

![Screenshot 2023-07-13 at 17 39 14](https://github.com/ParabolInc/parabol/assets/39854876/0e558093-cd53-4f1c-9392-8ef0fd9a938d)

![Screenshot 2023-07-13 at 17 50 38](https://github.com/ParabolInc/parabol/assets/39854876/79c93e79-c6ef-452a-91bd-2c2005183543)


@acressall in the issue AC we have `As a billing lead I can view all the teams on my org`. Just confirming that non-billing leaders can view all teams on the org too?

I made two changes from the design:

1. I haven't included the `6 teams` row at the top. This is because it took a bit of time to start customising the `Panel` component. I then wondered whether we need it as most orgs won't have so many teams that it's hard to count. Not including it saves some screen real estate.
2. `Last met at` isn't included. I'll include this in a later PR. @acressall I wanted to check that this date is the date the team last had a meeting?

### To test

- [ ] Users with the `checkoutFlow` feature flag can see all the teams in the org
- [ ] Billing leaders see "Manage Team". If they click it, they go to the team's settings page
- [ ] Team lead emails are visible on the right of the row