### PR TITLE
feat(standups): Standup AI Summaries

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -162,11 +162,11 @@ const SummarySheet = (props: Props) => {
             )}
         <EmailBorderBottom />
         <CreateAccountSection dataCy='create-account-section' isDemo={isDemo} />
+        <WholeMeetingSummary meetingRef={meeting} />
         {meetingType === 'teamPrompt' ? (
           <TeamPromptResponseSummary meetingRef={meeting} />
         ) : (
           <>
-            <WholeMeetingSummary meetingRef={meeting} />
             <MeetingMembersWithTasks meeting={meeting} />
             <MeetingMembersWithoutTasks meeting={meeting} />
             <RetroTopics

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -18,6 +18,12 @@ const WholeMeetingSummary = (props: Props) => {
         __typename
         id
         summary
+        organization {
+          featureFlags {
+            standupAISummary
+            noAISummary
+          }
+        }
         ... on RetrospectiveMeeting {
           reflectionGroups(sortBy: voteCount) {
             summary
@@ -53,7 +59,10 @@ const WholeMeetingSummary = (props: Props) => {
     if (hasOpenAISummary && !wholeMeetingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   } else if (meeting.__typename === 'TeamPromptMeeting') {
-    const {summary: wholeMeetingSummary, responses} = meeting
+    const {summary: wholeMeetingSummary, responses, organization} = meeting
+    if (!organization.featureFlags.standupAISummary || organization.featureFlags.noAISummary) {
+      return null
+    }
     if (!responses || responses.length === 0) return null
     if (!wholeMeetingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryResult.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummaryResult.tsx
@@ -30,8 +30,10 @@ const textStyle = {
   color: PALETTE.SLATE_700,
   fontFamily: FONT_FAMILY.SANS_SERIF,
   padding: '0px 48px 8px 48px',
-  fontSize: 14
-}
+  fontSize: 14,
+  whiteSpace: 'pre-line',
+  textAlign: 'left'
+} as const
 
 interface Props {
   meetingRef: WholeMeetingSummaryResult_meeting$key
@@ -41,7 +43,7 @@ const WholeMeetingSummaryResult = (props: Props) => {
   const {meetingRef} = props
   const meeting = useFragment(
     graphql`
-      fragment WholeMeetingSummaryResult_meeting on RetrospectiveMeeting {
+      fragment WholeMeetingSummaryResult_meeting on NewMeeting {
         __typename
         id
         summary

--- a/packages/client/mutations/EndTeamPromptMutation.ts
+++ b/packages/client/mutations/EndTeamPromptMutation.ts
@@ -41,6 +41,14 @@ graphql`
   }
 `
 
+graphql`
+  fragment EndTeamPromptMutation_meeting on EndTeamPromptSuccess {
+    meeting {
+      ...WholeMeetingSummary_meeting
+    }
+  }
+`
+
 const mutation = graphql`
   mutation EndTeamPromptMutation($meetingId: ID!) {
     endTeamPrompt(meetingId: $meetingId) {
@@ -50,6 +58,7 @@ const mutation = graphql`
         }
       }
       ...EndTeamPromptMutation_team @relay(mask: false)
+      ...EndTeamPromptMutation_meeting @relay(mask: false)
     }
   }
 `

--- a/packages/client/subscriptions/MeetingSubscription.ts
+++ b/packages/client/subscriptions/MeetingSubscription.ts
@@ -93,6 +93,9 @@ const subscription = graphql`
       EndRetrospectiveSuccess {
         ...EndRetrospectiveMutation_meeting @relay(mask: false)
       }
+      EndTeamPromptSuccess {
+        ...EndTeamPromptMutation_meeting @relay(mask: false)
+      }
       FlagReadyToAdvanceSuccess {
         ...FlagReadyToAdvanceMutation_meeting @relay(mask: false)
       }

--- a/packages/server/graphql/mutations/helpers/canAccessAISummary.ts
+++ b/packages/server/graphql/mutations/helpers/canAccessAISummary.ts
@@ -2,26 +2,21 @@ import {Threshold} from 'parabol-client/types/constEnums'
 import {Team} from '../../../postgres/queries/getTeamsByIds'
 import {DataLoaderWorker} from '../../graphql'
 
-// Returns whether AI summaries are allowed according to the user's + org's feature flags.
-export const isAISummaryAllowed = async (
-  team: Team,
-  featureFlags: string[],
-  dataLoader: DataLoaderWorker
-) => {
-  if (featureFlags.includes('noAISummary') || !team) return false
-  const {orgId} = team
-  const organization = await dataLoader.get('organizations').load(orgId)
-  if (organization.featureFlags?.includes('noAISummary')) return false
-  return true
-}
-
 const canAccessAISummary = async (
   team: Team,
   featureFlags: string[],
-  dataLoader: DataLoaderWorker
+  dataLoader: DataLoaderWorker,
+  meetingType: 'standup' | 'retrospective'
 ) => {
-  if (!isAISummaryAllowed(team, featureFlags, dataLoader)) return false
-  const {qualAIMeetingsCount, tier} = team
+  if (featureFlags.includes('noAISummary') || !team) return false
+  const {qualAIMeetingsCount, tier, orgId} = team
+  const organization = await dataLoader.get('organizations').load(orgId)
+  if (organization.featureFlags?.includes('noAISummary')) return false
+  if (meetingType === 'standup') {
+    if (!organization.featureFlags?.includes('standupAISummary')) return false
+    return true
+  }
+
   if (tier !== 'starter') return true
   return qualAIMeetingsCount < Threshold.MAX_QUAL_AI_MEETINGS
 }

--- a/packages/server/graphql/mutations/helpers/canAccessAISummary.ts
+++ b/packages/server/graphql/mutations/helpers/canAccessAISummary.ts
@@ -2,15 +2,26 @@ import {Threshold} from 'parabol-client/types/constEnums'
 import {Team} from '../../../postgres/queries/getTeamsByIds'
 import {DataLoaderWorker} from '../../graphql'
 
-const canAccessAISummary = async (
+// Returns whether AI summaries are allowed according to the user's + org's feature flags.
+export const isAISummaryAllowed = async (
   team: Team,
   featureFlags: string[],
   dataLoader: DataLoaderWorker
 ) => {
   if (featureFlags.includes('noAISummary') || !team) return false
-  const {qualAIMeetingsCount, tier, orgId} = team
+  const {orgId} = team
   const organization = await dataLoader.get('organizations').load(orgId)
   if (organization.featureFlags?.includes('noAISummary')) return false
+  return true
+}
+
+const canAccessAISummary = async (
+  team: Team,
+  featureFlags: string[],
+  dataLoader: DataLoaderWorker
+) => {
+  if (!isAISummaryAllowed(team, featureFlags, dataLoader)) return false
+  const {qualAIMeetingsCount, tier} = team
   if (tier !== 'starter') return true
   return qualAIMeetingsCount < Threshold.MAX_QUAL_AI_MEETINGS
 }

--- a/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateDiscussionSummary.ts
@@ -17,7 +17,12 @@ const generateDiscussionSummary = async (
     dataLoader.get('users').loadNonNull(facilitatorUserId),
     dataLoader.get('teams').loadNonNull(teamId)
   ])
-  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  const isAISummaryAccessible = await canAccessAISummary(
+    team,
+    facilitator.featureFlags,
+    dataLoader,
+    'retrospective'
+  )
   if (!isAISummaryAccessible) return
   const [comments, tasks] = await Promise.all([
     dataLoader.get('commentsByDiscussionId').load(discussionId),

--- a/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
@@ -16,7 +16,12 @@ const generateGroupSummaries = async (
     dataLoader.get('teams').loadNonNull(teamId)
   ])
   const organization = await dataLoader.get('organizations').load(team.orgId)
-  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  const isAISummaryAccessible = await canAccessAISummary(
+    team,
+    facilitator.featureFlags,
+    dataLoader,
+    'retrospective'
+  )
   if (!isAISummaryAccessible) return
   const [reflections, reflectionGroups] = await Promise.all([
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId),

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -1,6 +1,6 @@
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import {DataLoaderWorker} from '../../graphql'
-import canAccessAISummary from './canAccessAISummary'
+import {isAISummaryAllowed} from './canAccessAISummary'
 import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 
@@ -14,7 +14,7 @@ const generateStandupMeetingSummary = async (
   ])
   const organization = await dataLoader.get('organizations').load(team.orgId)
   const isAISummaryAccessible =
-    (await canAccessAISummary(team, facilitator.featureFlags, dataLoader)) &&
+    (await isAISummaryAllowed(team, facilitator.featureFlags, dataLoader)) &&
     organization.featureFlags?.includes('standupAISummary')
 
   if (!isAISummaryAccessible) return

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -12,7 +12,10 @@ const generateStandupMeetingSummary = async (
     dataLoader.get('users').loadNonNull(meeting.facilitatorUserId),
     dataLoader.get('teams').loadNonNull(meeting.teamId)
   ])
-  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  const organization = await dataLoader.get('organizations').load(team.orgId)
+  const isAISummaryAccessible =
+    (await canAccessAISummary(team, facilitator.featureFlags, dataLoader)) &&
+    organization.featureFlags?.includes('standupAISummary')
 
   if (!isAISummaryAccessible) return
   const responses = await getTeamPromptResponsesByMeetingId(meeting.id)

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -19,10 +19,11 @@ const generateStandupMeetingSummary = async (
 
   if (!isAISummaryAccessible) return
   const responses = await getTeamPromptResponsesByMeetingId(meeting.id)
-  const manager = new OpenAIServerManager()
 
   const contentToSummarize = responses.map((response) => response.plaintextContent)
   if (contentToSummarize.length === 0) return
+
+  const manager = new OpenAIServerManager()
   const summary = await manager.getStandupSummary(contentToSummarize, meeting.meetingPrompt)
   if (!summary) return
   return summary

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -1,0 +1,28 @@
+import OpenAIServerManager from '../../../utils/OpenAIServerManager'
+import {DataLoaderWorker} from '../../graphql'
+import canAccessAISummary from './canAccessAISummary'
+import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
+import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
+
+const generateStandupMeetingSummary = async (
+  meeting: MeetingTeamPrompt,
+  dataLoader: DataLoaderWorker
+) => {
+  const [facilitator, team] = await Promise.all([
+    dataLoader.get('users').loadNonNull(meeting.facilitatorUserId),
+    dataLoader.get('teams').loadNonNull(meeting.teamId)
+  ])
+  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+
+  if (!isAISummaryAccessible) return
+  const responses = await getTeamPromptResponsesByMeetingId(meeting.id)
+  const manager = new OpenAIServerManager()
+
+  const contentToSummarize = responses.map((response) => response.plaintextContent)
+  if (contentToSummarize.length === 0) return
+  const summary = await manager.getStandupSummary(contentToSummarize, meeting.meetingPrompt)
+  if (!summary) return
+  return summary
+}
+
+export default generateStandupMeetingSummary

--- a/packages/server/graphql/mutations/helpers/generateWholeMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateWholeMeetingSummary.ts
@@ -15,7 +15,12 @@ const generateWholeMeetingSummary = async (
     dataLoader.get('users').loadNonNull(facilitatorUserId),
     dataLoader.get('teams').loadNonNull(teamId)
   ])
-  const isAISummaryAccessible = await canAccessAISummary(team, facilitator.featureFlags, dataLoader)
+  const isAISummaryAccessible = await canAccessAISummary(
+    team,
+    facilitator.featureFlags,
+    dataLoader,
+    'retrospective'
+  )
   if (!isAISummaryAccessible) return
   const [commentsByDiscussions, tasksByDiscussions, reflections] = await Promise.all([
     dataLoader.get('commentsByDiscussionId').loadMany(discussionIds),

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -15,7 +15,7 @@ import updateTeamInsights from './updateTeamInsights'
 import generateStandupMeetingSummary from './generateStandupMeetingSummary'
 import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
 
-const asyncFinishTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalContext) => {
+const finishTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalContext) => {
   const {dataLoader} = context
   const r = await getRethink()
 
@@ -107,7 +107,7 @@ const safeEndTeamPrompt = async ({
   )
   const timelineEventId = events[0]!.id
   await r.table('TimelineEvent').insert(events).run()
-  asyncFinishTeamPrompt(meeting, context)
+  finishTeamPrompt(meeting, context)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses)
   checkTeamsLimit(team.orgId, dataLoader)
   dataLoader.get('newMeetings').clear(meetingId)

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -1,6 +1,6 @@
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {checkTeamsLimit} from '../../../billing/helpers/teamLimitsCheck'
-import {ParabolR} from '../../../database/rethinkDriver'
+import getRethink, {ParabolR} from '../../../database/rethinkDriver'
 import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 import TimelineEventTeamPromptComplete from '../../../database/types/TimelineEventTeamPromptComplete'
 import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
@@ -12,6 +12,42 @@ import collectReactjis from './collectReactjis'
 import sendNewMeetingSummary from './endMeeting/sendNewMeetingSummary'
 import {IntegrationNotifier} from './notifications/IntegrationNotifier'
 import updateTeamInsights from './updateTeamInsights'
+import generateStandupMeetingSummary from './generateStandupMeetingSummary'
+import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
+
+const asyncFinishTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalContext) => {
+  const {dataLoader} = context
+  const r = await getRethink()
+
+  const [summary, usedReactjis] = await Promise.all([
+    generateStandupMeetingSummary(meeting, dataLoader),
+    collectReactjis(meeting, dataLoader)
+  ])
+
+  await r
+    .table('NewMeeting')
+    .get(meeting.id)
+    .update(
+      {
+        summary,
+        usedReactjis
+      },
+      {nonAtomic: true}
+    )
+    .run()
+
+  dataLoader.get('newMeetings').clear(meeting.id)
+  // wait for whole meeting summary to be generated before sending summary email and updating qualAIMeetingCount
+  sendNewMeetingSummary(meeting, context).catch(console.log)
+  updateQualAIMeetingsCount(meeting.id, meeting.teamId, dataLoader)
+  updateTeamInsights(meeting.teamId, dataLoader)
+  // wait for meeting stats to be generated before sending Slack notification
+  IntegrationNotifier.endMeeting(dataLoader, meeting.id, meeting.teamId)
+  const data = {meetingId: meeting.id}
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
+  publish(SubscriptionChannel.MEETING, meeting.id, 'EndTeamPromptSuccess', data, subOptions)
+}
 
 const safeEndTeamPrompt = async ({
   meeting,
@@ -34,16 +70,13 @@ const safeEndTeamPrompt = async ({
 
   if (endedAt) return standardError(new Error('Meeting already ended'), {userId: viewerId})
 
-  const usedReactjis = await collectReactjis(meeting, dataLoader)
-
   // RESOLUTION
   const completedTeamPrompt = (await r
     .table('NewMeeting')
     .get(meetingId)
     .update(
       {
-        endedAt: now,
-        usedReactjis
+        endedAt: now
       },
       {returnChanges: true}
     )('changes')(0)('new_val')
@@ -74,11 +107,9 @@ const safeEndTeamPrompt = async ({
   )
   const timelineEventId = events[0]!.id
   await r.table('TimelineEvent').insert(events).run()
-  IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
-  sendNewMeetingSummary(completedTeamPrompt, context).catch(console.log)
-  checkTeamsLimit(team.orgId, dataLoader)
-  updateTeamInsights(teamId, dataLoader)
+  asyncFinishTeamPrompt(meeting, context)
   analytics.teamPromptEnd(completedTeamPrompt, meetingMembers, responses)
+  checkTeamsLimit(team.orgId, dataLoader)
   dataLoader.get('newMeetings').clear(meetingId)
 
   const data = {

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -27,13 +27,10 @@ const finishTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalCon
   await r
     .table('NewMeeting')
     .get(meeting.id)
-    .update(
-      {
-        summary,
-        usedReactjis
-      },
-      {nonAtomic: true}
-    )
+    .update({
+      summary,
+      usedReactjis
+    })
     .run()
 
   dataLoader.get('newMeetings').clear(meeting.id)

--- a/packages/server/graphql/mutations/helpers/updateQualAIMeetingsCount.ts
+++ b/packages/server/graphql/mutations/helpers/updateQualAIMeetingsCount.ts
@@ -1,3 +1,4 @@
+import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 import updateTeamByTeamId from '../../../postgres/queries/updateTeamByTeamId'
 import {DataLoaderWorker} from '../../graphql'
 
@@ -6,13 +7,20 @@ const updateQualAIMeetingsCount = async (
   teamId: string,
   dataLoader: DataLoaderWorker
 ) => {
-  const [meetingMembers, team, reflections, meeting] = await Promise.all([
+  const [meetingMembers, team, reflections, meeting, responses] = await Promise.all([
     dataLoader.get('meetingMembersByMeetingId').load(meetingId),
     dataLoader.get('teams').load(teamId),
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId),
-    dataLoader.get('newMeetings').load(meetingId)
+    dataLoader.get('newMeetings').load(meetingId),
+    getTeamPromptResponsesByMeetingId(meetingId)
   ])
-  if (meetingMembers.length < 3 || !team || !meeting.summary || reflections.length < 5) return
+  if (
+    meetingMembers.length < 3 ||
+    !team ||
+    !meeting.summary ||
+    !(reflections.length >= 5 || responses.length >= 3)
+  )
+    return
   const {qualAIMeetingsCount} = team
   const updates = {
     qualAIMeetingsCount: qualAIMeetingsCount + 1

--- a/packages/server/graphql/mutations/helpers/updateQualAIMeetingsCount.ts
+++ b/packages/server/graphql/mutations/helpers/updateQualAIMeetingsCount.ts
@@ -1,4 +1,3 @@
-import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 import updateTeamByTeamId from '../../../postgres/queries/updateTeamByTeamId'
 import {DataLoaderWorker} from '../../graphql'
 
@@ -7,20 +6,13 @@ const updateQualAIMeetingsCount = async (
   teamId: string,
   dataLoader: DataLoaderWorker
 ) => {
-  const [meetingMembers, team, reflections, meeting, responses] = await Promise.all([
+  const [meetingMembers, team, reflections, meeting] = await Promise.all([
     dataLoader.get('meetingMembersByMeetingId').load(meetingId),
     dataLoader.get('teams').load(teamId),
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId),
-    dataLoader.get('newMeetings').load(meetingId),
-    getTeamPromptResponsesByMeetingId(meetingId)
+    dataLoader.get('newMeetings').load(meetingId)
   ])
-  if (
-    meetingMembers.length < 3 ||
-    !team ||
-    !meeting.summary ||
-    !(reflections.length >= 5 || responses.length >= 3)
-  )
-    return
+  if (meetingMembers.length < 3 || !team || !meeting.summary || reflections.length < 5) return
   const {qualAIMeetingsCount} = team
   const updates = {
     qualAIMeetingsCount: qualAIMeetingsCount + 1

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -5,6 +5,7 @@ enum OrganizationFeatureFlagsEnum {
   SAMLUI
   noAISummary
   AIGeneratedDiscussionPrompt
+  standupAISummary
   promptToJoinOrg
   suggestGroups
   zoomTranscription

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -171,6 +171,7 @@ type OrganizationFeatureFlags {
   SAMLUI: Boolean!
   noAISummary: Boolean!
   AIGeneratedDiscussionPrompt: Boolean!
+  standupAISummary: Boolean!
   promptToJoinOrg: Boolean!
   suggestGroups: Boolean!
   zoomTranscription: Boolean!

--- a/packages/server/graphql/public/typeDefs/Subscriptions.graphql
+++ b/packages/server/graphql/public/typeDefs/Subscriptions.graphql
@@ -21,6 +21,7 @@ type MeetingSubscriptionPayload {
   EditReflectionPayload: EditReflectionPayload
   EndDraggingReflectionPayload: EndDraggingReflectionPayload
   EndRetrospectiveSuccess: EndRetrospectiveSuccess
+  EndTeamPromptSuccess: EndTeamPromptSuccess
   FlagReadyToAdvanceSuccess: FlagReadyToAdvanceSuccess
   GenerateGroupsSuccess: GenerateGroupsSuccess
   NewMeetingCheckInPayload: NewMeetingCheckInPayload

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -3,6 +3,7 @@ import {OrganizationFeatureFlagsResolvers} from '../resolverTypes'
 const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   SAMLUI: ({SAMLUI}) => !!SAMLUI,
   noAISummary: ({noAISummary}) => !!noAISummary,
+  standupAISummary: ({standupAISummary}) => !!standupAISummary,
   promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg,
   AIGeneratedDiscussionPrompt: ({AIGeneratedDiscussionPrompt}) => !!AIGeneratedDiscussionPrompt,
   zoomTranscription: ({zoomTranscription}) => !!zoomTranscription,

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -17,7 +17,7 @@ class OpenAIServerManager {
     this.openAIApi = new OpenAIApi(configuration)
   }
 
-  async getStandupSummary(htmlResponses: string[], meetingPrompt: string) {
+  async getStandupSummary(plaintextResponses: string[], meetingPrompt: string) {
     if (!this.openAIApi) return null
     // :TODO: (jmtaber129): Include info about who made each response in the prompt, so that the LLM
     // can include that in the response, e.g. "James is working on AI Summaries" vs. "Someone is
@@ -30,7 +30,7 @@ class OpenAIServerManager {
     - <theme title>: <theme summary>
 
     Responses: """
-    ${htmlResponses.join('\nNEW_RESPONSE\n')}
+    ${plaintextResponses.join('\nNEW_RESPONSE\n')}
     """`
     try {
       const response = await this.openAIApi.createChatCompletion({

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -22,7 +22,7 @@ class OpenAIServerManager {
     // :TODO: (jmtaber129): Include info about who made each response in the prompt, so that the LLM
     // can include that in the response, e.g. "James is working on AI Summaries" vs. "Someone is
     // working on AI Summaries".
-    const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". If there are multiple responses, the responses are delimited by the string "NEW_RESPONSE". Identify up to 5 themes found within the responses. For each theme, provide a 2 to 3 sentence summary. In the summaries, only include information specified in the repsonses. When referring to people in the output, do not assume their gender and default to using the pronouns "they" and "them".
+    const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". If there are multiple responses, the responses are delimited by the string "NEW_RESPONSE". Identify up to 5 themes found within the responses. For each theme, provide a 2 to 3 sentence summary. In the summaries, only include information specified in the responses. When referring to people in the output, do not assume their gender and default to using the pronouns "they" and "them".
 
     Desired format:
     * <theme title>: <theme summary>

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -25,9 +25,9 @@ class OpenAIServerManager {
     const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". If there are multiple responses, the responses are delimited by the string "NEW_RESPONSE". Identify up to 5 themes found within the responses. For each theme, provide a 2 to 3 sentence summary. In the summaries, only include information specified in the responses. When referring to people in the output, do not assume their gender and default to using the pronouns "they" and "them".
 
     Desired format:
-    * <theme title>: <theme summary>
-    * <theme title>: <theme summary>
-    * <theme title>: <theme summary>
+    - <theme title>: <theme summary>
+    - <theme title>: <theme summary>
+    - <theme title>: <theme summary>
 
     Responses: """
     ${htmlResponses.join('\nNEW_RESPONSE\n')}

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -33,16 +33,21 @@ class OpenAIServerManager {
     ${htmlResponses.join('\nNEW_RESPONSE\n')}
     """`
     try {
-      const response = await this.openAIApi.createCompletion({
-        model: 'text-davinci-003',
-        prompt: prompt,
+      const response = await this.openAIApi.createChatCompletion({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'user',
+            content: prompt
+          }
+        ],
         temperature: 0.7,
         max_tokens: 1000,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      return (response.data.choices[0]?.text?.trim() as string) ?? null
+      return (response.data.choices[0]?.message?.content?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8568

Implement AI Summaries for standups. Instead of prompting the model for an _overall_ summary, prompt the model to identify up to 5 themes found in responses, and provide brief summaries for those.

Reuse UI components for simplicity.

## Demo
This is the summary from several responses in our own July 17th Friday ship (copy-pasted to a local standup meeting).
<img width="680" alt="Screen Shot 2023-07-26 at 9 25 09 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/a064b9cb-81bd-4396-aef5-3cea9b2afcb5">

A different summary in slack: 
<img width="667" alt="Screen Shot 2023-07-26 at 9 59 22 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/a416e7b0-9d13-4089-b6a6-8acb35000a1e">

## Testing scenarios
- [ ] No changes for orgs without the feature flag.
- [ ] Fill out a standup with test data (e.g. dummy standups or copied from a Friday ship)
- [ ] End the standup, and confirm the meeting immediately navigates to the summary, with the AI component loading
- [ ] Confirm the AI component displays a reasonable summary after a few seconds
- [ ] Confirm the email summary includes an AI summary
- [ ] For a meeting with 3+ responses, confirm that the `qualAIMeetingCount` on the `Team` object in PG is incremented.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
