### PR TITLE
chore(analytics): Route analytics identify calls through analytics.ts

### DIFF
--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -11,7 +11,6 @@ import {analytics} from '../../utils/analytics/analytics'
 import getActiveDomainForOrgId from '../../utils/getActiveDomainForOrgId'
 import getDomainFromEmail from '../../utils/getDomainFromEmail'
 import isCompanyDomain from '../../utils/isCompanyDomain'
-import segmentIo from '../../utils/segmentIo'
 import handleEnterpriseOrgQuantityChanges from './handleEnterpriseOrgQuantityChanges'
 import handleTeamOrgQuantityChanges from './handleTeamOrgQuantityChanges'
 import {getUserById} from '../../postgres/queries/getUsersByIds'
@@ -44,12 +43,9 @@ const changePause = (inactive: boolean) => async (_orgIds: string[], user: IUser
   const r = await getRethink()
   const {id: userId, email} = user
   inactive ? analytics.accountPaused(userId) : analytics.accountUnpaused(userId)
-  segmentIo.identify({
-    userId,
-    traits: {
-      email,
-      isActive: !inactive
-    }
+  analytics.identify(userId, {
+    email,
+    isActive: !inactive
   })
   return Promise.all([
     updateUser(

--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -43,7 +43,8 @@ const changePause = (inactive: boolean) => async (_orgIds: string[], user: IUser
   const r = await getRethink()
   const {id: userId, email} = user
   inactive ? analytics.accountPaused(userId) : analytics.accountUnpaused(userId)
-  analytics.identify(userId, {
+  analytics.identify({
+    userId,
     email,
     isActive: !inactive
   })

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -51,19 +51,17 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   ])
 
   // Identify the user so user properties are set before any events are sent
-  analytics.identify(
+  analytics.identify({
     userId,
-    {
-      createdAt,
-      email,
-      name: preferredName,
-      isActive: true,
-      featureFlags: experimentalFlags,
-      highestTier: tier,
-      isPatient0
-    },
-    segmentId
-  )
+    createdAt,
+    email,
+    name: preferredName,
+    isActive: true,
+    featureFlags: experimentalFlags,
+    highestTier: tier,
+    isPatient0,
+    anonymousId: segmentId
+  })
 
   const tms = [] as string[]
   if (isOrganic) {

--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -51,9 +51,9 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
   ])
 
   // Identify the user so user properties are set before any events are sent
-  segmentIo.identify({
+  analytics.identify(
     userId,
-    traits: {
+    {
       createdAt,
       email,
       name: preferredName,
@@ -62,8 +62,8 @@ const bootstrapNewUser = async (newUser: User, isOrganic: boolean, searchParams?
       highestTier: tier,
       isPatient0
     },
-    anonymousId: segmentId
-  })
+    segmentId
+  )
 
   const tms = [] as string[]
   if (isOrganic) {

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -77,7 +77,8 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
     socketId,
     tms
   })
-  analytics.identify(userId, {
+  analytics.identify({
+    userId,
     email: user.email,
     isActive: true,
     featureFlags: user.featureFlags,

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -7,7 +7,6 @@ import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
 import publish from '../../../utils/publish'
-import segmentIo from '../../../utils/segmentIo'
 import {MutationResolvers} from '../resolverTypes'
 
 export interface UserPresence {
@@ -15,6 +14,7 @@ export interface UserPresence {
   socketInstanceId: string
   socketId: string
 }
+
 const connectSocket: MutationResolvers['connectSocket'] = async (
   _source,
   {socketInstanceId},
@@ -77,15 +77,12 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
     socketId,
     tms
   })
-  segmentIo.identify({
-    userId,
-    traits: {
-      email: user.email,
-      isActive: true,
-      featureFlags: user.featureFlags,
-      highestTier: user.tier,
-      isPatient0: user.isPatient0
-    }
+  analytics.identify(userId, {
+    email: user.email,
+    isActive: true,
+    featureFlags: user.featureFlags,
+    highestTier: user.tier,
+    isPatient0: user.isPatient0
   })
   return user
 }

--- a/packages/server/graphql/public/mutations/updateUserProfile.ts
+++ b/packages/server/graphql/public/mutations/updateUserProfile.ts
@@ -6,7 +6,6 @@ import updateUser from '../../../postgres/queries/updateUser'
 import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId, isAuthenticated} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
-import segmentIo from '../../../utils/segmentIo'
 import standardError from '../../../utils/standardError'
 import {MutationResolvers} from '../resolverTypes'
 
@@ -63,13 +62,11 @@ const updateUserProfile: MutationResolvers['updateUserProfile'] = async (
   const user = await dataLoader.get('users').loadNonNull(userId)
   if (normalizedPreferredName) {
     analytics.accountNameChanged(userId, normalizedPreferredName)
-    segmentIo.identify({
-      userId,
-      traits: {
+    analytics.identify(userId, {
         email: user.email,
         name: normalizedPreferredName
       }
-    })
+    )
   }
 
   const teamIds = teamMembers.map(({teamId}) => teamId)

--- a/packages/server/graphql/public/mutations/updateUserProfile.ts
+++ b/packages/server/graphql/public/mutations/updateUserProfile.ts
@@ -63,10 +63,9 @@ const updateUserProfile: MutationResolvers['updateUserProfile'] = async (
   if (normalizedPreferredName) {
     analytics.accountNameChanged(userId, normalizedPreferredName)
     analytics.identify(userId, {
-        email: user.email,
-        name: normalizedPreferredName
-      }
-    )
+      email: user.email,
+      name: normalizedPreferredName
+    })
   }
 
   const teamIds = teamMembers.map(({teamId}) => teamId)

--- a/packages/server/graphql/public/mutations/updateUserProfile.ts
+++ b/packages/server/graphql/public/mutations/updateUserProfile.ts
@@ -62,7 +62,8 @@ const updateUserProfile: MutationResolvers['updateUserProfile'] = async (
   const user = await dataLoader.get('users').loadNonNull(userId)
   if (normalizedPreferredName) {
     analytics.accountNameChanged(userId, normalizedPreferredName)
-    analytics.identify(userId, {
+    analytics.identify({
+      userId,
       email: user.email,
       name: normalizedPreferredName
     })

--- a/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
+++ b/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
@@ -18,7 +18,7 @@ export class AmplitudeAnalytics {
     })
   }
 
-  identify(userId: string, anonymousId?: string, traits?: Record<string, any>) {
+  identify(userId: string, traits: Record<string, any>, anonymousId?: string) {
     // used as a failsafe for PPMIs
     if (!AMPLITUDE_WRITE_KEY) return
     const identity = new Identify()

--- a/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
+++ b/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
@@ -19,6 +19,8 @@ export class AmplitudeAnalytics {
   }
 
   identify(userId: string, anonymousId?: string, traits?: Record<string, any>) {
+    // used as a failsafe for PPMIs
+    if (!AMPLITUDE_WRITE_KEY) return
     const identity = new Identify()
 
     for (const trait in traits) {

--- a/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
+++ b/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
@@ -24,7 +24,7 @@ export class AmplitudeAnalytics {
     const {userId, anonymousId, ...traits} = options
     const identity = new Identify()
 
-    let trait: keyof Omit<IdentifyOptions, 'userId' | 'anonymousId'>
+    let trait: keyof typeof traits
     for (trait in traits) {
       const traitValue = traits[trait]
       if (traitValue !== undefined) {

--- a/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
+++ b/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
@@ -1,5 +1,5 @@
 import {identify, Identify, init, track} from '@amplitude/analytics-node'
-import {AnalyticsEvent} from '../analytics'
+import {AnalyticsEvent, IdentifyOptions} from '../analytics'
 import PROD from '../../../PROD'
 import {CacheWorker, DataLoaderBase} from '../../../graphql/DataLoaderCache'
 
@@ -18,13 +18,18 @@ export class AmplitudeAnalytics {
     })
   }
 
-  identify(userId: string, traits: Record<string, any>, anonymousId?: string) {
+  identify(options: IdentifyOptions) {
     // used as a failsafe for PPMIs
     if (!AMPLITUDE_WRITE_KEY) return
+    const {userId, anonymousId, ...traits} = options
     const identity = new Identify()
 
-    for (const trait in traits) {
-      identity.set(trait, traits[trait])
+    let trait: keyof Omit<IdentifyOptions, 'userId' | 'anonymousId'>
+    for (trait in traits) {
+      const traitValue = traits[trait]
+      if (traitValue !== undefined) {
+        identity.set(trait, traitValue.toString())
+      }
     }
 
     return identify(identity, {

--- a/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
+++ b/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
@@ -1,4 +1,4 @@
-import {init, track} from '@amplitude/analytics-node'
+import {identify, Identify, init, track} from '@amplitude/analytics-node'
 import {AnalyticsEvent} from '../analytics'
 import PROD from '../../../PROD'
 import {CacheWorker, DataLoaderBase} from '../../../graphql/DataLoaderCache'
@@ -15,6 +15,19 @@ export class AmplitudeAnalytics {
     init(AMPLITUDE_WRITE_KEY, {
       flushQueueSize: PROD ? 20 : 1,
       optOut: !AMPLITUDE_WRITE_KEY
+    })
+  }
+
+  identify(userId: string, anonymousId?: string, traits?: Record<string, any>) {
+    const identity = new Identify()
+
+    for (const trait in traits) {
+      identity.set(trait, traits[trait])
+    }
+
+    return identify(identity, {
+      user_id: userId,
+      device_id: anonymousId
     })
   }
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -23,6 +23,18 @@ export type MeetingSeriesAnalyticsProperties = Pick<
   'id' | 'duration' | 'recurrenceRule' | 'meetingType' | 'title'
 > & {teamId: string; facilitatorId: string}
 
+export type IdentifyOptions = {
+  userId: string
+  email: string
+  anonymousId?: string
+  name?: string
+  isActive?: boolean
+  featureFlags?: string[]
+  highestTier?: string
+  isPatient0?: boolean
+  createdAt?: Date
+}
+
 export type OrgTierChangeEventProperties = {
   orgId: string
   domain?: string
@@ -448,11 +460,9 @@ class Analytics {
     this.track(userId, 'Reset Groups Clicked', {meetingId, teamId})
   }
 
-  identify = (userId: string, traits: Record<string, any>, anonymousId?: string) => {
-    Promise.all([
-      this.amplitudeAnalytics.identify(userId, traits, anonymousId),
-      this.segmentAnalytics.identify(userId, traits, anonymousId)
-    ])
+  identify = (options: IdentifyOptions) => {
+    this.amplitudeAnalytics.identify(options)
+    this.segmentAnalytics.identify(options)
   }
 
   private track = (userId: string, event: AnalyticsEvent, properties?: Record<string, any>) => {

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -448,10 +448,10 @@ class Analytics {
     this.track(userId, 'Reset Groups Clicked', {meetingId, teamId})
   }
 
-  identify = (userId: string, anonymousId?: string, traits?: Record<string, any>) => {
+  identify = (userId: string, traits: Record<string, any>, anonymousId?: string) => {
     Promise.all([
-      this.amplitudeAnalytics.identify(userId, anonymousId, traits),
-      this.segmentAnalytics.identify(userId, anonymousId, traits)
+      this.amplitudeAnalytics.identify(userId, traits, anonymousId),
+      this.segmentAnalytics.identify(userId, traits, anonymousId)
     ])
   }
 

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -448,6 +448,13 @@ class Analytics {
     this.track(userId, 'Reset Groups Clicked', {meetingId, teamId})
   }
 
+  identify = (userId: string, anonymousId?: string, traits?: Record<string, any>) => {
+    Promise.all([
+      this.amplitudeAnalytics.identify(userId, anonymousId, traits),
+      this.segmentAnalytics.identify(userId, anonymousId, traits)
+    ])
+  }
+
   private track = (userId: string, event: AnalyticsEvent, properties?: Record<string, any>) => {
     const dataloader = getDataLoader()
     this.amplitudeAnalytics.track(userId, event, dataloader, properties)

--- a/packages/server/utils/analytics/segment/SegmentAnalytics.ts
+++ b/packages/server/utils/analytics/segment/SegmentAnalytics.ts
@@ -1,4 +1,4 @@
-import {AnalyticsEvent} from '../analytics'
+import {AnalyticsEvent, IdentifyOptions} from '../analytics'
 import segment from '../../segmentIo'
 import {CacheWorker, DataLoaderBase} from '../../../graphql/DataLoaderCache'
 
@@ -14,9 +14,10 @@ export class SegmentAnalytics {
     this.segmentIo = segment
   }
 
-  identify(userId: string, traits: Record<string, any>, anonymousId?: string) {
+  identify(options: IdentifyOptions) {
     // used as a failsafe for PPMIs
     if (!SEGMENT_WRITE_KEY) return
+    const {userId, anonymousId, ...traits} = options
     return this.segmentIo.identify({
       userId,
       traits,

--- a/packages/server/utils/analytics/segment/SegmentAnalytics.ts
+++ b/packages/server/utils/analytics/segment/SegmentAnalytics.ts
@@ -14,7 +14,7 @@ export class SegmentAnalytics {
     this.segmentIo = segment
   }
 
-  identify(userId: string, anonymousId?: string, traits?: Record<string, any>) {
+  identify(userId: string, traits: Record<string, any>, anonymousId?: string) {
     // used as a failsafe for PPMIs
     if (!SEGMENT_WRITE_KEY) return
     return this.segmentIo.identify({

--- a/packages/server/utils/analytics/segment/SegmentAnalytics.ts
+++ b/packages/server/utils/analytics/segment/SegmentAnalytics.ts
@@ -12,6 +12,14 @@ export class SegmentAnalytics {
     this.segmentIo = segment
   }
 
+  identify(userId: string, anonymousId?: string, traits?: Record<string, any>) {
+    return this.segmentIo.identify({
+      userId,
+      traits,
+      anonymousId
+    })
+  }
+
   track(
     userId: string,
     event: AnalyticsEvent,

--- a/packages/server/utils/analytics/segment/SegmentAnalytics.ts
+++ b/packages/server/utils/analytics/segment/SegmentAnalytics.ts
@@ -2,6 +2,8 @@ import {AnalyticsEvent} from '../analytics'
 import segment from '../../segmentIo'
 import {CacheWorker, DataLoaderBase} from '../../../graphql/DataLoaderCache'
 
+const {SEGMENT_WRITE_KEY} = process.env
+
 /**
  * Wrapper for segment providing a more typesafe interface
  */
@@ -13,6 +15,8 @@ export class SegmentAnalytics {
   }
 
   identify(userId: string, anonymousId?: string, traits?: Record<string, any>) {
+    // used as a failsafe for PPMIs
+    if (!SEGMENT_WRITE_KEY) return
     return this.segmentIo.identify({
       userId,
       traits,
@@ -26,6 +30,8 @@ export class SegmentAnalytics {
     dataloader: CacheWorker<DataLoaderBase>,
     properties?: any
   ) {
+    // used as a failsafe for PPMIs
+    if (!SEGMENT_WRITE_KEY) return
     return this.segmentIo.track(
       {
         userId,

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -40,7 +40,8 @@ const setUserTierForUserIds = async (userIds: string[]) => {
   const users = await getUsersByIds(userIds)
   users.forEach((user) => {
     user &&
-      analytics.identify(user.id, {
+      analytics.identify({
+        userId: user.id,
         email: user.email,
         highestTier: user.tier
       })

--- a/packages/server/utils/setUserTierForUserIds.ts
+++ b/packages/server/utils/setUserTierForUserIds.ts
@@ -4,7 +4,7 @@ import OrganizationUser from '../database/types/OrganizationUser'
 import {TierEnum} from '../postgres/queries/generated/updateUserQuery'
 import {getUsersByIds} from '../postgres/queries/getUsersByIds'
 import updateUserTiers from '../postgres/queries/updateUserTiers'
-import segmentIo from './segmentIo'
+import {analytics} from './analytics/analytics'
 
 const setUserTierForUserIds = async (userIds: string[]) => {
   const r = await getRethink()
@@ -40,12 +40,9 @@ const setUserTierForUserIds = async (userIds: string[]) => {
   const users = await getUsersByIds(userIds)
   users.forEach((user) => {
     user &&
-      segmentIo.identify({
-        userId: user.id,
-        traits: {
-          email: user.email,
-          highestTier: user.tier
-        }
+      analytics.identify(user.id, {
+        email: user.email,
+        highestTier: user.tier
       })
   })
 }


### PR DESCRIPTION
# Description

Fixes #8680.  As part of our migration to Amplitude for analytics, this PR centralizes all `identify()` calls in analytics.ts instead of calling `segmentIo` directly, and makes `identify()` calls to Segment and Amplitude in parallel.  Segment writes will later be removed when we address #8677.

## Testing scenarios

- Get the development environment Amplitude write key from [here](https://app.amplitude.com/data/parabol/Parabol%20Production/sources/development) and save as the env var `AMPLITUDE_WRITE_KEY`
- Open any page and verify that the `Connect Websocket` event fires in both:
  - [ ] Amplitude - You can use the ingestion debugging page found [here](https://app.amplitude.com/data/parabol/Parabol%20Production/sources/development)
  - [ ] Segment - You can verify [here](https://app.segment.com/parabol-jordan/sources/actiondevelopment/debugger)
- Check that the `identify()` calls work properly by:
  - [ ] Amplitude - Confirm on the [User Lookup Page](https://app.amplitude.com/analytics/parabol/activity) that the connect websocket event has your `email`, `isActive`, `featureFlags`, `highestTier`, and `isPatient0` properties set.
  - [ ] Segment - Use the [debugger](https://app.segment.com/parabol-jordan/sources/actiondevelopment/debugger) to verify the same properties are set via an `identify()` call.
