### PR TITLE
feat: Add "Is this helpful?" for insights

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/MostUsedEmojisCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/MostUsedEmojisCard.tsx
@@ -15,6 +15,7 @@ const MostUsedEmojisCard = (props: Props) => {
   const insights = useFragment(
     graphql`
       fragment MostUsedEmojisCard_insights on TeamInsights {
+        ...TeamInsightsCard_insights
         mostUsedEmojis {
           id
           count
@@ -30,7 +31,11 @@ const MostUsedEmojisCard = (props: Props) => {
   }
 
   return (
-    <TeamInsightsCard title='Favorite Reactions' tooltip='Your team’s most used emoji reactions'>
+    <TeamInsightsCard
+      teamInsightsRef={insights}
+      title='Favorite Reactions'
+      tooltip='Your team’s most used emoji reactions'
+    >
       {mostUsedEmojis.map((emoji) => {
         const {unicode, shortName} = getReactji(emoji.id)
         return (

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/MostUsedEmojisCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/MostUsedEmojisCard.tsx
@@ -1,0 +1,49 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {MostUsedEmojisCard_insights$key} from '~/__generated__/MostUsedEmojisCard_insights.graphql'
+import Tooltip from '../../../../components/Tooltip'
+import getReactji from '../../../../utils/getReactji'
+import TeamInsightsCard from './TeamInsightsCard'
+
+interface Props {
+  teamInsightsRef: MostUsedEmojisCard_insights$key
+}
+
+const MostUsedEmojisCard = (props: Props) => {
+  const {teamInsightsRef} = props
+  const insights = useFragment(
+    graphql`
+      fragment MostUsedEmojisCard_insights on TeamInsights {
+        mostUsedEmojis {
+          id
+          count
+        }
+      }
+    `,
+    teamInsightsRef
+  )
+
+  const {mostUsedEmojis} = insights
+  if (!mostUsedEmojis || mostUsedEmojis.length === 0) {
+    return null
+  }
+
+  return (
+    <TeamInsightsCard title='Favorite Reactions' tooltip='Your team’s most used emoji reactions'>
+      {mostUsedEmojis.map((emoji) => {
+        const {unicode, shortName} = getReactji(emoji.id)
+        return (
+          <div key={emoji.id} className='flex h-24 w-1/4 flex-col items-center justify-center'>
+            <Tooltip text={`:${shortName}:`}>
+              <div className='text-2xl'>{unicode}</div>
+            </Tooltip>
+            <div className='p-2 font-semibold'>{emoji.count}</div>
+          </div>
+        )
+      })}
+    </TeamInsightsCard>
+  )
+}
+
+export default MostUsedEmojisCard

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -2,9 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
-import Tooltip from '../../../../components/Tooltip'
-import {Info as InfoIcon} from '@mui/icons-material'
-import getReactji from '../../../../utils/getReactji'
+import MostUsedEmojisCard from './MostUsedEmojisCard'
 
 interface Props {
   teamInsightsRef: TeamDashInsights_insights$key
@@ -16,47 +14,17 @@ const TeamDashInsights = (props: Props) => {
     graphql`
       fragment TeamDashInsights_insights on TeamInsights {
         id
-        mostUsedEmojis {
-          id
-          count
-        }
+        ...MostUsedEmojisCard_insights
       }
     `,
     teamInsightsRef
   )
 
-  const {mostUsedEmojis} = insights
-
   return (
     <div>
       <h3 className='mb-0 pl-2 text-base font-semibold'>Team Insights</h3>
       <div className='flex w-full flex-wrap'>
-        {mostUsedEmojis && mostUsedEmojis.length > 0 && (
-          <div className='relative m-2 flex w-[320px] flex-col rounded bg-white drop-shadow'>
-            <div className='flex items-center justify-between'>
-              <div className='p-4 text-sm font-semibold text-slate-600'>Favorite Reactions</div>
-              <Tooltip text='Your team’s most used emoji reactions' className='pr-3 text-slate-600'>
-                <InfoIcon />
-              </Tooltip>
-            </div>
-            <div className='flex flex-row justify-center'>
-              {mostUsedEmojis.map((emoji) => {
-                const {unicode, shortName} = getReactji(emoji.id)
-                return (
-                  <div
-                    key={emoji.id}
-                    className='flex h-24 w-1/4 flex-col items-center justify-center'
-                  >
-                    <Tooltip text={`:${shortName}:`}>
-                      <div className='text-2xl'>{unicode}</div>
-                    </Tooltip>
-                    <div className='p-2 font-semibold'>{emoji.count}</div>
-                  </div>
-                )
-              })}
-            </div>
-          </div>
-        )}
+        <MostUsedEmojisCard teamInsightsRef={insights} />
       </div>
     </div>
   )

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import React, {ReactNode} from 'react'
+import React, {ReactNode, useState} from 'react'
 import {useFragment} from 'react-relay'
 import Tooltip from '../../../../components/Tooltip'
 import {Info as InfoIcon} from '@mui/icons-material'
@@ -9,6 +9,7 @@ import SendClientSegmentEventMutation from '../../../../mutations/SendClientSegm
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import {TeamInsightsCard_insights$key} from '../../../../__generated__/TeamInsightsCard_insights.graphql'
 import TeamInsightsId from '../../../../shared/gqlIds/TeamInsightsId'
+import clsx from 'clsx'
 
 interface Props {
   title: string
@@ -19,6 +20,7 @@ interface Props {
 
 const TeamInsightsCard = (props: Props) => {
   const {children, teamInsightsRef, title, tooltip} = props
+  const [isHelpful, setIsHelpful] = useState<boolean>()
 
   const insights = useFragment(
     graphql`
@@ -41,6 +43,7 @@ const TeamInsightsCard = (props: Props) => {
       teamId,
       isHelpfulInsight
     })
+    setIsHelpful(isHelpfulInsight)
   }
 
   return (
@@ -54,10 +57,16 @@ const TeamInsightsCard = (props: Props) => {
       <div className='flex flex-row justify-center'>{children}</div>
       <div className='flex items-center justify-center bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-600'>
         <div className='grow'>Is this helpful?</div>
-        <FlatButton className='mx-4 p-0 text-slate-500' onClick={() => trackClick(false)}>
+        <FlatButton
+          className={clsx('mx-4 p-0', isHelpful === false ? 'text-slate-800' : 'text-slate-500')}
+          onClick={() => trackClick(false)}
+        >
           <ThumbDown />
         </FlatButton>
-        <FlatButton className='p-0 text-slate-500' onClick={() => trackClick(true)}>
+        <FlatButton
+          className={clsx('p-0', isHelpful ? 'text-slate-800' : 'text-slate-500')}
+          onClick={() => trackClick(true)}
+        >
           <ThumbUp />
         </FlatButton>
       </div>

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
@@ -38,9 +38,10 @@ const TeamInsightsCard = (props: Props) => {
   const {viewerId} = atmosphere
 
   const trackClick = (isHelpfulInsight: boolean) => {
-    SendClientSegmentEventMutation(atmosphere, title, {
+    SendClientSegmentEventMutation(atmosphere, 'Insight Card Feedback Clicked', {
       viewerId,
       teamId,
+      insightTitle: title,
       isHelpfulInsight
     })
     setIsHelpful(isHelpfulInsight)

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
@@ -1,0 +1,38 @@
+import React, {ReactNode} from 'react'
+import Tooltip from '../../../../components/Tooltip'
+import {Info as InfoIcon} from '@mui/icons-material'
+import {ThumbUp, ThumbDown} from '@mui/icons-material'
+import FlatButton from '../../../../components/FlatButton'
+
+interface Props {
+  title: string
+  tooltip: string
+  children: ReactNode
+}
+
+const TeamInsightsCard = (props: Props) => {
+  const {children, title, tooltip} = props
+
+  return (
+    <div className='relative m-2 flex w-[320px] flex-col overflow-hidden rounded bg-white drop-shadow'>
+      <div className='flex items-center justify-between'>
+        <div className='p-4 text-sm font-semibold text-slate-600'>{title}</div>
+        <Tooltip text={tooltip} className='pr-3 text-slate-600'>
+          <InfoIcon />
+        </Tooltip>
+      </div>
+      <div className='flex flex-row justify-center'>{children}</div>
+      <div className='flex items-center justify-center bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-600'>
+        <div className='grow'>Is this helpful?</div>
+        <FlatButton className='mx-4 p-0 text-slate-500'>
+          <ThumbDown />
+        </FlatButton>
+        <FlatButton className='p-0 text-slate-700'>
+          <ThumbUp />
+        </FlatButton>
+      </div>
+    </div>
+  )
+}
+
+export default TeamInsightsCard

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamInsightsCard.tsx
@@ -1,17 +1,47 @@
+import graphql from 'babel-plugin-relay/macro'
 import React, {ReactNode} from 'react'
+import {useFragment} from 'react-relay'
 import Tooltip from '../../../../components/Tooltip'
 import {Info as InfoIcon} from '@mui/icons-material'
 import {ThumbUp, ThumbDown} from '@mui/icons-material'
 import FlatButton from '../../../../components/FlatButton'
+import SendClientSegmentEventMutation from '../../../../mutations/SendClientSegmentEventMutation'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
+import {TeamInsightsCard_insights$key} from '../../../../__generated__/TeamInsightsCard_insights.graphql'
+import TeamInsightsId from '../../../../shared/gqlIds/TeamInsightsId'
 
 interface Props {
   title: string
   tooltip: string
   children: ReactNode
+  teamInsightsRef: TeamInsightsCard_insights$key
 }
 
 const TeamInsightsCard = (props: Props) => {
-  const {children, title, tooltip} = props
+  const {children, teamInsightsRef, title, tooltip} = props
+
+  const insights = useFragment(
+    graphql`
+      fragment TeamInsightsCard_insights on TeamInsights {
+        id
+      }
+    `,
+    teamInsightsRef
+  )
+
+  const {id} = insights
+  const teamId = TeamInsightsId.split(id)
+
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
+
+  const trackClick = (isHelpfulInsight: boolean) => {
+    SendClientSegmentEventMutation(atmosphere, title, {
+      viewerId,
+      teamId,
+      isHelpfulInsight
+    })
+  }
 
   return (
     <div className='relative m-2 flex w-[320px] flex-col overflow-hidden rounded bg-white drop-shadow'>
@@ -24,10 +54,10 @@ const TeamInsightsCard = (props: Props) => {
       <div className='flex flex-row justify-center'>{children}</div>
       <div className='flex items-center justify-center bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-600'>
         <div className='grow'>Is this helpful?</div>
-        <FlatButton className='mx-4 p-0 text-slate-500'>
+        <FlatButton className='mx-4 p-0 text-slate-500' onClick={() => trackClick(false)}>
           <ThumbDown />
         </FlatButton>
-        <FlatButton className='p-0 text-slate-700'>
+        <FlatButton className='p-0 text-slate-500' onClick={() => trackClick(true)}>
           <ThumbUp />
         </FlatButton>
       </div>

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -51,7 +51,8 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     notificationType: {type: NotificationEnum},
     tier: {type: TierEnum},
     discussionTopicId: {type: GraphQLID},
-    teamIds: {type: GraphQLList(GraphQLID)}
+    teamIds: {type: GraphQLList(GraphQLID)},
+    isHelpfulInsight: {type: GraphQLBoolean}
   })
 })
 

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -52,6 +52,7 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     tier: {type: TierEnum},
     discussionTopicId: {type: GraphQLID},
     teamIds: {type: GraphQLList(GraphQLID)},
+    insightTitle: {type: GraphQLString},
     isHelpfulInsight: {type: GraphQLBoolean}
   })
 })


### PR DESCRIPTION
# Description

Fixes #8466
Add a team insights card with buttons for "Is this helpful?". Clicks are tracked via `sendSegmentEvent`.
Because this alone would not give any feedback to the user, I thought about how we could preserve the fact that they've voted already. The best solution would be to store the information in the `TeamMember`, but that would require the additional field, it would need to get queried and we'd need to have a custom mutation just for the button highlight.
I've chosen a simpler approach to just store it in local state of the component, so the user sees that something had happened, but next time they're free to vote again.

## Demo

![Screenshot from 2023-08-17 16-33-50](https://github.com/ParabolInc/parabol/assets/7331043/1acc6ab4-a954-4c98-b9da-14e2baea58c6)
https://www.loom.com/share/0530da3c9dd047be81c871a1866f15c2?sid=9ade9d27-45af-4b70-a9ab-5dbb0320b4d3

## Testing scenarios

- [ ] with insights shown, press up or down vote button and see the send segment event mutation firing
- [ ] you can manually set `Team.mostUsedEmojis` to
  ```
  [
    {
        "id": "heavy_plus_sign",
        "count": 13
    },
    {
        "id": "thinking_face",
        "count": 5
    }
  ]
  ```
  to make the card appear


## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
