### PR TITLE
chore(suggest-groups): increase number of suggested groups

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -109,11 +109,12 @@ class OpenAIServerManager {
   async generateThemes(reflectionsText: string[]) {
     if (!this.openAIApi) return null
     const suggestedThemeCountMin = Math.floor(reflectionsText.length / 5)
-    const suggestedThemeCountMax = Math.floor(reflectionsText.length / 4)
+    const suggestedThemeCountMax = Math.floor(reflectionsText.length / 3)
+
     // Specify the approximate number of themes as it will often create too many themes otherwise
     const prompt = `Create a short list of common themes given the following reflections: ${reflectionsText.join(
       ', '
-    )}. Each theme should be no longer than a few words. There should be roughly ${suggestedThemeCountMin} or ${suggestedThemeCountMax} themes. Return the themes as a comma-separated list.`
+    )}. Each theme should be no longer than a few words. There should be roughly ${suggestedThemeCountMin} to ${suggestedThemeCountMax} themes. Return the themes as a comma-separated list.`
 
     try {
       const response = await this.openAIApi.createChatCompletion({

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -110,7 +110,6 @@ class OpenAIServerManager {
     if (!this.openAIApi) return null
     const suggestedThemeCountMin = Math.floor(reflectionsText.length / 5)
     const suggestedThemeCountMax = Math.floor(reflectionsText.length / 3)
-
     // Specify the approximate number of themes as it will often create too many themes otherwise
     const prompt = `Create a short list of common themes given the following reflections: ${reflectionsText.join(
       ', '


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8621

Here's a long-winded demo where I look through the reflection groups from the recent Growth Retro: https://www.loom.com/share/41e45efd828d49378db820582d6b4423

### To test

- [ ] Create a couple of Retros, click Suggest Groups, and get suggested groups that are at least as useful as the previous prompt
