### PR TITLE
feat(standups): rich text in slack notifications

### DIFF
--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -225,7 +225,7 @@ const addStandupResponsesToThread = async (
 
       const threadBlocks: Array<{type: string}> = [
         makeHeader(`${user.preferredName} responded:`),
-        makeSection(convertToMarkdown(response.content)),
+        makeSection(convertToMarkdown(response.content), true),
         makeButtons([{text: 'See their response', url: responseUrl, type: 'primary'}])
       ]
       const threadRes = await notifySlack(

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -16,7 +16,7 @@ import sendToSentry from '../../../../utils/sendToSentry'
 import SlackServerManager from '../../../../utils/SlackServerManager'
 import {DataLoaderWorker} from '../../../graphql'
 import getSummaryText from './getSummaryText'
-import {makeButtons, makeSection, makeSections} from './makeSlackBlocks'
+import {makeButtons, makeSection, makeSections, makeHeader} from './makeSlackBlocks'
 import {NotificationIntegrationHelper} from './NotificationIntegrationHelper'
 import {Notifier} from './Notifier'
 import SlackAuth from '../../../../database/types/SlackAuth'
@@ -224,7 +224,7 @@ const addStandupResponsesToThread = async (
       const responseUrl = makeAppURL(appOrigin, `meet/${meeting.id}/responses`, options)
 
       const threadBlocks: Array<{type: string}> = [
-        makeSection(`${user.preferredName} responded:`),
+        makeHeader(`${user.preferredName} responded:`),
         makeSection(convertToMarkdown(response.content)),
         makeButtons([{text: 'See their response', url: responseUrl, type: 'primary'}])
       ]

--- a/packages/server/graphql/mutations/helpers/notifications/makeSlackBlocks.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/makeSlackBlocks.ts
@@ -22,6 +22,17 @@ export const makeSection = (text: string) => {
   }
 }
 
+export const makeHeader = (text: string) => {
+  const maybeTruncatedText = maybeTruncate(text)
+  return {
+    type: 'header',
+    text: {
+      type: 'plain_text',
+      text: maybeTruncatedText
+    }
+  }
+}
+
 export const makeSections = (fields: string[]) => {
   const truncatedFields = fields.map((field) => {
     const maybeTruncatedField = maybeTruncate(field)

--- a/packages/server/graphql/mutations/helpers/notifications/makeSlackBlocks.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/makeSlackBlocks.ts
@@ -11,13 +11,14 @@ const maybeTruncate = (text: string) => {
   return text
 }
 
-export const makeSection = (text: string) => {
+export const makeSection = (text: string, disableAutomaticParsing = false) => {
   const maybeTruncatedText = maybeTruncate(text)
   return {
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: maybeTruncatedText
+      text: maybeTruncatedText,
+      verbatim: disableAutomaticParsing
     }
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -136,6 +136,7 @@
     "string-similarity": "^3.0.0",
     "stripe": "^9.13.0",
     "tslib": "^2.4.0",
+    "turndown": "^7.1.2",
     "uWebSockets.js": "uNetworking/uWebSockets.js#v20.19.0",
     "undici": "^5.22.1"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -136,7 +136,6 @@
     "string-similarity": "^3.0.0",
     "stripe": "^9.13.0",
     "tslib": "^2.4.0",
-    "turndown": "^7.1.2",
     "uWebSockets.js": "uNetworking/uWebSockets.js#v20.19.0",
     "undici": "^5.22.1"
   }

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -54,6 +54,12 @@ const textMarkHandlersLookup: {
   code: (text) => `\`${text}\``
 }
 
+/**
+ * Converts a tiptap JSONContent node to a markdown string supported by Slack
+ * See Slack markdown reference for limitations and features - https://api.slack.com/reference/surfaces/formatting#basics
+ * @param node - tiptap output in JSONContent format
+ * @param depth - used for nested lists
+ */
 export const convertToMarkdown = (node: JSONContent, depth?: number): string => {
   const handler = tiptapNodeHandlersLookup[node.type!]
   if (handler) {

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -33,7 +33,8 @@ const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: num
   codeBlock: ({content = []}) => {
     const markdownContent = content.map((node) => convertToMarkdown(node)).join('')
     return `\`\`\`${markdownContent}\`\`\`` // Triple backticks to denote a code block in Slack
-  }
+  },
+  blockquote: ({content = []}) => `> ${content.map((node) => convertToMarkdown(node)).join('')}`
 }
 
 const textMarkHandlersLookup: {

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -1,0 +1,55 @@
+import {JSONContent} from '@tiptap/core'
+
+const LIST_SPACING = '   '
+
+const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: number) => string} = {
+  doc: (node) => (node.content || []).map((node) => convertToMarkdown(node)).join('\n'),
+  paragraph: (node) => (node.content || []).map((node) => convertToMarkdown(node)).join(''),
+  text: (node) => {
+    let textContent = node.text || ''
+    if (node.marks) {
+      textContent = node.marks.reduce((accText, mark) => {
+        const handler = textMarkHandlersLookup[mark.type]
+        return handler ? handler(accText, mark) : accText
+      }, textContent)
+    }
+    return textContent
+  },
+  // for now lets just make headings bold
+  heading: (node) => `*${(node.content || []).map((node) => convertToMarkdown(node)).join('')}*`,
+  bulletList: (node, depth = 0) =>
+    (node.content || [])
+      .map((n) => `${LIST_SPACING.repeat(depth)}- ${convertToMarkdown(n, depth + 1)}`)
+      .join('\n'),
+  orderedList: (node, depth = 0) =>
+    (node.content || [])
+      .map(
+        (n, idx) => `${LIST_SPACING.repeat(depth)}${idx + 1}. ${convertToMarkdown(n, depth + 1)}`
+      )
+      .join('\n'),
+  listItem: (node, depth = 0) =>
+    (node.content || []).map((n) => convertToMarkdown(n, depth)).join('\n'),
+  codeBlock: (node) => {
+    const content = (node.content || []).map((node) => convertToMarkdown(node)).join('')
+    return `\`\`\`${content}\`\`\`` // Triple backticks to denote a code block in Slack
+  }
+}
+
+const textMarkHandlersLookup: {
+  [type: string]: (text: string, mark: {type: string; attrs?: any}) => string
+} = {
+  bold: (text) => `*${text}*`,
+  italic: (text) => `_${text}_`,
+  link: (text, mark) => (mark.attrs && mark.attrs.href ? `<${mark.attrs.href}|${text}>` : text),
+  strike: (text) => `~${text}~`
+}
+
+export const convertToMarkdown = (node: JSONContent, depth?: number): string => {
+  const handler = tiptapNodeHandlersLookup[node.type!]
+  if (handler) {
+    return handler(node, depth)
+  } else {
+    // If the node type isn't specifically handled (like an unsupported custom type), just iterate through its content if any
+    return (node.content || []).map((n) => convertToMarkdown(n)).join('')
+  }
+}

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -34,7 +34,14 @@ const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: num
     const markdownContent = content.map((node) => convertToMarkdown(node)).join('')
     return `\`\`\`${markdownContent}\`\`\`` // Triple backticks to denote a code block in Slack
   },
-  blockquote: ({content = []}) => `> ${content.map((node) => convertToMarkdown(node)).join('')}`
+  blockquote: ({content = []}) => `> ${content.map((node) => convertToMarkdown(node)).join('')}`,
+  mention: ({attrs}) => {
+    const {
+      /** id - here's our internal Parabol user id that'd need to bo mapped to Slack user id */
+      label
+    } = attrs!
+    return `<@${label}>`
+  }
 }
 
 const textMarkHandlersLookup: {

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -3,8 +3,8 @@ import {JSONContent} from '@tiptap/core'
 const LIST_SPACING = '   '
 
 const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: number) => string} = {
-  doc: (node) => (node.content || []).map((node) => convertToMarkdown(node)).join('\n'),
-  paragraph: (node) => (node.content || []).map((node) => convertToMarkdown(node)).join(''),
+  doc: ({content = []}) => content.map((node) => convertToMarkdown(node)).join('\n'),
+  paragraph: ({content = []}) => content.map((node) => convertToMarkdown(node)).join(''),
   text: (node) => {
     let textContent = node.text || ''
     if (node.marks) {
@@ -16,22 +16,23 @@ const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: num
     return textContent
   },
   // for now lets just make headings bold
-  heading: (node) => `*${(node.content || []).map((node) => convertToMarkdown(node)).join('')}*`,
-  bulletList: (node, depth = 0) =>
-    (node.content || [])
-      .map((n) => `${LIST_SPACING.repeat(depth)}- ${convertToMarkdown(n, depth + 1)}`)
+  heading: ({content = []}) => `*${content.map((node) => convertToMarkdown(node)).join('')}*`,
+  bulletList: ({content = []}, depth = 0) =>
+    content
+      .map((node) => `${LIST_SPACING.repeat(depth)}- ${convertToMarkdown(node, depth + 1)}`)
       .join('\n'),
-  orderedList: (node, depth = 0) =>
-    (node.content || [])
+  orderedList: ({content = []}, depth = 0) =>
+    content
       .map(
-        (n, idx) => `${LIST_SPACING.repeat(depth)}${idx + 1}. ${convertToMarkdown(n, depth + 1)}`
+        (node, idx) =>
+          `${LIST_SPACING.repeat(depth)}${idx + 1}. ${convertToMarkdown(node, depth + 1)}`
       )
       .join('\n'),
-  listItem: (node, depth = 0) =>
-    (node.content || []).map((n) => convertToMarkdown(n, depth)).join('\n'),
-  codeBlock: (node) => {
-    const content = (node.content || []).map((node) => convertToMarkdown(node)).join('')
-    return `\`\`\`${content}\`\`\`` // Triple backticks to denote a code block in Slack
+  listItem: ({content = []}, depth = 0) =>
+    content.map((node) => convertToMarkdown(node, depth)).join('\n'),
+  codeBlock: ({content = []}) => {
+    const markdownContent = content.map((node) => convertToMarkdown(node)).join('')
+    return `\`\`\`${markdownContent}\`\`\`` // Triple backticks to denote a code block in Slack
   }
 }
 
@@ -48,8 +49,7 @@ export const convertToMarkdown = (node: JSONContent, depth?: number): string => 
   const handler = tiptapNodeHandlersLookup[node.type!]
   if (handler) {
     return handler(node, depth)
-  } else {
-    // If the node type isn't specifically handled (like an unsupported custom type), just iterate through its content if any
-    return (node.content || []).map((n) => convertToMarkdown(n)).join('')
   }
+  // If the node type isn't specifically handled (like an unsupported custom type), just iterate through its content if any
+  return (node.content || []).map((n) => convertToMarkdown(n)).join('')
 }

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -19,7 +19,7 @@ const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: num
   heading: ({content = []}) => `*${content.map((node) => convertToMarkdown(node)).join('')}*`,
   bulletList: ({content = []}, depth = 0) =>
     content
-      .map((node) => `${LIST_SPACING.repeat(depth)}- ${convertToMarkdown(node, depth + 1)}`)
+      .map((node) => `${LIST_SPACING.repeat(depth)}• ${convertToMarkdown(node, depth + 1)}`)
       .join('\n'),
   orderedList: ({content = []}, depth = 0) =>
     content
@@ -41,7 +41,8 @@ const tiptapNodeHandlersLookup: {[type: string]: (node: JSONContent, depth?: num
       label
     } = attrs!
     return `<@${label}>`
-  }
+  },
+  horizontalRule: () => '---'
 }
 
 const textMarkHandlersLookup: {

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -58,7 +58,7 @@ const tiptapNodeHandlersLookup: Record<NodeType, NodeTypeHandler> = {
   blockquote: ({content = []}) => `> ${content.map((node) => convertToMarkdown(node)).join('')}`,
   mention: ({attrs}) => {
     const {
-      /** id - here's our internal Parabol user id that'd need to bo mapped to Slack user id */
+      /** id - TODO: here our internal Parabol user id would need to bo mapped to Slack user id */
       label
     } = attrs!
     return `<@${label}>`

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -42,7 +42,8 @@ const textMarkHandlersLookup: {
   bold: (text) => `*${text}*`,
   italic: (text) => `_${text}_`,
   link: (text, mark) => (mark.attrs && mark.attrs.href ? `<${mark.attrs.href}|${text}>` : text),
-  strike: (text) => `~${text}~`
+  strike: (text) => `~${text}~`,
+  code: (text) => `\`${text}\``
 }
 
 export const convertToMarkdown = (node: JSONContent, depth?: number): string => {

--- a/packages/server/utils/tiptap/convertToMarkdown.tsx
+++ b/packages/server/utils/tiptap/convertToMarkdown.tsx
@@ -61,7 +61,7 @@ const tiptapNodeHandlersLookup: Record<NodeType, NodeTypeHandler> = {
       /** id - TODO: here our internal Parabol user id would need to bo mapped to Slack user id */
       label
     } = attrs!
-    return `<@${label}>`
+    return `\`@${label}\``
   },
   horizontalRule: () => '---'
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11360,6 +11360,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.0:
   dependencies:
     domelementtype "^2.2.0"
 
+domino@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
+  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
+
 dompurify@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.1.tgz#f9cb1a275fde9af6f2d0a2644ef648dd6847b631"
@@ -20483,9 +20488,9 @@ tar@^4.4.13:
     yallist "^3.1.1"
 
 tar@^6.0.2:
-  version "6.1.15"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
-  integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
+  integrity sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -20964,6 +20969,13 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+turndown@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.2.tgz#7feb838c78f14241e79ed92a416e0d213e044a29"
+  integrity sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==
+  dependencies:
+    domino "^2.1.6"
 
 tv4@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9895,9 +9895,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001317, caniuse-lite@^1.0.30001359, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001517, caniuse-lite@~1.0.0:
-  version "1.0.30001520"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz#62e2b7a1c7b35269594cf296a80bdf8cb9565006"
-  integrity sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==
+  version "1.0.30001522"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz#44b87a406c901269adcdb834713e23582dd71856"
+  integrity sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -11359,11 +11359,6 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.0:
   integrity sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
   dependencies:
     domelementtype "^2.2.0"
-
-domino@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
-  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
 
 dompurify@^2.4.1:
   version "2.4.1"
@@ -20488,9 +20483,9 @@ tar@^4.4.13:
     yallist "^3.1.1"
 
 tar@^6.0.2:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
-  integrity sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.15.tgz#c9738b0b98845a3b344d334b8fa3041aaba53a69"
+  integrity sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -20969,13 +20964,6 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
-
-turndown@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.2.tgz#7feb838c78f14241e79ed92a416e0d213e044a29"
-  integrity sha512-ntI9R7fcUKjqBP6QU8rBK2Ehyt8LAzt3UBT9JR9tgo6GtuKvyUzpayWmeMKJw1DPdXzktvtIT8m2mVXz+bL/Qg==
-  dependencies:
-    domino "^2.1.6"
 
 tv4@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
# Description

Fixes #8651

## Demo

<img width="577" alt="Screenshot 2023-08-23 at 16 41 56" src="https://github.com/ParabolInc/parabol/assets/1017620/c7a2fee0-1779-4f11-9350-bf9eac65d6dd">

## Testing scenarios

Testing scenarios assume Slack is already integrated

- [ ] Open standup meeting, write an update that contains styling, close the meeting, see the slack notification

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
