### PR TITLE
chore: first pass at lastUsedAt caching

### DIFF
--- a/packages/client/mutations/StartRetrospectiveMutation.ts
+++ b/packages/client/mutations/StartRetrospectiveMutation.ts
@@ -1,7 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitMutation} from 'react-relay'
-import {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
 import {StartRetrospectiveMutation as TStartRetrospectiveMutation} from '../__generated__/StartRetrospectiveMutation.graphql'
+import {HistoryLocalHandler, StandardMutation} from '../types/relayMutations'
 
 graphql`
   fragment StartRetrospectiveMutation_team on StartRetrospectiveSuccess {
@@ -10,6 +10,13 @@ graphql`
     }
     team {
       ...MeetingsDashActiveMeetings @relay(mask: false)
+      meetingSettings(meetingType: retrospective) {
+        ... on RetrospectiveMeetingSettings {
+          selectedTemplate {
+            subCategories
+          }
+        }
+      }
     }
   }
 `

--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -1,5 +1,5 @@
 import DataLoader from 'dataloader'
-import {sql} from 'kysely'
+import {Selectable, sql} from 'kysely'
 import {PARABOL_AI_USER_ID} from '../../client/utils/constants'
 import getRethink, {RethinkSchema} from '../database/rethinkDriver'
 import {RDatum} from '../database/stricterR'
@@ -9,6 +9,7 @@ import OrganizationUser from '../database/types/OrganizationUser'
 import {Reactable, ReactableEnum} from '../database/types/Reactable'
 import Task, {TaskStatusEnum} from '../database/types/Task'
 import getKysely from '../postgres/getKysely'
+import {TeamMeetingTemplate} from '../postgres/pg.d'
 import {IGetLatestTaskEstimatesQueryResult} from '../postgres/queries/generated/getLatestTaskEstimatesQuery'
 import getApprovedOrganizationDomainsByDomainFromPG from '../postgres/queries/getApprovedOrganizationDomainsByDomainFromPG'
 import getApprovedOrganizationDomainsFromPG from '../postgres/queries/getApprovedOrganizationDomainsFromPG'
@@ -27,8 +28,8 @@ import getMeetingTaskEstimates, {
 } from '../postgres/queries/getMeetingTaskEstimates'
 import {AnyMeeting, MeetingTypeEnum} from '../postgres/types/Meeting'
 import getRedis from '../utils/getRedis'
-import normalizeResults from './normalizeResults'
 import RootDataLoader from './RootDataLoader'
+import normalizeResults from './normalizeResults'
 
 export interface MeetingSettingsKey {
   teamId: string
@@ -431,31 +432,20 @@ export const meetingTemplatesByType = (parent: RootDataLoader) => {
 }
 
 // :TODO:(jmtaber129): Generalize this to all meeting types if needed.
-export const retroTemplateLastUsedByTeam = (parent: RootDataLoader) => {
-  return new DataLoader<string, Record<string, Date>, string>(
+export const teamMeetingTemplateByTeamId = (parent: RootDataLoader) => {
+  return new DataLoader<string, Selectable<TeamMeetingTemplate>[], string>(
     async (teamIds) => {
-      const r = await getRethink()
-      const groups = (await (
-        r
-          .table('NewMeeting')
-          .getAll(r.args(teamIds), {index: 'teamId'})
-          .filter({meetingType: 'retrospective'})
-          .group((row) => ({teamId: row('teamId'), templateId: row('templateId')})) as any
-      )
-        .map((row: RDatum<AnyMeeting>) => row('createdAt'))
-        .reduce((timeA: Date, timeB: Date) => (timeA > timeB ? timeA : timeB))
-        .ungroup()
-        .run()) as {group: {teamId: string; templateId: string}; reduction: Date}[]
-      const lookup: Record<string, Record<string, Date>> = {}
-      groups.forEach(({group, reduction}) => {
-        if (lookup[group.teamId]) {
-          lookup[group.teamId]![group.templateId] = reduction
-        } else {
-          lookup[group.teamId] = {[group.templateId]: reduction}
-        }
+      const pg = getKysely()
+      const teamMeetingTemplates = await pg
+        .selectFrom('TeamMeetingTemplate')
+        .selectAll()
+        .where('teamId', 'in', teamIds)
+        .execute()
+      return teamIds.map((teamId) => {
+        return teamMeetingTemplates.filter(
+          (teamMeetingTemplate) => teamMeetingTemplate.teamId === teamId
+        )
       })
-
-      return teamIds.map((teamId) => lookup[teamId] || {})
     },
     {
       ...parent.dataLoaderOptions

--- a/packages/server/graphql/mutations/startRetrospective.ts
+++ b/packages/server/graphql/mutations/startRetrospective.ts
@@ -94,7 +94,7 @@ export default {
     const template = await dataLoader.get('meetingTemplates').load(selectedTemplateId)
     await Promise.all([
       r.table('NewMeeting').insert(meeting).run(),
-      updateMeetingTemplateLastUsedAt(selectedTemplateId)
+      updateMeetingTemplateLastUsedAt(selectedTemplateId, teamId)
     ])
 
     // Disallow accidental starts (2 meetings within 2 seconds)

--- a/packages/server/graphql/mutations/startSprintPoker.ts
+++ b/packages/server/graphql/mutations/startSprintPoker.ts
@@ -135,7 +135,7 @@ export default {
     const template = await dataLoader.get('meetingTemplates').load(selectedTemplateId)
     await Promise.all([
       r.table('NewMeeting').insert(meeting).run(),
-      updateMeetingTemplateLastUsedAt(selectedTemplateId)
+      updateMeetingTemplateLastUsedAt(selectedTemplateId, teamId)
     ])
 
     // Disallow accidental starts (2 meetings within 2 seconds)

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -57,7 +57,6 @@ const ReflectTemplate: ReflectTemplateResolvers = {
       (tmt) => tmt.templateId === id
     )
 
-    //
     const lastUsedAtOnTeam = Math.max(
       ...orgTeamMeetingTemplatesForTemplateId
         .filter((row) => authToken.tms.includes(row.teamId))

--- a/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
+++ b/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
@@ -1,0 +1,70 @@
+import {sql} from 'kysely'
+import {Client} from 'pg'
+import {r} from 'rethinkdb-ts'
+import getKysely from '../getKysely'
+import getPgConfig from '../getPgConfig'
+
+interface TeamMeetingTemplate {
+  teamId: string
+  templateId: string
+  lastUsedAt: Date
+}
+
+const connectRethinkDB = async () => {
+  const {hostname: host, port, pathname} = new URL(process.env.RETHINKDB_URL!)
+  await r.connectPool({
+    host,
+    port: parseInt(port, 10),
+    db: pathname.split('/')[1]
+  })
+}
+
+export async function up() {
+  await connectRethinkDB()
+  const pg = getKysely()
+  await sql`
+  CREATE TABLE IF NOT EXISTS "TeamMeetingTemplate" (
+    "teamId" VARCHAR(100) NOT NULL,
+    "templateId" VARCHAR(100) NOT NULL,
+    "lastUsedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS "idx_TeamMeetingTemplate_teamId" ON "TeamMeetingTemplate"("teamId");
+  `.execute(pg)
+
+  // If we miss a new team or 2 that gets created while this is running that's OK!
+  // They don't have any used templates to start with
+  const teamIdsRes = await pg.selectFrom('Team').select('id').execute()
+  const teamIds = teamIdsRes.map((row) => row.id)
+  const BATCH_SIZE = 10000
+
+  for (let i = 0; i < 10000; i++) {
+    const start = i * BATCH_SIZE
+    const end = start + BATCH_SIZE
+    const teamIdBatch = teamIds.slice(start, end)
+    if (teamIdBatch.length === 0) break
+    const res = (await r
+      .table('NewMeeting')
+      .getAll(r.args(teamIdBatch), {index: 'teamId'})
+      .group((row) => ({teamId: row('teamId'), templateId: row('templateId')}))
+      .max('createdAt')('createdAt')
+      .ungroup()
+      .map((row) => ({
+        teamId: row('group')('teamId').default(null),
+        templateId: row('group')('templateId').default(null),
+        lastUsedAt: row('reduction')
+      }))
+      .filter((row: any) => row('templateId').default(null).ne(null))
+      .run()) as TeamMeetingTemplate[]
+    await pg.insertInto('TeamMeetingTemplate').values(res).execute()
+  }
+
+  await r.getPoolMaster()?.drain()
+  await pg.destroy()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`DROP TABLE IF EXISTS "TeamMeetingTemplate";`)
+  await client.end()
+}

--- a/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
+++ b/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
@@ -1,7 +1,7 @@
-import {sql} from 'kysely'
+import {Kysely, PostgresDialect, sql} from 'kysely'
 import {Client} from 'pg'
 import {r} from 'rethinkdb-ts'
-import getKysely from '../getKysely'
+import getPg from '../getPg'
 import getPgConfig from '../getPgConfig'
 
 interface TeamMeetingTemplate {
@@ -21,7 +21,11 @@ const connectRethinkDB = async () => {
 
 export async function up() {
   await connectRethinkDB()
-  const pg = getKysely()
+  const pg = new Kysely<any>({
+    dialect: new PostgresDialect({
+      pool: getPg()
+    })
+  })
   await sql`
   CREATE TABLE IF NOT EXISTS "TeamMeetingTemplate" (
     "teamId" VARCHAR(100) NOT NULL,

--- a/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
+++ b/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
@@ -26,21 +26,27 @@ export async function up() {
       pool: getPg()
     })
   })
