### PR TITLE
style: Normalize link styles

### DIFF
--- a/packages/client/components/PokerEstimateHeaderCardContent.tsx
+++ b/packages/client/components/PokerEstimateHeaderCardContent.tsx
@@ -41,7 +41,7 @@ const CardTitleWrapper = styled('div')({
   width: '100%'
 })
 
-const CardDescription = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
+const CardDescriptionWrapper = styled('div')<{isExpanded: boolean}>(({isExpanded}) => ({
   color: PALETTE.SLATE_700,
   fontWeight: 'normal',
   lineHeight: '20px',
@@ -51,6 +51,16 @@ const CardDescription = styled('div')<{isExpanded: boolean}>(({isExpanded}) => (
   overflowY: isExpanded ? 'auto' : 'hidden',
   transition: 'all 300ms'
 }))
+
+const CardDescriptionContent = styled('div')`
+  a {
+    text-decoration: underline;
+    :hover,
+    :focus {
+      color: ${PALETTE.SLATE_700};
+    }
+  }
+`
 
 const StyledIcon = styled(Launch)({
   height: 18,
@@ -97,10 +107,9 @@ const PokerEstimateHeaderCardContent = (props: PokerEstimateHeaderCardContentPro
             </CardButton>
           </CardIcons>
         </CardTitleWrapper>
-        <CardDescription
-          isExpanded={isExpanded}
-          dangerouslySetInnerHTML={{__html: descriptionHTML}}
-        />
+        <CardDescriptionWrapper isExpanded={isExpanded}>
+          <CardDescriptionContent dangerouslySetInnerHTML={{__html: descriptionHTML}} />
+        </CardDescriptionWrapper>
         <StyledLink href={url} rel='noopener noreferrer' target='_blank' title={linkTitle}>
           <StyledLabel>{linkText}</StyledLabel>
           <StyledIcon />

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -101,7 +101,7 @@ const StyledEditor = styled('div')`
 
   a {
     text-decoration: underline;
-    color: ${PALETTE.SLATE_600};
+    color: ${PALETTE.SLATE_700};
     :hover {
       cursor: pointer;
     }


### PR DESCRIPTION
# Description

Linked text can be in Standup response cards, thread comments, task cards, and in Poker item descriptions. We wanted to normalize the minimal styles, links use:
- Body color (Slate 700)
- Text decoration underline
- Have an outline on tab (this is the browser default)

This PR adds the text decoration to the Poker item description and updates the color of links in Standup response cards

## Testing
- [x] When linking text on a Standup response card the text is the same as the body color (Slate 700)
- [x] Using 2 local users in a Standup, you can tab to the link on another’s response card, it has an outline on focus
- [x] Add an item with linked text to a Poker meeting, the linked text is underlined, body color (Slate 700) and has an outline on focus
