### PR TITLE
feat(standups): "Your tasks" drawer with Parabol tasks

### DIFF
--- a/packages/client/components/IconLabel.tsx
+++ b/packages/client/components/IconLabel.tsx
@@ -22,6 +22,8 @@ import {
   Reply,
   Search,
   SentimentSatisfied,
+  TaskAlt,
+  Tune,
   UnfoldMore,
   WebAsset
 } from '@mui/icons-material'
@@ -95,7 +97,9 @@ const IconLabel = forwardRef((props: Props, ref: any) => {
             arrow_forward: <ArrowForward />,
             archive: <Archive />,
             close: <Close />,
-            publish: <Publish />
+            publish: <Publish />,
+            tune: <Tune />,
+            task_alt: <TaskAlt />
           }[icon]
         }
       </StyledIcon>

--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -44,7 +44,7 @@ const DiscussionResponseCard = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-  padding: '8px 8px 8px 12px',
+  padding: '16px 8px 8px 12px',
   width: '100%'
 })
 
@@ -52,7 +52,6 @@ const Header = styled('div')({
   display: 'flex',
   justifyContent: 'flex-start',
   flexDirection: 'row',
-  alignItems: 'center',
   padding: '0 8px'
 })
 
@@ -157,16 +156,18 @@ const TeamPromptDiscussionDrawer = ({meetingRef, onToggleDrawer}: Props) => {
     <>
       <DiscussionResponseCard>
         <Header>
-          <Avatar picture={teamMember.picture} size={48} />
-          <TeamMemberName>
-            {teamMember.preferredName}
-            {response && (
-              <TeamPromptLastUpdatedTime
-                updatedAt={response.updatedAt}
-                createdAt={response.createdAt}
-              />
-            )}
-          </TeamMemberName>
+          <div className='flex items-center'>
+            <Avatar picture={teamMember.picture} size={48} />
+            <TeamMemberName>
+              {teamMember.preferredName}
+              {response && (
+                <TeamPromptLastUpdatedTime
+                  updatedAt={response.updatedAt}
+                  createdAt={response.createdAt}
+                />
+              )}
+            </TeamMemberName>
+          </div>
           <StyledCloseButton onClick={onToggleDrawer}>
             <CloseIcon />
           </StyledCloseButton>

--- a/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
@@ -5,37 +5,42 @@ import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {TeamPromptDrawer_meeting$key} from '~/__generated__/TeamPromptDrawer_meeting.graphql'
 import {desktopSidebarShadow} from '../../styles/elevation'
-import {BezierCurve, DiscussionThreadEnum, ZIndex} from '../../types/constEnums'
+import {BezierCurve, Breakpoint, DiscussionThreadEnum, ZIndex} from '../../types/constEnums'
 import ResponsiveDashSidebar from '../ResponsiveDashSidebar'
 import TeamPromptDiscussionDrawer from './TeamPromptDiscussionDrawer'
 import TeamPromptWorkDrawerRoot from './TeamPromptWorkDrawerRoot'
+import useBreakpoint from '../../hooks/useBreakpoint'
 
-const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop, isOpen}) => ({
-  boxShadow: isDesktop ? desktopSidebarShadow : undefined,
-  backgroundColor: '#FFFFFF',
-  display: 'flex',
-  flex: 1,
-  flexDirection: 'column',
-  justifyContent: 'stretch',
-  overflow: 'hidden',
-  position: isDesktop ? 'fixed' : 'static',
-  bottom: 0,
-  top: 0,
-  right: isDesktop ? 0 : undefined,
-  userSelect: isDesktop ? undefined : 'none',
-  transition: `all 200ms ${BezierCurve.DECELERATE}`,
-  transform: `translateX(${
-    isOpen
-      ? `calc(${DiscussionThreadEnum.WIDTH}px - min(${DiscussionThreadEnum.WIDTH}px, 100vw))`
-      : `${DiscussionThreadEnum.WIDTH}px`
-  })`,
-  width: `min(${DiscussionThreadEnum.WIDTH}px, 100vw)`,
-  zIndex: ZIndex.SIDEBAR,
-  height: '100%',
-  '@supports (height: 1svh) and (height: 1lvh)': {
-    height: isDesktop ? '100lvh' : '100svh'
-  }
-}))
+const Drawer = styled('div')<{isDesktop: boolean; isMobile: boolean; isOpen: boolean}>(
+  ({isDesktop, isMobile, isOpen}) => ({
+    boxShadow: isDesktop ? desktopSidebarShadow : undefined,
+    backgroundColor: '#FFFFFF',
+    display: 'flex',
+    flex: 1,
+    flexDirection: 'column',
+    justifyContent: 'stretch',
+    overflow: 'hidden',
+    position: isDesktop ? 'fixed' : 'static',
+    bottom: 0,
+    top: 0,
+    right: isDesktop ? 0 : undefined,
+    userSelect: isDesktop ? undefined : 'none',
+    transition: `all 200ms ${BezierCurve.DECELERATE}`,
+    transform: `translateX(${
+      isOpen
+        ? isMobile
+          ? `calc(${DiscussionThreadEnum.WIDTH}px - 100vw)`
+          : 0
+        : `${DiscussionThreadEnum.WIDTH}px`
+    })`,
+    width: isMobile ? '100vw' : `min(${DiscussionThreadEnum.WIDTH}px, 100vw)`,
+    zIndex: ZIndex.SIDEBAR,
+    height: '100%',
+    '@supports (height: 1svh) and (height: 1lvh)': {
+      height: isDesktop ? '100lvh' : '100svh'
+    }
+  })
+)
 
 interface Props {
   meetingRef: TeamPromptDrawer_meeting$key
@@ -54,6 +59,7 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
     meetingRef
   )
 
