### PR TITLE
chore: add version and sha to predeploy logs

### DIFF
--- a/scripts/toolboxSrc/modules.d.ts
+++ b/scripts/toolboxSrc/modules.d.ts
@@ -5,3 +5,4 @@ declare module '*.png' {
 
 declare const __PROJECT_ROOT__: string
 declare const __APP_VERSION__: string
+declare const __COMMIT_HASH__: string

--- a/scripts/toolboxSrc/preDeploy.ts
+++ b/scripts/toolboxSrc/preDeploy.ts
@@ -34,13 +34,13 @@ const preDeploy = async () => {
   const envPath = path.join(__PROJECT_ROOT__, '.env')
   const myEnv = dotenv.config({path: envPath})
   dotenvExpand(myEnv)
-
+  console.log(`🚀 Predeploy Started v${__APP_VERSION__} sha:${__COMMIT_HASH__}`)
   // first we migrate DBs & add env vars to client assets
   await Promise.all([standaloneMigrations(), applyEnvVarsToClientAssets()])
 
   // The we can prime the DB & CDN
   await Promise.all([storePersistedQueries(), primeIntegrations(), pushToCDN()])
-
+  console.log(`🚀 Predeploy Complete`)
   process.exit()
 }
 

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -7,6 +7,7 @@ const webpack = require('webpack')
 const TerserPlugin = require('terser-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const {CleanWebpackPlugin} = require('clean-webpack-plugin')
+const cp = require('child_process')
 
 const PROJECT_ROOT = getProjectRoot()
 const CLIENT_ROOT = path.join(PROJECT_ROOT, 'packages', 'client')
@@ -14,6 +15,8 @@ const SERVER_ROOT = path.join(PROJECT_ROOT, 'packages', 'server')
 const GQL_ROOT = path.join(PROJECT_ROOT, 'packages', 'gql-executor')
 const DOTENV = path.join(PROJECT_ROOT, 'scripts/webpack/utils/dotenv.js')
 const distPath = path.join(PROJECT_ROOT, 'dist')
+
+const COMMIT_HASH = cp.execSync('git rev-parse HEAD').toString().trim()
 
 module.exports = ({noDeps}) => ({
   mode: 'production',
@@ -79,6 +82,7 @@ module.exports = ({noDeps}) => ({
       __PRODUCTION__: true,
       __PROJECT_ROOT__: JSON.stringify(PROJECT_ROOT),
       __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+      __COMMIT_HASH__: JSON.stringify(COMMIT_HASH),
       'process.env.DEBUG': false,
       // hardcode architecture so uWebSockets.js dynamic require becomes deterministic at build time & requires 1 binary
       'process.platform': JSON.stringify(process.platform),


### PR DESCRIPTION
# Description

Fix #7557

I use the `sha:` prefix in the logs because that's how you search by hash in github so it makes for easy copypasta.

## Demo

```
🚀 Predeploy Started v6.115.0 sha:568070ed9f899b93cef4abd2640b6a0021eca27c
```

TEST
- [x] CI did the testing: https://github.com/ParabolInc/parabol/actions/runs/5825418487/job/15796937391?pr=8646#step:13:14
- [x] `yarn && yarn build && node dist/preDeploy`. See the rocket ship go 🚀 
