### PR TITLE
fix: unable to ungroup some reflection groups

### DIFF
--- a/packages/server/postgres/migrations/1691421540088_updateRetroReflectionGroupSortOrderType.ts
+++ b/packages/server/postgres/migrations/1691421540088_updateRetroReflectionGroupSortOrderType.ts
@@ -1,0 +1,21 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    ALTER TABLE "RetroReflectionGroup"
+    ALTER COLUMN "sortOrder" TYPE DOUBLE PRECISION;
+  `)
+  await client.end()
+}
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    ALTER TABLE "RetroReflectionGroup"
+    ALTER COLUMN "sortOrder" TYPE INT;
+  `)
+  await client.end()
+}

--- a/packages/server/postgres/migrations/1691421540088_updateRetroReflectionGroupSortOrderType.ts
+++ b/packages/server/postgres/migrations/1691421540088_updateRetroReflectionGroupSortOrderType.ts
@@ -10,6 +10,7 @@ export async function up() {
   `)
   await client.end()
 }
+
 export async function down() {
   const client = new Client(getPgConfig())
   await client.connect()


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8598

We moved the `RetroReflectionGroup` table to pg in https://github.com/ParabolInc/parabol/pull/8504 and defined `sortOrder` as an `INT`, but it can be a float.

An alternate approach would be to ensure that `sortOrder` is always an integer. Perhaps @mattkrick knows whether the `sortOrder` is accidentally or deliberately a float?

Demo: https://www.loom.com/share/435ac05016ee4fb489b525f2caee2c02


### To test

- [ ] Can consistently ungroup reflection groups without getting any errors
