### PR TITLE
feat(standups): Notify slack when user submits standup response

### DIFF
--- a/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationList.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationList.tsx
@@ -47,7 +47,8 @@ const Heading = styled(LabelHeading)({
 const TEAM_EVENTS = [
   'meetingStart',
   'meetingEnd',
-  'MEETING_STAGE_TIME_LIMIT_START'
+  'MEETING_STAGE_TIME_LIMIT_START',
+  'STANDUP_RESPONSE_SUBMITTED'
 ] as SlackNotificationEventEnum[]
 const USER_EVENTS = ['MEETING_STAGE_TIME_LIMIT_END'] as SlackNotificationEventEnum[]
 

--- a/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/SlackNotificationRow.tsx
@@ -25,7 +25,8 @@ const labelLookup = {
   meetingStart: 'Meeting Start',
   MEETING_STAGE_TIME_LIMIT_END: `Meeting ${MeetingLabels.TIME_LIMIT} Ended`,
   MEETING_STAGE_TIME_LIMIT_START: `Meeting ${MeetingLabels.TIME_LIMIT} Started`,
-  TOPIC_SHARED: `Topic Shared`
+  TOPIC_SHARED: `Topic Shared`,
+  STANDUP_RESPONSE_SUBMITTED: 'Standup Response Submitted'
 } as Record<SlackNotificationEventEnum, string>
 
 const Row = styled('div')({

--- a/packages/server/database/types/SlackNotification.ts
+++ b/packages/server/database/types/SlackNotification.ts
@@ -5,7 +5,8 @@ export const slackNotificationEventTypeLookup = {
   meetingEnd: 'team',
   MEETING_STAGE_TIME_LIMIT_END: 'member',
   MEETING_STAGE_TIME_LIMIT_START: 'team',
-  TOPIC_SHARED: 'member'
+  TOPIC_SHARED: 'member',
+  STANDUP_RESPONSE_SUBMITTED: 'team'
 } as const
 
 export type SlackNotificationEvent = keyof typeof slackNotificationEventTypeLookup
@@ -15,6 +16,7 @@ export type SlackNotificationEventEnum =
   | 'meetingEnd'
   | 'meetingStart'
   | 'TOPIC_SHARED'
+  | 'STANDUP_RESPONSE_SUBMITTED'
 
 interface Input {
   event: SlackNotificationEvent

--- a/packages/server/graphql/mutations/addSlackAuth.ts
+++ b/packages/server/graphql/mutations/addSlackAuth.ts
@@ -26,7 +26,8 @@ export const upsertNotifications = async (
   const teamEvents = [
     'meetingStart',
     'meetingEnd',
-    'MEETING_STAGE_TIME_LIMIT_START'
+    'MEETING_STAGE_TIME_LIMIT_START',
+    'STANDUP_RESPONSE_SUBMITTED'
   ] as SlackNotificationEvent[]
   const userEvents = ['MEETING_STAGE_TIME_LIMIT_END'] as SlackNotificationEvent[]
   const events = [...teamEvents, ...userEvents]

--- a/packages/server/graphql/mutations/helpers/notifications/IntegrationNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/IntegrationNotifier.ts
@@ -32,5 +32,12 @@ export const IntegrationNotifier: Notifier = {
     await Promise.allSettled(
       notifiers.map(async (notifier) => notifier.integrationUpdated(dataLoader, teamId, userId))
     )
+  },
+  async standupResponseSubmitted(dataLoader, meetingId, teamId, userId) {
+    await Promise.allSettled(
+      notifiers.map(async (notifier) =>
+        notifier.standupResponseSubmitted(dataLoader, meetingId, teamId, userId)
+      )
+    )
   }
 }

--- a/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
@@ -414,9 +414,11 @@ export const MSTeamsNotifier: Notifier = {
     teamId: string,
     userId: string
   ) {
-    const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
-    const user = await dataLoader.get('users').load(userId)
-    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    const [{meeting, team}, user, responses] = await Promise.all([
+      loadMeetingTeam(dataLoader, meetingId, teamId),
+      dataLoader.get('users').load(userId),
+      getTeamPromptResponsesByMeetingId(meetingId)
+    ])
     const response = responses.find(({userId: responseUserId}) => responseUserId === userId)
     if (!meeting || !team || !response || !user) return
     ;(await getMSTeams(dataLoader, teamId, userId))?.standupResponseSubmitted(

--- a/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
@@ -23,6 +23,7 @@ import {
 } from './makeMattermostAttachments'
 import {NotificationIntegrationHelper} from './NotificationIntegrationHelper'
 import {Notifier} from './Notifier'
+import {getTeamPromptResponsesByMeetingId} from '../../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 
 const notifyMattermost = async (
   event: EventEnum,
@@ -316,6 +317,10 @@ const MattermostNotificationHelper: NotificationIntegrationHelper<MattermostNoti
       )
     ]
     return notifyMattermost('meetingEnd', webhookUrl, userId, teamId, attachments)
+  },
+  async standupResponseSubmitted() {
+    // Not implemented
+    return 'success'
   }
 })
 
@@ -387,5 +392,24 @@ export const MattermostNotifier: Notifier = {
 
   async integrationUpdated(dataLoader: DataLoaderWorker, teamId: string, userId: string) {
     ;(await getMattermost(dataLoader, teamId, userId))?.integrationUpdated()
+  },
+
+  async standupResponseSubmitted(
+    dataLoader: DataLoaderWorker,
+    meetingId: string,
+    teamId: string,
+    userId: string
+  ) {
+    const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
+    const user = await dataLoader.get('users').load(userId)
+    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    const response = responses.find(({userId: responseUserId}) => responseUserId === userId)
+    if (!meeting || !team || !response || !user) return
+    ;(await getMattermost(dataLoader, teamId, userId))?.standupResponseSubmitted(
+      meeting,
+      team,
+      user,
+      response
+    )
   }
 }

--- a/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
@@ -400,9 +400,11 @@ export const MattermostNotifier: Notifier = {
     teamId: string,
     userId: string
   ) {
-    const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
-    const user = await dataLoader.get('users').load(userId)
-    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    const [{meeting, team}, user, responses] = await Promise.all([
+      loadMeetingTeam(dataLoader, meetingId, teamId),
+      dataLoader.get('users').load(userId),
+      getTeamPromptResponsesByMeetingId(meetingId)
+    ])
     const response = responses.find(({userId: responseUserId}) => responseUserId === userId)
     if (!meeting || !team || !response || !user) return
     ;(await getMattermost(dataLoader, teamId, userId))?.standupResponseSubmitted(

--- a/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
@@ -1,5 +1,7 @@
 import Meeting from '../../../../database/types/Meeting'
+import {TeamPromptResponse} from '../../../../postgres/queries/getTeamPromptResponsesByIds'
 import {Team} from '../../../../postgres/queries/getTeamsByIds'
+import User from '../../../../postgres/types/IUser'
 
 export type NotifyResponse =
   | 'success'
@@ -15,6 +17,12 @@ export type NotificationIntegration = {
   startTimeLimit(scheduledEndTime: Date, meeting: Meeting, team: Team): Promise<NotifyResponse>
   endTimeLimit(meeting: Meeting, team: Team): Promise<NotifyResponse>
   integrationUpdated(): Promise<NotifyResponse>
+  standupResponseSubmitted(
+    meeting: Meeting,
+    team: Team,
+    user: User,
+    response: TeamPromptResponse
+  ): Promise<NotifyResponse>
 }
 
 export type NotificationIntegrationHelper<NotificationChannel> = (

--- a/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
@@ -21,4 +21,10 @@ export type Notifier = {
     stageIndex: number,
     channelId: string
   ): Promise<NotifyResponse>
+  standupResponseSubmitted(
+    dataLoader: DataLoaderWorker,
+    meetingId: string,
+    teamId: string,
+    userId: string
+  ): Promise<void>
 }

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -20,6 +20,7 @@ import {makeButtons, makeSection, makeSections} from './makeSlackBlocks'
 import {NotificationIntegrationHelper, NotifyResponse} from './NotificationIntegrationHelper'
 import {Notifier} from './Notifier'
 import SlackAuth from '../../../../database/types/SlackAuth'
+import {getTeamPromptResponsesByMeetingId} from '../../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
 
 type SlackNotification = {
   title: string
@@ -250,6 +251,24 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
   async integrationUpdated() {
     // Slack sends a system message on its own
     return 'success'
+  },
+
+  async standupResponseSubmitted(meeting, team, user, response) {
+    const options = {
+      searchParams: {
+        utm_source: 'slack share',
+        utm_medium: 'product',
+        utm_campaign: 'sharing',
+        responseId: response.id
+      }
+    }
+    const responseUrl = makeAppURL(appOrigin, `meet/${meeting.id}/responses`, options)
+    const title = `${user.preferredName} has added their response in ${meeting.name}`
+    const blocks: Array<{type: string}> = [
+      makeSection(title),
+      makeButtons([{text: 'See their response', url: responseUrl, type: 'primary'}])
+    ]
+    return notifySlack(notificationChannel, 'STANDUP_RESPONSE_SUBMITTED', team.id, blocks, title)
   }
 })
 
@@ -311,6 +330,26 @@ export const SlackNotifier: Notifier = {
 
   async integrationUpdated() {
     // Slack sends a system message on its own
+  },
+
+  async standupResponseSubmitted(
+    dataLoader: DataLoaderWorker,
+    meetingId: string,
+    teamId: string,
+    userId: string
+  ) {
+    const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
+    const user = await dataLoader.get('users').load(userId)
+    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    const response = responses.find(({userId: responseUserId}) => responseUserId === userId)
+    if (!meeting || !team || !response || !user) {
+      return
+    }
+
+    const notifiers = await getSlack(dataLoader, 'STANDUP_RESPONSE_SUBMITTED', team.id)
+    notifiers.forEach((notifier) =>
+      notifier.standupResponseSubmitted(meeting, team, user, response)
+    )
   },
 
   async shareTopic(

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -338,9 +338,11 @@ export const SlackNotifier: Notifier = {
     teamId: string,
     userId: string
   ) {
-    const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
-    const user = await dataLoader.get('users').load(userId)
-    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    const [{meeting, team}, user, responses] = await Promise.all([
+      loadMeetingTeam(dataLoader, meetingId, teamId),
+      dataLoader.get('users').load(userId),
+      getTeamPromptResponsesByMeetingId(meetingId)
+    ])
     const response = responses.find(({userId: responseUserId}) => responseUserId === userId)
     if (!meeting || !team || !response || !user) {
       return

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -256,9 +256,9 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
   async standupResponseSubmitted(meeting, team, user, response) {
     const options = {
       searchParams: {
-        utm_source: 'slack share',
+        utm_source: 'slack standup submission',
         utm_medium: 'product',
-        utm_campaign: 'sharing',
+        utm_campaign: 'standups',
         responseId: response.id
       }
     }

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -258,7 +258,7 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
       searchParams: {
         utm_source: 'slack standup submission',
         utm_medium: 'product',
-        utm_campaign: 'standups',
+        utm_campaign: 'notifications',
         responseId: response.id
       }
     }

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -11,6 +11,7 @@ import standardError from '../../../utils/standardError'
 import {MutationResolvers} from '../resolverTypes'
 import publishNotification from './helpers/publishNotification'
 import createTeamPromptMentionNotifications from './helpers/publishTeamPromptMentions'
+import {IntegrationNotifier} from '../../mutations/helpers/notifications/IntegrationNotifier'
 
 const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = async (
   _source,
@@ -94,6 +95,10 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
   notifications.forEach((notification) => {
     publishNotification(notification, subOptions)
   })
+
+  if (!oldTeamPromptResponse) {
+    IntegrationNotifier.standupResponseSubmitted(dataLoader, meetingId, teamId, viewerId)
+  }
 
   analytics.responseAdded(viewerId, meetingId, teamPromptResponseId, !!inputTeamPromptResponseId)
   publish(

--- a/packages/server/graphql/types/SlackNotificationEventEnum.ts
+++ b/packages/server/graphql/types/SlackNotificationEventEnum.ts
@@ -8,7 +8,8 @@ const SlackNotificationEventEnum = new GraphQLEnumType({
     meetingEnd: {},
     MEETING_STAGE_TIME_LIMIT_END: {}, // user event
     MEETING_STAGE_TIME_LIMIT_START: {},
-    TOPIC_SHARED: {}
+    TOPIC_SHARED: {},
+    STANDUP_RESPONSE_SUBMITTED: {}
   }
 })
 


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8606

When a user submits their standup response, send a message to slack with a direct link to their response.

To minimize scope, only supports slack for now.

## Demo
<img width="424" alt="Screen Shot 2023-08-02 at 11 49 07 AM" src="https://github.com/ParabolInc/parabol/assets/9013217/8d387c28-0d8d-4ac7-be26-5316a8758af0">


## Testing scenarios
- [ ] Start a standup meeting on a team with a slack integration
- [ ] Make sure "Standup response submitted" is checked in the team integrations view
- [ ] Submit a standup response
- [ ] See the notification in the integrated slack channel
- [ ] Open the link in the slack notification, and confirm it opens the side drawer for that response
- [ ] Update the standup response, and confirm no additional slack messages are sent

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
