### PR TITLE
feat: show loading feedback while upgrading

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -16,6 +16,7 @@ import SendClientSegmentEventMutation from '../../../../mutations/SendClientSegm
 import {StripeElementChangeEvent} from '@stripe/stripe-js'
 import CreateStripeSubscriptionMutation from '../../../../mutations/CreateStripeSubscriptionMutation'
 import {CreateStripeSubscriptionMutation$data} from '../../../../__generated__/CreateStripeSubscriptionMutation.graphql'
+import Ellipsis from '../../../../components/Ellipsis/Ellipsis'
 
 const ButtonBlock = styled('div')({
   display: 'flex',
@@ -226,7 +227,13 @@ const BillingForm = (props: Props) => {
           isDisabled={isUpgradeDisabled}
           type={'submit'}
         >
-          {'Upgrade'}
+          {isLoading ? (
+            <>
+              Upgrading <Ellipsis />
+            </>
+          ) : (
+            'Upgrade'
+          )}
         </UpgradeButton>
       </ButtonBlock>
     </form>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8497


![Screenshot 2023-07-14 at 15 12 23](https://github.com/ParabolInc/parabol/assets/39854876/7e72cdd4-61e5-4732-955e-c8674d1b0b1f)
![Screenshot 2023-07-14 at 15 12 20](https://github.com/ParabolInc/parabol/assets/39854876/f0e04d6d-7287-4ab9-a434-5dcb9a65169a)
![Screenshot 2023-07-14 at 15 12 15](https://github.com/ParabolInc/parabol/assets/39854876/ecd36a63-312f-4df2-a60a-ad3c24f35b4a)


### To test

- [ ] Add the checkout flow flag and run `stripe listen --forward-to localhost:3000/stripe` in your terminal
- [ ] Upgrade to the Team tier
- [ ] See that there's feedback while upgrading with an ellipsis and the text changing from Upgrade to Upgrading