### PR TITLE
POC: feat(slack): Send certain notifications via slack DM

### DIFF
--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -40,6 +40,7 @@ import TemplateDimension from './types/TemplateDimension'
 import TemplateScale from './types/TemplateScale'
 import TimelineEvent from './types/TimelineEvent'
 import User from './types/User'
+import NotificationResponseReplied from './types/NotificationResponseReplied'
 
 export type RethinkSchema = {
   AgendaItem: {
@@ -113,6 +114,7 @@ export type RethinkSchema = {
       | NotificationPromoteToBillingLeader
       | NotificationTeamInvitation
       | NotificationResponseMentioned
+      | NotificationResponseReplied
     index: 'userId'
   }
   Organization: {

--- a/packages/server/database/types/NotificationDiscussionMentioned.ts
+++ b/packages/server/database/types/NotificationDiscussionMentioned.ts
@@ -9,6 +9,7 @@ interface Input {
 }
 
 export default class NotificationDiscussionMentioned extends Notification {
+  type: 'DISCUSSION_MENTIONED'
   meetingId: string
   authorId: string
   commentId: string
@@ -17,6 +18,7 @@ export default class NotificationDiscussionMentioned extends Notification {
   constructor(input: Input) {
     const {meetingId, authorId, userId, commentId, discussionId} = input
     super({userId, type: 'DISCUSSION_MENTIONED'})
+    this.type = 'DISCUSSION_MENTIONED'
     this.meetingId = meetingId
     this.authorId = authorId
     this.commentId = commentId

--- a/packages/server/database/types/NotificationKickedOut.ts
+++ b/packages/server/database/types/NotificationKickedOut.ts
@@ -7,11 +7,13 @@ interface Input {
 }
 
 export default class NotificationKickedOut extends Notification {
+  type: 'KICKED_OUT'
   teamId: string
   evictorUserId: string
   constructor(input: Input) {
     const {evictorUserId, teamId, userId} = input
     super({userId, type: 'KICKED_OUT'})
+    this.type = 'KICKED_OUT'
     this.teamId = teamId
     this.evictorUserId = evictorUserId
   }

--- a/packages/server/database/types/NotificationMeetingStageTimeLimitEnd.ts
+++ b/packages/server/database/types/NotificationMeetingStageTimeLimitEnd.ts
@@ -6,10 +6,12 @@ interface Input {
 }
 
 export default class NotificationMeetingStageTimeLimitEnd extends Notification {
+  type: 'MEETING_STAGE_TIME_LIMIT_END'
   meetingId: string
   constructor(input: Input) {
     const {meetingId, userId} = input
     super({userId, type: 'MEETING_STAGE_TIME_LIMIT_END'})
+    this.type = 'MEETING_STAGE_TIME_LIMIT_END'
     this.meetingId = meetingId
   }
 }

--- a/packages/server/database/types/NotificationPaymentRejected.ts
+++ b/packages/server/database/types/NotificationPaymentRejected.ts
@@ -8,6 +8,7 @@ interface Input {
 }
 
 export default class NotificationPaymentRejected extends Notification {
+  type: 'PAYMENT_REJECTED'
   orgId: string
   last4: string
   brand: string
@@ -15,6 +16,7 @@ export default class NotificationPaymentRejected extends Notification {
   constructor(input: Input) {
     const {orgId, last4, brand, userId} = input
     super({userId, type: 'PAYMENT_REJECTED'})
+    this.type = 'PAYMENT_REJECTED'
     this.orgId = orgId
     this.last4 = last4
     this.brand = brand

--- a/packages/server/database/types/NotificationPromoteToBillingLeader.ts
+++ b/packages/server/database/types/NotificationPromoteToBillingLeader.ts
@@ -6,11 +6,13 @@ interface Input {
 }
 
 export default class NotificationPromoteToBillingLeader extends Notification {
+  type: 'PROMOTE_TO_BILLING_LEADER'
   orgId: string
 
   constructor(input: Input) {
     const {orgId, userId} = input
     super({userId, type: 'PROMOTE_TO_BILLING_LEADER'})
+    this.type = 'PROMOTE_TO_BILLING_LEADER'
     this.orgId = orgId
   }
 }

--- a/packages/server/database/types/NotificationPromptToJoinOrg.ts
+++ b/packages/server/database/types/NotificationPromptToJoinOrg.ts
@@ -6,10 +6,12 @@ interface Input {
 }
 
 export default class NotificationPromptToJoinOrg extends Notification {
+  type: 'PROMPT_TO_JOIN_ORG'
   activeDomain: string
   constructor(input: Input) {
     const {userId, activeDomain} = input
     super({userId, type: 'PROMPT_TO_JOIN_ORG'})
+    this.type = 'PROMPT_TO_JOIN_ORG'
     this.activeDomain = activeDomain
   }
 }

--- a/packages/server/database/types/NotificationRequestToJoinOrg.ts
+++ b/packages/server/database/types/NotificationRequestToJoinOrg.ts
@@ -10,6 +10,7 @@ interface Input {
 }
 
 export default class NotificationRequestToJoinOrg extends Notification {
+  type: 'REQUEST_TO_JOIN_ORG'
   domainJoinRequestId: number
   email: string
   name: string
@@ -18,6 +19,7 @@ export default class NotificationRequestToJoinOrg extends Notification {
   constructor(input: Input) {
     const {domainJoinRequestId, requestCreatedBy, email, name, picture, userId} = input
     super({userId, type: 'REQUEST_TO_JOIN_ORG'})
+    this.type = 'REQUEST_TO_JOIN_ORG'
     this.domainJoinRequestId = domainJoinRequestId
     this.email = email
     this.name = name

--- a/packages/server/database/types/NotificationResponseMentioned.ts
+++ b/packages/server/database/types/NotificationResponseMentioned.ts
@@ -7,12 +7,14 @@ interface Input {
 }
 
 export default class NotificationResponseMentioned extends Notification {
+  type: 'RESPONSE_MENTIONED'
   responseId: string
   meetingId: string
 
   constructor(input: Input) {
     const {responseId, meetingId, userId} = input
     super({userId, type: 'RESPONSE_MENTIONED'})
+    this.type = 'RESPONSE_MENTIONED'
     this.responseId = responseId
     this.meetingId = meetingId
   }

--- a/packages/server/database/types/NotificationResponseReplied.ts
+++ b/packages/server/database/types/NotificationResponseReplied.ts
@@ -8,6 +8,7 @@ interface Input {
 }
 
 export default class NotificationResponseReplied extends Notification {
+  type: 'RESPONSE_REPLIED'
   meetingId: string
   authorId: string
   commentId: string
@@ -15,6 +16,7 @@ export default class NotificationResponseReplied extends Notification {
   constructor(input: Input) {
     const {meetingId, authorId, userId, commentId} = input
     super({userId, type: 'RESPONSE_REPLIED'})
+    this.type = 'RESPONSE_REPLIED'
     this.meetingId = meetingId
     this.authorId = authorId
     this.commentId = commentId

--- a/packages/server/database/types/NotificationTaskInvolves.ts
+++ b/packages/server/database/types/NotificationTaskInvolves.ts
@@ -11,6 +11,7 @@ interface Input {
 }
 
 export default class NotificationTaskInvolves extends Notification {
+  type: 'TASK_INVOLVES'
   changeAuthorId: string
   involvement: TaskInvolvement
   taskId: string
@@ -19,6 +20,7 @@ export default class NotificationTaskInvolves extends Notification {
   constructor(input: Input) {
     const {teamId, changeAuthorId, involvement, taskId, userId} = input
     super({userId, type: 'TASK_INVOLVES'})
+    this.type = 'TASK_INVOLVES'
     this.changeAuthorId = changeAuthorId
     this.involvement = involvement
     this.taskId = taskId

--- a/packages/server/database/types/NotificationTeamArchived.ts
+++ b/packages/server/database/types/NotificationTeamArchived.ts
@@ -7,11 +7,13 @@ interface Input {
 }
 
 export default class NotificationTeamArchived extends Notification {
+  type: 'TEAM_ARCHIVED'
   archivorUserId: string
   teamId: string
   constructor(input: Input) {
     const {archivorUserId, teamId, userId} = input
     super({userId, type: 'TEAM_ARCHIVED'})
+    this.type = 'TEAM_ARCHIVED'
     this.archivorUserId = archivorUserId
     this.teamId = teamId
   }

--- a/packages/server/database/types/NotificationTeamInvitation.ts
+++ b/packages/server/database/types/NotificationTeamInvitation.ts
@@ -7,11 +7,13 @@ interface Input {
 }
 
 export default class NotificationTeamInvitation extends Notification {
+  type: 'TEAM_INVITATION'
   invitationId: string
   teamId: string
   constructor(input: Input) {
     const {invitationId, teamId, userId} = input
     super({userId, type: 'TEAM_INVITATION'})
+    this.type = 'TEAM_INVITATION'
     this.invitationId = invitationId
     this.teamId = teamId
   }

--- a/packages/server/database/types/NotificationTeamsLimitExceeded.ts
+++ b/packages/server/database/types/NotificationTeamsLimitExceeded.ts
@@ -8,12 +8,14 @@ interface Input {
 }
 
 export default class NotificationTeamsLimitExceeded extends Notification {
+  type: 'TEAMS_LIMIT_EXCEEDED'
   orgId: string
   orgName: string
   orgPicture?: string
   constructor(input: Input) {
     const {userId, orgId, orgName, orgPicture} = input
     super({userId, type: 'TEAMS_LIMIT_EXCEEDED'})
+    this.type = 'TEAMS_LIMIT_EXCEEDED'
     this.orgId = orgId
     this.orgName = orgName
     this.orgPicture = orgPicture

--- a/packages/server/database/types/NotificationTeamsLimitReminder.ts
+++ b/packages/server/database/types/NotificationTeamsLimitReminder.ts
@@ -9,6 +9,7 @@ interface Input {
 }
 
 export default class NotificationTeamsLimitReminder extends Notification {
+  type: 'TEAMS_LIMIT_REMINDER'
   orgId: string
   orgName: string
   orgPicture?: string
@@ -16,6 +17,7 @@ export default class NotificationTeamsLimitReminder extends Notification {
   constructor(input: Input) {
     const {userId, orgId, orgName, orgPicture, scheduledLockAt} = input
     super({userId, type: 'TEAMS_LIMIT_REMINDER'})
+    this.type = 'TEAMS_LIMIT_REMINDER'
     this.orgId = orgId
     this.scheduledLockAt = scheduledLockAt
     this.orgName = orgName

--- a/packages/server/graphql/mutations/addComment.ts
+++ b/packages/server/graphql/mutations/addComment.ts
@@ -20,6 +20,7 @@ import {GQLContext} from '../graphql'
 import publishNotification from '../public/mutations/helpers/publishNotification'
 import AddCommentInput from '../types/AddCommentInput'
 import AddCommentPayload from '../types/AddCommentPayload'
+import {SlackNotifier} from './helpers/notifications/SlackNotifier'
 
 type AddCommentMutationVariables = {
   comment: {
@@ -135,6 +136,7 @@ const addComment = {
 
         await r.table('Notification').insert(notification).run()
 
+        SlackNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
         publishNotification(notification, subOptions)
       }
     }

--- a/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
@@ -21,6 +21,11 @@ export type Notifier = {
     stageIndex: number,
     channelId: string
   ): Promise<NotifyResponse>
+  sendNotificationToUser?(
+    dataLoader: DataLoaderWorker,
+    notificationId: string,
+    userId: string
+  ): Promise<void>
   standupResponseSubmitted(
     dataLoader: DataLoaderWorker,
     meetingId: string,

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -21,6 +21,8 @@ import {NotificationIntegrationHelper, NotifyResponse} from './NotificationInteg
 import {Notifier} from './Notifier'
 import SlackAuth from '../../../../database/types/SlackAuth'
 import {getTeamPromptResponsesByMeetingId} from '../../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
+import errorFilter from '../../../errorFilter'
+import {isNotNull} from '../../../../../client/utils/predicates'
 
 type SlackNotification = {
   title: string
@@ -294,6 +296,46 @@ async function loadMeetingTeam(dataLoader: DataLoaderWorker, meetingId: string, 
   }
 }
 
+const getDmSlackForMeeting = async (
+  dataLoader: DataLoaderWorker,
+  meeting: Meeting,
+  userId: string
+) => {
+  // Order of slack auth is:
+  // 1. Auth on team
+  // 2. Auth in org (auth team is in same org as meeting team)
+  // 3. Any auth for user
+  const meetingTeamOrgId = (await dataLoader.get('teams').loadNonNull(meeting.teamId)).orgId
+  const userSlackAuths = (await dataLoader.get('slackAuthByUserId').load(userId)).filter(
+    (auth) => !!auth.botAccessToken
+  )
+
+  const authTeamsLookup = Object.fromEntries(
+    (await dataLoader.get('teams').loadMany(userSlackAuths.map((auth) => auth.teamId)))
+      .filter(errorFilter)
+      .filter(isNotNull)
+      .map((team) => [team.id, team])
+  )
+
+  return userSlackAuths.sort((a, b) => {
+    if (a.teamId === meeting.teamId) {
+      return -1
+    } else if (b.teamId === meeting.teamId) {
+      return 1
+    }
+
+    const aHasOrg = authTeamsLookup[a.teamId]?.orgId === meetingTeamOrgId
+    const bHasOrg = authTeamsLookup[b.teamId]?.orgId === meetingTeamOrgId
+    if (aHasOrg && !bHasOrg) {
+      return -1
+    } else if (!aHasOrg && bHasOrg) {
+      return 1
+    }
+
+    return 0
+  })[0]
+}
+
 export const SlackNotifier: Notifier = {
   async startMeeting(dataLoader: DataLoaderWorker, meetingId: string, teamId: string) {
     const {meeting, team} = await loadMeetingTeam(dataLoader, meetingId, teamId)
@@ -442,5 +484,64 @@ export const SlackNotifier: Notifier = {
     return notifySlack(notificationChannel, 'TOPIC_SHARED', team.id, slackBlocks, undefined, {
       reflectionGroupId
     })
+  },
+
+  async sendNotificationToUser(
+    dataLoader: DataLoaderWorker,
+    notificationId: string,
+    userId: string
+  ) {
+    const notification = await dataLoader.get('notifications').load(notificationId)
+    if (notification.type !== 'RESPONSE_MENTIONED' && notification.type !== 'RESPONSE_REPLIED') {
+      return
+    }
+
+    const meeting = await dataLoader.get('newMeetings').load(notification.meetingId)
+
+    const userSlackAuth = await getDmSlackForMeeting(dataLoader, meeting, userId)
+    if (!userSlackAuth) {
+      return
+    }
+
+    let responseId: string | undefined
+    let title: string | undefined
+    let buttonText: string | undefined
+
+    if (notification.type === 'RESPONSE_REPLIED') {
+      const responses = await getTeamPromptResponsesByMeetingId(notification.meetingId)
+      responseId = responses.find(({userId: responseUserId}) => responseUserId === userId)?.id
+      const user = await dataLoader.get('users').loadNonNull(notification.authorId)
+      title = `${user.preferredName} replied to your response in ${meeting.name}`
+      buttonText = 'See the discussion'
+    } else {
+      responseId = notification.responseId
+      const response = await dataLoader.get('teamPromptResponses').loadNonNull(responseId)
+      const user = await dataLoader.get('users').loadNonNull(response.userId)
+      title = `${user.preferredName} mentioned you in their response in ${meeting.name}`
+      buttonText = 'See their response'
+    }
+
+    if (!responseId) {
+      return
+    }
+
+    const options = {
+      searchParams: {
+        utm_source: 'slack standup notification',
+        utm_medium: 'product',
+        utm_campaign: 'notifications',
+        responseId
+      }
+    }
+
+    const responseUrl = makeAppURL(appOrigin, `meet/${notification.meetingId}/responses`, options)
+    const blocks: Array<{type: string}> = [
+      makeSection(title),
+      makeButtons([{text: buttonText, url: responseUrl, type: 'primary'}])
+    ]
+
+    const {botAccessToken} = userSlackAuth
+    const manager = new SlackServerManager(botAccessToken!)
+    manager.postMessage(userSlackAuth.slackUserId, blocks, title)
   }
 }

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -12,6 +12,7 @@ import {MutationResolvers} from '../resolverTypes'
 import publishNotification from './helpers/publishNotification'
 import createTeamPromptMentionNotifications from './helpers/publishTeamPromptMentions'
 import {IntegrationNotifier} from '../../mutations/helpers/notifications/IntegrationNotifier'
+import {SlackNotifier} from '../../mutations/helpers/notifications/SlackNotifier'
 
 const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = async (
   _source,
@@ -93,6 +94,7 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
   }
 
   notifications.forEach((notification) => {
+    SlackNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
     publishNotification(notification, subOptions)
   })
 


### PR DESCRIPTION
# Description
Wouldn't it be nice if we could send slack DMs to users who have integrated? Things like notifications, meeting reminders, etc.

We could potentially refactor our slack auth code to decouple team integrations with the authorizing user - i.e., instead of an integration for `(userId, teamId)`, make it an integration for just `teamId` that anyone can auth, modify, etc.. Then, users can auth _themselves_ to slack as a way to bind their slack user with their Parabol user.

This POC does the most basic thing by trying to find a user's slack auth _somewhere_, and then uses that to send them a DM with a standup notification.

## Demo
<img width="665" alt="Screen Shot 2023-08-11 at 2 54 57 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/d75fc555-a8e8-4875-89ec-7a4cbd98534c">