### PR TITLE
fix(standups): Error when ending standup

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -260,31 +260,33 @@ const PromptResponseEditor = (props: Props) => {
       <StyledEditor>
         {editor && !readOnly && (
           <>
-            <BubbleMenu editor={editor} tippyOptions={{duration: 100}}>
-              <BubbleMenuWrapper>
-                <BubbleMenuButton
-                  onClick={() => editor.chain().focus().toggleBold().run()}
-                  isActive={editor.isActive('bold')}
-                >
-                  <b>B</b>
-                </BubbleMenuButton>
-                <BubbleMenuButton
-                  onClick={() => editor.chain().focus().toggleItalic().run()}
-                  isActive={editor.isActive('italic')}
-                >
-                  <i>I</i>
-                </BubbleMenuButton>
-                <BubbleMenuButton
-                  onClick={() => editor.chain().focus().toggleStrike().run()}
-                  isActive={editor.isActive('strike')}
-                >
-                  <s>S</s>
-                </BubbleMenuButton>
-                <BubbleMenuButton onClick={onAddHyperlink} isActive={editor.isActive('link')}>
-                  <LinkIcon />
-                </BubbleMenuButton>
-              </BubbleMenuWrapper>
-            </BubbleMenu>
+            <div>
+              <BubbleMenu editor={editor} tippyOptions={{duration: 100}}>
+                <BubbleMenuWrapper>
+                  <BubbleMenuButton
+                    onClick={() => editor.chain().focus().toggleBold().run()}
+                    isActive={editor.isActive('bold')}
+                  >
+                    <b>B</b>
+                  </BubbleMenuButton>
+                  <BubbleMenuButton
+                    onClick={() => editor.chain().focus().toggleItalic().run()}
+                    isActive={editor.isActive('italic')}
+                  >
+                    <i>I</i>
+                  </BubbleMenuButton>
+                  <BubbleMenuButton
+                    onClick={() => editor.chain().focus().toggleStrike().run()}
+                    isActive={editor.isActive('strike')}
+                  >
+                    <s>S</s>
+                  </BubbleMenuButton>
+                  <BubbleMenuButton onClick={onAddHyperlink} isActive={editor.isActive('link')}>
+                    <LinkIcon />
+                  </BubbleMenuButton>
+                </BubbleMenuWrapper>
+              </BubbleMenu>
+            </div>
             <EmojiMenuTipTap tiptapEditor={editor} />
             {teamId && <MentionsTipTap tiptapEditor={editor} teamId={teamId} />}
             {linkOverlayProps?.linkMenuProps && (


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8471

A bug in the tiptap `BubbleMenu` component (see https://github.com/ueberdosis/tiptap/issues/3784) is causing this. The workaround described in the issue is to just wrap the `BubbleMenu` component with a `div`, which is what I'm doing here

## Testing scenarios
End a standup meeting, and confirm no error appears.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
