### PR TITLE
fix: exit code 1 on preDeploy failure

### DIFF
--- a/scripts/toolboxSrc/preDeploy.ts
+++ b/scripts/toolboxSrc/preDeploy.ts
@@ -33,15 +33,11 @@ const preDeploy = async () => {
   const myEnv = dotenv.config({path: envPath})
   dotenvExpand(myEnv)
 
-  try {
-    // first we migrate DBs
-    await standaloneMigrations()
+  // first we migrate DBs
+  await standaloneMigrations()
 
-    // The we can prime the DB & CDN
-    await Promise.all([storePersistedQueries(), primeIntegrations(), pushToCDN()])
-  } catch (e) {
-    console.log('Post deploy error', e)
-  }
+  // The we can prime the DB & CDN
+  await Promise.all([storePersistedQueries(), primeIntegrations(), pushToCDN()])
 
   process.exit()
 }

--- a/scripts/toolboxSrc/primeIntegrations.ts
+++ b/scripts/toolboxSrc/primeIntegrations.ts
@@ -35,13 +35,9 @@ const upsertGlobalIntegrationProvidersFromEnv = async () => {
 
 const primeIntegrations = async () => {
   console.log('⛓️ Prime Integrationgs Started')
-  try {
-    const pg = getPg()
-    await upsertGlobalIntegrationProvidersFromEnv()
-    await pg.end()
-  } catch (e) {
-    console.log('⛓️ Prime Integrations error', e)
-  }
+  const pg = getPg()
+  await upsertGlobalIntegrationProvidersFromEnv()
+  await pg.end()
   console.log('⛓️ Prime Integrations Complete')
 }
 

--- a/scripts/toolboxSrc/standaloneMigrations.ts
+++ b/scripts/toolboxSrc/standaloneMigrations.ts
@@ -26,16 +26,12 @@ const migrateRethinkDB = async () => {
     const {name} = path.parse(relativePath)
     collector[name] = context(relativePath)
   })
-  try {
-    await rethinkMigrate.up({all: true, migrations: collector})
-  } catch (e) {
-    console.error('Migration error', e)
-  }
+  await rethinkMigrate.up({all: true, migrations: collector})
   console.log('👴 RethinkDB Migraiton Complete')
 }
 
 const migratePG = async () => {
-  console.log('🐘 Postgres Migraiton Started')
+  console.log('🐘 Postgres Migration Started')
   // pgm uses a dynamic require statement, which doesn't work with webpack
   // if we ignore that dynamic require, we'd still have to include the migrations directory AND any dependencies it might have
   // by processing through webpack's require.context, we let webpack handle everything
@@ -58,7 +54,7 @@ const migratePG = async () => {
     migrations: collector
   }
   await pgMigrate(programmaticPgmConfig as any)
-  console.log('🐘 Postgres Migraiton Complete')
+  console.log('🐘 Postgres Migration Complete')
 }
 
 const migrateDBs = async () => {


### PR DESCRIPTION
# Description

fix #8523

## Demo

See https://github.com/ParabolInc/parabol/issues/8523#issuecomment-1638641082 for logs & how to reproduce in test


## Testing scenarios

- [ ] set FILE_STORAGE=local & PROTO='' in the .env
- [ ] the process exits with code 1 instead of swallowing the error