### PR TITLE
chore(share-summary): add utm params and reflectionGroupId param

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
@@ -77,7 +77,7 @@ const RetroTopics = (props: Props) => {
         searchParams: {
           utm_source: 'summary email',
           utm_medium: 'email',
-          utm_campaign: 'sharing'
+          utm_campaign: 'after-meeting'
         }
       })
     : meetingPath
@@ -97,7 +97,7 @@ const RetroTopics = (props: Props) => {
                   searchParams: {
                     utm_source: 'summary email',
                     utm_medium: 'email',
-                    utm_campaign: 'sharing'
+                    utm_campaign: 'after-meeting'
                   }
                 })
               : topicUrlPath

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopics.tsx
@@ -77,7 +77,7 @@ const RetroTopics = (props: Props) => {
         searchParams: {
           utm_source: 'summary email',
           utm_medium: 'email',
-          utm_campaign: 'after-meeting'
+          utm_campaign: 'sharing'
         }
       })
     : meetingPath
@@ -97,7 +97,7 @@ const RetroTopics = (props: Props) => {
                   searchParams: {
                     utm_source: 'summary email',
                     utm_medium: 'email',
-                    utm_campaign: 'after-meeting'
+                    utm_campaign: 'sharing'
                   }
                 })
               : topicUrlPath

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ShareTopic.tsx
@@ -33,7 +33,13 @@ const ShareTopic = (props: Props) => {
   const {isDemo, isEmail, meetingId, stageId, appOrigin} = props
 
   const path = `new-summary/${meetingId}/share/${stageId}`
-  const href = makeAppURL(appOrigin, path)
+  const href = makeAppURL(appOrigin, path, {
+    searchParams: {
+      utm_source: 'summary email',
+      utm_medium: 'email',
+      utm_campaign: 'sharing'
+    }
+  })
 
   if (isEmail) {
     return (

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -359,8 +359,19 @@ export const SlackNotifier: Notifier = {
     }
 
     const topic = reflectionGroup.title
-    const discussionUrl = makeAppURL(appOrigin, `meet/${meetingId}/discuss/${stageIndex + 1}`)
-    const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`)
+    const options = {
+      searchParams: {
+        utm_source: 'slack share',
+        utm_medium: 'product',
+        utm_campaign: 'sharing'
+      }
+    }
+    const discussionUrl = makeAppURL(
+      appOrigin,
+      `meet/${meetingId}/discuss/${stageIndex + 1}`,
+      options
+    )
+    const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`, options)
 
     const reflectionsText = reflections
       .map((reflection) => `• ${reflection.plaintextContent}`)

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -36,7 +36,8 @@ const notifySlack = async (
   event: SlackNotificationEvent,
   teamId: string,
   slackMessage: string | Array<{type: string}>,
-  notificationText?: string
+  notificationText?: string,
+  segmentProperties?: object
 ): Promise<NotifyResponse> => {
   const {channelId, auth} = notificationChannel
   const {botAccessToken, userId} = auth
@@ -47,7 +48,8 @@ const notifySlack = async (
     event: 'Slack notification sent',
     properties: {
       teamId,
-      notificationEvent: event
+      notificationEvent: event,
+      ...segmentProperties
     }
   })
 
@@ -396,6 +398,8 @@ export const SlackNotifier: Notifier = {
       auth: slackAuth
     }
 
-    return notifySlack(notificationChannel, 'TOPIC_SHARED', team.id, slackBlocks)
+    return notifySlack(notificationChannel, 'TOPIC_SHARED', team.id, slackBlocks, undefined, {
+      reflectionGroupId
+    })
   }
 }


### PR DESCRIPTION
added utm params and reflectionGroupId to the segment event

**How to test:**

- Add shareSummary org-level feature flag
- Run a retro and have some topics
- Click on Share topic button
- Share some topic
- Check that segment event is sent correctly
- Check that shared slack message has UTM params in its links
