### PR TITLE
feat: add emoji insights

### DIFF
--- a/packages/client/components/Tooltip.tsx
+++ b/packages/client/components/Tooltip.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx'
+import React, {ReactNode} from 'react'
+import {MenuPosition} from '../hooks/useCoords'
+import useTooltip from '../hooks/useTooltip'
+
+interface Props {
+  text: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+const Tooltip = (props: Props) => {
+  const {text, children, className} = props
+  const {openTooltip, closeTooltip, tooltipPortal, originRef} = useTooltip<HTMLDivElement>(
+    MenuPosition.UPPER_CENTER
+  )
+
+  return (
+    <div
+      onMouseEnter={openTooltip}
+      onMouseLeave={closeTooltip}
+      className={clsx('cursor-pointer', className)}
+      ref={originRef}
+    >
+      {children}
+      {tooltipPortal(text)}
+    </div>
+  )
+}
+
+export default Tooltip

--- a/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashActivityTab/TeamDashActivityTab.tsx
@@ -70,7 +70,7 @@ const TeamDashActivityTab = (props: Props) => {
         )}
       </div>
       {insights && (
-        <div className='flex w-full flex-wrap pl-2 pr-4'>
+        <div className='flex w-full flex-wrap pr-4'>
           <TeamDashInsights teamInsightsRef={insights} />
         </div>
       )}

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -1,7 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
-import {unifiedToNative} from 'emoji-mart/dist-modern/utils/index.js'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
 import emojis from '../../../../utils/emojis'
 
