### PR TITLE
fix: Uncompressing emojies twice causes a failure

### DIFF
--- a/packages/client/components/ReflectionCard/ReactjiCount.tsx
+++ b/packages/client/components/ReflectionCard/ReactjiCount.tsx
@@ -1,8 +1,5 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import data from 'emoji-mart/data/apple.json'
-import {uncompress} from 'emoji-mart/dist-modern/utils/data.js'
-import {unifiedToNative} from 'emoji-mart/dist-modern/utils/index.js'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import PlainButton from '~/components/PlainButton/PlainButton'
@@ -14,8 +11,7 @@ import {MenuPosition} from '../../hooks/useCoords'
 import useTooltip from '../../hooks/useTooltip'
 import ReactjiId from '../../shared/gqlIds/ReactjiId'
 import EmojiUsersReaction from './EmojiUsersReaction'
-
-uncompress(data)
+import getReactji from '../../utils/getReactji'
 
 const Parent = styled('div')<{status: TransitionStatus}>(({status}) => ({
   height: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : 24,
@@ -82,11 +78,9 @@ const ReactjiCount = (props: Props) => {
   if (!reactji) return null
   const {count, id, isViewerReactji} = reactji
   const reactjiObj = ReactjiId.split(id)
-  const name = reactjiObj.name as keyof typeof emojis
-  const {emojis} = data
-  const emojiData = emojis[name] as any
-  const unified = emojiData?.unified ?? ''
-  const unicode = unifiedToNative(unified) || ''
+  const name = reactjiObj.name
+
+  const {unicode, shortName} = getReactji(name)
   const onClick = () => {
     onToggle(name)
   }
@@ -102,9 +96,7 @@ const ReactjiCount = (props: Props) => {
       >
         <Emoji>{unicode}</Emoji>
         <Count>{count}</Count>
-        {tooltipPortal(
-          <EmojiUsersReaction reactjiRef={reactji} reactjiShortName={emojiData?.short_names[0]} />
-        )}
+        {tooltipPortal(<EmojiUsersReaction reactjiRef={reactji} reactjiShortName={shortName} />)}
       </Inner>
     </Parent>
   )

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -2,20 +2,12 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
-import appleEmojis from 'emoji-mart/data/apple.json'
-import {uncompress} from 'emoji-mart/dist-modern/utils/data.js'
 import Tooltip from '../../../../components/Tooltip'
 import {Info as InfoIcon} from '@mui/icons-material'
-import {unifiedToNative} from 'emoji-mart/dist-modern/utils/index.js'
+import getReactji from '../../../../utils/getReactji'
 
 interface Props {
   teamInsightsRef: TeamDashInsights_insights$key
-}
-
-uncompress(appleEmojis)
-const emojiToNative = (emoji: string) => {
-  const value = appleEmojis.emojis[emoji as keyof typeof appleEmojis.emojis] as any
-  return unifiedToNative(value.unified) || ''
 }
 
 const TeamDashInsights = (props: Props) => {
@@ -48,15 +40,20 @@ const TeamDashInsights = (props: Props) => {
               </Tooltip>
             </div>
             <div className='flex flex-row justify-center'>
-              {mostUsedEmojis.map((emoji) => (
-                <div
-                  key={emoji.id}
-                  className='flex h-24 w-1/4 flex-col items-center justify-center'
-                >
-                  <div className='text-2xl'>{emojiToNative(emoji.id)}</div>
-                  <div className='p-2 font-semibold'>{emoji.count}</div>
-                </div>
-              ))}
+              {mostUsedEmojis.map((emoji) => {
+                const {unicode, shortName} = getReactji(emoji.id)
+                return (
+                  <div
+                    key={emoji.id}
+                    className='flex h-24 w-1/4 flex-col items-center justify-center'
+                  >
+                    <Tooltip text={`:${shortName}:`}>
+                      <div className='text-2xl'>{unicode}</div>
+                    </Tooltip>
+                    <div className='p-2 font-semibold'>{emoji.count}</div>
+                  </div>
+                )
+              })}
             </div>
           </div>
         )}

--- a/packages/client/utils/getReactji.ts
+++ b/packages/client/utils/getReactji.ts
@@ -1,0 +1,15 @@
+import appleEmojis from 'emoji-mart/data/apple.json'
+import {uncompress} from 'emoji-mart/dist-modern/utils/data.js'
+import {unifiedToNative} from 'emoji-mart/dist-modern/utils/index.js'
+
+uncompress(appleEmojis)
+
+const getReactji = (emoji: string) => {
+  const value = appleEmojis.emojis[emoji as keyof typeof appleEmojis.emojis] as any
+  return {
+    unicode: unifiedToNative(value.unified) || '',
+    shortName: value.short_names[0] ?? ''
+  }
+}
+
+export default getReactji


### PR DESCRIPTION
TeamDashInsights and ReactjiCount both uncompressed the emojies provided by emoji-mart. This caused occasional exceptions. Moving this to a helper instead used by both.

## Demo

no demo

## Testing scenarios

- have a team which shows emoji insights
- start a meeting and add some reactions
- see no exception

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
