### PR TITLE
fix(al): Number of activities exceeds number requested

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -74,7 +74,7 @@ graphql`
 const query = graphql`
   query ActivityLibraryQuery {
     viewer {
-      availableTemplates(first: 200) @connection(key: "ActivityLibrary_availableTemplates") {
+      availableTemplates(first: 2000) @connection(key: "ActivityLibrary_availableTemplates") {
         edges {
           node {
             ...ActivityLibrary_template @relay(mask: false)

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -121,7 +121,7 @@ const query = graphql`
         ...NewMeetingTeamPicker_selectedTeam
         ...NewMeetingTeamPicker_teams
       }
-      availableTemplates(first: 200) @connection(key: "ActivityLibrary_availableTemplates") {
+      availableTemplates(first: 2000) @connection(key: "ActivityLibrary_availableTemplates") {
         edges {
           node {
             name

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -130,7 +130,10 @@ const User: UserResolvers = {
         )
       }
     } else if (parabolActivities!.length + allUserActivities.length > 1000) {
-      sendToSentry(new Error('User.activities exceeds 1000 activities'))
+      sendToSentry(new Error('User.activities exceeds 1000 activities'), {
+        userId,
+        extras: {numActivities: parabolActivities!.length + allUserActivities.length}
+      })
     }
     const getScore = (activity: MeetingTemplate, teamIds: string[]) => {
       const SEASONAL = 1 << 8 // put seasonal templates at the top

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -19,6 +19,7 @@ import standardError from '../../../utils/standardError'
 import {getStripeManager} from '../../../utils/stripe'
 import connectionFromTemplateArray from '../../queries/helpers/connectionFromTemplateArray'
 import {UserResolvers} from '../resolverTypes'
+import sendToSentry from '../../../utils/sendToSentry'
 
 declare const __PRODUCTION__: string
 
@@ -128,6 +129,8 @@ const User: UserResolvers = {
           'Please implement pagination for User.activities or increase `first` for the query'
         )
       }
+    } else if (parabolActivities!.length + allUserActivities.length > 1000) {
+      sendToSentry(new Error('User.activities exceeds 1000 activities'))
     }
     const getScore = (activity: MeetingTemplate, teamIds: string[]) => {
       const SEASONAL = 1 << 8 // put seasonal templates at the top

--- a/packages/server/utils/sendToSentry.ts
+++ b/packages/server/utils/sendToSentry.ts
@@ -8,12 +8,18 @@ export interface SentryOptions {
   tags?: {
     [tag: string]: string | number
   }
+  extras?: Record<string, unknown>
 }
 
 // Even though this is a promise we'll never need to await it, so we'll never need to worry about catching an error
 const sendToSentry = async (error: Error, options: SentryOptions = {}) => {
-  console.trace('SEND TO SENTRY', JSON.stringify(error), JSON.stringify(options.tags))
-  const {sampleRate, tags, userId, ip} = options
+  console.trace(
+    'SEND TO SENTRY',
+    JSON.stringify(error),
+    JSON.stringify(options.tags),
+    JSON.stringify(options.extras)
+  )
+  const {sampleRate, tags, extras, userId, ip} = options
   if (sampleRate && Math.random() > sampleRate) return
   const fullUser = userId ? await getUserById(userId) : null
   const user = fullUser ? {id: fullUser.id, email: fullUser.email} : null
@@ -26,6 +32,9 @@ const sendToSentry = async (error: Error, options: SentryOptions = {}) => {
       Object.keys(tags).forEach((tag) => {
         scope.setTag(tag, String(tags[tag]))
       })
+    }
+    if (extras) {
+      scope.setExtras(extras)
     }
     Sentry.captureException(error)
   })


### PR DESCRIPTION
# Description
see [slack](https://parabol.slack.com/archives/C042HTVBH8D/p1691596459048329) 🔒 

If a user has access to more than 200 activities, we won't return all of their activities to the client. Sometimes, this means that even basic activities like check-ins won't be shown on the client.

Bump up the max number of activities we return to 2000, and send an error to sentry if we ever see more than 1000 activities.

Also add an `extras` field to our sentry util for capturing additional non-tag context (in this case, number of activities seen).

## Testing scenarios
Smoke test AL.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
