### PR TITLE
chore: fix cleanup-changelog.sh on mac os

### DIFF
--- a/scripts/cleanup-changelog.sh
+++ b/scripts/cleanup-changelog.sh
@@ -2,8 +2,8 @@
 # replace uppercase words: with bold to preserve these
 # replace lowercase words: with nothing as these are the conventional commit categories
 # replace lowercase words (with parens): with bold to preserve the title
-sed -i '' -E '
+sed -i.bak -E '
   s/^- ([A-Z][[:lower:]]*): /- **\1**: /
   s/^- ([[:lower:]]*): ?/- /
   s/^- ([[:lower:]]*)\((.*)\): ?/- **\2**: /
-' CHANGELOG.md
+' CHANGELOG.md && rm CHANGELOG.md.bak

--- a/scripts/cleanup-changelog.sh
+++ b/scripts/cleanup-changelog.sh
@@ -3,7 +3,7 @@
 # replace lowercase words: with nothing as these are the conventional commit categories
 # replace lowercase words (with parens): with bold to preserve the title
 sed -i.bak -E '
-  s/^- ([A-Z][[:lower:]]*): /- **\1**: /
-  s/^- ([[:lower:]]*): ?/- /
-  s/^- ([[:lower:]]*)\((.*)\): ?/- **\2**: /
+  s/^- ([[:upper:]][[:alnum:]]*): /- **\1**: /
+  s/^- ([[:alnum:]]*): ?/- /
+  s/^- ([[:alnum:]]*)\((.*)\): ?/- **\2**: /
 ' CHANGELOG.md && rm CHANGELOG.md.bak

--- a/scripts/cleanup-changelog.sh
+++ b/scripts/cleanup-changelog.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# replace uppercase words: with bold to preserver these
+# replace uppercase words: with bold to preserve these
 # replace lowercase words: with nothing as these are the conventional commit categories
 # replace lowercase words (with parens): with bold to preserve the title
-sed -i -E '
-  s/^- ([A-Z]\w*): /- **\1**: /
-  s/^- \w*: ?/- /
-  s/^- \w*\((.*)\): ?/- **\1**: /
+sed -i '' -E '
+  s/^- ([A-Z][[:alnum:]]*): /- **\1**: /
+  s/^- ([[:lower:]]*): ?/- /
+  s/^- ([[:lower:]]*)\((.*)\): ?/- **\2**: /
 ' CHANGELOG.md

--- a/scripts/cleanup-changelog.sh
+++ b/scripts/cleanup-changelog.sh
@@ -3,7 +3,7 @@
 # replace lowercase words: with nothing as these are the conventional commit categories
 # replace lowercase words (with parens): with bold to preserve the title
 sed -i '' -E '
-  s/^- ([A-Z][[:alnum:]]*): /- **\1**: /
+  s/^- ([A-Z][[:lower:]]*): /- **\1**: /
   s/^- ([[:lower:]]*): ?/- /
   s/^- ([[:lower:]]*)\((.*)\): ?/- **\2**: /
 ' CHANGELOG.md


### PR DESCRIPTION
cleanup-changelog.sh fails on mac os with an error:

```
sed: 2: "
  s/^- ([A-Z]\w*): /-  ...": \1 not defined in the RE
```