### PR TITLE
chore: CI=true in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,6 @@ jobs:
 
       - name: Start testing server in background
         run: |
-          echo CI: ${{ env.CI }}
           yarn start &
         env:
           CI: true
@@ -118,11 +117,13 @@ jobs:
         run: yarn test:server -- --reporters=default --reporters=jest-junit
         env:
           JEST_JUNIT_OUTPUT_DIR: ./test-results/junit/server
+          CI: true
 
       - name: Run client tests
         run: yarn test:client -- --reporters=default --reporters=jest-junit
         env:
           JEST_JUNIT_OUTPUT_DIR: ./test-results/junit/client
+          CI: true
 
       - name: Store Playwright Version
         run: |


### PR DESCRIPTION
# Description

force CI=true for CI. Allows us to get rid of the env var kept in GH.