### PR TITLE
fix: do not trust invites sent to emails from the untrusted domains

### DIFF
--- a/packages/server/__tests__/inviteToTeam.test.ts
+++ b/packages/server/__tests__/inviteToTeam.test.ts
@@ -1,6 +1,6 @@
 import {getUserTeams, sendPublic, signUp} from './common'
 
-test('Invite to team', async () => {
+test('Invite to team, works for ordinary email domain', async () => {
   const {userId, authToken} = await signUp()
   const {email: inviteeEmail} = await signUp()
 
@@ -29,6 +29,42 @@ test('Invite to team', async () => {
       inviteToTeam: {
         error: null,
         invitees: ['foo@example.com', inviteeEmail]
+      }
+    }
+  })
+})
+
+test('Invite to team, deny for untrusted domain', async () => {
+  const {userId, authToken} = await signUp()
+  const {email: inviteeEmail} = await signUp()
+
+  const teamId = (await getUserTeams(userId))[0].id
+  const inviteToTeam = await sendPublic({
+    query: `
+      mutation InviteToTeam($teamId: ID!, $invitees: [Email!]!) {
+        inviteToTeam(teamId: $teamId, invitees: $invitees) {
+          error {
+            title
+            message
+          }
+          invitees
+        }
+      }
+    `,
+    variables: {
+      teamId,
+      invitees: ['foo@qq.com', inviteeEmail]
+    },
+    authToken
+  })
+
+  expect(inviteToTeam).toMatchObject({
+    data: {
+      inviteToTeam: {
+        error: {
+          message: 'Cannot invite by email. Try using invite link',
+          title: null
+        }
       }
     }
   })

--- a/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
+++ b/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
@@ -44,7 +44,9 @@ const getInviteTrustScore = async (
   const inviteeDomains = inviteeEmails.map((inviteeEmail) =>
     getDomainFromEmail(inviteeEmail).toLowerCase()
   )
-  if (inviteeDomains.filter((domain: string) => untrustedDomains.includes(domain))) return 0.05
+  const overlapped =
+    inviteeDomains.filter((domain: string) => untrustedDomains.includes(domain)).length > 0
+  if (overlapped) return 0.05
 
   const [total, pending] = await Promise.all([
     r.table('TeamInvitation').getAll(teamId, {index: 'teamId'}).count().run(),


### PR DESCRIPTION
# Description

Looking at [Amplitude](https://app.amplitude.com/analytics/parabol/chart/xv8lafw7/edit/v85plt3b), spammers have been sending almost all of the invites to @qq.com. This PR modifies the trust score logic to also look at domains from the invitees.

## Demo
![2023-07-27 10 58 28](https://github.com/ParabolInc/parabol/assets/1879975/49227701-581b-4138-81d3-da17bddc2f1a)

## Testing scenarios

- [ ] Cannot send invite emails to @qq.com
- [ ] Can still send invite emails to other people

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
