### PR TITLE
fix: Promote new facilitator when facilitator leaves the team

### DIFF
--- a/packages/server/graphql/mutations/helpers/removeTeamMember.ts
+++ b/packages/server/graphql/mutations/helpers/removeTeamMember.ts
@@ -14,6 +14,7 @@ import {DataLoaderWorker} from '../../graphql'
 import removeSlackAuths from './removeSlackAuths'
 import removeStagesFromMeetings from './removeStagesFromMeetings'
 import removeUserFromMeetingStages from './removeUserFromMeetingStages'
+import errorFilter from '../../errorFilter'
 
 interface Options {
   evictorUserId?: string
@@ -127,6 +128,41 @@ const removeTeamMember = async (
     .filter({userId})
     .delete()
     .run()
+
+  // Reassign facilitator for meetings this user is facilitating.
+  const facilitatingMeetings = await r
+    .table('NewMeeting')
+    .getAll(r.args(meetingIds), {index: 'id'})
+    .filter({
+      facilitatorUserId: userId
+    })
+    .run()
+
+  const newMeetingFacilitators = (
+    await dataLoader
+      .get('meetingMembersByMeetingId')
+      .loadMany(facilitatingMeetings.map((meeting) => meeting.id))
+  )
+    .filter(errorFilter)
+    .map((members) => members[0])
+    .filter((member) => !!member)
+
+  Promise.allSettled(
+    newMeetingFacilitators.map(async (newFacilitator) => {
+      if (!newFacilitator) {
+        return
+      }
+      await r
+        .table('NewMeeting')
+        .get(newFacilitator.meetingId)
+        .update({
+          facilitatorUserId: newFacilitator.userId,
+          updatedAt: now
+        })
+        .run()
+    })
+  )
+
   return {
     user,
     notificationId,


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8602

When a user is removed from a team on which they're facilitating meetings, reassign one of the meeting members (the first one returned by the DB for simplicity) to be the facilitator. Do nothing for meetings in which the user is the only meeting member.

## Testing scenarios
- [ ] Start a meeting with users A and B, where user A is the facilitator
- [ ] As user A, leave the team
- [ ] Confirm user B is now the facilitator of the meeting
- [ ] Confirm reasonable behavior for other cases:
  - [ ] User is facilitating no meetings
  - [ ] User is facilitating a meeting with no other meeting members

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
