### PR TITLE
fix: build in dev mode from clean clone

### DIFF
--- a/packages/server/createSSR.ts
+++ b/packages/server/createSSR.ts
@@ -6,7 +6,8 @@ import acceptsBrotli from './acceptsBrotli'
 
 const localClientAssetsDir = path.join(__PROJECT_ROOT__, 'build')
 const indexPath = path.join(localClientAssetsDir, 'index.html')
-const minifiedHTML = fs.readFileSync(indexPath, 'utf8')
+// In dev mode we don't use this, we proxy to the in-memory Dev Server
+const minifiedHTML = __PRODUCTION__ ? fs.readFileSync(indexPath, 'utf8') : ''
 const brotliHTML = brotliCompressSync(minifiedHTML)
 
 const createSSR = (res: HttpResponse, req: HttpRequest) => {

--- a/scripts/codegenGraphQL.js
+++ b/scripts/codegenGraphQL.js
@@ -5,7 +5,7 @@
   Reruns whenever the underlying schema file changes
 */
 require('sucrase/register')
-const {generate} = require('@graphql-codegen/cli')
+const {generate, CodegenContext} = require('@graphql-codegen/cli')
 const path = require('path')
 const config = require('../codegen.json')
 const waitForFileExists = require('./waitForFileExists').default
@@ -16,14 +16,24 @@ const codegenGraphQL = async () => {
   if (!schemaExists) throw Error('GraphQL Schema Not Available. Run `yarn relay:build`')
   const watch = process.argv.find((arg) => arg === '--watch')
   if (watch) {
-    // watches the `schema` files and re-runs if it changes
-    // on the first run, schemas won't exist
-    // When GQL Schema Compiler finished, the schemas will exist & it'll rerun
-    config.watch = true
-    // output is pretty verbose, comment this out to debug
-    config.silent = true
+    generate(
+      new CodegenContext({
+        config: {
+          ...config,
+          // watches the `schema` files and re-runs if it changes
+          // on the first run, schemas won't exist
+          // When GQL Schema Compiler finished, the schemas will exist & it'll rerun
+          watch: true,
+          // output is pretty verbose, comment this out to debug
+          silent: true
+        },
+        // https://github.com/dotansimha/graphql-code-generator/issues/9490#issue-1743840530
+        filepath: 'i-must-be-set'
+      })
+    )
+  } else {
+    generate(config)
   }
-  generate(config)
 }
 
 codegenGraphQL()


### PR DESCRIPTION
# Description

After a fresh clone of the repo I noticed that the app wasn't building in dev mode. All our CI tests only run in prod mode, so they didn't catch this.

## Demo

No demo, the app just starts

## Testing scenarios

- [x] `yarn clean && yarn && yarn dev`