### PR TITLE
chore: Restrict Team Health phase for starter tier

### DIFF
--- a/packages/client/utils/features/isTeamHealthAvailable.ts
+++ b/packages/client/utils/features/isTeamHealthAvailable.ts
@@ -1,9 +1,7 @@
 import {TierEnum} from '~/../server/database/types/Invoice'
 
-function isTeamHealthAvailable(_tier: TierEnum) {
-  // we're making it free for all for the beginning
-  //return tier !== 'starter'
-  return true
+function isTeamHealthAvailable(tier: TierEnum) {
+  return tier !== 'starter'
 }
 
 export default isTeamHealthAvailable


### PR DESCRIPTION
# Description

Fixes #8589 

## Demo

Ignore the wtf moment at the end, this will be fixed in #8588 separately.
https://www.loom.com/share/aaaf0d924e7642a0a16cf48922fa7575?sid=dc6c7995-c7d8-4cda-9e0d-73e53d5e019d


[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

### Existing meetings
- on **master** create a retro with team health with a starter team
- checkout **PR**
- check that existing meeting still works

### Starter new Retro
- see Team Health option is not present anymore in meeting settings
- new retro does not have Team Health phase

### Enterprise and Team tier
- check that Team Health can still be enabled and disabled
- check it appears in the Retro

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
