### PR TITLE
feat(standups): Post standup responses in 'meeting ended' message thread

### DIFF
--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -1,4 +1,4 @@
-interface ErrorResponse {
+export interface ErrorResponse {
   ok: false
   error: string
 }
@@ -69,8 +69,9 @@ interface ConversationJoinResponse {
   }
 }
 
-interface PostMessageResponse {
+export interface PostMessageResponse {
   ok: true
+  ts: string
 }
 
 interface UpdateMessageResponse {
@@ -212,14 +213,20 @@ abstract class SlackManager {
     )
   }
 
-  postMessage(channelId: string, text: string | Array<{type: string}>, notificationText?: string) {
+  postMessage(
+    channelId: string,
+    text: string | Array<{type: string}>,
+    notificationText?: string,
+    threadTs?: string
+  ) {
     const prop = typeof text === 'string' ? 'text' : Array.isArray(text) ? 'blocks' : null
     if (!prop) throw new Error('Invalid Slack postMessage')
     const defaultPayload = {
       channel: channelId,
       unfurl_links: false,
       unfurl_media: false,
-      [prop]: text
+      [prop]: text,
+      thread_ts: threadTs
     }
     const payload =
       prop === 'text'

--- a/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MSTeamsNotifier.ts
@@ -380,7 +380,11 @@ export const MSTeamsNotifier: Notifier = {
   async endMeeting(dataLoader: DataLoaderWorker, meetingId: string, teamId: string) {
     const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
     if (!meeting || !team) return
-    ;(await getMSTeams(dataLoader, team.id, meeting.facilitatorUserId))?.endMeeting(meeting, team)
+    ;(await getMSTeams(dataLoader, team.id, meeting.facilitatorUserId))?.endMeeting(
+      meeting,
+      team,
+      null
+    )
   },
 
   async startTimeLimit(

--- a/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
@@ -362,7 +362,8 @@ export const MattermostNotifier: Notifier = {
     if (!meeting || !team) return
     ;(await getMattermost(dataLoader, team.id, meeting.facilitatorUserId))?.endMeeting(
       meeting,
-      team
+      team,
+      null
     )
   },
 

--- a/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
@@ -13,7 +13,11 @@ export type NotifyResponse =
 
 export type NotificationIntegration = {
   startMeeting(meeting: Meeting, team: Team): Promise<NotifyResponse>
-  endMeeting(meeting: Meeting, team: Team): Promise<NotifyResponse>
+  endMeeting(
+    meeting: Meeting,
+    team: Team,
+    standupResponses?: {user: User; response: TeamPromptResponse}[]
+  ): Promise<NotifyResponse>
   startTimeLimit(scheduledEndTime: Date, meeting: Meeting, team: Team): Promise<NotifyResponse>
   endTimeLimit(meeting: Meeting, team: Team): Promise<NotifyResponse>
   integrationUpdated(): Promise<NotifyResponse>

--- a/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
@@ -16,7 +16,7 @@ export type NotificationIntegration = {
   endMeeting(
     meeting: Meeting,
     team: Team,
-    standupResponses?: {user: User; response: TeamPromptResponse}[]
+    standupResponses: {user: User; response: TeamPromptResponse}[] | null
   ): Promise<NotifyResponse>
   startTimeLimit(scheduledEndTime: Date, meeting: Meeting, team: Team): Promise<NotifyResponse>
   endTimeLimit(meeting: Meeting, team: Team): Promise<NotifyResponse>

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -214,9 +214,9 @@ const addStandupResponsesToThread = async (
     standupResponses.map(async ({user, response}) => {
       const options = {
         searchParams: {
-          utm_source: 'slack share',
+          utm_source: 'slack standup summary',
           utm_medium: 'product',
-          utm_campaign: 'sharing',
+          utm_campaign: 'standups',
           responseId: response.id
         }
       }

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -417,15 +417,13 @@ export const SlackNotifier: Notifier = {
   async endMeeting(dataLoader: DataLoaderWorker, meetingId: string, teamId: string) {
     const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
     const meetingResponses = await getTeamPromptResponsesByMeetingId(meetingId)
-    const standupResponses: Array<{user: User; response: TeamPromptResponse}> = []
-    await Promise.allSettled(
+    // const standupResponses: Array<{user: User; response: TeamPromptResponse}> = []
+    const standupResponses = await Promise.all(
       meetingResponses.map(async (response) => {
-        const user = await dataLoader.get('users').load(response.userId)
-        if (user) {
-          standupResponses.push({
-            user,
-            response
-          })
+        const user = await dataLoader.get('users').loadNonNull(response.userId)
+        return {
+          user,
+          response
         }
       })
     )

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -216,7 +216,7 @@ const addStandupResponsesToThread = async (
         searchParams: {
           utm_source: 'slack standup summary',
           utm_medium: 'product',
-          utm_campaign: 'standups',
+          utm_campaign: 'after-meeting',
           responseId: response.id
         }
       }

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -17,10 +17,13 @@ import SlackServerManager from '../../../../utils/SlackServerManager'
 import {DataLoaderWorker} from '../../../graphql'
 import getSummaryText from './getSummaryText'
 import {makeButtons, makeSection, makeSections} from './makeSlackBlocks'
-import {NotificationIntegrationHelper, NotifyResponse} from './NotificationIntegrationHelper'
+import {NotificationIntegrationHelper} from './NotificationIntegrationHelper'
 import {Notifier} from './Notifier'
 import SlackAuth from '../../../../database/types/SlackAuth'
 import {getTeamPromptResponsesByMeetingId} from '../../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
+import {ErrorResponse, PostMessageResponse} from '../../../../../client/utils/SlackManager'
+import {TeamPromptResponse} from '../../../../postgres/queries/getTeamPromptResponsesByIds'
+import User from '../../../../postgres/types/IUser'
 
 type SlackNotification = {
   title: string
@@ -32,28 +35,12 @@ type NotificationChannel = {
   channelId: string | null
 }
 
-const notifySlack = async (
-  notificationChannel: NotificationChannel,
-  event: SlackNotificationEvent,
+const handleError = async (
+  res: PostMessageResponse | ErrorResponse,
   teamId: string,
-  slackMessage: string | Array<{type: string}>,
-  notificationText?: string,
-  segmentProperties?: object
-): Promise<NotifyResponse> => {
+  notificationChannel: NotificationChannel
+) => {
   const {channelId, auth} = notificationChannel
-  const {botAccessToken, userId} = auth
-  const manager = new SlackServerManager(botAccessToken!)
-  const res = await manager.postMessage(channelId!, slackMessage, notificationText)
-  segmentIo.track({
-    userId,
-    event: 'Slack notification sent',
-    properties: {
-      teamId,
-      notificationEvent: event,
-      ...segmentProperties
-    }
-  })
-
   if ('error' in res) {
     const {error} = res
     if (error === 'channel_not_found') {
@@ -83,7 +70,34 @@ const notifySlack = async (
       }
     }
   }
+
   return 'success'
+}
+
+const notifySlack = async (
+  notificationChannel: NotificationChannel,
+  event: SlackNotificationEvent,
+  teamId: string,
+  slackMessage: string | Array<{type: string}>,
+  notificationText?: string,
+  ts?: string,
+  segmentProperties?: object
+): Promise<PostMessageResponse | ErrorResponse> => {
+  const {channelId, auth} = notificationChannel
+  const {botAccessToken, userId} = auth
+  const manager = new SlackServerManager(botAccessToken!)
+  const res = await manager.postMessage(channelId!, slackMessage, notificationText, ts)
+  segmentIo.track({
+    userId,
+    event: 'Slack notification sent',
+    properties: {
+      teamId,
+      notificationEvent: event,
+      ...segmentProperties
+    }
+  })
+
+  return res
 }
 
 const makeEndMeetingButtons = (meeting: Meeting) => {
@@ -190,10 +204,14 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
       meetingUrl
     )
 
-    return notifySlack(notificationChannel, 'meetingStart', team.id, blocks, title)
+    const res = await notifySlack(notificationChannel, 'meetingStart', team.id, blocks, title)
+    if ('error' in res) {
+      return handleError(res, team.id, notificationChannel)
+    }
+    return 'success'
   },
 
-  async endMeeting(meeting, team) {
+  async endMeeting(meeting, team, standupResponses) {
     const summaryText = await getSummaryText(meeting)
     const title = 'Meeting completed :tada:'
     const blocks: Array<{type: string}> = [
@@ -206,7 +224,66 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
       blocks.push(makeSection(`*${aiSummaryTitle}*:\n${meeting.summary}`))
     }
     blocks.push(makeEndMeetingButtons(meeting))
-    return notifySlack(notificationChannel, 'meetingEnd', team.id, blocks, title)
+    const res = await notifySlack(notificationChannel, 'meetingEnd', team.id, blocks, title)
+    if ('error' in res) {
+      return handleError(res, team.id, notificationChannel)
+    }
+    if (meeting.meetingType !== 'teamPrompt') {
+      return 'success'
+    }
+
+    if (!standupResponses || standupResponses.length === 0) {
+      const threadBlocks: Array<{type: string}> = [makeSection('No responses were submitted')]
+      const threadRes = await notifySlack(
+        notificationChannel,
+        'meetingEnd',
+        team.id,
+        threadBlocks,
+        title,
+        res.ts
+      )
+      if ('error' in threadRes) {
+        return handleError(threadRes, team.id, notificationChannel)
+      }
+      return 'success'
+    }
+
+    const results = await Promise.all(
+      standupResponses.map(async ({user, response}) => {
+        const options = {
+          searchParams: {
+            utm_source: 'slack share',
+            utm_medium: 'product',
+            utm_campaign: 'sharing',
+            responseId: response.id
+          }
+        }
+        const responseUrl = makeAppURL(appOrigin, `meet/${meeting.id}/responses`, options)
+        const threadBlocks: Array<{type: string}> = [
+          makeSection(`${user.preferredName} responded:`),
+          makeSection(response.plaintextContent),
+          makeButtons([{text: 'See their response', url: responseUrl, type: 'primary'}])
+        ]
+        const threadRes = await notifySlack(
+          notificationChannel,
+          'meetingEnd',
+          team.id,
+          threadBlocks,
+          title,
+          res.ts
+        )
+        if ('error' in threadRes) {
+          return handleError(threadRes, team.id, notificationChannel)
+        }
+        return 'success'
+      })
+    )
+
+    const error = results.find((res) => res !== 'success')
+    if (error) {
+      return error
+    }
+    return 'success'
   },
 
   async startTimeLimit(scheduledEndTime, meeting, team) {
@@ -232,20 +309,34 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
       makeSection(constraint),
       makeButtons([button])
     ]
-    return notifySlack(
+    const res = await notifySlack(
       notificationChannel,
       'MEETING_STAGE_TIME_LIMIT_START',
       team.id,
       blocks,
       title
     )
+    if ('error' in res) {
+      return handleError(res, team.id, notificationChannel)
+    }
+    return 'success'
   },
 
   async endTimeLimit(meeting, team) {
     const meetingUrl = makeAppURL(appOrigin, `meet/${meeting.id}`)
     // TODO now is a good time to make the message nice with the `meetingName`
     const slackText = `Time’s up! Advance your meeting to the next phase: ${meetingUrl}`
-    return notifySlack(notificationChannel, 'MEETING_STAGE_TIME_LIMIT_END', team.id, slackText)
+    const res = await notifySlack(
+      notificationChannel,
+      'MEETING_STAGE_TIME_LIMIT_END',
+      team.id,
+      slackText
+    )
+
+    if ('error' in res) {
+      return handleError(res, team.id, notificationChannel)
+    }
+    return 'success'
   },
 
   async integrationUpdated() {
@@ -268,7 +359,17 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
       makeSection(title),
       makeButtons([{text: 'See their response', url: responseUrl, type: 'primary'}])
     ]
-    return notifySlack(notificationChannel, 'STANDUP_RESPONSE_SUBMITTED', team.id, blocks, title)
+    const res = await notifySlack(
+      notificationChannel,
+      'STANDUP_RESPONSE_SUBMITTED',
+      team.id,
+      blocks,
+      title
+    )
+    if ('error' in res) {
+      return handleError(res, team.id, notificationChannel)
+    }
+    return 'success'
   }
 })
 
@@ -304,9 +405,22 @@ export const SlackNotifier: Notifier = {
 
   async endMeeting(dataLoader: DataLoaderWorker, meetingId: string, teamId: string) {
     const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
+    const meetingResponses = await getTeamPromptResponsesByMeetingId(meetingId)
+    const standupResponses: Array<{user: User; response: TeamPromptResponse}> = []
+    Promise.allSettled(
+      meetingResponses.map(async (response) => {
+        const user = await dataLoader.get('users').load(response.userId)
+        if (user) {
+          standupResponses.push({
+            user,
+            response
+          })
+        }
+      })
+    )
     if (!meeting || !team) return
     const notifiers = await getSlack(dataLoader, 'meetingEnd', team.id)
-    notifiers.forEach((notifier) => notifier.endMeeting(meeting, team))
+    notifiers.forEach((notifier) => notifier.endMeeting(meeting, team, standupResponses))
   },
 
   async startTimeLimit(
@@ -439,8 +553,20 @@ export const SlackNotifier: Notifier = {
       auth: slackAuth
     }
 
-    return notifySlack(notificationChannel, 'TOPIC_SHARED', team.id, slackBlocks, undefined, {
-      reflectionGroupId
-    })
+    const res = await notifySlack(
+      notificationChannel,
+      'TOPIC_SHARED',
+      team.id,
+      slackBlocks,
+      undefined,
+      undefined,
+      {
+        reflectionGroupId
+      }
+    )
+    if ('error' in res) {
+      return handleError(res, team.id, notificationChannel)
+    }
+    return 'success'
   }
 }


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8608

When a standup meeting ends, post the submitted responses in a thread on the "meeting ended" slack message.

Only do this in slack for now to minimize scope.

Needs rebase once https://github.com/ParabolInc/parabol/pull/8607 lands.

## Demo
With responses:
<img width="384" alt="Screen Shot 2023-08-02 at 1 11 51 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/910bf44e-50da-446a-8838-b189d53394b6">
Without responses:
<img width="395" alt="Screen Shot 2023-08-02 at 1 11 57 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/a280ccd2-58a8-43e3-b574-361ebe4d8f26">


## Testing scenarios
- [ ] Start a standup on a team with slack integrated, and fill out a few users' responses, then end the meeting.
- [ ] Confirm that the "meeting ended" message appears, with a message in the thread for each user's response containing the user's name + plaintext response, and a link to the response in the Parabol app
- [ ] Start a standup on the same team, and end the standup without any responses
- [ ] Confirm that the "meeting ended" message appears, with a message in the thread saying that no responses were submitted.
 
## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
