### PR TITLE
feat(tiptap): Loom embed extension

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -111,6 +111,20 @@ const StyledEditor = styled('div')`
     margin-block-start: 4px;
     margin-block-end: 4px;
   }
+
+  .ProseMirror iframe {
+    border: 8px solid #000;
+    border-radius: 4px;
+    min-width: 200px;
+    min-height: 200px;
+    display: block;
+    outline: 0px solid transparent;
+  }
+
+  .ProseMirror-selectednode iframe {
+    transition: outline 0.15s;
+    outline: 6px solid #ece111;
+  }
 `
 
 interface Props {

--- a/packages/client/components/promptResponse/loomExtension.ts
+++ b/packages/client/components/promptResponse/loomExtension.ts
@@ -1,13 +1,61 @@
-import {Node, nodeInputRule, nodePasteRule} from '@tiptap/core'
+import {Node} from '@tiptap/core'
+import {JSONContent} from '@tiptap/react'
 
 const LOOM_REGEX = /^(?:https:\/\/)?(?:www\.)?loom\.com\/share\/[a-zA-Z0-9]*\?.*$/g
+
+export const unfurlLoomLinks = (rawContent: JSONContent): JSONContent => {
+  if (!rawContent.content) {
+    return rawContent
+  }
+
+  const newContent: JSONContent[] = []
+  rawContent.content.forEach((content) => {
+    if (content.type === 'paragraph') {
+      newContent.push(content, ...getLoomNodesForParagraph(content))
+    } else {
+      newContent.push(unfurlLoomLinks(content))
+    }
+  })
+
+  return {
+    type: rawContent.type,
+    content: newContent
+  }
+}
+
+const getLoomNodesForParagraph = (content: JSONContent) => {
+  const distinctLoomLinks: Record<string, string> = {}
+  content.content?.forEach((subContent) => {
+    if (subContent.type === 'text') {
+      const link = subContent.marks?.find((mark) => mark.type === 'link')
+      if (!link) {
+        return
+      }
+
+      if (link.attrs?.href.match(LOOM_REGEX)) {
+        const linkKey = link.attrs.href.split('?')[0]
+        if (!distinctLoomLinks[linkKey]) {
+          distinctLoomLinks[linkKey] = link.attrs.href
+        }
+      }
+    }
+  })
+
+  return Object.values(distinctLoomLinks).map((link) => {
+    return {
+      type: 'loom',
+      attrs: {
+        src: link
+      }
+    }
+  })
+}
 
 export const LoomExtension = Node.create({
   name: 'loom',
 
   group: 'block',
   inline: false,
-  draggable: true,
 
   addAttributes() {
     return {
@@ -25,7 +73,7 @@ export const LoomExtension = Node.create({
       HTMLAttributes,
       [
         'div',
-        {style: 'position: relative; padding-bottom: 75%; height: 0;'},
+        {style: 'position: relative; padding-bottom: 75%; height: 0; margin-bottom: 4px'},
         [
           'iframe',
           {
@@ -38,34 +86,6 @@ export const LoomExtension = Node.create({
           }
         ]
       ]
-    ]
-  },
-
-  addInputRules() {
-    return [
-      nodeInputRule({
-        find: LOOM_REGEX,
-        type: this.type,
-        getAttributes: (match) => {
-          return {
-            src: match.input
-          }
-        }
-      })
-    ]
-  },
-
-  addPasteRules() {
-    return [
-      nodePasteRule({
-        find: LOOM_REGEX,
-        type: this.type,
-        getAttributes: (match) => {
-          return {
-            src: match.input
-          }
-        }
-      })
     ]
   }
 })

--- a/packages/client/components/promptResponse/loomExtension.ts
+++ b/packages/client/components/promptResponse/loomExtension.ts
@@ -1,5 +1,5 @@
 import {Node} from '@tiptap/core'
-import {JSONContent} from '@tiptap/react'
+import {JSONContent, mergeAttributes} from '@tiptap/react'
 
 const LOOM_REGEX = /^(?:https:\/\/)?(?:www\.)?loom\.com\/share\/[a-zA-Z0-9]*\?.*$/g
 
@@ -70,21 +70,19 @@ export const LoomExtension = Node.create({
     const components = HTMLAttributes.src.split('/')
     return [
       'div',
-      HTMLAttributes,
+      mergeAttributes(HTMLAttributes, {
+        style: 'position: relative; padding-bottom: 75%; height: 0; margin: 8px 0px;'
+      }),
       [
-        'div',
-        {style: 'position: relative; padding-bottom: 75%; height: 0; margin-bottom: 4px'},
-        [
-          'iframe',
-          {
-            src: `https://www.loom.com/embed/${components[components.length - 1]}`,
-            style: 'position: absolute; top: 0; left: 0; width: 100%; height: 100%;',
-            frameborder: '0',
-            webkitallowfullscreen: true,
-            mozallowfullscreen: true,
-            allowfullscreen: true
-          }
-        ]
+        'iframe',
+        {
+          src: `https://www.loom.com/embed/${components[components.length - 1]}`,
+          style: 'position: absolute; top: 0; left: 0; width: 100%; height: 100%;',
+          frameborder: '0',
+          webkitallowfullscreen: true,
+          mozallowfullscreen: true,
+          allowfullscreen: true
+        }
       ]
     ]
   }

--- a/packages/client/components/promptResponse/loomExtension.ts
+++ b/packages/client/components/promptResponse/loomExtension.ts
@@ -1,0 +1,71 @@
+import {Node, nodeInputRule, nodePasteRule} from '@tiptap/core'
+
+const LOOM_REGEX = /^(?:https:\/\/)?(?:www\.)?loom\.com\/share\/[a-zA-Z0-9]*\?.*$/g
+
+export const LoomExtension = Node.create({
+  name: 'loom',
+
+  group: 'block',
+  inline: false,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null
+      }
+    }
+  },
+
+  renderHTML(props) {
+    const {HTMLAttributes} = props
+    const components = HTMLAttributes.src.split('/')
+    return [
+      'div',
+      HTMLAttributes,
+      [
+        'div',
+        {style: 'position: relative; padding-bottom: 75%; height: 0;'},
+        [
+          'iframe',
+          {
+            src: `https://www.loom.com/embed/${components[components.length - 1]}`,
+            style: 'position: absolute; top: 0; left: 0; width: 100%; height: 100%;',
+            frameborder: '0',
+            webkitallowfullscreen: true,
+            mozallowfullscreen: true,
+            allowfullscreen: true
+          }
+        ]
+      ]
+    ]
+  },
+
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: LOOM_REGEX,
+        type: this.type,
+        getAttributes: (match) => {
+          return {
+            src: match.input
+          }
+        }
+      })
+    ]
+  },
+
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: LOOM_REGEX,
+        type: this.type,
+        getAttributes: (match) => {
+          return {
+            src: match.input
+          }
+        }
+      })
+    ]
+  }
+})

