### PR TITLE
fix(ai-summary): update the prompt to emphasize brevity

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -62,6 +62,7 @@ class OpenAIServerManager {
     const prompt = `Below is a newline delimited text from a ${location}.
     Summarize the text for the meeting facilitator in one or two sentences.
     When referring to people in the summary, do not assume their gender and default to using the pronouns "they" and "them".
+    Aim for brevity and clarity. If your summary exceeds 50 characters, iterate until it fits while retaining the essence. Your final response should only include the shortened summary.
 
     Text: """
     ${textStr}


### PR DESCRIPTION
## Description
At first I tried a step approach and that worked pretty well. I then asked ChatGPT to improve my prompt:

<img width="662" alt="Screenshot 2023-08-18 at 11 33 38" src="https://github.com/ParabolInc/parabol/assets/1879975/2cb3a5db-47fb-470f-871e-c653591e1900">

I then borrowed the last bit of the improved prompt.

## Demo/Test
I'm taking this discussion thread from production as a test case:

<img width="885" alt="Screenshot 2023-08-18 at 11 28 06" src="https://github.com/ParabolInc/parabol/assets/1879975/bd31d4f0-b308-4b6e-9d53-52ef1d71db42">


Using the prompt in Playground, together with the parameters we set, I can get shorter summary consistently:

<img width="855" alt="Screenshot 2023-08-18 at 11 29 48" src="https://github.com/ParabolInc/parabol/assets/1879975/28698d0e-bd4f-422b-b791-00167cf79cb5">


In the app:
<img width="1145" alt="Screenshot 2023-08-18 at 11 31 39" src="https://github.com/ParabolInc/parabol/assets/1879975/ca9aeab9-3fe3-4c0c-8042-db40c6ef0786">


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
