### PR TITLE
fix: Show correct error message on login failure with invitation

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -176,7 +176,11 @@ export const handleAcceptTeamInvitationErrors = (
 ) => {
   if (acceptTeamInvitation?.error) {
     const {message} = acceptTeamInvitation.error
-    if (message === InvitationTokenError.ALREADY_ACCEPTED) return
+    if (
+      message === InvitationTokenError.ALREADY_ACCEPTED ||
+      message === InvitationTokenError.NOT_SIGNED_IN
+    )
+      return
     atmosphere.eventEmitter.emit('addSnackbar', {
       autoDismiss: 0,
       key: `acceptTeamInvitation:${message}`,

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -170,7 +170,8 @@ export const enum Gutters {
 export const enum InvitationTokenError {
   NOT_FOUND = 'notFound',
   EXPIRED = 'expired',
-  ALREADY_ACCEPTED = 'accepted'
+  ALREADY_ACCEPTED = 'accepted',
+  NOT_SIGNED_IN = 'notSignedIn'
 }
 export const enum InvoiceItemType {
   ADD_USER = 'addUser',

--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -28,6 +28,11 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   const viewerId = getUserId(authToken)
 
   // VALIDATION
+  // This can happen if login with an invitation failed. We want to handle this gracefully so the client shows a nice error message
+  if (!viewerId) {
+    return {error: {message: InvitationTokenError.NOT_SIGNED_IN}}
+  }
+
   const viewer = await dataLoader.get('users').loadNonNull(viewerId)
   const invitationRes = await handleInvitationToken(
     invitationToken,

--- a/packages/server/graphql/public/permissions.ts
+++ b/packages/server/graphql/public/permissions.ts
@@ -28,7 +28,8 @@ export type PermissionMap<T> = {
 const permissionMap: PermissionMap<Resolvers> = {
   Mutation: {
     '*': isAuthenticated,
-    acceptTeamInvitation: and(isAuthenticated, rateLimit({perMinute: 50, perHour: 100})),
+    // don't check isAuthenticated for acceptTeamInvitation here because there are special cases handled in the resolver
+    acceptTeamInvitation: rateLimit({perMinute: 50, perHour: 100}),
     createImposterToken: isSuperUser,
     loginWithGoogle: and(
       not(isEnvVarTrue('AUTH_GOOGLE_DISABLED')),


### PR DESCRIPTION
# Description

Fixes #8669 

Before this fix the wrong error would be shown when a user followed an invitation link but then failed to sign in. Now we're not throwing a permission exception anymore in `acceptTeamInvitation` if the caller is not signed in, but instead return an error result. This way we can handle it on the client side and the return of the login mutation is not lost.

## Demo

https://www.loom.com/share/98da2c53aae444e88cb7243cff504427?sid=08dd92d4-c5d3-421c-ba40-3cfe156d264d

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Follow an invite link (personal or mass invitation)
- [ ] cause a login error
  - [ ] wrong password
  - [ ] signup with existing account
  - [ ] password login with google account
- [ ] see the login field show the correct error message

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
