### PR TITLE
chore: Show disabled Team Health option to Starter tier

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -28,7 +28,6 @@ import {RecurrenceSettings} from '../TeamPrompt/Recurrence/RecurrenceSettings'
 import NewMeetingSettingsToggleAnonymity from '../NewMeetingSettingsToggleAnonymity'
 import NewMeetingSettingsToggleTeamHealth from '../NewMeetingSettingsToggleTeamHealth'
 import NewMeetingSettingsToggleCheckIn from '../NewMeetingSettingsToggleCheckIn'
-import isTeamHealthAvailable from '../../utils/features/isTeamHealthAvailable'
 import StyledError from '../StyledError'
 import FlatPrimaryButton from '../FlatPrimaryButton'
 import NewMeetingActionsCurrentMeetings from '../NewMeetingActionsCurrentMeetings'
@@ -95,6 +94,7 @@ const ActivityDetailsSidebar = (props: Props) => {
         actionSettings: meetingSettings(meetingType: action) {
           ...NewMeetingSettingsToggleCheckIn_settings
         }
+        ...NewMeetingSettingsToggleTeamHealth_team
         ...NewMeetingTeamPicker_selectedTeam
         ...NewMeetingTeamPicker_teams
         ...NewMeetingActionsCurrentMeetings_team
@@ -281,9 +281,10 @@ const ActivityDetailsSidebar = (props: Props) => {
               {type === 'retrospective' && (
                 <>
                   <NewMeetingSettingsToggleCheckIn settingsRef={selectedTeam.retroSettings} />
-                  {isTeamHealthAvailable(selectedTeam.tier) && (
-                    <NewMeetingSettingsToggleTeamHealth settingsRef={selectedTeam.retroSettings} />
-                  )}
+                  <NewMeetingSettingsToggleTeamHealth
+                    settingsRef={selectedTeam.retroSettings}
+                    teamRef={selectedTeam}
+                  />
                   <NewMeetingSettingsToggleAnonymity settingsRef={selectedTeam.retroSettings} />
                 </>
               )}

--- a/packages/client/components/NewMeetingSettingsRetrospective.tsx
+++ b/packages/client/components/NewMeetingSettingsRetrospective.tsx
@@ -14,9 +14,9 @@ const NewMeetingSettingsRetrospective = (props: Props) => {
   const team = useFragment(
     graphql`
       fragment NewMeetingSettingsRetrospective_team on Team {
+        ...NewMeetingSettingsRetrospectiveSettings_team
         retroSettings: meetingSettings(meetingType: retrospective) {
           ...RetroTemplatePicker_settings
-          ...NewMeetingSettingsRetrospectiveSettings_settings
         }
         organization {
           ...NewMeetingSettingsRetrospectiveSettings_organization
@@ -30,10 +30,7 @@ const NewMeetingSettingsRetrospective = (props: Props) => {
   return (
     <>
       <RetroTemplatePicker settingsRef={retroSettings} />
-      <NewMeetingSettingsRetrospectiveSettings
-        settingsRef={retroSettings}
-        organizationRef={organization}
-      />
+      <NewMeetingSettingsRetrospectiveSettings teamRef={team} organizationRef={organization} />
     </>
   )
 }

--- a/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
@@ -12,6 +12,7 @@ import {PALETTE} from '../styles/paletteV3'
 import Checkbox from './Checkbox'
 import PlainButton from './PlainButton/PlainButton'
 import Tooltip from './Tooltip'
+import NewMeetingSettingsUpgradeForTeamHealth from './NewMeetingSettingsUpgradeForTeamHealth'
 
 const ButtonRow = styled(PlainButton)({
   background: PALETTE.SLATE_200,
@@ -64,6 +65,7 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
   const team = useFragment(
     graphql`
       fragment NewMeetingSettingsToggleTeamHealth_team on Team {
+        ...NewMeetingSettingsUpgradeForTeamHealth_team
         id
         tier
       }
@@ -96,6 +98,9 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
       {teamHealthEnabled: !hasTeamHealth, settingsId},
       {onError, onCompleted}
     )
+  }
+  if (!teamHealthAvailable) {
+    return <NewMeetingSettingsUpgradeForTeamHealth teamRef={team} className={className} />
   }
   return (
     <Tooltip

--- a/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
@@ -3,12 +3,15 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {NewMeetingSettingsToggleTeamHealth_settings$key} from '~/__generated__/NewMeetingSettingsToggleTeamHealth_settings.graphql'
+import {NewMeetingSettingsToggleTeamHealth_team$key} from '~/__generated__/NewMeetingSettingsToggleTeamHealth_team.graphql'
+import isTeamHealthAvailable from '../utils/features/isTeamHealthAvailable'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import SetMeetingSettingsMutation from '../mutations/SetMeetingSettingsMutation'
 import {PALETTE} from '../styles/paletteV3'
 import Checkbox from './Checkbox'
 import PlainButton from './PlainButton/PlainButton'
+import Tooltip from './Tooltip'
 
 const ButtonRow = styled(PlainButton)({
   background: PALETTE.SLATE_200,
@@ -26,15 +29,15 @@ const ButtonRow = styled(PlainButton)({
   alignItems: 'center'
 })
 
-const Label = styled('div')({
+const Label = styled('div')<{disabled: boolean}>(({disabled}) => ({
   flex: 1,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   fontSize: 20,
   fontWeight: 600,
-  color: PALETTE.SLATE_900
-})
+  color: disabled ? PALETTE.SLATE_600 : PALETTE.SLATE_900
+}))
 
 const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
   '&&': {
@@ -50,13 +53,25 @@ const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
 }))
 
 interface Props {
+  teamRef: NewMeetingSettingsToggleTeamHealth_team$key
   settingsRef: NewMeetingSettingsToggleTeamHealth_settings$key
   className?: string
 }
 
 const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
-  const {settingsRef, className} = props
+  const {teamRef, settingsRef, className} = props
 
+  const team = useFragment(
+    graphql`
+      fragment NewMeetingSettingsToggleTeamHealth_team on Team {
+        id
+        tier
+      }
+    `,
+    teamRef
+  )
+
+  // not part of the team fragment as we don't want to specify the meeting type here
   const settings = useFragment(
     graphql`
       fragment NewMeetingSettingsToggleTeamHealth_settings on TeamMeetingSettings {
@@ -66,6 +81,8 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
     `,
     settingsRef
   )
+  const {tier} = team
+  const teamHealthAvailable = isTeamHealthAvailable(tier)
 
   const {id: settingsId, phaseTypes} = settings
   const hasTeamHealth = phaseTypes.includes('TEAM_HEALTH')
@@ -81,10 +98,18 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
     )
   }
   return (
-    <ButtonRow onClick={toggleTeamHealth} className={className}>
-      <Label>{'Include Team Health check'}</Label>
-      <StyledCheckbox active={hasTeamHealth} />
-    </ButtonRow>
+    <Tooltip
+      text={
+        teamHealthAvailable
+          ? undefined
+          : 'Team Health is only available on Team and Enterprise plans'
+      }
+    >
+      <ButtonRow onClick={toggleTeamHealth} className={className} disabled={!teamHealthAvailable}>
+        <Label disabled={!teamHealthAvailable}>{'Include Team Health check'}</Label>
+        <StyledCheckbox active={hasTeamHealth} disabled={!teamHealthAvailable} />
+      </ButtonRow>
+    </Tooltip>
   )
 }
 