--- a/packages/client/components/promptResponse/loomExtension.ts
+++ b/packages/client/components/promptResponse/loomExtension.ts
@@ -1,7 +1,7 @@
 import {Node} from '@tiptap/core'
 import {JSONContent, mergeAttributes} from '@tiptap/react'
 
-const LOOM_REGEX = /^(?:https:\/\/)?(?:www\.)?loom\.com\/share\/[a-zA-Z0-9]*\?.*$/g
+const LOOM_REGEX = /^(?:https?:\/\/)?(?:www\.)?loom\.com\/share\/[a-zA-Z0-9]+/g
 
 export const unfurlLoomLinks = (rawContent: JSONContent): JSONContent => {
   if (!rawContent.content) {

--- a/packages/client/components/promptResponse/tiptapConfig.ts
+++ b/packages/client/components/promptResponse/tiptapConfig.ts
@@ -4,6 +4,7 @@ import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
 import StarterKit from '@tiptap/starter-kit'
 import {BBox} from '~/types/animations'
+import {LoomExtension} from './loomExtension'
 
 export interface LinkMenuProps {
   text: string
@@ -72,6 +73,7 @@ export const createEditorExtensions = (
   placeholder?: string
 ) => [
   StarterKit,
+  LoomExtension,
   Link.extend({
     inclusive: false,
     addKeyboardShortcuts() {


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8659

Implement a read-only Loom extension - when loom links are present in a standup response, add a Loom TipTap node immediately after the paragraph containing the link.

Because this is read-only, other users will always see the expanded Loom embeds, while the author will only see them in closed meetings and the discussion drawer.

Do nothing for summaries, though we could leverage Loom gif thumbnails if we wanted to.

## Demo
What the author sees:
<img width="795" alt="Screen Shot 2023-08-15 at 1 12 15 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/118330ee-f9ad-4d03-9388-c57c4ffaabc5">

What the reader sees:
<img width="482" alt="Screen Shot 2023-08-15 at 1 12 08 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/159ee314-a573-48d7-8c61-b0188e7b2279">

Discussion drawer (both author and readers see this):
<img width="391" alt="Screen Shot 2023-08-15 at 1 15 38 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/f3edc120-d283-479f-8ad6-aa0306fe4b86">


## Testing scenarios
- [ ] Write a response with non-loom and loom links, and check the link expansion in various scenarios (bullets, quotes, etc.)
- [ ] Smoke test responses.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
