### PR TITLE
chore: active plan visual cue

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlan.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlan.tsx
@@ -1,0 +1,218 @@
+import React, {useState} from 'react'
+import {Info} from '@mui/icons-material'
+import {Elevation} from '../../../../styles/elevation'
+import BaseButton from '../../../../components/BaseButton'
+import {Radius} from '../../../../types/constEnums'
+import {PALETTE} from '../../../../styles/paletteV3'
+import {TierEnum} from '../../../../__generated__/SendClientSegmentEventMutation.graphql'
+import styled from '@emotion/styled'
+import useTooltip from '../../../../hooks/useTooltip'
+import {MenuPosition} from '../../../../hooks/useCoords'
+
+const PlanTitle = styled('h6')({
+  color: PALETTE.SLATE_700,
+  fontSize: 22,
+  fontWeight: 600,
+  lineHeight: '30px',
+  textTransform: 'capitalize',
+  textAlign: 'center',
+  display: 'flex',
+  margin: 0,
+  width: '100%',
+  paddingBottom: 8,
+  justifyContent: 'center'
+})
+
+const HeadingBlock = styled('div')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  width: '100%',
+  lineHeight: '30px',
+  paddingBottom: 24
+})
+
+const PlanSubtitle = styled('span')<{isItalic?: boolean}>(({isItalic}) => ({
+  color: PALETTE.SLATE_800,
+  fontSize: 16,
+  width: '100%',
+  lineHeight: '24px',
+  textTransform: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontWeight: 400,
+  fontStyle: isItalic ? 'italic' : 'normal'
+}))
+
+const UL = styled('ul')({
+  margin: '0 0 16px 0',
+  height: '100%',
+  padding: 0,
+  width: '80%'
+})
+
+const LI = styled('li')({
+  fontSize: 16,
+  lineHeight: '32px',
+  color: PALETTE.SLATE_900,
+  textTransform: 'none',
+  fontWeight: 400
+})
+
+const StyledIcon = styled('span')({
+  width: 18,
+  height: 18,
+  color: PALETTE.SLATE_600,
+  paddingLeft: 8,
+  display: 'flex',
+  alignItems: 'center',
+  '&:hover': {
+    cursor: 'pointer'
+  }
+})
+
+const Plan = styled('div')<{tier: TierEnum; isTablet: boolean; isActive: boolean}>(
+  ({tier, isTablet, isActive}) => ({
+    background:
+      tier === 'starter' ? PALETTE.STARTER : tier === 'team' ? PALETTE.TEAM : PALETTE.ENTERPRISE,
+    fontSize: 12,
+    fontWeight: 600,
+    lineHeight: '16px',
+    textTransform: 'capitalize',
+    textAlign: 'center',
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+    alignItems: 'center',
+    marginBottom: isTablet ? 0 : '8px',
+    marginRight: isTablet ? '8px' : 0,
+    padding: '16px 8px',
+    borderRadius: 4,
+    border: '2px solid white',
+    outline: isActive
+      ? tier === 'starter'
+        ? `2px solid ${PALETTE.GRAPE_500}`
+        : tier === 'team'
+        ? `2px solid ${PALETTE.AQUA_400}`
+        : `2px solid ${PALETTE.TOMATO_400}`
+      : '2px solid transparent',
+    transition: 'all ease 0.5s',
+    '&:hover': {
+      cursor: 'pointer',
+      outline: `2px solid ${
+        tier === 'starter'
+          ? PALETTE.GRAPE_500
+          : tier === 'team'
+          ? PALETTE.AQUA_400
+          : PALETTE.TOMATO_500
+      }`
+    },
+    '&:last-of-type': {
+      marginBottom: 0,
+      marginRight: 0
+    }
+  })
+)
+
+const CTAButton = styled(BaseButton)<{
+  buttonStyle: 'disabled' | 'primary' | 'secondary'
+}>(({buttonStyle}) => ({
+  width: '80%',
+  boxShadow: buttonStyle === 'primary' ? Elevation.Z8 : Elevation.Z0,
+  bottom: 0,
+  fontWeight: 600,
+  borderRadius: Radius.BUTTON_PILL,
+  background:
+    buttonStyle === 'primary'
+      ? PALETTE.GRADIENT_TOMATO_600_ROSE_500
+      : buttonStyle === 'secondary'
+      ? PALETTE.WHITE
+      : PALETTE.SLATE_300,
+  color:
+    buttonStyle === 'primary'
+      ? PALETTE.WHITE
+      : buttonStyle === 'secondary'
+      ? PALETTE.SLATE_900
+      : PALETTE.SLATE_600,
+  border: buttonStyle === 'secondary' ? `1px solid ${PALETTE.SLATE_600}` : 'none',
+  transition: 'all ease 0.5s',
+  ':hover': {
+    cursor: buttonStyle === 'disabled' ? 'default' : 'pointer',
+    background:
+      buttonStyle === 'primary'
+        ? PALETTE.GRADIENT_TOMATO_700_ROSE_600
+        : buttonStyle === 'secondary'
+        ? PALETTE.TOMATO_100
+        : PALETTE.SLATE_300,
+    borderColor: buttonStyle === 'secondary' ? PALETTE.TOMATO_500 : 'none'
+  }
+}))
+
+type Props = {
+  plan: {
+    tier: TierEnum
+    subtitle?: string
+    details: readonly string[]
+    buttonStyle: 'disabled' | 'primary' | 'secondary'
+    buttonLabel: 'Contact' | 'Select Plan' | 'Downgrade' | 'Current Plan'
+    isActive: boolean
+  }
+  isTablet: boolean
+  handleClick: (
+    label: 'Contact' | 'Select Plan' | 'Downgrade' | 'Current Plan',
+    tier: TierEnum
+  ) => void
+}
+
+const OrgPlan = (props: Props) => {
+  const {plan, isTablet, handleClick} = props
+  const {subtitle, tier: planTier, details, buttonStyle, buttonLabel: defaultLabel, isActive} = plan
+  const [hasSelectedTeamPlan, setHasSelectedTeamPlan] = useState(false)
+  const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
+    MenuPosition.LOWER_CENTER
+  )
+
+  const handleClickCTA = () => {
+    handleClick(defaultLabel, planTier)
+    if (buttonLabel === 'Select Plan') {
+      setHasSelectedTeamPlan(true)
+    }
+  }
+
+  const buttonLabel =
+    defaultLabel === 'Select Plan' && hasSelectedTeamPlan ? 'Selected Plan' : defaultLabel
+
+  return (
+    <Plan tier={planTier} isTablet={isTablet} isActive={isActive}>
+      <HeadingBlock>
+        <PlanTitle>{planTier}</PlanTitle>
+        {planTier === 'team' ? (
+          <>
+            <PlanSubtitle>
+              {'$6 per active user '}
+              <StyledIcon ref={originRef} onMouseOver={openTooltip} onMouseOut={closeTooltip}>
+                {<Info />}
+              </StyledIcon>
+            </PlanSubtitle>
+            <PlanSubtitle isItalic>{'paid monthly'}</PlanSubtitle>
+            {tooltipPortal('Active users are anyone who uses Parabol within a billing period')}
+          </>
+        ) : (
+          <PlanSubtitle>{subtitle}</PlanSubtitle>
+        )}
+      </HeadingBlock>
+      <UL className={'flex flex-col items-center md:items-start'}>
+        {details.map((detail) => (
+          <LI className={'list-none text-center md:list-disc md:text-left'} key={detail}>
+            {detail}
+          </LI>
+        ))}
+      </UL>
+      <CTAButton onClick={handleClickCTA} buttonStyle={buttonStyle} size='medium'>
+        {buttonLabel}
+      </CTAButton>
+    </Plan>
+  )
+}
+
+export default OrgPlan

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -292,6 +292,7 @@ const OrgPlans = (props: Props) => {
       })
     }
   }