-  console.log('1')
   await sql`
   CREATE TABLE IF NOT EXISTS "TeamMeetingTemplate" (
     "teamId" VARCHAR(100) NOT NULL,
     "templateId" VARCHAR(100) NOT NULL,
-    "lastUsedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+    "lastUsedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE ("teamId","templateId"),
+    CONSTRAINT "fk_teamId"
+      FOREIGN KEY("teamId")
+        REFERENCES "Team"("id")
+        ON DELETE CASCADE,
+    CONSTRAINT "fk_templateId"
+      FOREIGN KEY("templateId")
+        REFERENCES "MeetingTemplate"("id")
+        ON DELETE CASCADE
   );
   CREATE INDEX IF NOT EXISTS "idx_TeamMeetingTemplate_teamId" ON "TeamMeetingTemplate"("teamId");
   `.execute(pg)
-  console.log(2)
 
   // If we miss a new team or 2 that gets created while this is running that's OK!
   // They don't have any used templates to start with
   const teamIdsRes = await pg.selectFrom('Team').select('id').execute()
-  console.log(3)
   const teamIds = teamIdsRes.map((row) => row.id)
   const BATCH_SIZE = 10000
 
@@ -49,7 +55,6 @@ export async function up() {
     const end = start + BATCH_SIZE
     const teamIdBatch = teamIds.slice(start, end)
     if (teamIdBatch.length === 0) break
-    console.log(4 + i)
     const res = (await r
       .table('NewMeeting')
       .getAll(r.args(teamIdBatch), {index: 'teamId'})
@@ -63,8 +68,9 @@ export async function up() {
       }))
       .filter((row: any) => row('templateId').default(null).ne(null))
       .run()) as TeamMeetingTemplate[]
