### PR TITLE
feat(gcal): unauthed schedule button ux

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -81,6 +81,16 @@ const ActivityDetailsSidebar = (props: Props) => {
         name
         tier
         orgId
+        teamMembers {
+          isSelf
+          integrations {
+            gcal {
+              auth {
+                id
+              }
+            }
+          }
+        }
         organization {
           name
         }
@@ -125,6 +135,9 @@ const ActivityDetailsSidebar = (props: Props) => {
       availableTeams.find((team) => team.id === preferredTeamId) ??
       templateTeam ??
       sortByTier(availableTeams)[0]!
+  )
+  const selectedTeamHasGcalAuth = selectedTeam.teamMembers.some(
+    (teamMember) => teamMember.integrations.gcal.auth && teamMember.isSelf
   )
   const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
   const history = useHistory()

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -18,9 +18,6 @@ import SendClientSegmentEventMutation from '../../mutations/SendClientSegmentEve
 import StartCheckInMutation from '../../mutations/StartCheckInMutation'
 import StartTeamPromptMutation from '../../mutations/StartTeamPromptMutation'
 import {PALETTE} from '../../styles/paletteV3'
-import SecondaryButton from '../SecondaryButton'
-import GcalModal from '../../modules/userDashboard/components/GcalModal/GcalModal'
-import {useDialogState} from '../../ui/Dialog/useDialogState'
 import {CreateGcalEventInput} from '../../__generated__/StartRetrospectiveMutation.graphql'
 import sortByTier from '../../utils/sortByTier'
 import {MeetingTypeEnum} from '../../__generated__/ActivityDetailsQuery.graphql'
@@ -35,6 +32,7 @@ import NewMeetingActionsCurrentMeetings from '../NewMeetingActionsCurrentMeeting
 import RaisedButton from '../RaisedButton'
 import NewMeetingTeamPicker from '../NewMeetingTeamPicker'
 import {ActivityDetailsRecurrenceSettings} from './ActivityDetailsRecurrenceSettings'
+import ScheduleMeetingButton from './ScheduleMeetingButton'
 
 interface Props {
   selectedTemplateRef: ActivityDetailsSidebar_template$key
@@ -64,14 +62,11 @@ const ActivityDetailsSidebar = (props: Props) => {
   const viewer = useFragment(
     graphql`
       fragment ActivityDetailsSidebar_viewer on User {
-        featureFlags {
-          gcal
-        }
+        ...ScheduleMeetingButton_viewer
       }
     `,
     viewerRef
   )
-  const hasGcalFlag = viewer.featureFlags.gcal
 
   const teams = useFragment(
     graphql`
@@ -81,16 +76,6 @@ const ActivityDetailsSidebar = (props: Props) => {
         name
         tier
         orgId
-        teamMembers {
-          isSelf
-          integrations {
-            gcal {
-              auth {
-                id
-              }
-            }
-          }
-        }
         organization {
           name
         }
@@ -108,7 +93,7 @@ const ActivityDetailsSidebar = (props: Props) => {
         ...NewMeetingTeamPicker_selectedTeam
         ...NewMeetingTeamPicker_teams
         ...NewMeetingActionsCurrentMeetings_team
-        ...GcalModal_team
+        ...ScheduleMeetingButton_team
       }
     `,
     teamsRef
@@ -136,16 +121,9 @@ const ActivityDetailsSidebar = (props: Props) => {
       templateTeam ??
       sortByTier(availableTeams)[0]!
   )
-  const selectedTeamHasGcalAuth = selectedTeam.teamMembers.some(
-    (teamMember) => teamMember.integrations.gcal.auth && teamMember.isSelf
-  )
-  const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
+  const mutationProps = useMutationProps()
+  const {onError, onCompleted, submitting, submitMutation, error} = mutationProps
   const history = useHistory()
-  const {
-    isOpen: isScheduleDialogOpen,
-    open: openScheduleDialog,
-    close: closeScheduleDialog
-  } = useDialogState()
 
   const handleStartActivity = (gcalInput?: CreateGcalEventInput) => {
     if (submitting) return
@@ -311,15 +289,12 @@ const ActivityDetailsSidebar = (props: Props) => {
               <div className='flex grow flex-col justify-end gap-2'>
                 {error && <StyledError>{error.message}</StyledError>}
                 <NewMeetingActionsCurrentMeetings team={selectedTeam} />
-                {hasGcalFlag && (
-                  <SecondaryButton
-                    onClick={openScheduleDialog}
-                    waiting={submitting}
-                    className='h-14'
-                  >
-                    <div className='text-lg'>Schedule</div>
-                  </SecondaryButton>
-                )}
+                <ScheduleMeetingButton
+                  handleStartActivity={handleStartActivity}
+                  mutationProps={mutationProps}
+                  teamRef={selectedTeam}
+                  viewerRef={viewer}
+                />
                 <FlatPrimaryButton
                   onClick={() => handleStartActivity()}
                   waiting={submitting}
@@ -332,12 +307,6 @@ const ActivityDetailsSidebar = (props: Props) => {
           )}
         </div>
       </div>
-      <GcalModal
-        closeModal={closeScheduleDialog}
-        isOpen={isScheduleDialogOpen}
-        handleStartActivityWithGcalEvent={handleStartActivity}
-        teamRef={selectedTeam}
-      />
     </>
   )
 }

--- a/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
+++ b/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
@@ -1,0 +1,104 @@
+import React, {useEffect, useState} from 'react'
+import graphql from 'babel-plugin-relay/macro'
+import {useDialogState} from '../../ui/Dialog/useDialogState'
+import SecondaryButton from '../SecondaryButton'
+import GcalModal from '../../modules/userDashboard/components/GcalModal/GcalModal'
+import {CreateGcalEventInput} from '../../__generated__/StartRetrospectiveMutation.graphql'
+import GcalClientManager from '../../utils/GcalClientManager'
+import useAtmosphere from '../../hooks/useAtmosphere'
+import {useFragment} from 'react-relay'
+import {ScheduleMeetingButton_team$key} from '~/__generated__/ScheduleMeetingButton_team.graphql'
+import {ScheduleMeetingButton_viewer$key} from '~/__generated__/ScheduleMeetingButton_viewer.graphql'
+import {MenuMutationProps} from '../../hooks/useMutationProps'
+
+type Props = {
+  mutationProps: MenuMutationProps
+  handleStartActivity: (gcalInput?: CreateGcalEventInput) => void
+  teamRef: ScheduleMeetingButton_team$key
+  viewerRef: ScheduleMeetingButton_viewer$key
+}
+
+const ScheduleMeetingButton = (props: Props) => {
+  const {mutationProps, handleStartActivity, teamRef, viewerRef} = props
+  const {
+    isOpen: isScheduleDialogOpen,
+    open: openScheduleDialog,
+    close: closeScheduleDialog
+  } = useDialogState()
+  const atmosphere = useAtmosphere()
+  const [hasStartedGcalAuth, setHasStartedGcalAuth] = useState(false)
+  const {submitting} = mutationProps
+
+  const viewer = useFragment(
+    graphql`
+      fragment ScheduleMeetingButton_viewer on User {
+        featureFlags {
+          gcal
+        }
+      }
+    `,
+    viewerRef
+  )
+  const hasGcalFlag = viewer.featureFlags.gcal
+
+  const team = useFragment(
+    graphql`
+      fragment ScheduleMeetingButton_team on Team {
+        id
+        teamMembers {
+          isSelf
+          integrations {
+            gcal {
+              auth {
+                id
+              }
+              cloudProvider {
+                id
+                clientId
+              }
+            }
+          }
+        }
+        ...GcalModal_team
+      }
+    `,
+    teamRef
+  )
+  const {id: teamId, teamMembers} = team
+  const viewerGcalIntegration = teamMembers.find((teamMember) => teamMember.isSelf)?.integrations
+    .gcal
+
+  const handleClick = () => {
+    if (viewerGcalIntegration?.auth) {
+      openScheduleDialog()
+    } else if (viewerGcalIntegration?.cloudProvider) {
+      const {cloudProvider} = viewerGcalIntegration
+      const {clientId, id: providerId} = cloudProvider
+      GcalClientManager.openOAuth(atmosphere, providerId, clientId, teamId, mutationProps)
+      setHasStartedGcalAuth(true)
+    }
+  }
+
+  useEffect(() => {
+    if (hasStartedGcalAuth && viewerGcalIntegration?.auth) {
+      openScheduleDialog()
+    }
+  }, [hasStartedGcalAuth, viewerGcalIntegration])
+
+  if (!hasGcalFlag) return null
+  return (
+    <>
+      <SecondaryButton onClick={handleClick} waiting={submitting} className='h-14'>
+        <div className='text-lg'>Schedule</div>
+      </SecondaryButton>
+      <GcalModal
+        closeModal={closeScheduleDialog}
+        isOpen={isScheduleDialogOpen}
+        handleStartActivityWithGcalEvent={handleStartActivity}
+        teamRef={team}
+      />
+    </>
+  )
+}
+
+export default ScheduleMeetingButton

--- a/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
+++ b/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
@@ -45,7 +45,7 @@ const ScheduleMeetingButton = (props: Props) => {
     graphql`
       fragment ScheduleMeetingButton_team on Team {
         id
-        teamMembers {
+        viewerTeamMember {
           isSelf
           integrations {
             gcal {
@@ -64,11 +64,10 @@ const ScheduleMeetingButton = (props: Props) => {
     `,
     teamRef
   )
-  const {id: teamId, teamMembers} = team
+  const {id: teamId, viewerTeamMember} = team
   const hasStartedGcalAuth = hasStartedGcalAuthTeamId === teamId
 
-  const viewerGcalIntegration = teamMembers.find((teamMember) => teamMember.isSelf)?.integrations
-    .gcal
+  const viewerGcalIntegration = viewerTeamMember?.integrations.gcal
 
   const handleClick = () => {
     if (viewerGcalIntegration?.auth) {

--- a/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
+++ b/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
@@ -68,12 +68,12 @@ const ScheduleMeetingButton = (props: Props) => {
   const hasStartedGcalAuth = hasStartedGcalAuthTeamId === teamId
 
   const viewerGcalIntegration = viewerTeamMember?.integrations.gcal
+  const cloudProvider = viewerGcalIntegration?.cloudProvider
 
   const handleClick = () => {
     if (viewerGcalIntegration?.auth) {
       openScheduleDialog()
-    } else if (viewerGcalIntegration?.cloudProvider) {
-      const {cloudProvider} = viewerGcalIntegration
+    } else if (cloudProvider) {
       const {clientId, id: providerId} = cloudProvider
       GcalClientManager.openOAuth(atmosphere, providerId, clientId, teamId, mutationProps)
       setHasStartedGcalAuthTeamId(teamId)
@@ -86,7 +86,7 @@ const ScheduleMeetingButton = (props: Props) => {
     }
   }, [hasStartedGcalAuth, viewerGcalIntegration])
 
-  if (!hasGcalFlag) return null
+  if (!hasGcalFlag || !cloudProvider) return null
   return (
     <>
       <SecondaryButton onClick={handleClick} waiting={submitting} className='h-14'>

--- a/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
+++ b/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
@@ -26,7 +26,7 @@ const ScheduleMeetingButton = (props: Props) => {
     close: closeScheduleDialog
   } = useDialogState()
   const atmosphere = useAtmosphere()
-  const [hasStartedGcalAuth, setHasStartedGcalAuth] = useState(false)
+  const [hasStartedGcalAuthTeamId, setHasStartedGcalAuthTeamId] = useState<null | string>(null)
   const {submitting} = mutationProps
 
   const viewer = useFragment(
@@ -65,6 +65,8 @@ const ScheduleMeetingButton = (props: Props) => {
     teamRef
   )
   const {id: teamId, teamMembers} = team
+  const hasStartedGcalAuth = hasStartedGcalAuthTeamId === teamId
+
   const viewerGcalIntegration = teamMembers.find((teamMember) => teamMember.isSelf)?.integrations
     .gcal
 
@@ -75,7 +77,7 @@ const ScheduleMeetingButton = (props: Props) => {
       const {cloudProvider} = viewerGcalIntegration
       const {clientId, id: providerId} = cloudProvider
       GcalClientManager.openOAuth(atmosphere, providerId, clientId, teamId, mutationProps)
-      setHasStartedGcalAuth(true)
+      setHasStartedGcalAuthTeamId(teamId)
     }
   }
 

--- a/packages/server/graphql/public/typeDefs/Team.graphql
+++ b/packages/server/graphql/public/typeDefs/Team.graphql
@@ -160,4 +160,8 @@ type Team {
   Insights for the team, null if not enough data or feature flag isn't set
   """
   insights: TeamInsights
+  """
+  The team member that is the viewer
+  """
+  viewerTeamMember: TeamMember
 }

--- a/packages/server/graphql/public/types/Team.ts
+++ b/packages/server/graphql/public/types/Team.ts
@@ -1,5 +1,7 @@
 import {TeamResolvers} from '../resolverTypes'
 import TeamInsightsId from 'parabol-client/shared/gqlIds/TeamInsightsId'
+import toTeamMemberId from '../../../../client/utils/relay/toTeamMemberId'
+import {getUserId} from '../../../utils/authorization'
 
 const Team: TeamResolvers = {
   insights: async ({id, orgId, mostUsedEmojis}, _args, {dataLoader}) => {
@@ -11,6 +13,13 @@ const Team: TeamResolvers = {
       id: TeamInsightsId.join(id),
       mostUsedEmojis
     } as any
+  },
+  viewerTeamMember: async ({id: teamId}, _args, {authToken, dataLoader}) => {
+    const viewerId = getUserId(authToken)
+    if (!viewerId) return null
+    const teamMemberId = toTeamMemberId(teamId, viewerId)
+    const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
+    return teamMember
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8636

Demo: https://www.loom.com/share/30ebfc16554e41b2bdcbece0d9eba1a8

### To Test

- [ ] If a user doesn't have the gcal feature flag, they don't see the "Schedule" button
- [ ] If they do, but they haven't integrated with gcal, they get taken to the gcal auth page when they click "Schedule"
- [ ] After integrating with gcal, the modal opens automatically 
- [ ] If they have already integrated with gcal, the schedule button opens the gcal modal immediately 