### PR TITLE
fix(analytics): preserve GA4 `client_id` after sign-up/sign-in

### DIFF
--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -111,18 +111,16 @@ const AnalyticsPage = () => {
         const res = await atmosphere.fetchQuery<AnalyticsPageQuery>(query)
         if (!res) return
         const {viewer} = res
-        const {id, segmentId, isPatient0} = viewer
+        const {id, isPatient0} = viewer
         ReactGA.set({
           userId: id,
-          clientId: segmentId ?? getAnonymousId(),
           user_properties: {
             is_patient_0: !!isPatient0
           }
         })
       } else {
         ReactGA.set({
-          userId: null,
-          clientId: getAnonymousId()
+          userId: null
         })
       }
     }

--- a/packages/client/components/AnalyticsPage.tsx
+++ b/packages/client/components/AnalyticsPage.tsx
@@ -18,7 +18,6 @@ const query = graphql`
   query AnalyticsPageQuery {
     viewer {
       id
-      segmentId
       email
       isPatient0
     }
@@ -28,6 +27,12 @@ const query = graphql`
 declare global {
   interface Window {
     analytics: SegmentAnalytics.AnalyticsJS
+    gtag: (
+      command: 'config' | 'get' | 'set',
+      targetId: string,
+      fieldName: string,
+      callback: (field: string) => void
+    ) => void
     HubSpotConversations?: {
       widget?: {
         refresh?: () => void
@@ -174,7 +179,7 @@ const AnalyticsPage = () => {
     if (!isSegmentLoaded || !window.analytics || typeof window.analytics.page !== 'function') return
     const prevPathname = pathnameRef.current
     pathnameRef.current = pathname
-    setTimeout(() => {
+    setTimeout(async () => {
       const title = document.title || ''
       // This is the magic. Ignore everything after hitting the pipe
       const [pageName] = title.split(' | ')
@@ -192,7 +197,7 @@ const AnalyticsPage = () => {
           translated
         },
         // See: segmentIo.ts:28 for more information on the next line
-        {integrations: {'Google Analytics': {clientId: getAnonymousId()}}}
+        {integrations: {'Google Analytics': {clientId: await getAnonymousId()}}}
       )
       ReactGA.send({hitType: 'pageview', content_group: getContentGroup(pathname)})
     }, TIME_TO_RENDER_TREE)

--- a/packages/client/components/EmailPasswordAuthForm.tsx
+++ b/packages/client/components/EmailPasswordAuthForm.tsx
@@ -217,7 +217,7 @@ const EmailPasswordAuthForm = forwardRef((props: Props, ref: any) => {
         {onError, onCompleted, history}
       )
     } else {
-      const segmentId = getAnonymousId()
+      const segmentId = await getAnonymousId()
       SignUpWithPasswordMutation(
         atmosphere,
         {

--- a/packages/client/utils/GoogleClientManager.ts
+++ b/packages/client/utils/GoogleClientManager.ts
@@ -43,14 +43,14 @@ class GoogleClientManager extends GoogleManager {
         window.removeEventListener('message', handler)
       }
     }, 100)
-    const handler = (event: MessageEvent) => {
+    const handler = async (event: MessageEvent) => {
       if (typeof event.data !== 'object' || event.origin !== window.location.origin || submitting) {
         return
       }
       const {code, state} = event.data
       if (state !== providerState || typeof code !== 'string') return
       window.clearInterval(closeCheckerId)
-      const segmentId = getAnonymousId()
+      const segmentId = await getAnonymousId()
       window.localStorage.removeItem(LocalStorageKey.INVITATION_TOKEN)
       const handleComplete: typeof onCompleted = (...args) => {
         popup && popup.close()

--- a/packages/client/utils/getAnonymousId.ts
+++ b/packages/client/utils/getAnonymousId.ts
@@ -1,8 +1,21 @@
-const getAnonymousId = (): string | undefined => {
-  const analytics: any = window && window.analytics
-  return analytics && typeof analytics.user === 'function'
-    ? analytics.user().anonymousId()
-    : undefined
+import ReactGA from 'react-ga4'
+
+const retrieveGtagClientId = async (
+  gtag: any,
+  measurementId: string
+): Promise<string | undefined> => {
+  return new Promise((resolve) => {
+    gtag('get', measurementId, 'client_id', resolve)
+  })
+}
+
+const getAnonymousId = async (): Promise<string | undefined> => {
+  if (!ReactGA.isInitialized) return
+
+  const gtag = window && window.gtag
+  const measurementId = window.__ACTION__.googleAnalytics
+  if (!gtag || !measurementId) return
+  return await retrieveGtagClientId(gtag, measurementId)
 }
 
 export default getAnonymousId


### PR DESCRIPTION
# Description

Fixes #8647, please watch the reproduction step GIF demo in the issue to understand what's wrong.  Compare with the demo below after this fix.

What's **NOT** in this PR:
1. Although after this PR, we will use the GA4 style client id for new account, they are still stored in the `segmentId` column. There will be migration scripts later, as part of the Segment deprecation work
2. If you have an existing session, the GA4 `client_id` was probably already written as the `segmentId` before, so it will be carried on, unless you clear the cookie. This is fine as the issue is specifically for new users.

## Demo
![2023-08-10 15 14 21](https://github.com/ParabolInc/parabol/assets/1879975/cf67a28a-f90a-4d71-83ce-958d66f411c5)

Notice the `client_id` stays as `599954635.1691705492` even after signing up & redirecting to the meeting page.


## Testing scenarios

You need to install the [Analytics Debugger](https://chrome.google.com/webstore/detail/analytics-debugger/ilnpmccnfdjdjjikgkefkcegefikecdc) extension to test this.

- [ ] Reproduction step from original issue #8647:
  - Open an invitation link in an incognito window
  - Open up dev tools, click `Analytics Debugger`
  - Check the `Client Id` for the `scroll` event, it should be in the format of `\d+\.\d+`
  - Now sign up or log in
  - Check `Analytics Debugger` again for a recent `page_view` event, and observe the `Client Id` should stay the same

- [ ] Sign up through Google still wrok
- [ ] Sign up though username & password still work
- [ ] Sign up through SSO still work
- [ ] Log in through Google still work
- [ ] Log in through username & password still work
- [ ] Log in through SSO still work

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