@@ -28,10 +27,10 @@ const TeamDashInsights = (props: Props) => {
 
   return (
     <div>
-      <h3 className='mb-0 text-base font-semibold'>Team Insights</h3>
+      <h3 className='mb-0 pl-2 text-base font-semibold'>Team Insights</h3>
       <div className='flex w-full flex-wrap'>
         {mostUsedEmojis && mostUsedEmojis.length > 0 && (
-          <div className='relative flex w-[320px] flex-col rounded bg-white'>
+          <div className='relative m-2 flex w-[320px] flex-col rounded bg-white drop-shadow'>
             <div className='p-4 text-sm font-semibold text-slate-600'>Favorite Emojis</div>
             <div className='flex flex-row justify-center'>
               {mostUsedEmojis.map((emoji) => (
@@ -39,9 +38,7 @@ const TeamDashInsights = (props: Props) => {
                   key={emoji.id}
                   className='flex h-24 w-1/4 flex-col items-center justify-center'
                 >
-                  <div className='text-2xl'>
-                    {unifiedToNative([emoji.id as keyof typeof emojis])}
-                  </div>
+                  <div className='text-2xl'>{emojis[emoji.id as keyof typeof emojis]}</div>
                   <div className='p-2 font-semibold'>{emoji.count}</div>
                 </div>
               ))}

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -1,7 +1,9 @@
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {unifiedToNative} from 'emoji-mart/dist-modern/utils/index.js'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
+import emojis from '../../../../utils/emojis'
 
 interface Props {
   teamInsightsRef: TeamDashInsights_insights$key
@@ -9,21 +11,44 @@ interface Props {
 
 const TeamDashInsights = (props: Props) => {
   const {teamInsightsRef} = props
-  // TODO: implement
-  useFragment(
+  const insights = useFragment(
     graphql`
       fragment TeamDashInsights_insights on TeamInsights {
         id
-        mostUsedEmojis
+        mostUsedEmojis {
+          id
+          count
+        }
       }
     `,
     teamInsightsRef
   )
 
+  const {mostUsedEmojis} = insights
+
   return (
     <div>
       <h3 className='mb-0 text-base font-semibold'>Team Insights</h3>
-      <div className='flex w-full flex-wrap'></div>
+      <div className='flex w-full flex-wrap'>
+        {mostUsedEmojis && mostUsedEmojis.length > 0 && (
+          <div className='relative flex w-[320px] flex-col rounded bg-white'>
+            <div className='p-4 text-sm font-semibold text-slate-600'>Favorite Emojis</div>
+            <div className='flex flex-row justify-center'>
+              {mostUsedEmojis.map((emoji) => (
+                <div
+                  key={emoji.id}
+                  className='flex h-24 w-1/4 flex-col items-center justify-center'
+                >
+                  <div className='text-2xl'>
+                    {unifiedToNative([emoji.id as keyof typeof emojis])}
+                  </div>
+                  <div className='p-2 font-semibold'>{emoji.count}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
 import emojis from '../../../../utils/emojis'
+import Tooltip from '../../../../components/Tooltip'
+import {Info as InfoIcon} from '@mui/icons-material'
 
 interface Props {
   teamInsightsRef: TeamDashInsights_insights$key
@@ -31,7 +33,12 @@ const TeamDashInsights = (props: Props) => {
       <div className='flex w-full flex-wrap'>
         {mostUsedEmojis && mostUsedEmojis.length > 0 && (
           <div className='relative m-2 flex w-[320px] flex-col rounded bg-white drop-shadow'>
-            <div className='p-4 text-sm font-semibold text-slate-600'>Favorite Emojis</div>
+            <div className='flex items-center justify-between'>
+              <div className='p-4 text-sm font-semibold text-slate-600'>Favorite Reactions</div>
+              <Tooltip text='Your team’s most used emoji reactions' className='pr-3 text-slate-600'>
+                <InfoIcon />
+              </Tooltip>
+            </div>
             <div className='flex flex-row justify-center'>
               {mostUsedEmojis.map((emoji) => (
                 <div

--- a/packages/server/database/types/Meeting.ts
+++ b/packages/server/database/types/Meeting.ts
@@ -43,6 +43,7 @@ export default abstract class Meeting {
   scheduledEndTime?: Date | null
   summary?: string
   sentimentScore?: number
+  usedReactjis?: Record<string, number>
 
   constructor(input: Input) {
     const {

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -20,9 +20,11 @@ import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {DataLoaderWorker, GQLContext} from '../graphql'
 import EndCheckInPayload from '../types/EndCheckInPayload'
+import collectReactjis from './helpers/collectReactjis'
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
+import updateTeamInsights from './helpers/updateTeamInsights'
 
 type SortOrderTask = Pick<Task, 'id' | 'sortOrder'>
 const updateTaskSortOrders = async (userIds: string[], tasks: SortOrderTask[]) => {
@@ -192,6 +194,7 @@ export default {
       stage.endAt = now
     }
     const phase = getMeetingPhase(phases)
+    const usedReactjis = await collectReactjis(meeting, dataLoader)
 
     const completedCheckIn = (await r
       .table('NewMeeting')
@@ -199,7 +202,8 @@ export default {
       .update(
         {
           endedAt: now,
-          phases
+          phases,
+          usedReactjis
         },
         {returnChanges: true}
       )('changes')(0)('new_val')
@@ -226,6 +230,8 @@ export default {
     analytics.checkInEnd(completedCheckIn, meetingMembers)
     sendNewMeetingSummary(completedCheckIn, context).catch(console.log)
     checkTeamsLimit(team.orgId, dataLoader)
+    updateTeamInsights(teamId)
+
     const events = teamMembers.map(
       (teamMember) =>
         new TimelineEventCheckinComplete({

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -230,7 +230,7 @@ export default {
     analytics.checkInEnd(completedCheckIn, meetingMembers)
     sendNewMeetingSummary(completedCheckIn, context).catch(console.log)
     checkTeamsLimit(team.orgId, dataLoader)
-    updateTeamInsights(teamId)
+    updateTeamInsights(teamId, dataLoader)
 
     const events = teamMembers.map(
       (teamMember) =>

--- a/packages/server/graphql/mutations/endRetrospective.ts
+++ b/packages/server/graphql/mutations/endRetrospective.ts
@@ -118,7 +118,7 @@ const finishRetroMeeting = async (meeting: MeetingRetrospective, context: GQLCon
   // wait for whole meeting summary to be generated before sending summary email and updating qualAIMeetingCount
   sendNewMeetingSummary(meeting, context).catch(console.log)
   updateQualAIMeetingsCount(meetingId, teamId, dataLoader)
-  updateTeamInsights(teamId)
+  updateTeamInsights(teamId, dataLoader)
   // wait for meeting stats to be generated before sending Slack notification
   IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
   const data = {meetingId}

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -110,7 +110,7 @@ export default {
       dataLoader.get('meetingTemplates').loadNonNull(templateId)
     ])
     IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
-    updateTeamInsights(teamId)
+    updateTeamInsights(teamId, dataLoader)
     analytics.sprintPokerEnd(completedMeeting, meetingMembers, template)
     const isKill = !!(phase && phase.phaseType !== 'ESTIMATE')
     if (!isKill) {

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -15,9 +15,11 @@ import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import EndSprintPokerPayload from '../types/EndSprintPokerPayload'
+import collectReactjis from './helpers/collectReactjis'
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
+import updateTeamInsights from './helpers/updateTeamInsights'
 
 export default {
   type: new GraphQLNonNull(EndSprintPokerPayload),
@@ -72,6 +74,7 @@ export default {
       estimateStages.filter(({isComplete}) => isComplete).map(({taskId}) => taskId)
     ).size
     const discussionIds = estimateStages.map((stage) => stage.discussionId)
+    const usedReactjis = await collectReactjis(meeting, dataLoader)
 
     const completedMeeting = (await r
       .table('NewMeeting')
@@ -85,7 +88,8 @@ export default {
             .getAll(r.args(discussionIds), {index: 'discussionId'})
             .count()
             .default(0) as unknown as number,
-          storyCount
+          storyCount,
+          usedReactjis
         },
         {returnChanges: true, nonAtomic: true}
       )('changes')(0)('new_val')
@@ -106,6 +110,7 @@ export default {
       dataLoader.get('meetingTemplates').loadNonNull(templateId)
     ])
     IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
+    updateTeamInsights(teamId)
     analytics.sprintPokerEnd(completedMeeting, meetingMembers, template)
     const isKill = !!(phase && phase.phaseType !== 'ESTIMATE')
     if (!isKill) {

--- a/packages/server/graphql/mutations/helpers/collectReactjis.ts
+++ b/packages/server/graphql/mutations/helpers/collectReactjis.ts
@@ -1,0 +1,53 @@
+import Meeting from '../../../database/types/Meeting'
+import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
+import {DataLoaderWorker} from '../../graphql'
+import isValid from '../../isValid'
+
+const collectReactjis = async (meeting: Meeting, dataLoader: DataLoaderWorker) => {
+  const {id: meetingId, phases} = meeting
+
+  const usedReactjis: Record<string, number> = {}
+
+  // Discussions can happen in many different stage types: discuss, ESTIMATE, reflect, RESPONSES
+  const stages = phases.flatMap(({stages}) => stages)
+  const discussionIds = stages
+    .map((stage) => 'discussionId' in stage && stage.discussionId)
+    .filter(isValid) as string[]
+  const discussions = (
+    await dataLoader.get('commentsByDiscussionId').loadMany(discussionIds)
+  ).filter(isValid)
+
+  discussions.forEach((comments) => {
+    comments.forEach(({reactjis}) => {
+      reactjis.forEach(({id}) => {
+        usedReactjis[id] = (usedReactjis[id] ?? 0) + 1
+      })
+    })
+  })
+
+  // Reflections
+  if (phases.find(({phaseType}) => phaseType === 'reflect')) {
+    const reflections = await dataLoader.get('retroReflectionsByMeetingId').load(meetingId)
+    reflections.forEach((reflection) => {
+      const {reactjis} = reflection
+      reactjis.forEach(({id}) => {
+        usedReactjis[id] = (usedReactjis[id] ?? 0) + 1
+      })
+    })
+  }
+
+  // Team prompt responses
+  if (phases.find(({phaseType}) => phaseType === 'RESPONSES')) {
+    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    responses.forEach((response) => {
+      const {reactjis} = response
+      reactjis.forEach(({id}) => {
+        usedReactjis[id] = (usedReactjis[id] ?? 0) + 1
+      })
+    })
+  }
+
+  return usedReactjis
+}
+
+export default collectReactjis

--- a/packages/server/graphql/mutations/helpers/collectTeamInsights.ts
+++ b/packages/server/graphql/mutations/helpers/collectTeamInsights.ts
@@ -1,0 +1,45 @@
+import ms from 'ms'
+import {RValue} from 'rethinkdb-ts'
+import getRethink from '../../../database/rethinkDriver'
+import getKysely from '../../../postgres/getKysely'
+
+const TEAM_INSIGHTS_PERIOD = ms('90 days')
+
+const collectTeamInsights = async (teamId: string) => {
+  const r = await getRethink()
+  const pg = getKysely()
+  const now = new Date()
+  const insightsPeriod = new Date(now.getTime() - TEAM_INSIGHTS_PERIOD)
+
+  const meetingInsights = await r
+    .table('NewMeeting')
+    .getAll(teamId, {index: 'teamId'})
+    .filter((row: RValue) => row('createdAt').gt(insightsPeriod))
+    .pluck('endedAt', 'usedReactjis', 'meetingType', 'templateId')
+    .run()
+
+  const allUsedEmojis = meetingInsights.reduce((acc, meeting) => {
+    if (!meeting?.usedReactjis) return acc
+    Object.entries(meeting?.usedReactjis).forEach(([emoji, count]) => {
+      acc[emoji] = (acc[emoji] ?? 0) + count
+    })
+    return acc
+  }, {} as Record<string, number>)
+
+  const mostUsedEmojis = Object.entries(allUsedEmojis)
+    .map(([id, count]) => ({id, count}))
+    .filter(({count}) => count > 5)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 3)
+
+  await pg
+    .updateTable('Team')
+    .set({
+      insightsUpdatedAt: now,
+      mostUsedEmojis: mostUsedEmojis.length >= 2 ? JSON.stringify(mostUsedEmojis) : null
+    })
+    .where('id', '=', teamId)
+    .execute()
+}
+
+export default collectTeamInsights

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -77,7 +77,7 @@ const safeEndTeamPrompt = async ({
   IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
   sendNewMeetingSummary(completedTeamPrompt, context).catch(console.log)
   checkTeamsLimit(team.orgId, dataLoader)
-  updateTeamInsights(teamId)
+  updateTeamInsights(teamId, dataLoader)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses)
   dataLoader.get('newMeetings').clear(meetingId)
 

--- a/packages/server/graphql/mutations/helpers/updateTeamInsights.ts
+++ b/packages/server/graphql/mutations/helpers/updateTeamInsights.ts
@@ -28,7 +28,7 @@ const collectTeamInsights = async (teamId: string) => {
 
   const mostUsedEmojis = Object.entries(allUsedEmojis)
     .map(([id, count]) => ({id, count}))
-    .filter(({count}) => count > 5)
+    .filter(({count}) => count >= 5)
     .sort((a, b) => b.count - a.count)
     .slice(0, 3)
 

--- a/packages/server/graphql/public/typeDefs/TeamInsights.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamInsights.graphql
@@ -1,8 +1,13 @@
+type Emoji {
+  id: ID!
+  count: Int!
+}
+
 type TeamInsights {
   id: ID!
 
   """
   Most used emojis in the team, null if not enough signal
   """
-  mostUsedEmojis: [String!]
+  mostUsedEmojis: [Emoji!]
 }

--- a/packages/server/graphql/public/types/Team.ts
+++ b/packages/server/graphql/public/types/Team.ts
@@ -2,13 +2,15 @@ import {TeamResolvers} from '../resolverTypes'
 import TeamInsightsId from 'parabol-client/shared/gqlIds/TeamInsightsId'
 
 const Team: TeamResolvers = {
-  insights: async ({id, orgId}, _args, {dataLoader}) => {
+  insights: async ({id, orgId, mostUsedEmojis}, _args, {dataLoader}) => {
     const org = await dataLoader.get('organizations').load(orgId)
     if (!org?.featureFlags?.includes('teamInsights')) return null
+    if (!mostUsedEmojis) return null
+
     return {
       id: TeamInsightsId.join(id),
-      mostUsedEmojis: []
-    }
+      mostUsedEmojis
+    } as any
   }
 }
 

--- a/packages/server/postgres/migrations/1689949187848_addTeamInsights.ts
+++ b/packages/server/postgres/migrations/1689949187848_addTeamInsights.ts
@@ -1,0 +1,40 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    DO $$
+    BEGIN
+      ALTER TABLE "Team"
+        ADD COLUMN "insightsUpdatedAt" TIMESTAMP WITH TIME ZONE,
+        -- 3 most used emojis in format [{id: string, count: number}]
+        ADD COLUMN "mostUsedEmojis" JSONB,
+        -- 3 most used retro templates in format [{templateId: string, count: number}]
+        ADD COLUMN "topRetroTemplates" JSONB,
+        -- meeting engagement in format {meetingType: string, engagement: number}
+        ADD COLUMN "meetingEngagement" JSONB;
+    END
+    $$;
+  `)
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    DO $$
+    BEGIN
+      ALTER TABLE "Team"
+        DROP COLUMN "mostUsedEmojis",
+        DROP COLUMN "insightsUpdatedAt",
+        DROP COLUMN "topRetroTemplates",
+        DROP COLUMN "meetingEngagement";
+    END
+    $$;
+ 
+  `)
+  await client.end()
+}

--- a/packages/server/postgres/migrations/1689949187848_addTeamInsights.ts
+++ b/packages/server/postgres/migrations/1689949187848_addTeamInsights.ts
@@ -34,7 +34,6 @@ export async function down() {
         DROP COLUMN "meetingEngagement";
     END
     $$;
- 
   `)
   await client.end()
 }


### PR DESCRIPTION
# Description

Fixes #8465
At the end of a meeting, count the used emojis and add them to the
insights.

## Demo

https://www.loom.com/share/f040d0e3cb274754bcfb9f2fd0fa9878?sid=ef83dfb1-7105-40d3-a8dc-01ff88d8c31f

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] add `teamInsights` org feature flag
- [ ] run and end different meeting types with reactjis
- [ ] collect at least 2 reactjis used 5 times or more
- [ ] see the insights card in team dash

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
