### PR TITLE
fix: exit early if no segment write key

### DIFF
--- a/packages/server/graphql/mutations/segmentEventTrack.ts
+++ b/packages/server/graphql/mutations/segmentEventTrack.ts
@@ -54,8 +54,14 @@ export default {
     {event, options}: SendClientSegmentEventMutationVariables,
     {authToken, dataLoader}: GQLContext
   ) => {
+    // For PPMIs & dev envs
+    if (!process.env.SEGMENT_WRITE_KEY) return
+
     // AUTH
     const viewerId = getUserId(authToken)
+    // segment requires a userId or anonymousId
+    if (!viewerId) return false
+
     const {teamId, orgId} = options || {teamId: undefined, orgId: undefined}
     if (teamId) {
       // fail silently. they're being sneaky

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -10,6 +10,8 @@ const segmentIo = new SegmentIo(SEGMENT_WRITE_KEY || 'x', {
 }) as any
 segmentIo._track = segmentIo.track
 segmentIo.track = async (options: any) => {
+  // used as a failsafe for PPMIs
+  if (!SEGMENT_WRITE_KEY) return
   const {userId, event, properties: inProps} = options
   const user = options.userId ? await getUserById(options.userId) : null
   const {email, segmentId} = user ?? {}

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -1,6 +1,6 @@
 import SegmentIo from 'analytics-node'
-import {getUserById} from '../postgres/queries/getUsersByIds'
 import PROD from '../PROD'
+import {getUserById} from '../postgres/queries/getUsersByIds'
 
 const {SEGMENT_WRITE_KEY} = process.env
 
@@ -13,7 +13,8 @@ segmentIo.track = async (options: any) => {
   // used as a failsafe for PPMIs
   if (!SEGMENT_WRITE_KEY) return
   const {userId, event, properties: inProps} = options
-  const user = options.userId ? await getUserById(options.userId) : null
+  if (!userId) return
+  const user = await getUserById(userId)
   const {email, segmentId} = user ?? {}
   const properties = {...inProps, email}
   return (segmentIo as any)._track({


### PR DESCRIPTION
# Description

fixes #8674
We had a PPMI who does not use segment get segment-related errors in their server logs. This should fix that.

## Testing scenarios

- [ ] nuke the SEGMENT_WRITE_KEY & run in prod mode. when segmentEventTrack gets called, it exits early.