### PR TITLE
chore: remove __PROJECT_ROOT__

### DIFF
--- a/packages/server/types/modules.d.ts
+++ b/packages/server/types/modules.d.ts
@@ -25,7 +25,6 @@ declare module 'json2csv/lib/JSON2CSVParser'
 declare module 'object-hash'
 declare module 'string-score'
 
-declare const __PROJECT_ROOT__: string
 declare const __APP_VERSION__: string
 declare const __PRODUCTION__: string
 declare const __SOCKET_PORT__: string

--- a/packages/server/utils/updateGQLSchema.ts
+++ b/packages/server/utils/updateGQLSchema.ts
@@ -10,8 +10,7 @@ import path from 'path'
 import {promisify} from 'util'
 import privateSchema from '../graphql/private/rootSchema'
 import publicSchema from '../graphql/public/rootSchema'
-
-declare const __PROJECT_ROOT__: string
+import getProjectRoot from '../../../scripts/webpack/utils/getProjectRoot'
 
 const writeIfChanged = async (dataPath: string, data: string) => {
   const write = promisify(fs.writeFile)
@@ -26,7 +25,8 @@ const writeIfChanged = async (dataPath: string, data: string) => {
 }
 
 const updateGQLSchema = async () => {
-  const GQL_ROOT = path.join(__PROJECT_ROOT__, 'packages/server/graphql')
+  const projectRoot = getProjectRoot()!
+  const GQL_ROOT = path.join(projectRoot, 'packages/server/graphql')
   const publicSchemaPath = path.join(GQL_ROOT, 'public/schema.graphql')
   const privateSchemaPath = path.join(GQL_ROOT, 'private/schema.graphql')
   await Promise.all([

--- a/scripts/toolboxSrc/modules.d.ts
+++ b/scripts/toolboxSrc/modules.d.ts
@@ -8,6 +8,5 @@ declare module '*/getProjectRoot' {
   export = value
 }
 
-declare const __PROJECT_ROOT__: string
 declare const __APP_VERSION__: string
 declare const __COMMIT_HASH__: string

--- a/scripts/webpack/dev.servers.config.js
+++ b/scripts/webpack/dev.servers.config.js
@@ -55,7 +55,6 @@ module.exports = {
   ],
   plugins: [
     new webpack.DefinePlugin({
-      __PROJECT_ROOT__: JSON.stringify(PROJECT_ROOT),
       __PRODUCTION__: false
     })
   ],

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -80,7 +80,6 @@ module.exports = ({noDeps}) => ({
     new CleanWebpackPlugin(),
     new webpack.DefinePlugin({
       __PRODUCTION__: true,
-      __PROJECT_ROOT__: JSON.stringify(PROJECT_ROOT),
       __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
       __COMMIT_HASH__: JSON.stringify(COMMIT_HASH),
       // hardcode architecture so uWebSockets.js dynamic require becomes deterministic at build time & requires 1 binary

--- a/scripts/webpack/toolbox.config.js
+++ b/scripts/webpack/toolbox.config.js
@@ -53,8 +53,7 @@ module.exports = {
   ],
   plugins: [
     new webpack.DefinePlugin({
-      __PRODUCTION__: true,
-      __PROJECT_ROOT__: JSON.stringify(PROJECT_ROOT)
+      __PRODUCTION__: true
     })
   ],
   module: {


### PR DESCRIPTION
# Description

Fixes #8202

`__PROJECT_ROOT__` is no longer possible since we are doing so much work in predeploy vs build

## Demo

If it builds in CI, it works!