### PR TITLE
fix(pipeline): increase size of the runner used for the build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ env:
   PARABOL_DOCKERFILE: ./docker/parabol-ubi/docker-build/dockerfiles/pipeline.dockerfile
   PARABOL_BUILD_ENV_PATH: docker/parabol-ubi/docker-build/environments/pipeline
 
+
 jobs:
   build:
     runs-on: ubuntu-4core
@@ -90,6 +91,8 @@ jobs:
 
       - name: Build for deploying
         if: env.DOCKERIZE == 'true'
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: yarn build --no-deps
 
       - name: Verify source is clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build for deploying
         if: env.DOCKERIZE == 'true'
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=8192"
         run: yarn build --no-deps
 
       - name: Verify source is clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,6 @@ jobs:
 
       - name: Build for deploying
         if: env.DOCKERIZE == 'true'
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
         run: yarn build --no-deps
 
       - name: Verify source is clean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,9 @@ env:
   PARABOL_DOCKERFILE: ./docker/parabol-ubi/docker-build/dockerfiles/pipeline.dockerfile
   PARABOL_BUILD_ENV_PATH: docker/parabol-ubi/docker-build/environments/pipeline
 
-
 jobs:
   build:
-    runs-on: ubuntu-4core
+    runs-on: ubuntu-8cores
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Build for deploying
         if: env.DOCKERIZE == 'true'
+        env:
+          NODE_OPTIONS: "--max_old_space_size=8192"
         run: yarn build --no-deps
 
       - name: Verify source is clean


### PR DESCRIPTION
# Description

Build Github Action was broken due to a exit code 137 in the command `yarn build --no-deps` which means JVM Heap memory limit for the max_old_space_size. Setting max_old_space_size to 8192 only changed the exit code to 134 which means not enough memory.

After some testing, it was required to increase the RAM available on the system, and not only the Heap parameters. A new Github Large Runner was created with 8 cores and 32 GB RAM. Even with that, the max_old_space_size must be set to 8192 to make it build correctly.

Since [this commit](https://github.com/ParabolInc/parabol/actions/runs/5727737418) the build process takes longer and requires more memory. Before it took about 3m40s and now, even in a more powerful machine, it takes about 4m10s. Also, before it worked in 16 GB RAM machines without any max_old_space_size customization and now it requires more memory and customized heap parameters.
