### PR TITLE
fix: Allow login with google with ad blocker enabled

### DIFF
--- a/packages/client/utils/getAnonymousId.ts
+++ b/packages/client/utils/getAnonymousId.ts
@@ -6,6 +6,8 @@ const retrieveGtagClientId = async (
 ): Promise<string | undefined> => {
   return new Promise((resolve) => {
     gtag('get', measurementId, 'client_id', resolve)
+    // if the call gets blocked, then it might never resolve
+    window.setTimeout(() => resolve(undefined), 1000)
   })
 }
 


### PR DESCRIPTION
# Description

Fixes #8725 

The ad blocker (like uBlock origin) are blocking a call to `gtag` which never resolves and thus leaves the app hanging with the popup window blank. Added a timeout for the call.

## Demo

https://www.loom.com/share/3f301ab7d4f34525af3201161184e393?sid=ca8e275e-2177-4c5c-a882-2f7f98135784

## Testing scenarios

- [ ] with uBlock origin installed and activated try login with google

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
