### PR TITLE
fix: fix share topic modal can't see slack integration

### DIFF
--- a/packages/client/components/ShareTopicRoot.tsx
+++ b/packages/client/components/ShareTopicRoot.tsx
@@ -18,7 +18,7 @@ const ShareTopicRoot = (props: Props) => {
   const queryRef = useQueryLoaderNow<ShareTopicModalQuery>(
     shareTopicModalQuery,
     {meetingId},
-    'store-or-network'
+    'network-only'
   )
 
   return (

--- a/packages/client/components/ShareTopicRouterRoot.tsx
+++ b/packages/client/components/ShareTopicRouterRoot.tsx
@@ -17,7 +17,7 @@ const ShareTopicRouterRoot = () => {
   const queryRef = useQueryLoaderNow<ShareTopicModalQuery>(
     shareTopicModalQuery,
     {meetingId},
-    'store-or-network'
+    'network-only'
   )
 
   const location = useLocation<{backgroundLocation?: Location}>()


### PR DESCRIPTION
Looks like for some users share topic modal can't see the slack integration added

This should probably fix it