### PR TITLE
chore: Cleanup old starter tier organizations

### DIFF
--- a/packages/server/database/migrations/20230801200811-fixOrganizationTier.ts
+++ b/packages/server/database/migrations/20230801200811-fixOrganizationTier.ts
@@ -1,0 +1,9 @@
+import {R} from 'rethinkdb-ts'
+
+export const up = async function (r: R) {
+  r.table('Organization').filter(r.row('tier').eq('personal')).update({tier: 'starter'}).run()
+}
+
+export const down = async function (r: R) {
+  // noop
+}

--- a/packages/server/database/migrations/20230801200811-fixOrganizationTier.ts
+++ b/packages/server/database/migrations/20230801200811-fixOrganizationTier.ts
@@ -1,9 +1,0 @@
-import {R} from 'rethinkdb-ts'
-
-export const up = async function (r: R) {
-  r.table('Organization').filter(r.row('tier').eq('personal')).update({tier: 'starter'}).run()
-}
-
-export const down = async function (r: R) {
-  // noop
-}

--- a/packages/server/postgres/migrations/1691422128820_fixOrganizationTier.ts
+++ b/packages/server/postgres/migrations/1691422128820_fixOrganizationTier.ts
@@ -1,0 +1,18 @@
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+export async function up() {
+  await connectRethinkDB()
+  try {
+    await r
+      .table('Organization')
+      .filter(r.row('tier').eq('personal'))
+      .update({tier: 'starter'})
+      .run()
+  } catch {}
+  await r.getPoolMaster()?.drain()
+}
+
+export async function down() {
+  // noop
+}


### PR DESCRIPTION
Fixes #8507 

When we changed the names of our plan tiers in #7505, there were two organizations created while the migration `20221220161224-updateTier.ts` was running that are left with the old `personal` tier name.  This migration cleans up those tier values, and migrates them to the new `starter` tier name.