### PR TITLE
fix: Show Team Insights emojis correctly

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -2,12 +2,20 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
-import emojis from '../../../../utils/emojis'
+import appleEmojis from 'emoji-mart/data/apple.json'
+import {uncompress} from 'emoji-mart/dist-modern/utils/data.js'
 import Tooltip from '../../../../components/Tooltip'
 import {Info as InfoIcon} from '@mui/icons-material'
+import {unifiedToNative} from 'emoji-mart/dist-modern/utils/index.js'
 
 interface Props {
   teamInsightsRef: TeamDashInsights_insights$key
+}
+
+uncompress(appleEmojis)
+const emojiToNative = (emoji: string) => {
+  const value = appleEmojis.emojis[emoji as keyof typeof appleEmojis.emojis] as any
+  return unifiedToNative(value.unified) || ''
 }
 
 const TeamDashInsights = (props: Props) => {
@@ -45,7 +53,7 @@ const TeamDashInsights = (props: Props) => {
                   key={emoji.id}
                   className='flex h-24 w-1/4 flex-col items-center justify-center'
                 >
-                  <div className='text-2xl'>{emojis[emoji.id as keyof typeof emojis]}</div>
+                  <div className='text-2xl'>{emojiToNative(emoji.id)}</div>
                   <div className='p-2 font-semibold'>{emoji.count}</div>
                 </div>
               ))}


### PR DESCRIPTION
# Description

There are two different sets of emojis in use in the app: emoji-mart for reactions and a custom list used for emojis in tasks and responses. Team Insights shows only reactions, but used the other list to convert the text to an emoji.

## Demo
![Screenshot from 2023-08-15 10-45-59](https://github.com/ParabolInc/parabol/assets/7331043/47fcd80e-1501-4798-8f0e-9d782416372c)

## Testing scenarios

- with feature flag enabled, react with :thinking_face: more than 4 times and end the meeting to make it show up in insights
- make sure another emoji has been used 5 or more times as well so the card shows up in insights
- check it's shown correctly in team insights

- alternatively with the feature flag set, just manually set the "Team.mostUsedEmojis" column to
  ```
  [
    {
        "id": "heavy_plus_sign",
        "count": 13
    },
    {
        "id": "thinking_face",
        "count": 5
    }
  ]
  ```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
