### PR TITLE
fix: stripe console err

### DIFF
--- a/packages/server/utils/stripe/StripeManager.ts
+++ b/packages/server/utils/stripe/StripeManager.ts
@@ -6,7 +6,10 @@ export default class StripeManager {
   static PARABOL_TEAM_600 = 'parabol-pro-600' // $6/seat/mo
   static PARABOL_ENTERPRISE_2021_LOW = 'plan_2021_ann_low'
   static WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET!
-  stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {apiVersion: '2020-08-27'})
+  stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: '2020-08-27',
+    maxNetworkRetries: 3 // retry failed requests up to 3 times. This can happen when accessing the same Stripe object in quick succession: https://github.com/ParabolInc/parabol/issues/8544
+  })
 
   constructEvent(rawBody: string, signature: string) {
     try {


### PR DESCRIPTION
Fix: https://github.com/ParabolInc/parabol/issues/8544

Credit to @mattkrick for helping me with this during office hours. 

Sorry, this includes the updated changelog from the Ship. It'll end up in master shortly, so I think it's OK leaving it here.

This PR will increase the time it takes to upgrade as there could be a few retries. I've created a GitHub issue here to sped things up: https://github.com/ParabolInc/parabol/issues/8546

### To test

- Run `stripe listen --forward-to localhost:3000/stripe` in your terminal
- Upgrade to Team tier a few times using the new checkout flow
- You don't see the console error message mentioned in the linked issue