-    console.log('4a' + i)
-    await pg.insertInto('TeamMeetingTemplate').values(res).execute()
+    if (res.length > 0) {
+      await pg.insertInto('TeamMeetingTemplate').values(res).execute()
+    }
   }
 
   await r.getPoolMaster()?.drain()

--- a/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
+++ b/packages/server/postgres/migrations/1692650094687_TeamMeetingTemplate.ts
@@ -26,6 +26,7 @@ export async function up() {
       pool: getPg()
     })
   })
+  console.log('1')
   await sql`
   CREATE TABLE IF NOT EXISTS "TeamMeetingTemplate" (
     "teamId" VARCHAR(100) NOT NULL,
@@ -34,10 +35,12 @@ export async function up() {
   );
   CREATE INDEX IF NOT EXISTS "idx_TeamMeetingTemplate_teamId" ON "TeamMeetingTemplate"("teamId");
   `.execute(pg)
+  console.log(2)
 
   // If we miss a new team or 2 that gets created while this is running that's OK!
   // They don't have any used templates to start with
   const teamIdsRes = await pg.selectFrom('Team').select('id').execute()
+  console.log(3)
   const teamIds = teamIdsRes.map((row) => row.id)
   const BATCH_SIZE = 10000
 
@@ -46,6 +49,7 @@ export async function up() {
     const end = start + BATCH_SIZE
     const teamIdBatch = teamIds.slice(start, end)
     if (teamIdBatch.length === 0) break
+    console.log(4 + i)
     const res = (await r
       .table('NewMeeting')
       .getAll(r.args(teamIdBatch), {index: 'teamId'})
@@ -59,6 +63,7 @@ export async function up() {
       }))
       .filter((row: any) => row('templateId').default(null).ne(null))
       .run()) as TeamMeetingTemplate[]
+    console.log('4a' + i)
     await pg.insertInto('TeamMeetingTemplate').values(res).execute()
   }
 


### PR DESCRIPTION
# Description

fix #8581 speeds up queries for recently used activities

Before merging I think we should add in a little extra logic so templates can't appear in both popular and recently used, but I wanna leave out changes until we like the refactor.

## Demo

No visual difference 😕 
https://www.loom.com/share/e64150215e9d4067bd6c8232f48d4b8c?sid=1b6e632a-b893-48d2-97b1-1cecd0442ac1

## Testing scenarios

- [ ] look at the retros in your activity library before you run this branch, then checkout this branch & run the migration. you shouldn't see a change!

