### PR TITLE
fix: change default tab to activities in team dash

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashHeader/TeamDashHeader.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashHeader/TeamDashHeader.tsx
@@ -112,7 +112,7 @@ const TeamDashHeader = (props: Props) => {
   )
   const {organization, id: teamId, name: teamName, teamMembers} = team
   const {name: orgName, id: orgId} = organization
-  const isActivity = useRouteMatch('/team/:teamId/activity')
+  const isTasks = useRouteMatch('/team/:teamId/tasks')
   const {history} = useRouter()
 
   return (
@@ -157,7 +157,7 @@ const TeamDashHeader = (props: Props) => {
         </Avatars>
       </TeamHeaderAndAvatars>
       <Tabs
-        activeIdx={isActivity ? 0 : 1}
+        activeIdx={isTasks ? 1 : 0}
         className='full-w max-w-none border-b border-solid border-slate-300'
       >
         <Tab label='Activity' onClick={() => history.push(`/team/${teamId}/activity`)} />


### PR DESCRIPTION
# Description

Fixes #8582
Highlight the correct tab

## Testing scenarios

- Go from the meeting dash to the team dashboard
- See the activity tab being selected and shown

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