--- a/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsToggleTeamHealth.tsx
@@ -11,7 +11,6 @@ import SetMeetingSettingsMutation from '../mutations/SetMeetingSettingsMutation'
 import {PALETTE} from '../styles/paletteV3'
 import Checkbox from './Checkbox'
 import PlainButton from './PlainButton/PlainButton'
-import Tooltip from './Tooltip'
 import NewMeetingSettingsUpgradeForTeamHealth from './NewMeetingSettingsUpgradeForTeamHealth'
 
 const ButtonRow = styled(PlainButton)({
@@ -30,15 +29,15 @@ const ButtonRow = styled(PlainButton)({
   alignItems: 'center'
 })
 
-const Label = styled('div')<{disabled: boolean}>(({disabled}) => ({
+const Label = styled('div')({
   flex: 1,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
   fontSize: 20,
   fontWeight: 600,
-  color: disabled ? PALETTE.SLATE_600 : PALETTE.SLATE_900
-}))
+  color: PALETTE.SLATE_900
+})
 
 const StyledCheckbox = styled(Checkbox)<{active: boolean}>(({active}) => ({
   '&&': {
@@ -103,18 +102,10 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
     return <NewMeetingSettingsUpgradeForTeamHealth teamRef={team} className={className} />
   }
   return (
-    <Tooltip
-      text={
-        teamHealthAvailable
-          ? undefined
-          : 'Team Health is only available on Team and Enterprise plans'
-      }
-    >
-      <ButtonRow onClick={toggleTeamHealth} className={className} disabled={!teamHealthAvailable}>
-        <Label disabled={!teamHealthAvailable}>{'Include Team Health check'}</Label>
-        <StyledCheckbox active={hasTeamHealth} disabled={!teamHealthAvailable} />
-      </ButtonRow>
-    </Tooltip>
+    <ButtonRow onClick={toggleTeamHealth} className={className}>
+      <Label>{'Include Team Health check'}</Label>
+      <StyledCheckbox active={hasTeamHealth} />
+    </ButtonRow>
   )
 }
 

--- a/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
@@ -63,7 +63,7 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
           <u>Upgrade</u> to enable team health checks
         </div>
       </div>
-      <Lock className='text-slate-600' />
+      <Lock className='m-0.5 text-slate-600' />
     </ButtonRow>
   )
 }

--- a/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
@@ -45,10 +45,19 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
   const {orgId} = team
   const atmosphere = useAtmosphere()
 
+  React.useEffect(() => {
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Viewed', {
+      upgradeCTALocation: 'meetingSettingsTeamHealth',
+      meetingType: 'retrospective',
+      orgId
+    })
+  }, [])
+
   const handleUpgrade = () => {
     SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
       upgradeCTALocation: 'meetingSettingsTeamHealth',
-      meetingType: 'retrospective'
+      meetingType: 'retrospective',
+      orgId
     })
     window.open(`/me/organizations/${orgId}/billing`, '_blank', 'noreferrer')
   }

