### PR TITLE
fix: make AIGeneratedDiscussionPrompt org level feature flag

### DIFF
--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -302,7 +302,8 @@ const initDemoOrg = () => {
       zoomTranscription: false,
       suggestGroups: false,
       teamsLimit: false,
-      promptToJoinOrg: false
+      promptToJoinOrg: false,
+      AIGeneratedDiscussionPrompt: false
     },
     showConversionModal: false
   } as const

--- a/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
@@ -30,9 +30,9 @@ const generateGroupSummaries = async (
     sendToSentry(error, {userId: facilitator.id, tags: {meetingId}})
     return
   }
-  const aiGeneratedDiscussionPromptEnabled =
-    facilitator.featureFlags.includes('AIGeneratedDiscussionPrompt') ||
-    organization.featureFlags?.includes('AIGeneratedDiscussionPrompt')
+  const aiGeneratedDiscussionPromptEnabled = organization.featureFlags?.includes(
+    'AIGeneratedDiscussionPrompt'
+  )
   await Promise.all(
     reflectionGroups.map(async (group) => {
       const reflectionsByGroupId = reflections.filter(

--- a/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
+++ b/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
@@ -8,7 +8,6 @@ enum UserFlagEnum {
   insights
   recurrence
   noAISummary
-  AIGeneratedDiscussionPrompt
   noMeetingHistoryLimit
   checkoutFlow
   retrosInDisguise
@@ -25,7 +24,6 @@ type UserFeatureFlags {
   insights: Boolean!
   recurrence: Boolean!
   noAISummary: Boolean!
-  AIGeneratedDiscussionPrompt: Boolean!
   noMeetingHistoryLimit: Boolean!
   checkoutFlow: Boolean!
   retrosInDisguise: Boolean!

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -4,6 +4,7 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   SAMLUI: ({SAMLUI}) => !!SAMLUI,
   noAISummary: ({noAISummary}) => !!noAISummary,
   promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg,
+  AIGeneratedDiscussionPrompt: ({AIGeneratedDiscussionPrompt}) => !!AIGeneratedDiscussionPrompt,
   zoomTranscription: ({zoomTranscription}) => !!zoomTranscription,
   shareSummary: ({shareSummary}) => !!shareSummary,
   suggestGroups: ({suggestGroups}) => !!suggestGroups,


### PR DESCRIPTION
# Description
Previously `AIGeneratedDiscussionPrompt` is a user-level feature flag. This PR makes it also an org-level feature flag so we can roll out to non-Parabol orgs/users.

## Testing scenarios

- [ ] Add feature flag `AIGeneratedDiscussionPrompt` to an org and verify discussion question is generated for meetings from the org
- [ ] Add feature flag `AIGeneratedDiscussionPrompt` to an user and verify discussion question is generated for the meetings facilitated by the user

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
