### PR TITLE
fix(tiptap): Show <hr/> nodes

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -111,6 +111,14 @@ const StyledEditor = styled('div')`
     margin-block-start: 4px;
     margin-block-end: 4px;
   }
+
+  hr.ProseMirror-selectednode {
+    border-top: 1px solid #68cef8;
+  }
+
+  hr {
+    border-top: 1px solid ${PALETTE.SLATE_400};
+  }
 `
 
 interface Props {


### PR DESCRIPTION
# Description
Support `HorizontalRule` (`<hr/>`) nodes in tiptap.

See https://parabol.slack.com/archives/C03LL1JRFH8/p1692299915145879

## Demo
Normal:
<img width="526" alt="Screen Shot 2023-08-17 at 2 55 10 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/da615634-23fc-4de7-8b36-880311d30739">

Selected:
<img width="530" alt="Screen Shot 2023-08-17 at 3 01 11 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/68d4c19b-1d1a-4b57-8115-69453f50a1df">

## Testing scenarios
Type `---` on a new line in a standup and confirm you see a horizontal rule.
Confirm styles when selected.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
