### PR TITLE
feat: Add meetings to the team dashboard

### DIFF
--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {Fragment, useMemo} from 'react'
 import {useFragment} from 'react-relay'
+import {useRouteMatch} from 'react-router'
 import {PALETTE} from '~/styles/paletteV3'
 import {Breakpoint} from '~/types/constEnums'
 import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
@@ -89,6 +90,9 @@ const DashNavList = (props: Props) => {
     return team.isPaid && !team.organization.lockedAt ? 'group' : 'warning'
   }
 
+  const teamRouteMatch = useRouteMatch<{teamSubPage: string}>('/team/:teamId/:teamSubPage')
+  const {teamSubPage = ''} = teamRouteMatch?.params || {}
+
   return (
     <DashNavListStyles>
       {isSingleOrg
@@ -98,7 +102,7 @@ const DashNavList = (props: Props) => {
               onClick={onClick}
               key={team.id}
               icon={showWarningIcon(team)}
-              href={`/team/${team.id}`}
+              href={`/team/${team.id}/${teamSubPage}`}
               label={team.name}
             />
           ))
@@ -114,7 +118,7 @@ const DashNavList = (props: Props) => {
                     onClick={onClick}
                     key={team.id}
                     icon={showWarningIcon(team)}
-                    href={`/team/${team.id}`}
+                    href={`/team/${team.id}/${teamSubPage}`}
                     label={team.name}
                   />
                 ))}

--- a/packages/client/components/TimelineEventTeamCreated.tsx
+++ b/packages/client/components/TimelineEventTeamCreated.tsx
@@ -46,7 +46,7 @@ const TimelineEventTeamCreated = (props: Props) => {
         ) : (
           <>
             {'Visit your '}
-            <Link to={`/team/${teamId}`}>team dashboard</Link>
+            <Link to={`/team/${teamId}/tasks`}>team dashboard</Link>
           </>
         )}
       </TimelineEventBody>

--- a/packages/client/modules/summary/components/NewMeetingSummary.tsx
+++ b/packages/client/modules/summary/components/NewMeetingSummary.tsx
@@ -55,7 +55,7 @@ const NewMeetingSummary = (props: Props) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   useDocumentTitle(title, 'Summary')
   const meetingUrl = makeHref(`/meet/${meetingId}`)
-  const teamDashUrl = `/team/${teamId}`
+  const teamDashUrl = `/team/${teamId}/tasks`
   const emailCSVUrl = isDemoRoute()
     ? `/retrospective-demo-summary/csv`
     : `/new-summary/${meetingId}/csv`