+
   return (
     <>
       <StyledPanel label='Plans'>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -121,7 +121,6 @@ const OrgPlans = (props: Props) => {
     label: 'Contact' | 'Select Plan' | 'Downgrade' | 'Current Plan',
     planTier: TierEnum
   ) => {
-    console.log('🚀 ~ planTier:', {planTier, label})
     SendClientSegmentEventMutation(atmosphere, 'Plan Tier Selected', {
       orgId,
       tier: planTier

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgPlans.tsx
@@ -1,16 +1,11 @@
 import styled from '@emotion/styled'
-import {Info} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useState} from 'react'
 import {useFragment} from 'react-relay'
 import Panel from '../../../../components/Panel/Panel'
 import Row from '../../../../components/Row/Row'
-import {MenuPosition} from '../../../../hooks/useCoords'
-import useTooltip from '../../../../hooks/useTooltip'
-import {Elevation} from '../../../../styles/elevation'
-import {PALETTE} from '../../../../styles/paletteV3'
 import {OrgPlans_organization$key} from '../../../../__generated__/OrgPlans_organization.graphql'
-import {ElementWidth, Radius, Threshold} from '../../../../types/constEnums'
+import {ElementWidth, Threshold} from '../../../../types/constEnums'
 import {TierEnum} from '../../../../__generated__/SendClientSegmentEventMutation.graphql'
 import OrgStats from './OrgStats'
 import useModal from '../../../../hooks/useModal'
@@ -18,10 +13,10 @@ import DowngradeModal from './DowngradeModal'
 import {EnterpriseBenefits, TeamBenefits} from '../../../../utils/constants'
 import SendClientSegmentEventMutation from '../../../../mutations/SendClientSegmentEventMutation'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
-import BaseButton from '../../../../components/BaseButton'
 import LimitExceededWarning from '../../../../components/LimitExceededWarning'
 import {Breakpoint} from '~/types/constEnums'
 import useBreakpoint from '~/hooks/useBreakpoint'
+import OrgPlan from './OrgPlan'
 
 const StyledPanel = styled(Panel)({
   maxWidth: ElementWidth.PANEL_WIDTH,
@@ -39,145 +34,6 @@ const StyledRow = styled(Row)<{isTablet: boolean}>(({isTablet}) => ({
   },
   ':nth-of-type(2)': {
     border: 'none'
-  }
-}))
-
-const PlanTitle = styled('h6')({
-  color: PALETTE.SLATE_700,
-  fontSize: 22,
-  fontWeight: 600,
-  lineHeight: '30px',
-  textTransform: 'capitalize',
-  textAlign: 'center',
-  display: 'flex',
-  margin: 0,
-  width: '100%',
-  paddingBottom: 8,
-  justifyContent: 'center'
-})
-
-const HeadingBlock = styled('div')({
-  display: 'flex',
-  flexWrap: 'wrap',
-  width: '100%',
-  lineHeight: '30px',
-  paddingBottom: 24
-})
-
-const PlanSubtitle = styled('span')<{isItalic?: boolean}>(({isItalic}) => ({
-  color: PALETTE.SLATE_800,
-  fontSize: 16,
-  width: '100%',
-  lineHeight: '24px',
-  textTransform: 'none',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  fontWeight: 400,
-  fontStyle: isItalic ? 'italic' : 'normal'
-}))
-
-const Plan = styled('div')<{tier: TierEnum; isTablet: boolean; isActive: boolean}>(
-  ({tier, isTablet, isActive}) => ({
-    background:
-      tier === 'starter' ? PALETTE.STARTER : tier === 'team' ? PALETTE.TEAM : PALETTE.ENTERPRISE,
-    fontSize: 12,
-    fontWeight: 600,
-    lineHeight: '16px',
-    textTransform: 'capitalize',
-    textAlign: 'center',
-    display: 'flex',
-    flex: 1,
-    flexDirection: 'column',
-    alignItems: 'center',
-    marginBottom: isTablet ? 0 : '8px',
-    marginRight: isTablet ? '8px' : 0,
-    padding: '16px 8px',
-    borderRadius: 4,
-    border: '2px solid white',
-    outline: isActive
-      ? tier === 'starter'
-        ? `2px solid ${PALETTE.GRAPE_500}`
-        : tier === 'team'
-        ? `2px solid ${PALETTE.AQUA_400}`
-        : `2px solid ${PALETTE.TOMATO_400}`
-      : '2px solid transparent',
-    transition: 'all ease 0.5s',
-    '&:hover': {
-      cursor: 'pointer',
-      outline: `2px solid ${
-        tier === 'starter'
-          ? PALETTE.GRAPE_500
-          : tier === 'team'
-          ? PALETTE.AQUA_400
-          : PALETTE.TOMATO_500
-      }`
-    },
-    '&:last-of-type': {
-      marginBottom: 0,
-      marginRight: 0
-    }
-  })
-)
-
-const UL = styled('ul')({
-  margin: '0 0 16px 0',
-  height: '100%',
-  padding: 0,
-  width: '80%'
-})
-
-const LI = styled('li')({
-  fontSize: 16,
-  lineHeight: '32px',
-  color: PALETTE.SLATE_900,
-  textTransform: 'none',
-  fontWeight: 400
-})
-
-const StyledIcon = styled('span')({
-  width: 18,
-  height: 18,
-  color: PALETTE.SLATE_600,
-  paddingLeft: 8,
-  display: 'flex',
-  alignItems: 'center',
-  '&:hover': {
-    cursor: 'pointer'
-  }
-})
-
-const CTAButton = styled(BaseButton)<{
-  buttonStyle: 'disabled' | 'primary' | 'secondary'
-}>(({buttonStyle}) => ({
-  width: '80%',
-  boxShadow: buttonStyle === 'primary' ? Elevation.Z8 : Elevation.Z0,
-  bottom: 0,
-  fontWeight: 600,
-  borderRadius: Radius.BUTTON_PILL,
-  background:
-    buttonStyle === 'primary'
-      ? PALETTE.GRADIENT_TOMATO_600_ROSE_500
-      : buttonStyle === 'secondary'
-      ? PALETTE.WHITE
-      : PALETTE.SLATE_300,
-  color:
-    buttonStyle === 'primary'
-      ? PALETTE.WHITE
-      : buttonStyle === 'secondary'
-      ? PALETTE.SLATE_900
-      : PALETTE.SLATE_600,
-  border: buttonStyle === 'secondary' ? `1px solid ${PALETTE.SLATE_600}` : 'none',
-  transition: 'all ease 0.5s',
-  ':hover': {
-    cursor: buttonStyle === 'disabled' ? 'default' : 'pointer',
-    background:
-      buttonStyle === 'primary'
-        ? PALETTE.GRADIENT_TOMATO_700_ROSE_600
-        : buttonStyle === 'secondary'
-        ? PALETTE.TOMATO_100
-        : PALETTE.SLATE_300,
-    borderColor: buttonStyle === 'secondary' ? PALETTE.TOMATO_500 : 'none'
   }
 }))
 
@@ -223,22 +79,12 @@ const OrgPlans = (props: Props) => {
     `,
     organizationRef
   )
-  const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
-    MenuPosition.LOWER_CENTER
-  )
   const {closePortal: closeModal, openPortal, modalPortal} = useModal()
   const atmosphere = useAtmosphere()
-  const [selectedPlan, setSelectedPlan] = useState<TierEnum | null>(null)
-  const {id: orgId, tier, scheduledLockAt, lockedAt} = organization
+  const {id: orgId, scheduledLockAt, lockedAt, tier} = organization
   const showNudge = scheduledLockAt || lockedAt
   const isTablet = useBreakpoint(Breakpoint.FUZZY_TABLET)
-
-  const getActivePlan = (tier: TierEnum, plan: TierEnum) => {
-    if (selectedPlan) {
-      return selectedPlan === plan
-    }
-    return tier === plan
-  }
+  const [hasSelectedTeamPlan, setHasSelectedTeamPlan] = useState(false)
 
   const plans = [
     {
@@ -250,17 +96,16 @@ const OrgPlans = (props: Props) => {
         'Retrospectives, Sprint Poker, Standups, Check-Ins',
         'Unlimited team members'
       ],
-      activeColor: PALETTE.GRAPE_500,
       buttonStyle: getButtonStyle(tier, 'starter'),
       buttonLabel: getButtonLabel(tier, 'starter'),
-      isActive: getActivePlan(tier, 'starter')
+      isActive: !hasSelectedTeamPlan && tier === 'starter'
     },
     {
       tier: 'team',
       details: ['Everything in Starter', ...TeamBenefits],
       buttonStyle: getButtonStyle(tier, 'team'),
       buttonLabel: getButtonLabel(tier, 'team'),
-      isActive: getActivePlan(tier, 'team')
+      isActive: hasSelectedTeamPlan || tier === 'team'
     },
     {
       tier: 'enterprise',
@@ -268,27 +113,28 @@ const OrgPlans = (props: Props) => {
       details: ['Everything in Team', ...EnterpriseBenefits],
       buttonStyle: getButtonStyle(tier, 'enterprise'),
       buttonLabel: getButtonLabel(tier, 'enterprise'),
-      isActive: getActivePlan(tier, 'enterprise')
+      isActive: tier === 'enterprise'
     }
   ] as const
 
   const handleClick = (
     label: 'Contact' | 'Select Plan' | 'Downgrade' | 'Current Plan',
-    tier: TierEnum
+    planTier: TierEnum
   ) => {
+    console.log('🚀 ~ planTier:', {planTier, label})
     SendClientSegmentEventMutation(atmosphere, 'Plan Tier Selected', {
       orgId,
-      tier
+      tier: planTier
     })
     if (label === 'Contact') {
       window.open('mailto:love@parabol.co', '_blank')
     } else if (label === 'Select Plan') {
-      setSelectedPlan(tier)
+      setHasSelectedTeamPlan(true)
     } else if (label === 'Downgrade') {
       openPortal()
       SendClientSegmentEventMutation(atmosphere, 'Downgrade Clicked', {
         orgId,
-        tier
+        tier: planTier
       })
     }
   }
@@ -302,45 +148,7 @@ const OrgPlans = (props: Props) => {
         </StyledRow>
         <StyledRow isTablet={isTablet}>
           {plans.map((plan) => (
-            <Plan key={plan.tier} tier={plan.tier} isTablet={isTablet} isActive={plan.isActive}>
-              <HeadingBlock>
-                <PlanTitle>{plan.tier}</PlanTitle>
-                {plan.tier === 'team' ? (
-                  <>
-                    <PlanSubtitle>
-                      {'$6 per active user '}
-                      <StyledIcon
-                        ref={originRef}
-                        onMouseOver={openTooltip}
-                        onMouseOut={closeTooltip}
-                      >
-                        {<Info />}
-                      </StyledIcon>
-                    </PlanSubtitle>
-                    <PlanSubtitle isItalic>{'paid monthly'}</PlanSubtitle>
-                    {tooltipPortal(
-                      'Active users are anyone who uses Parabol within a billing period'
-                    )}
-                  </>
-                ) : (
-                  <PlanSubtitle>{plan.subtitle}</PlanSubtitle>
-                )}
-              </HeadingBlock>
-              <UL className={'flex flex-col items-center md:items-start'}>
-                {plan.details.map((detail) => (
-                  <LI className={'list-none text-center md:list-disc md:text-left'} key={detail}>
-                    {detail}
-                  </LI>
-                ))}
-              </UL>
-              <CTAButton
-                onClick={() => handleClick(plan.buttonLabel, plan.tier)}
-                buttonStyle={plan.buttonStyle}
-                size='medium'
-              >
-                {plan.buttonLabel}
-              </CTAButton>
-            </Plan>
+            <OrgPlan key={plan.tier} plan={plan} isTablet={isTablet} handleClick={handleClick} />
           ))}
         </StyledRow>
       </StyledPanel>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8628

Loom demo: https://www.loom.com/share/bbfd53b43b59418eb152321be0023a14

### To test

- [ ] Click "Select Plan" and see that the plan's border is now outlined, indicating that it's active