+  const isMobile = !useBreakpoint(Breakpoint.FUZZY_TABLET)
   const atmosphere = useAtmosphere()
   const {id: meetingId, isRightDrawerOpen} = meeting
 
@@ -81,7 +87,7 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
       onToggle={onToggleDrawer}
       sidebarWidth={DiscussionThreadEnum.WIDTH}
     >
-      <Drawer isDesktop={isDesktop} isOpen={isRightDrawerOpen}>
+      <Drawer isDesktop={isDesktop} isMobile={isMobile} isOpen={isRightDrawerOpen}>
         {renderedInnerDrawer}
       </Drawer>
     </ResponsiveDashSidebar>

--- a/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
@@ -24,8 +24,12 @@ const Drawer = styled('div')<{isDesktop: boolean; isOpen: boolean}>(({isDesktop,
   right: isDesktop ? 0 : undefined,
   userSelect: isDesktop ? undefined : 'none',
   transition: `all 200ms ${BezierCurve.DECELERATE}`,
-  transform: `translateX(${isOpen ? 0 : DiscussionThreadEnum.WIDTH}px)`,
-  width: DiscussionThreadEnum.WIDTH,
+  transform: `translateX(${
+    isOpen
+      ? `calc(${DiscussionThreadEnum.WIDTH}px - min(${DiscussionThreadEnum.WIDTH}px, 100vw))`
+      : `${DiscussionThreadEnum.WIDTH}px`
+  })`,
+  width: `min(${DiscussionThreadEnum.WIDTH}px, 100vw)`,
   zIndex: ZIndex.SIDEBAR,
   height: '100%',
   '@supports (height: 1svh) and (height: 1lvh)': {

--- a/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
@@ -45,15 +45,13 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
         ...TeamPromptDiscussionDrawer_meeting
         id
         isRightDrawerOpen
-        localStageId
-        showWorkSidebar
       }
     `,
     meetingRef
   )
 
   const atmosphere = useAtmosphere()
-  const {id: meetingId, isRightDrawerOpen, localStageId, showWorkSidebar} = meeting
+  const {id: meetingId, isRightDrawerOpen} = meeting
 
   const onToggleDrawer = () => {
     commitLocalUpdate(atmosphere, (store) => {
@@ -64,22 +62,13 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
     })
   }
 
-  let renderedInnerDrawer: React.ReactNode | null = null
-  if (localStageId && showWorkSidebar) {
-    renderedInnerDrawer = (
-      <TeamPromptDiscussionDrawer meetingRef={meeting} onToggleDrawer={onToggleDrawer} />
-    ) ?? <TeamPromptWorkDrawerRoot onToggleDrawer={onToggleDrawer} />
-  } else if (localStageId) {
-    renderedInnerDrawer = (
-      <TeamPromptDiscussionDrawer meetingRef={meeting} onToggleDrawer={onToggleDrawer} />
-    )
-  } else if (showWorkSidebar) {
-    renderedInnerDrawer = <TeamPromptWorkDrawerRoot onToggleDrawer={onToggleDrawer} />
-  }
-
-  if (!renderedInnerDrawer) {
-    return null
-  }
+  // Render the discussion thread if it can be rendered, otherwise fall back on the work sidebar.
+  // :TRICKY: Elements rendered with JSX never return null, so we need to render both possible
+  // internal drawers via function calls in order to nullish coalesce. We also have to call both
+  // every time for the React hooks to be consistent.
+  const renderedDiscussionDrawer = TeamPromptDiscussionDrawer({meetingRef: meeting, onToggleDrawer})
+  const renderedWorkDrawer = TeamPromptWorkDrawerRoot({onToggleDrawer})
+  const renderedInnerDrawer = renderedDiscussionDrawer ?? renderedWorkDrawer
 
   return (
     <ResponsiveDashSidebar

--- a/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptions.tsx
@@ -15,15 +15,15 @@ import TeamPromptOptionsMenu from './TeamPromptOptionsMenu'
 const COPIED_TOOLTIP_DURATION_MS = 2000
 
 const OptionsButton = styled(BaseButton)({
-  color: PALETTE.SLATE_600,
+  color: PALETTE.SKY_500,
+  display: 'flex',
+  flexDirection: 'column',
   height: '100%',
-  aspectRatio: '1 / 1',
   opacity: 1,
-  borderRadius: '100%',
-  padding: 0,
+  padding: '0px 8px',
+  fontWeight: 600,
   ':hover, :focus, :active': {
-    color: PALETTE.SLATE_700,
-    backgroundColor: PALETTE.SLATE_300
+    color: PALETTE.SKY_600
   }
 })
 
@@ -35,12 +35,6 @@ interface Props {
 
 const TeamPromptOptions = (props: Props) => {
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
-  const {
-    tooltipPortal: optionsTooltipPortal,
-    openTooltip: openOptionsTooltip,
-    closeTooltip: closeOptionsTooltip,
-    originRef: optionsTooltipOriginRef
-  } = useTooltip<HTMLButtonElement>(MenuPosition.UPPER_CENTER)
   const {
     tooltipPortal: copiedTooltipPortal,
     openTooltip: openCopiedTooltip,
@@ -67,15 +61,10 @@ const TeamPromptOptions = (props: Props) => {
 
   return (
     <>
-      <OptionsButton
-        ref={mergeRefs(originRef, optionsTooltipOriginRef, copiedTooltipRef)}
-        onClick={togglePortal}
-        onMouseEnter={openOptionsTooltip}
-        onMouseLeave={closeOptionsTooltip}
-      >
-        <IconLabel ref={originRef} icon='more_vert' iconLarge />
+      <OptionsButton ref={mergeRefs(originRef, copiedTooltipRef)} onClick={togglePortal}>
+        <IconLabel ref={originRef} icon='tune' iconLarge />
+        <div className='text-slate-700'>Options</div>
       </OptionsButton>
-      {optionsTooltipPortal('Options')}
       {copiedTooltipPortal('Copied!')}
       {menuPortal(
         <TeamPromptOptionsMenu

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -162,6 +162,7 @@ const TeamPromptResponseCard = (props: Props) => {
         const meetingProxy = store.get(responseStage.meetingId)
         if (!meetingProxy) return
         meetingProxy.setValue(responseStage.id, 'localStageId')
+        meetingProxy.setValue(false, 'showWorkSidebar')
         meetingProxy.setValue(true, 'isRightDrawerOpen')
       })
     }

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -95,6 +95,8 @@ const TeamPromptTopBar = (props: Props) => {
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         id
         name
+        isRightDrawerOpen
+        showWorkSidebar
         facilitatorUserId
         prevMeeting {
           id
@@ -135,13 +137,22 @@ const TeamPromptTopBar = (props: Props) => {
   const isRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
 
   const onOpenWorkSidebar = () => {
-    commitLocalUpdate(atmosphere, (store) => {
-      const meetingProxy = store.get(meetingId)
-      if (!meetingProxy) return
-      meetingProxy.setValue(null, 'localStageId')
-      meetingProxy.setValue(true, 'showWorkSidebar')
-      meetingProxy.setValue(true, 'isRightDrawerOpen')
-    })
+    if (meeting.isRightDrawerOpen && meeting.showWorkSidebar) {
+      // If we're selecting a discussion that's already open, just close the drawer.
+      commitLocalUpdate(atmosphere, (store) => {
+        const meetingProxy = store.get(meetingId)
+        if (!meetingProxy) return
+        meetingProxy.setValue(false, 'isRightDrawerOpen')
+      })
+    } else {
+      commitLocalUpdate(atmosphere, (store) => {
+        const meetingProxy = store.get(meetingId)
+        if (!meetingProxy) return
+        meetingProxy.setValue(null, 'localStageId')
+        meetingProxy.setValue(true, 'showWorkSidebar')
+        meetingProxy.setValue(true, 'isRightDrawerOpen')
+      })
+    }
   }
 
   const buttons = (

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {Link} from 'react-router-dom'
 import React from 'react'
-import {useFragment} from 'react-relay'
+import {commitLocalUpdate, useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {useRenameMeeting} from '~/hooks/useRenameMeeting'
 import NewMeetingAvatarGroup from '~/modules/meeting/components/MeetingAvatarGroup/NewMeetingAvatarGroup'
@@ -18,6 +18,7 @@ import {EndRecurringMeetingModal} from './Recurrence/EndRecurringMeetingModal'
 import {TeamPromptMeetingStatus} from './TeamPromptMeetingStatus'
 import TeamPromptOptions from './TeamPromptOptions'
 import {KeyboardArrowLeft, KeyboardArrowRight} from '@mui/icons-material'
+import IconLabel from '../IconLabel'
 
 const TeamPromptLogoBlock = styled(LogoBlock)({
   marginRight: '8px',
@@ -72,7 +73,7 @@ const ButtonContainer = styled('div')({
   alignItems: 'center',
   justifyContent: 'center',
   display: 'flex',
-  height: 32,
+  marginLeft: '16px',
   [meetingAvatarMediaQueries[0]]: {
     height: 48,
     marginLeft: 10
@@ -84,11 +85,10 @@ const ButtonContainer = styled('div')({
 
 interface Props {
   meetingRef: TeamPromptTopBar_meeting$key
-  isDesktop: boolean
 }
 
 const TeamPromptTopBar = (props: Props) => {
-  const {meetingRef, isDesktop} = props
+  const {meetingRef} = props
 
   const meeting = useFragment(
     graphql`
@@ -134,74 +134,103 @@ const TeamPromptTopBar = (props: Props) => {
   const {handleSubmit, validate, error} = useRenameMeeting(meetingId)
   const isRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
 
+  const onOpenWorkSidebar = () => {
+    commitLocalUpdate(atmosphere, (store) => {
+      const meetingProxy = store.get(meetingId)
+      if (!meetingProxy) return
+      meetingProxy.setValue(null, 'localStageId')
+      meetingProxy.setValue(true, 'showWorkSidebar')
+      meetingProxy.setValue(true, 'isRightDrawerOpen')
+    })
+  }
+
+  const buttons = (
+    <ButtonContainer>
+      <button
+        className='group flex h-max w-max cursor-pointer flex-col items-center px-2 text-sm font-semibold text-sky-500 hover:text-sky-600'
+        onClick={onOpenWorkSidebar}
+      >
+        <IconLabel icon='task_alt' iconLarge />
+        <div className='text-slate-700 group-hover:text-slate-900'>Your tasks</div>
+      </button>
+      <TeamPromptOptions
+        meetingRef={meeting}
+        openRecurrenceSettingsModal={toggleRecurrenceSettingsModal}
+        openEndRecurringMeetingModal={toggleEndRecurringMeetingModal}
+      />
+    </ButtonContainer>
+  )
+
   return (
-    <MeetingTopBarStyles>
-      <MeetingTitleSection>
-        <TeamPromptLogoBlock />
-        <div>
-          <div className='flex w-max gap-1'>
-            {isRecurrenceEnabled && prevMeeting && (
-              <Link className='text-slate-600' to={`/meet/${prevMeeting.id}`}>
-                <KeyboardArrowLeft />
-              </Link>
-            )}
-            <div>
-              {isFacilitator ? (
-                <EditableTeamPromptHeaderTitle
-                  error={error?.message}
-                  handleSubmit={handleSubmit}
-                  initialValue={meetingName}
-                  isWrap
-                  maxLength={50}
-                  validate={validate}
-                  placeholder={'Best Meeting Ever!'}
-                />
-              ) : (
-                <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
+    <>
+      <MeetingTopBarStyles>
+        <MeetingTitleSection>
+          <TeamPromptLogoBlock />
+          <div>
+            <div className='flex w-max gap-1'>
+              {isRecurrenceEnabled && prevMeeting && (
+                <Link className='text-slate-600' to={`/meet/${prevMeeting.id}`}>
+                  <KeyboardArrowLeft />
+                </Link>
               )}
-              {isRecurrenceEnabled && (
-                <HumanReadableRecurrenceRule recurrenceRule={meetingSeries.recurrenceRule} />
+              <div>
+                {isFacilitator ? (
+                  <EditableTeamPromptHeaderTitle
+                    error={error?.message}
+                    handleSubmit={handleSubmit}
+                    initialValue={meetingName}
+                    isWrap
+                    maxLength={50}
+                    validate={validate}
+                    placeholder={'Best Meeting Ever!'}
+                  />
+                ) : (
+                  <TeamPromptHeaderTitle>{meetingName}</TeamPromptHeaderTitle>
+                )}
+                {isRecurrenceEnabled && (
+                  <div className='hidden md:block'>
+                    <HumanReadableRecurrenceRule recurrenceRule={meetingSeries.recurrenceRule} />
+                  </div>
+                )}
+              </div>
+              {isRecurrenceEnabled && nextMeeting && (
+                <Link className='text-slate-600' to={`/meet/${nextMeeting.id}`}>
+                  <KeyboardArrowRight />
+                </Link>
               )}
             </div>
-            {isRecurrenceEnabled && nextMeeting && (
-              <Link className='text-slate-600' to={`/meet/${nextMeeting.id}`}>
-                <KeyboardArrowRight />
-              </Link>
-            )}
           </div>
-        </div>
-      </MeetingTitleSection>
-      {isDesktop && (
-        <MiddleSection>
+        </MeetingTitleSection>
+        <MiddleSection className='hidden md:flex'>
           <TeamPromptMeetingStatus meetingRef={meeting} />
         </MiddleSection>
-      )}
-      <RightSection>
-        <RightSectionContainer>
-          <NewMeetingAvatarGroup meetingRef={meeting} />
-          <ButtonContainer>
-            <TeamPromptOptions
-              meetingRef={meeting}
-              openRecurrenceSettingsModal={toggleRecurrenceSettingsModal}
-              openEndRecurringMeetingModal={toggleEndRecurringMeetingModal}
-            />
-          </ButtonContainer>
-        </RightSectionContainer>
-      </RightSection>
-      {recurrenceSettingsModal(
-        <UpdateRecurrenceSettingsModal
-          meeting={meeting}
-          closeModal={toggleRecurrenceSettingsModal}
-        />
-      )}
-      {endRecurringMeetingModal(
-        <EndRecurringMeetingModal
-          meetingId={meetingId}
-          recurrenceRule={isRecurrenceEnabled ? meetingSeries.recurrenceRule : undefined}
-          closeModal={toggleEndRecurringMeetingModal}
-        />
-      )}
-    </MeetingTopBarStyles>
+        <RightSection>
+          <RightSectionContainer>
+            <NewMeetingAvatarGroup meetingRef={meeting} />
+            <div className='hidden md:block'>{buttons}</div>
+          </RightSectionContainer>
+        </RightSection>
+        {recurrenceSettingsModal(
+          <UpdateRecurrenceSettingsModal
+            meeting={meeting}
+            closeModal={toggleRecurrenceSettingsModal}
+          />
+        )}
+        {endRecurringMeetingModal(
+          <EndRecurringMeetingModal
+            meetingId={meetingId}
+            recurrenceRule={isRecurrenceEnabled ? meetingSeries.recurrenceRule : undefined}
+            closeModal={toggleEndRecurringMeetingModal}
+          />
+        )}
+      </MeetingTopBarStyles>
+      <div className='block flex justify-between border-y border-solid border-slate-300 px-4 py-2 md:hidden'>
+        <div className='my-1'>
+          <TeamPromptMeetingStatus meetingRef={meeting} />
+        </div>
+        {buttons}
+      </div>
+    </>
   )
 }
 

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -1,0 +1,108 @@
+import {Close} from '@mui/icons-material'
+import graphql from 'babel-plugin-relay/macro'
+import React, {useState} from 'react'
+import {PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import {
+  TaskStatusEnum,
+  TeamPromptWorkDrawerQuery
+} from '../../__generated__/TeamPromptWorkDrawerQuery.graphql'
+import NullableTask from '../NullableTask/NullableTask'
+import {TaskStatus} from '../../types/constEnums'
+import clsx from 'clsx'
+import {meetingColumnArray} from '../../utils/constants'
+import {taskStatusLabels} from '../../utils/taskStatus'
+import halloweenRetrospectiveTemplate from '../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
+
+interface Props {
+  queryRef: PreloadedQuery<TeamPromptWorkDrawerQuery>
+  onToggleDrawer: () => void
+}
+
+const TeamPromptWorkDrawer = (props: Props) => {
+  const {queryRef, onToggleDrawer} = props
+  const data = usePreloadedQuery<TeamPromptWorkDrawerQuery>(
+    graphql`
+      query TeamPromptWorkDrawerQuery($after: DateTime, $userIds: [ID!]) {
+        viewer {
+          tasks(first: 1000, after: $after, userIds: $userIds)
+            @connection(key: "UserColumnsContainer_tasks", filters: ["userIds"]) {
+            edges {
+              node {
+                ...NullableTask_task
+                # grab these so we can sort correctly
+                id
+                content
+                plaintextContent
+                status
+                sortOrder
+                teamId
+                userId
+              }
+            }
+          }
+        }
+      }
+    `,
+    queryRef
+  )
+  const {viewer} = data
+  const {tasks} = viewer
+
+  const [selectedStatus, setSelectedStatus] = useState<TaskStatusEnum>(TaskStatus.DONE)
+  const selectedTasks = tasks.edges
+    .map((edge) => edge.node)
+    .filter((task) => task.status === selectedStatus)
+
+  return (
+    <>
+      <div className='px-4 pt-4'>
+        <div className='flex justify-between pr-4'>
+          <div className='text-base font-semibold'>Your Tasks</div>
+          <div className='cursor-pointer text-slate-600 hover:opacity-50' onClick={onToggleDrawer}>
+            <Close />
+          </div>
+        </div>
+        <div className='my-4 flex gap-2'>
+          {meetingColumnArray.map((status) => (
+            <div
+              key={status}
+              className={clsx(
+                'flex-shrink-0 cursor-pointer rounded-full py-2 px-4 text-sm leading-3 text-slate-800',
+                status === selectedStatus
+                  ? 'bg-grape-700 font-semibold text-white focus:text-white'
+                  : 'border border-slate-300 bg-white'
+              )}
+              onClick={() => setSelectedStatus(status)}
+            >
+              {taskStatusLabels[status]}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className='flex h-full flex-col items-center gap-y-2 overflow-auto px-4 pt-1 pb-4'>
+        {selectedTasks.length > 0 ? (
+          selectedTasks.map((task) => (
+            <NullableTask
+              className='w-full rounded border border-solid border-slate-100'
+              key={task.id}
+              dataCy='foo'
+              area={'userDash'}
+              task={task}
+            />
+          ))
+        ) : (
+          <div className='-mt-14 flex h-full flex-col items-center justify-center'>
+            <img className='w-20' src={halloweenRetrospectiveTemplate} />
+            <div className='mt-7'>
+              You don’t have any <b>{taskStatusLabels[selectedStatus]}</b> tasks.
+              <br />
+              Try adding new tasks below.
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+export default TeamPromptWorkDrawer

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -50,7 +50,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
   return (
     <>
       <div className='px-4 pt-4'>
-        <div className='flex justify-between pr-4'>
+        <div className='flex justify-between'>
           <div className='text-base font-semibold'>Your Tasks</div>
           <div className='cursor-pointer text-slate-600 hover:opacity-50' onClick={onToggleDrawer}>
             <Close />

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -29,14 +29,8 @@ const TeamPromptWorkDrawer = (props: Props) => {
             edges {
               node {
                 ...NullableTask_task
-                # grab these so we can sort correctly
                 id
-                content
-                plaintextContent
                 status
-                sortOrder
-                teamId
-                userId
               }
             }
           }

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawerRoot.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawerRoot.tsx
@@ -1,0 +1,30 @@
+import React, {Suspense} from 'react'
+import useAtmosphere from '../../hooks/useAtmosphere'
+import useQueryLoaderNow from '../../hooks/useQueryLoaderNow'
+import teamPromptWorkDrawerQuery, {
+  TeamPromptWorkDrawerQuery
+} from '../../__generated__/TeamPromptWorkDrawerQuery.graphql'
+import ErrorBoundary from '../ErrorBoundary'
+import TeamPromptWorkDrawer from './TeamPromptWorkDrawer'
+import {renderLoader} from '~/utils/relay/renderLoader'
+
+interface Props {
+  onToggleDrawer: () => void
+}
+
+const TeamPromptWorkDrawerRoot = (props: Props) => {
+  const {onToggleDrawer} = props
+  const atmosphere = useAtmosphere()
+  const queryRef = useQueryLoaderNow<TeamPromptWorkDrawerQuery>(teamPromptWorkDrawerQuery, {
+    userIds: [atmosphere.viewerId]
+  })
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={renderLoader()}>
+        {queryRef && <TeamPromptWorkDrawer queryRef={queryRef} onToggleDrawer={onToggleDrawer} />}
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+
+export default TeamPromptWorkDrawerRoot

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -17,13 +17,12 @@ import MeetingContent from './MeetingContent'
 import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import MeetingLockedOverlay from './MeetingLockedOverlay'
 import MeetingStyles from './MeetingStyles'
-import TeamPromptDiscussionDrawer from './TeamPrompt/TeamPromptDiscussionDrawer'
+import TeamPromptDrawer from './TeamPrompt/TeamPromptDrawer'
 import TeamPromptEditablePrompt from './TeamPrompt/TeamPromptEditablePrompt'
 import {
   GRID_PADDING_LEFT_RIGHT_PERCENT,
   ResponsesGridBreakpoints
 } from './TeamPrompt/TeamPromptGridDimensions'
-import {TeamPromptMeetingStatus} from './TeamPrompt/TeamPromptMeetingStatus'
 import TeamPromptResponseCard from './TeamPrompt/TeamPromptResponseCard'
 import TeamPromptTopBar from './TeamPrompt/TeamPromptTopBar'
 
@@ -46,13 +45,6 @@ const ResponsesGrid = styled('div')({
   gap: 32
 })
 
-const BadgeContainer = styled('div')({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  marginTop: 16
-})
-
 interface Props {
   meeting: TeamPromptMeeting_meeting$key
 }
@@ -70,7 +62,7 @@ const TeamPromptMeeting = (props: Props) => {
       fragment TeamPromptMeeting_meeting on TeamPromptMeeting {
         ...useMeeting_meeting
         ...TeamPromptTopBar_meeting
-        ...TeamPromptDiscussionDrawer_meeting
+        ...TeamPromptDrawer_meeting
         ...TeamPromptEditablePrompt_meeting
         ...TeamPromptMeetingStatus_meeting
         ...MeetingLockedOverlay_meeting
@@ -164,10 +156,7 @@ const TeamPromptMeeting = (props: Props) => {
               isOpen={isRightDrawerOpen && isDesktop}
               hideBottomBar={true}
             >
-              <TeamPromptTopBar meetingRef={meeting} isDesktop={isDesktop} />
-              {!isDesktop && (
-                <BadgeContainer>{<TeamPromptMeetingStatus meetingRef={meeting} />}</BadgeContainer>
-              )}
+              <TeamPromptTopBar meetingRef={meeting} />
               <TeamPromptEditablePrompt meetingRef={meeting} />
               <ErrorBoundary>
                 <ResponsesGridContainer>
@@ -190,7 +179,7 @@ const TeamPromptMeeting = (props: Props) => {
                 </ResponsesGridContainer>
               </ErrorBoundary>
             </StyledMeetingHeaderAndPhase>
-            <TeamPromptDiscussionDrawer meetingRef={meeting} isDesktop={isDesktop} />
+            <TeamPromptDrawer meetingRef={meeting} isDesktop={isDesktop} />
           </MeetingContent>
         </Suspense>
       </MeetingArea>

--- a/packages/client/schemaExtensions/clientSchema.graphql
+++ b/packages/client/schemaExtensions/clientSchema.graphql
@@ -44,6 +44,7 @@ extend type RetrospectiveMeeting {
 extend type TeamPromptMeeting {
   localStageId: String
   isRightDrawerOpen: Boolean!
+  showWorkSidebar: Boolean!
 }
 
 extend type Team {

--- a/packages/client/styles/helpers/cardRootStyles.ts
+++ b/packages/client/styles/helpers/cardRootStyles.ts
@@ -7,7 +7,6 @@ const cardRootStyles = {
   borderRadius: Card.BORDER_RADIUS,
   boxShadow: cardShadow,
   minWidth: 256,
-  maxWidth: 296,
   position: 'relative' as const,
   width: '100%'
 }


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8679

Implement the "Your tasks" drawer to show a user's Parabol tasks within a standup meeting, and update the topbar with the new "your tasks" button.

This PR does a few things to implement this:
1. Refactor the existing `TeamPromptDiscussionDrawer` into a `TeamPromptDrawer` and a `TeamPromptDiscussionDrawer`. The `TeamPromptDrawer` acts as the container for any components that exist in the drawer, handling things like overlay vs static sidebar, sliding in/out, etc.
  1. This is a sizeable chunk of the overall diff.
3. Adding a new `TeamPromptWorkDrawer` to hold all "your work" components, starting with Parabol tasks.
4. Refactors + updates components in the `TeamPromptTopBar` to match updated designs.

**I recommend reviewers review with whitespace hidden** due to the drawer refactor.

## Demo
https://www.loom.com/share/75f2739a64604199a785e203b8d9cb91?sid=4431ced3-cbed-4a74-913b-c8ef843f3ff3

## Testing scenarios
- [ ] Top bar is updated according to designs, including on mobile
- [ ] Click "Your tasks" button to open the sidebar
- [ ] Sidebar shows user's tasks from all teams. Click through each tab
- [ ] Move all tasks from a specific status into a different status, and check empty state for that status
- [ ] Add a task in a different window, and confirm task appears in sidebar with no refresh
- [ ] With task sidebar open, click "reply" on a response to transition to discussion sidebar, then click "your tasks" to transition back.
- [ ] Move a task to a different status, and confirm the task appears under the new status

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
