### PR TITLE
feat(al): Roll out Activity Library to all new users

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -19,8 +19,6 @@ import sendPromptToJoinOrg from '../../../utils/sendPromptToJoinOrg'
 import {makeDefaultTeamName} from 'parabol-client/utils/makeDefaultTeamName'
 import isCompanyDomain from '../../../utils/isCompanyDomain'
 
-const PERCENT_ADDED_TO_RID = 0.05
-
 const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?: string) => {
   const r = await getRethink()
   const {id: userId, createdAt, preferredName, email, featureFlags, tier, segmentId} = newUser
@@ -42,9 +40,7 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   if (Boolean(params.get('rid')) || domainUserHasRidFlag) {
     experimentalFlags.push('retrosInDisguise')
   } else if (usersWithDomain.length === 0) {
-    if (Math.random() < PERCENT_ADDED_TO_RID) {
-      experimentalFlags.push('retrosInDisguise')
-    }
+    experimentalFlags.push('retrosInDisguise')
   }
 
   await Promise.all([


### PR DESCRIPTION
# Description
L&E Squad has decided to roll out the Activity Library to all new P0 users. Instead of adding only 5% of new P0s to the flag, add all new P0s to the flag.

For non-P0 signups (i.e. another user already exists with the same company domain), we'll continue using domain affinity (user will be added to the flag iff another user in the domain has the flag).

## Testing scenarios
- [ ] Sign up as a P0 (a non-company email domain like gmail.com also works)
- [ ] Confirm you're added to the feature flag.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
