### PR TITLE
fix: prevent scroll jump when emoji is added 

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -236,9 +236,9 @@ const TeamPromptResponseCard = (props: Props) => {
               placeholder={viewerEmptyResponsePlaceholder}
               draftStorageKey={`draftResponse:${stageId}`}
             />
-            {!!plaintextContent && (
+            {!!response && (
               <ResponseCardFooter>
-                <TeamPromptResponseEmojis responseRef={response!} meetingId={meetingId} />
+                <TeamPromptResponseEmojis responseRef={response} meetingId={meetingId} />
                 <ReplyButton onClick={() => onSelectDiscussion()}>
                   {replyCount > 0 ? (
                     <>

--- a/packages/client/components/TeamPrompt/TeamPromptResponseEmojis.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseEmojis.tsx
@@ -1,5 +1,4 @@
 import graphql from 'babel-plugin-relay/macro'
-import styled from '@emotion/styled'
 import {useFragment} from 'react-relay'
 import {TeamPromptResponseEmojis_response$key} from '~/__generated__/TeamPromptResponseEmojis_response.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
@@ -8,11 +7,6 @@ import AddReactjiToReactableMutation from '../../mutations/AddReactjiToReactable
 import ReactjiId from '../../shared/gqlIds/ReactjiId'
 import React from 'react'
 import ReactjiSection from '../ReflectionCard/ReactjiSection'
-
-const StyledReactjis = styled(ReactjiSection)({
-  paddingRight: '8px',
-  paddingTop: '8px'
-})
 
 interface Props {
   meetingId: string
@@ -38,7 +32,6 @@ export const TeamPromptResponseEmojis = (props: Props) => {
   )
   const {reactjis} = response
   const atmosphere = useAtmosphere()
-
   const {onError, onCompleted, submitMutation, submitting} = useMutationProps()
 
   const onToggleReactji = (emojiId: string) => {
@@ -60,5 +53,5 @@ export const TeamPromptResponseEmojis = (props: Props) => {
     )
   }
 
-  return <StyledReactjis reactjis={reactjis} onToggle={onToggleReactji} />
+  return <ReactjiSection className='pt-2 pr-2' reactjis={reactjis} onToggle={onToggleReactji} />
 }

--- a/packages/client/components/TeamPrompt/TeamPromptResponseEmojis.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseEmojis.tsx
@@ -35,7 +35,7 @@ export const TeamPromptResponseEmojis = (props: Props) => {
   const {onError, onCompleted, submitMutation, submitting} = useMutationProps()
 
   const onToggleReactji = (emojiId: string) => {
-    if (submitting || !response) return
+    if (submitting) return
     const isRemove = !!reactjis.find((reactji) => {
       return reactji.isViewerReactji && ReactjiId.split(reactji.id).name === emojiId
     })


### PR DESCRIPTION
# Description

Fixes #7458 

It was simply caused by rerendering whole response card component instead of just emoji part, when emoji is added/removed.

## Demo

No demo

## Testing scenarios

- [ ] Add enough users to a standup meeting so it's possible to have a scrolling layout 
a. Join as user A, add response
b. Join as user B from different window, add response
c. In the user's A window scroll so the response current window user isn't visible
d. In the user's B window add reaction to the user's A response
e. User's A window isn't scrolled 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
