### PR TITLE
fix: Check if team member status on accepting an invite twice

### DIFF
--- a/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
+++ b/packages/server/graphql/public/mutations/acceptTeamInvitation.ts
@@ -7,7 +7,7 @@ import {
 import AuthToken from '../../../database/types/AuthToken'
 import acceptTeamInvitationSafe from '../../../safeMutations/acceptTeamInvitation'
 import {analytics} from '../../../utils/analytics/analytics'
-import {getUserId} from '../../../utils/authorization'
+import {getUserId, isTeamMember} from '../../../utils/authorization'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
 import publish from '../../../utils/publish'
 import RedisLock from '../../../utils/RedisLock'
@@ -37,7 +37,12 @@ const acceptTeamInvitation: MutationResolvers['acceptTeamInvitation'] = async (
   )
   if (invitationRes.error) {
     const {error: message, teamId, meetingId} = invitationRes
-    if (message === InvitationTokenError.ALREADY_ACCEPTED) {
+    // If the user already accepted the invite, then we want to send the needed data together with the error, unless they were removed in the meantime
+    if (
+      message === InvitationTokenError.ALREADY_ACCEPTED &&
+      teamId &&
+      isTeamMember(authToken, teamId)
+    ) {
       return {error: {message}, teamId, meetingId, teamMemberId: toTeamMemberId(teamId!, viewerId)}
     }
     return {error: {message}}

--- a/packages/server/safeMutations/acceptTeamInvitation.ts
+++ b/packages/server/safeMutations/acceptTeamInvitation.ts
@@ -50,12 +50,9 @@ const acceptTeamInvitation = async (team: Team, userId: string, dataLoader: Data
   const now = new Date()
   const {id: teamId, orgId} = team
   const [user, organizationUser] = await Promise.all([
-    dataLoader.get('users').load(userId),
+    dataLoader.get('users').loadNonNull(userId),
     dataLoader.get('organizationUsersByUserIdOrgId').load({userId, orgId})
   ])
-  if (!user) {
-    throw new Error('User not found')
-  }
   const {email} = user
   const teamLeadUserIdWithNewActions = await handleFirstAcceptedInvitation(team)
   const [, invitationNotificationIds] = await Promise.all([


### PR DESCRIPTION
# Description

Fixes #8668

When an invite was accepted a second time, we did try to return the team and meeting information regardless of whether or not the user was still on the team. This was checked further down in the GraphQL tree, but can result in misleading errors in Sentry. Checking for this particular case now to see if it still shows up for users down the road which might cause to a real bug somewhere.

## Demo

https://www.loom.com/share/2e945766e47548e7ab586b28a8c78eee?sid=28d68b0e-191d-4ee7-8099-3c9635ab6552

## Testing scenarios

- [ ] Ioreth creates a personal invite with a meeting
- [ ] Aragorn accepts the invite
- [ ] Ioreth removes Aragorn from the team again
- [ ] Aragorn accepts the invite a second time
- [ ] No error is send to Sentry

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