--- a/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
@@ -1,0 +1,60 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {NewMeetingSettingsUpgradeForTeamHealth_team$key} from '~/__generated__/NewMeetingSettingsUpgradeForTeamHealth_team.graphql'
+import PlainButton from './PlainButton/PlainButton'
+import {Lock} from '@mui/icons-material'
+import clsx from 'clsx'
+import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
+import useAtmosphere from '../hooks/useAtmosphere'
+
+interface Props {
+  teamRef: NewMeetingSettingsUpgradeForTeamHealth_team$key
+  className?: string
+}
+
+const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
+  const {teamRef, className} = props
+
+  const team = useFragment(
+    graphql`
+      fragment NewMeetingSettingsUpgradeForTeamHealth_team on Team {
+        orgId
+      }
+    `,
+    teamRef
+  )
+
+  const {orgId} = team
+  const atmosphere = useAtmosphere()
+
+  const handleUpgrade = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'meetingSettingsTeamHealth',
+      meetingType: 'retrospective'
+    })
+    window.open(`/me/organizations/${orgId}/billing`, '_blank', 'noreferrer')
+  }
+
+  return (
+    <PlainButton
+      className={clsx(
+        'flex w-full select-none items-center rounded-lg bg-slate-200 p-4 py-3 text-white hover:bg-slate-300',
+        className
+      )}
+      onClick={handleUpgrade}
+    >
+      <div className='mt-1 flex w-full flex-col'>
+        <div className='flex-1 overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-semibold text-slate-600'>
+          Health Check
+        </div>
+        <div className='w-full text-slate-800'>
+          <u>Upgrade</u> to enable team health checks
+        </div>
+      </div>
+      <Lock className='m-1 text-slate-600' />
+    </PlainButton>
+  )
+}
+
+export default NewMeetingSettingsToggleTeamHealth

--- a/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
+++ b/packages/client/components/NewMeetingSettingsUpgradeForTeamHealth.tsx
@@ -4,9 +4,26 @@ import {useFragment} from 'react-relay'
 import {NewMeetingSettingsUpgradeForTeamHealth_team$key} from '~/__generated__/NewMeetingSettingsUpgradeForTeamHealth_team.graphql'
 import PlainButton from './PlainButton/PlainButton'
 import {Lock} from '@mui/icons-material'
-import clsx from 'clsx'
 import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import useAtmosphere from '../hooks/useAtmosphere'