--- a/packages/client/modules/teamDashboard/components/TeamArchiveHeader/TeamArchiveHeader.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchiveHeader/TeamArchiveHeader.tsx
@@ -36,7 +36,7 @@ interface Props {
 const TeamArchiveHeader = (props: Props) => {
   const {teamId} = props
   const {history} = useRouter()
-  const goToTeamDash = () => history.push(`/team/${teamId}/`)
+  const goToTeamDash = () => history.push(`/team/${teamId}/tasks`)
   return (
     <RootBlock>
       <HeadingBlock>

--- a/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
@@ -1,0 +1,53 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {TeamDashActivityTab_team$key} from '~/__generated__/TeamDashActivityTab_team.graphql'
+import useTransition from '../../../../hooks/useTransition'
+import MeetingCard from '../../../../components/MeetingCard'
+
+interface Props {
+  teamRef: TeamDashActivityTab_team$key
+}
+
+const TeamDashActivityTab = (props: Props) => {
+  const {teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment TeamDashActivityTab_team on Team {
+        activeMeetings {
+          id
+          ...MeetingCard_meeting
+        }
+      }
+    `,
+    teamRef
+  )
+
+  const {activeMeetings} = team
+  const transitioningMeetings = useTransition(
+    activeMeetings.map((meeting, displayIdx) => ({
+      ...meeting,
+      key: meeting.id,
+      displayIdx
+    }))
+  )
+
+  return (
+    <div className='flex h-full w-full'>
+      {transitioningMeetings.map((meeting) => {
+        const {child} = meeting
+        const {id, displayIdx} = child
+        return (
+          <MeetingCard
+            key={id}
+            displayIdx={displayIdx}
+            meeting={meeting.child}
+            onTransitionEnd={meeting.onTransitionEnd}
+            status={meeting.status}
+          />
+        )
+      })}
+    </div>
+  )
+}
+export default TeamDashActivityTab

--- a/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
@@ -42,7 +42,7 @@ const TeamDashActivityTab = (props: Props) => {
           <p className='my-2'>No meetings yet? You've come to the right place!</p>
         )}
       </div>
-      <div className='flex w-full flex-wrap'>
+      <div className='flex w-full flex-wrap pr-4'>
         {transitioningMeetings.length > 0 ? (
           transitioningMeetings.map((meeting) => {
             const {child} = meeting

--- a/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
@@ -4,6 +4,8 @@ import {useFragment} from 'react-relay'
 import {TeamDashActivityTab_team$key} from '~/__generated__/TeamDashActivityTab_team.graphql'
 import useTransition from '../../../../hooks/useTransition'
 import MeetingCard from '../../../../components/MeetingCard'
+import DemoMeetingCard from '../../../../components/DemoMeetingCard'
+import TutorialMeetingCard from '../../../../components/TutorialMeetingCard'
 
 interface Props {
   teamRef: TeamDashActivityTab_team$key
@@ -33,20 +35,35 @@ const TeamDashActivityTab = (props: Props) => {
   )
 
   return (
-    <div className='flex h-full w-full'>
-      {transitioningMeetings.map((meeting) => {
-        const {child} = meeting
-        const {id, displayIdx} = child
-        return (
-          <MeetingCard
-            key={id}
-            displayIdx={displayIdx}
-            meeting={meeting.child}
-            onTransitionEnd={meeting.onTransitionEnd}
-            status={meeting.status}
-          />
-        )
-      })}
+    <div className='flex h-full w-full flex-1 flex-col overflow-auto pl-4'>
+      <div className='flex flex-col pl-2'>
+        <h3 className='mb-0 text-base font-semibold'>Open Meetings</h3>
+        {transitioningMeetings.length === 0 && (
+          <p className='my-2'>No meetings yet? You've come to the right place!</p>
+        )}
+      </div>
+      <div className='flex w-full flex-wrap'>
+        {transitioningMeetings.length > 0 ? (
+          transitioningMeetings.map((meeting) => {
+            const {child} = meeting
+            const {id, displayIdx} = child
+            return (
+              <MeetingCard
+                key={id}
+                displayIdx={displayIdx}
+                meeting={meeting.child}
+                onTransitionEnd={meeting.onTransitionEnd}
+                status={meeting.status}
+              />
+            )
+          })
+        ) : (
+          <>
+            <DemoMeetingCard />
+            <TutorialMeetingCard />
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/packages/client/modules/teamDashboard/components/TeamDashHeader/TeamDashHeader.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashHeader/TeamDashHeader.tsx
@@ -3,22 +3,19 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {useRouteMatch} from 'react-router'
 import {NavLink} from 'react-router-dom'
 import DashboardAvatars from '~/components/DashboardAvatars/DashboardAvatars'
-import DashFilterToggle from '~/components/DashFilterToggle/DashFilterToggle'
 import AgendaToggle from '~/modules/teamDashboard/components/AgendaToggle/AgendaToggle'
 import makeMinWidthMediaQuery from '~/utils/makeMinWidthMediaQuery'
-import DashSectionControls from '../../../../components/Dashboard/DashSectionControls'
 import DashSectionHeader from '../../../../components/Dashboard/DashSectionHeader'
-import DashNavControl from '../../../../components/DashNavControl/DashNavControl'
 import InviteTeamMemberAvatar from '../../../../components/InviteTeamMemberAvatar'
-import {MenuPosition} from '../../../../hooks/useCoords'
-import useMenu from '../../../../hooks/useMenu'
+import Tab from '../../../../components/Tab/Tab'
+import Tabs from '../../../../components/Tabs/Tabs'
 import useRouter from '../../../../hooks/useRouter'
 import {PALETTE} from '../../../../styles/paletteV3'
 import {Breakpoint} from '../../../../types/constEnums'
-import lazyPreload from '../../../../utils/lazyPreload'
-import {TeamTasksHeader_team$key} from '../../../../__generated__/TeamTasksHeader_team.graphql'
+import {TeamDashHeader_team$key} from '../../../../__generated__/TeamDashHeader_team.graphql'
 
 const desktopBreakpoint = makeMinWidthMediaQuery(Breakpoint.SIDEBAR_LEFT)
 
@@ -69,20 +66,8 @@ const secondLink = {
   marginRight: 0,
   marginLeft: 8
 }
-
-const TeamDashTeamMemberMenu = lazyPreload(
-  () =>
-    import(
-      /* webpackChunkName: 'TeamDashTeamMemberMenu' */
-      '../../../../components/TeamDashTeamMemberMenu'
-    )
-)
-
 const TeamHeaderAndAvatars = styled('div')({
-  borderBottom: `1px solid ${PALETTE.SLATE_300}`,
   flexShrink: 0,
-  margin: '0 0 16px',
-  padding: '0 0 16px',
   width: '100%',
   [desktopBreakpoint]: {
     display: 'flex',
@@ -100,23 +85,20 @@ const Avatars = styled('div')({
 })
 
 interface Props {
-  team: TeamTasksHeader_team$key
+  team: TeamDashHeader_team$key
 }
 
-const TeamTasksHeader = (props: Props) => {
+const TeamDashHeader = (props: Props) => {
   const {team: teamRef} = props
   const team = useFragment(
     graphql`
-      fragment TeamTasksHeader_team on Team {
+      fragment TeamDashHeader_team on Team {
         ...DashboardAvatars_team
         id
         name
         organization {
           id
           name
-        }
-        teamMemberFilter {
-          preferredName
         }
         teamMembers(sortBy: "preferredName") {
           ...InviteTeamMemberAvatar_teamMembers
@@ -128,14 +110,11 @@ const TeamTasksHeader = (props: Props) => {
     `,
     teamRef
   )
-  const {history} = useRouter()
-  const {organization, id: teamId, name: teamName, teamMemberFilter, teamMembers} = team
-  const teamMemberFilterName =
-    (teamMemberFilter && teamMemberFilter.preferredName) || 'All team members'
+  const {organization, id: teamId, name: teamName, teamMembers} = team
   const {name: orgName, id: orgId} = organization
-  const {togglePortal, menuProps, originRef, menuPortal} = useMenu(MenuPosition.UPPER_RIGHT, {
-    isDropdown: true
-  })
+  const isActivity = useRouteMatch('/team/:teamId/activity')
+  const {history} = useRouter()
+
   return (
     <DashSectionHeader>
       <TeamHeaderAndAvatars>
@@ -177,29 +156,15 @@ const TeamTasksHeader = (props: Props) => {
           <AgendaToggle teamId={teamId} />
         </Avatars>
       </TeamHeaderAndAvatars>
-      <DashSectionControls>
-        {/* Filter by Owner */}
-        <TeamMeta>
-          {teamMembers.length > 1 && (
-            <DashFilterToggle
-              label='Team Member'
-              onClick={togglePortal}
-              onMouseEnter={TeamDashTeamMemberMenu.preload}
-              ref={originRef}
-              value={teamMemberFilterName}
-            />
-          )}
-          {menuPortal(<TeamDashTeamMemberMenu menuProps={menuProps} team={team} />)}
-        </TeamMeta>
-        {/* Archive Link */}
-        <DashNavControl
-          icon='archive'
-          label='Archived Tasks'
-          onClick={() => history.push(`/team/${teamId}/archive`)}
-        />
-      </DashSectionControls>
+      <Tabs
+        activeIdx={isActivity ? 0 : 1}
+        className='full-w max-w-none border-b border-solid border-slate-300'
+      >
+        <Tab label='Activity' onClick={() => history.push(`/team/${teamId}/activity`)} />
+        <Tab label='Tasks' onClick={() => history.push(`/team/${teamId}/tasks`)} />
+      </Tabs>
     </DashSectionHeader>
   )
 }
 
-export default TeamTasksHeader
+export default TeamDashHeader

--- a/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
@@ -53,12 +53,12 @@ const TeamDashMain = (props: Props) => {
           <TeamTasksHeaderContainer team={team} />
         </div>
         <Switch>
-          <Route path='/team/:teamId/activity'>
-            <TeamDashActivityTab teamRef={team} />
-          </Route>
-          {/*Fall back to tasks view if nothing is specified*/}
-          <Route path='/team/:teamId'>
+          <Route path='/team/:teamId/tasks'>
             <TeamDashTasksTab viewerRef={viewer} />
+          </Route>
+          {/*Fall back to activity view if nothing is specified*/}
+          <Route path='/team/:teamId'>
+            <TeamDashActivityTab teamRef={team} />
           </Route>
         </Switch>
         <AbsoluteFab hasRid={viewer.featureFlags.retrosInDisguise} />

--- a/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
@@ -54,11 +54,11 @@ const TeamDashMain = (props: Props) => {
         </div>
         <Switch>
           <Route path='/team/:teamId/activity'>
-            <TeamDashTasksTab viewerRef={viewer} />
+            <TeamDashActivityTab teamRef={team} />
           </Route>
           {/*Fall back to tasks view if nothing is specified*/}
           <Route path='/team/:teamId'>
-            <TeamDashActivityTab teamRef={team} />
+            <TeamDashTasksTab viewerRef={viewer} />
           </Route>
         </Switch>
         <AbsoluteFab hasRid={viewer.featureFlags.retrosInDisguise} />

--- a/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashMain/TeamDashMain.tsx
@@ -5,42 +5,14 @@ import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import {TeamDashMainQuery} from '~/__generated__/TeamDashMainQuery.graphql'
 import StartMeetingFAB from '../../../../components/StartMeetingFAB'
 import useDocumentTitle from '../../../../hooks/useDocumentTitle'
-import TeamColumnsContainer from '../../containers/TeamColumns/TeamColumnsContainer'
 import TeamTasksHeaderContainer from '../../containers/TeamTasksHeader/TeamTasksHeaderContainer'
 import TeamDrawer from './TeamDrawer'
+import TeamDashTasksTab from '../TeamDashTasksTab/TeamDashTasksTab'
+import TeamDashActivityTab from '../TeamDashActivityTab/TeamDashActivityTab'
+import {Route, Switch} from 'react-router-dom'
 
 const AbsoluteFab = styled(StartMeetingFAB)({
   position: 'absolute'
-})
-
-const RootBlock = styled('div')({
-  display: 'flex',
-  height: '100%',
-  width: '100%'
-})
-
-const TasksMain = styled('div')({
-  display: 'flex',
-  flex: 1,
-  flexDirection: 'column',
-  height: '100%',
-  overflow: 'auto',
-  position: 'relative'
-})
-
-const TasksHeader = styled('div')({
-  display: 'flex',
-  justifyContent: 'flex-start',
-  width: '100%'
-})
-
-const TasksContent = styled('div')({
-  display: 'flex',
-  flex: 1,
-  height: '100%',
-  margin: 0,
-  minHeight: 0,
-  width: '100%'
 })
 
 interface Props {
@@ -56,11 +28,12 @@ const TeamDashMain = (props: Props) => {
           team(teamId: $teamId) {
             name
             ...TeamTasksHeaderContainer_team
+            ...TeamDashActivityTab_team
           }
           featureFlags {
             retrosInDisguise
           }
-          ...TeamColumnsContainer_viewer
+          ...TeamDashTasksTab_viewer
           ...TeamDrawer_viewer
         }
       }
@@ -74,18 +47,24 @@ const TeamDashMain = (props: Props) => {
   useDocumentTitle(`Team Dashboard | ${teamName}`, teamName)
 
   return (
-    <RootBlock>
-      <TasksMain>
-        <TasksHeader>
+    <div className='flex h-full w-full'>
+      <div className='relative flex h-full flex-1 flex-col overflow-auto'>
+        <div className='flex w-full justify-start'>
           <TeamTasksHeaderContainer team={team} />
-        </TasksHeader>
-        <TasksContent>
-          <TeamColumnsContainer viewer={viewer} />
-        </TasksContent>
+        </div>
+        <Switch>
+          <Route path='/team/:teamId/activity'>
+            <TeamDashTasksTab viewerRef={viewer} />
+          </Route>
+          {/*Fall back to tasks view if nothing is specified*/}
+          <Route path='/team/:teamId'>
+            <TeamDashActivityTab teamRef={team} />
+          </Route>
+        </Switch>
         <AbsoluteFab hasRid={viewer.featureFlags.retrosInDisguise} />
-      </TasksMain>
+      </div>
       <TeamDrawer viewer={viewer} />
-    </RootBlock>
+    </div>
   )
 }
 export default TeamDashMain

--- a/packages/client/modules/teamDashboard/components/TeamDashTasksTab/TeamDashTasksTab.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashTasksTab/TeamDashTasksTab.tsx
@@ -1,0 +1,89 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {TeamDashTasksTab_viewer$key} from '~/__generated__/TeamDashTasksTab_viewer.graphql'
+import TeamColumnsContainer from '../../containers/TeamColumns/TeamColumnsContainer'
+import DashFilterToggle from '~/components/DashFilterToggle/DashFilterToggle'
+import DashNavControl from '../../../../components/DashNavControl/DashNavControl'
+import useRouter from '../../../../hooks/useRouter'
+import useMenu from '../../../../hooks/useMenu'
+import {MenuPosition} from '../../../../hooks/useCoords'
+import lazyPreload from '../../../../utils/lazyPreload'
+import DashSectionHeader from '../../../../components/Dashboard/DashSectionHeader'
+
+const TeamDashTeamMemberMenu = lazyPreload(
+  () =>
+    import(
+      /* webpackChunkName: 'TeamDashTeamMemberMenu' */
+      '../../../../components/TeamDashTeamMemberMenu'
+    )
+)
+
+interface Props {
+  viewerRef: TeamDashTasksTab_viewer$key
+}
+
+const TeamDashTasksTab = (props: Props) => {
+  const {viewerRef} = props
+  const viewer = useFragment(
+    graphql`
+      fragment TeamDashTasksTab_viewer on User {
+        team(teamId: $teamId) {
+          ...TeamDashTeamMemberMenu_team
+          id
+          name
+          teamMemberFilter {
+            preferredName
+          }
+          teamMembers(sortBy: "preferredName") {
+            id
+          }
+        }
+        ...TeamColumnsContainer_viewer
+      }
+    `,
+    viewerRef
+  )
+
+  const {history} = useRouter()
+  const team = viewer.team!
+  const {id: teamId, teamMembers, teamMemberFilter} = team
+
+  const teamMemberFilterName =
+    (teamMemberFilter && teamMemberFilter.preferredName) || 'All team members'
+  const {togglePortal, menuProps, originRef, menuPortal} = useMenu(MenuPosition.UPPER_RIGHT, {
+    isDropdown: true
+  })
+
+  return (
+    <div className='flex h-full w-full'>
+      <div className='relative flex h-full flex-1 flex-col overflow-auto'>
+        <DashSectionHeader className='flex-row justify-between'>
+          {/* Filter by Owner */}
+          <div>
+            {teamMembers.length > 1 && (
+              <DashFilterToggle
+                label='Team Member'
+                onClick={togglePortal}
+                onMouseEnter={TeamDashTeamMemberMenu.preload}
+                ref={originRef}
+                value={teamMemberFilterName}
+              />
+            )}
+            {menuPortal(<TeamDashTeamMemberMenu menuProps={menuProps} team={team} />)}
+          </div>
+          {/* Archive Link */}
+          <DashNavControl
+            icon='archive'
+            label='Archived Tasks'
+            onClick={() => history.push(`/team/${teamId}/archive`)}
+          />
+        </DashSectionHeader>
+        <div className='m-0 flex h-full min-h-0 w-full flex-1'>
+          <TeamColumnsContainer viewer={viewer} />
+        </div>
+      </div>
+    </div>
+  )
+}
+export default TeamDashTasksTab

--- a/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/Team/TeamContainer.tsx
@@ -72,7 +72,6 @@ const TeamContainer = (props: Props) => {
         <Suspense fallback={''}>
           <Switch>
             {/* TODO: replace match.path with a relative when the time comes: https://github.com/ReactTraining/react-router/pull/4539 */}
-            <Route exact path={match.path} component={TeamDashMain} />
             <Route path={`${match.path}/settings`} component={TeamSettings} />
             <Route
               path={`${match.path}/archive`}
@@ -80,6 +79,7 @@ const TeamContainer = (props: Props) => {
                 <ArchivedTasks {...p} team={team} returnToTeamId={teamId} teamIds={[teamId]} />
               )}
             />
+            <Route path={match.path} component={TeamDashMain} />
           </Switch>
         </Suspense>
       </Team>

--- a/packages/client/modules/teamDashboard/containers/TeamTasksHeader/TeamTasksHeaderContainer.tsx
+++ b/packages/client/modules/teamDashboard/containers/TeamTasksHeader/TeamTasksHeaderContainer.tsx
@@ -4,7 +4,7 @@ import {useFragment} from 'react-relay'
 import filterTeamMember from '~/utils/relay/filterTeamMember'
 import {TeamTasksHeaderContainer_team$key} from '~/__generated__/TeamTasksHeaderContainer_team.graphql'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
-import TeamTasksHeader from '../../components/TeamTasksHeader/TeamTasksHeader'
+import TeamTasksHeader from '../../components/TeamDashHeader/TeamDashHeader'
 
 interface Props {
   team: TeamTasksHeaderContainer_team$key
@@ -16,7 +16,7 @@ const TeamTasksHeaderContainer = (props: Props) => {
     graphql`
       fragment TeamTasksHeaderContainer_team on Team {
         id
-        ...TeamTasksHeader_team
+        ...TeamDashHeader_team
       }
     `,
     teamRef


### PR DESCRIPTION
# Description

Fixes #8502 
Add a tab for meetings to the team dashboard. The default view is still "Tasks" to not interrupt users habits too much.

## Demo

https://www.loom.com/share/d3a5e74fd16842d387c59648f3539a48?sid=92906de6-0297-4f1e-b09d-bb9c62e9fe48

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] open team dashboard
- [ ] switch between tabs
- [ ] try different filters
- [ ] open a meeting
- [ ] check the sidebar highlight

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
