### PR TITLE
fix: Correctly show error when email invite fails

### DIFF
--- a/packages/client/components/AddTeamMemberModal.tsx
+++ b/packages/client/components/AddTeamMemberModal.tsx
@@ -8,6 +8,7 @@ import useMutationProps from '~/hooks/useMutationProps'
 import {PALETTE} from '~/styles/paletteV3'
 import modalTeamInvitePng from '../../../static/images/illustrations/illus-modal-team-invite.png'
 import {AddTeamMemberModal_teamMembers$key} from '../__generated__/AddTeamMemberModal_teamMembers.graphql'
+import {InviteToTeamMutation as TInviteToTeamMutation} from '../__generated__/InviteToTeamMutation.graphql'
 import useBreakpoint from '../hooks/useBreakpoint'
 import InviteToTeamMutation from '../mutations/InviteToTeamMutation'
 import {CompletedHandler} from '../types/relayMutations'
@@ -185,17 +186,21 @@ const AddTeamMemberModal = (props: Props) => {
   const sendInvitations = () => {
     if (invitees.length === 0) return
     submitMutation()
-    const handleCompleted: CompletedHandler = (res) => {
+    const handleCompleted: CompletedHandler<TInviteToTeamMutation['response']> = (res) => {
       setIsSubmitted(true)
       onCompleted()
       if (res) {
         const {inviteToTeam} = res
-        if (inviteToTeam.invitees.length === invitees.length) {
+        if (inviteToTeam.invitees?.length === invitees.length) {
           setSuccessfulInvitations(pendingSuccessfulInvitations.concat(inviteToTeam.invitees))
         } else {
           // there was a problem with at least 1 email
-          const goodInvitees = invitees.filter((invitee) => inviteToTeam.invitees.includes(invitee))
-          const badInvitees = invitees.filter((invitee) => !inviteToTeam.invitees.includes(invitee))
+          const goodInvitees = invitees.filter((invitee) =>
+            inviteToTeam.invitees?.includes(invitee)
+          )
+          const badInvitees = invitees.filter(
+            (invitee) => !inviteToTeam.invitees?.includes(invitee)
+          )
 
           onError(
             new Error(


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8519

When `inviteToTeam` returns an error, we weren't correctly catching and surfacing that error on the front-end.

Update types + check for errors better.

## Testing scenarios
Perform repro steps in original issue.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
