### PR TITLE
chore: Allow non-facilitator to advance to reflect phase

### DIFF
--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -106,7 +106,8 @@ const RetroMeetingSidebar = (props: Props) => {
             const {isComplete: isPrevItemStageComplete = true, readyCount = 0} = prevItemStage ?? {}
 
             const activeCount = meetingMembers.length
-            const isConfirmRequired = readyCount < activeCount - 1 && activeCount > 1
+            const isConfirmRequired =
+              isViewerFacilitator && readyCount < activeCount - 1 && activeCount > 1
 
             if (
               isComplete ||
@@ -141,7 +142,7 @@ const RetroMeetingSidebar = (props: Props) => {
                 key={phaseType}
                 phaseCount={phaseCount}
                 phaseType={phaseType}
-                isConfirming={confirmingPhase === phaseType}
+                isConfirming={isViewerFacilitator && confirmingPhase === phaseType}
               />
               <RetroSidebarPhaseListItemChildren
                 gotoStageId={gotoStageId}

--- a/packages/server/database/types/ReflectPhase.ts
+++ b/packages/server/database/types/ReflectPhase.ts
@@ -8,6 +8,13 @@ export default class ReflectPhase extends GenericMeetingPhase {
 
   constructor(public teamId: string, durations: number[] | undefined) {
     super('reflect')
-    this.stages = [new GenericMeetingStage({phaseType: REFLECT, durations})]
+    this.stages = [
+      new GenericMeetingStage({
+        phaseType: REFLECT,
+        durations,
+        isNavigable: true,
+        isNavigableByFacilitator: true
+      })
+    ]
   }
 }

--- a/packages/server/database/types/TeamHealthStage.ts
+++ b/packages/server/database/types/TeamHealthStage.ts
@@ -7,6 +7,6 @@ export default class TeamHealthStage extends GenericMeetingStage {
   isRevealed = false
 
   constructor(public question: string, public labels: string[], durations?: number[] | undefined) {
-    super({phaseType: 'TEAM_HEALTH', durations})
+    super({phaseType: 'TEAM_HEALTH', durations, isNavigable: true})
   }
 }


### PR DESCRIPTION
# Description

Fixes #8077

Open the reflect phase even if the facilitator is still on icebreaker or team health.

## Demo

https://www.loom.com/share/a076b547d34c42999662a6e32ef75bce?sid=d5abac53-7773-4b43-a329-ff8ac6d95d3e

## Testing scenarios

- start a retrospective with icebreaker or team health phase as facilitator Frank
- join with a non-facilitator user Nordberg
- Nordberg can advance to team health and reflect phase while Frank is still on icebreaker

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
