### PR TITLE
chore: docker rm queryMap

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -33,7 +33,6 @@ RUN yarn install --prod --frozen-lockfile && \
 COPY . .
 COPY --from=build /parabol/build ./build
 COPY --from=build /parabol/dist ./dist
-COPY --from=build /parabol/queryMap.json ./
 
 RUN cp docker/entrypoint.prod.sh /bin/entrypoint && \
       chmod +x /bin/entrypoint

--- a/docker/parabol-ubi/docker-build/dockerfiles/pipeline.dockerfile
+++ b/docker/parabol-ubi/docker-build/dockerfiles/pipeline.dockerfile
@@ -99,8 +99,6 @@ COPY --chown=node docker/parabol-ubi/docker-build/tools/ip-to-server_id ${HOME}/
 
 # The application requires a yarn.lock file on the root folder to identify it
 COPY --chown=node yarn.lock ${HOME}/parabol/yarn.lock
-# Required for post-deploy to work
-COPY --chown=node queryMap.json ${HOME}/parabol/queryMap.json
 # Required for pushToCDN to work with FILE_STORE_PROVIDER set to 'local'
 RUN mkdir -p ${HOME}/parabol/self-hosted && \
     chown node:node ${HOME}/parabol/self-hosted


### PR DESCRIPTION
# Description

queryMap is now imported through the native JS `import` syntax so we don't have to issue a filesystem read. That means we no longer need queryMap.json in the docker image.


## Demo

Check out CI, if it passes, it should work!