+import styled from '@emotion/styled'
+import {PALETTE} from '../styles/paletteV3'
+
+const ButtonRow = styled(PlainButton)({
+  background: PALETTE.SLATE_200,
+  borderRadius: '8px',
+  display: 'flex',
+  fontSize: 14,
+  fontWeight: 600,
+  userSelect: 'none',
+  width: '100%',
+  ':hover': {
+    backgroundColor: PALETTE.SLATE_300
+  },
+  height: '72px',
+  padding: '12px 16px',
+  alignItems: 'center'
+})
 
 interface Props {
   teamRef: NewMeetingSettingsUpgradeForTeamHealth_team$key
@@ -37,13 +54,7 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
   }
 
   return (
-    <PlainButton
-      className={clsx(
-        'flex w-full select-none items-center rounded-lg bg-slate-200 p-4 py-3 text-white hover:bg-slate-300',
-        className
-      )}
-      onClick={handleUpgrade}
-    >
+    <ButtonRow className={className} onClick={handleUpgrade}>
       <div className='mt-1 flex w-full flex-col'>
         <div className='flex-1 overflow-hidden overflow-ellipsis whitespace-nowrap text-xl font-semibold text-slate-600'>
           Health Check
@@ -52,8 +63,8 @@ const NewMeetingSettingsToggleTeamHealth = (props: Props) => {
           <u>Upgrade</u> to enable team health checks
         </div>
       </div>
-      <Lock className='m-1 text-slate-600' />
-    </PlainButton>
+      <Lock className='text-slate-600' />
+    </ButtonRow>
   )
 }
 

--- a/packages/client/components/Tooltip.tsx
+++ b/packages/client/components/Tooltip.tsx
@@ -15,14 +15,10 @@ const Tooltip = (props: Props) => {
     MenuPosition.UPPER_CENTER
   )
 
-  if (!text) {
-    return <>{children}</>
-  }
-
   return (
     <div
-      onPointerEnter={openTooltip}
-      onPointerLeave={closeTooltip} //onMouseLeave does not fire for disabled buttons
+      onMouseEnter={openTooltip}
+      onMouseLeave={closeTooltip}
       className={clsx('cursor-pointer', className)}
       ref={originRef}
     >

--- a/packages/client/components/Tooltip.tsx
+++ b/packages/client/components/Tooltip.tsx
@@ -15,10 +15,14 @@ const Tooltip = (props: Props) => {
     MenuPosition.UPPER_CENTER
   )
 
+  if (!text) {
+    return <>{children}</>
+  }
+
   return (
     <div
-      onMouseEnter={openTooltip}
-      onMouseLeave={closeTooltip}
+      onPointerEnter={openTooltip}
+      onPointerLeave={closeTooltip} //onMouseLeave does not fire for disabled buttons
       className={clsx('cursor-pointer', className)}
       ref={originRef}
     >

--- a/packages/server/graphql/types/UpgradeCTALocationEnum.ts
+++ b/packages/server/graphql/types/UpgradeCTALocationEnum.ts
@@ -17,6 +17,7 @@ export type UpgradeCTALocationEnumType =
   | 'startNewMeetingOrganizationLockedError'
   | 'createNewTemplateAL'
   | 'cloneTemplateAL'
+  | 'meetingSettingsTeamHealth'
 
 const UpgradeCTALocationEnum = new GraphQLEnumType({
   name: 'UpgradeCTALocationEnum',
@@ -37,7 +38,8 @@ const UpgradeCTALocationEnum = new GraphQLEnumType({
     organizationLockedModal: {},
     startNewMeetingOrganizationLockedError: {},
     createNewTemplateAL: {},
-    cloneTemplateAL: {}
+    cloneTemplateAL: {},
+    meetingSettingsTeamHealth: {}
   }
 })
 


### PR DESCRIPTION
# Description

Fixes #8663

## Demo

![Screenshot from 2023-08-16 10-53-50](https://github.com/ParabolInc/parabol/assets/7331043/405d6351-2a39-4847-8dfe-24508fb5f362)
![Screenshot from 2023-08-16 10-56-17](https://github.com/ParabolInc/parabol/assets/7331043/5559cb80-42c5-42bb-bb62-4f2657bdc361)

## Testing scenarios

- [ ] check both start meeting dialogs with a Starter team
- [ ] check both start meeting dialogs with a Team team

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
