### PR TITLE
chore: fix open pgtyped connections after running `yarn dev`

### DIFF
--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -66,7 +66,9 @@ module.exports = {
     },
     {
       name: 'PG Typed',
-      script: 'yarn pg:build -w'
+      script: 'yarn pg:build',
+      watch: ['packages/server/postgres/queries/src/*.sql'],
+      autorestart: false
     }
   ].map((app) => ({
     env_production: {


### PR DESCRIPTION
# Description

`yarn pg:build -w` would keep the node process running after pm2 was killed. Switched to use the watch mode from pm2 instead so we don't run out of PG connections while developing.

## Testing scenarios

- run `yarn dev` a couple of times and kill it again by ^C
- check `ps aux | grep pgtyped` and see no running process

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
