### PR TITLE
fix: Remove check for whether template was updated

### DIFF
--- a/packages/server/graphql/mutations/selectTemplate.ts
+++ b/packages/server/graphql/mutations/selectTemplate.ts
@@ -73,9 +73,9 @@ const selectTemplate = {
       .default(null)
       .run()
 
-    if (!meetingSettingsId) {
-      return standardError(new Error('Template already updated'), {userId: viewerId})
-    }
+    // No need to check if a non-null 'meetingSettingsId' was returned - the Activity Library client
+    // will always attempt to update the template, even if it's already selected, and we don't need
+    // to return a 'meetingSettingsId' if no updates took place.
 
     const data = {meetingSettingsId}
     publish(SubscriptionChannel.TEAM, teamId, 'SelectTemplatePayload', data, subOptions)


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8570

## Testing scenarios
On master, repro the issue:
- [ ] Start a retro from the AL, then start another retro with the same template
- [ ] Confirm a "Template already updated" error appears in the server logs.

On this branch:
- [ ] Start a retro from the AL, then start another retro with the same template
- [ ] Confirm the "Template already updated" error does not appear in the server logs.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
