### PR TITLE
fix: optimistic updater in UpsertTeamPromptResponseMutation 

### DIFF
--- a/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
+++ b/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
@@ -15,6 +15,7 @@ graphql`
       plaintextContent
       updatedAt
       createdAt
+      ...TeamPromptResponseEmojis_response
     }
   }
 `
@@ -82,7 +83,8 @@ const UpsertTeamPromptResponseMutation: StandardMutation<
         content,
         plaintextContent,
         updatedAt: now,
-        createdAt: !teamPromptResponseId ? now : undefined
+        createdAt: !teamPromptResponseId ? now : undefined,
+        reactjis: []
       }
     }
   }


### PR DESCRIPTION
# Description

Fixes an issue with undefined emoji list when adding initial standup response

## Demo

No demo

## Testing scenarios

- [ ] Open a new standup meeting, add response and check if app is not crashing 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
