### PR TITLE
fix(standups): Selecting team in Parabol card throws error

### DIFF
--- a/packages/client/modules/outcomeCard/components/TaskFooterTeamAssigneeMenuRoot.tsx
+++ b/packages/client/modules/outcomeCard/components/TaskFooterTeamAssigneeMenuRoot.tsx
@@ -22,7 +22,7 @@ const TaskFooterTeamAssigneeMenuRoot = (props: Props) => {
     {}
   )
   return (
-    <Suspense fallback={MockFieldList}>
+    <Suspense fallback={<MockFieldList />}>
       {queryRef && (
         <TaskFooterTeamAssigneeMenu queryRef={queryRef} menuProps={menuProps} task={task} />
       )}


### PR DESCRIPTION
# Description
An incorrectly rendered Suspense fallback causes us to throw an error in the "Your Work" drawer when a user attempts to select a different team in a parabol task card.

It seems like this only manifested now because other parts of the app using this component already have this data loaded, and therefore never suspends.

Interestingly, TS doesn't catch this - not sure why not.

## Testing scenarios
- [ ] On master, refresh the page on a standup meeting, and open the Your Work drawer, and try to change the team. Confirm there is an error.
- [ ] On this branch, do the above, and confirm teams load correctly.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
