### PR TITLE
fix: move PRODUCTION bool to build time

### DIFF
--- a/packages/server/PROD.ts
+++ b/packages/server/PROD.ts
@@ -1,1 +1,0 @@
-export default process.env.NODE_ENV === 'production'

--- a/packages/server/graphql/CompiledQueryCache.ts
+++ b/packages/server/graphql/CompiledQueryCache.ts
@@ -2,7 +2,6 @@ import tracer from 'dd-trace'
 import {GraphQLSchema, parse} from 'graphql'
 import {CompiledQuery} from 'graphql-jit'
 import getRethink from '../database/rethinkDriver'
-import PROD from '../PROD'
 import {MutationResolvers, QueryResolvers, Resolver} from './public/resolverTypes'
 import {tracedCompileQuery} from './traceGraphQL'
 
@@ -45,7 +44,7 @@ export default class CompiledQueryCache {
     if (compiledQuery) return compiledQuery
     const r = await getRethink()
     let queryString = await r.table('QueryMap').get(docId)('query').default(null).run()
-    if (!queryString && !PROD) {
+    if (!queryString && !__PRODUCTION__) {
       // try/catch block required for building the toolbox
       try {
         const queryMap = require('../../../queryMap.json')

--- a/packages/server/graphql/DocumentCache.ts
+++ b/packages/server/graphql/DocumentCache.ts
@@ -6,7 +6,6 @@
 
 import {DocumentNode, parse} from 'graphql'
 import getRethink from '../database/rethinkDriver'
-import PROD from '../PROD'
 
 export default class DocumentCache {
   store = {} as {[docId: string]: DocumentNode}
@@ -19,7 +18,7 @@ export default class DocumentCache {
     if (!document) {
       const r = await getRethink()
       let queryString = await r.table('QueryMap').get(docId)('query').default(null).run()
-      if (!queryString && !PROD) {
+      if (!queryString && !__PRODUCTION__) {
         // In development, use the frequently changing queryMap to look up persisted queries by hash
         const queryMap = require('../../../queryMap.json')
         queryString = queryMap[docId]

--- a/packages/server/graphql/executeGraphQL.ts
+++ b/packages/server/graphql/executeGraphQL.ts
@@ -8,7 +8,6 @@ import tracer from 'dd-trace'
 import {graphql} from 'graphql'
 import {FormattedExecutionResult} from 'graphql/execution/execute'
 import AuthToken from '../database/types/AuthToken'
-import PROD from '../PROD'
 import CompiledQueryCache from './CompiledQueryCache'
 import getDataLoader from './getDataLoader'
 import getRateLimiter from './getRateLimiter'
@@ -77,7 +76,7 @@ const executeGraphQL = async (req: GQLRequest) => {
       response = {errors: [new Error(message)] as any}
     }
   }
-  if (!PROD && response.errors) {
+  if (!__PRODUCTION__ && response.errors) {
     const [firstError] = response.errors
     console.log((firstError as Error).stack)
     console.trace({error: JSON.stringify(response)})

--- a/packages/server/graphql/handleGraphQLTrebuchetRequest.ts
+++ b/packages/server/graphql/handleGraphQLTrebuchetRequest.ts
@@ -1,6 +1,5 @@
 import {OutgoingMessage} from '@mattkrick/graphql-trebuchet-client'
 import tracer from 'dd-trace'
-import PROD from '../PROD'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 import {getUserId} from '../utils/authorization'
 import getGraphQLExecutor from '../utils/getGraphQLExecutor'
@@ -25,14 +24,14 @@ const handleGraphQLTrebuchetRequest = async (
         id: opId || '',
         payload: {errors: [{message: 'No payload provided'}]}
       }
-    if (PROD && !docId)
+    if (__PRODUCTION__ && !docId)
       return {
         type: 'error' as const,
         id: opId || '',
         payload: {errors: [{message: 'DocumentId not provided'}]}
       }
 
-    const isSubscription = PROD ? docId![0] === 's' : query?.startsWith('subscription')
+    const isSubscription = __PRODUCTION__ ? docId![0] === 's' : query?.startsWith('subscription')
     if (isSubscription) {
       subscribeGraphQL({docId, query, opId: opId!, variables, connectionContext})
       return

--- a/packages/server/graphql/private/mutations/disconnectSocket.ts
+++ b/packages/server/graphql/private/mutations/disconnectSocket.ts
@@ -1,5 +1,4 @@
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import PROD from '../../../PROD'
 import {analytics} from '../../../utils/analytics/analytics'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
@@ -31,7 +30,7 @@ const disconnectSocket: MutationResolvers['disconnectSocket'] = async (
   )
   if (!disconnectingSocket) {
     // this happens a lot on server restart in dev mode
-    if (!PROD) return {user}
+    if (!__PRODUCTION__) return {user}
     throw new Error('Called disconnect without a valid socket')
   }
   await redis.lrem(`presence:${userId}`, 0, disconnectingSocket)

--- a/packages/server/listenHandler.ts
+++ b/packages/server/listenHandler.ts
@@ -1,10 +1,9 @@
 import {us_listen_socket} from 'uWebSockets.js'
-import PROD from './PROD'
 import getGraphQLExecutor from './utils/getGraphQLExecutor'
 import serverHealthChecker from './utils/serverHealthChecker'
 
 const listenHandler = (listenSocket: us_listen_socket) => {
-  const PORT = Number(PROD ? process.env.PORT : process.env.SOCKET_PORT)
+  const PORT = Number(__PRODUCTION__ ? process.env.PORT : process.env.SOCKET_PORT)
   const SERVER_ID = process.env.SERVER_ID
   if (listenSocket) {
     console.log(`\n🔥🔥🔥 Server ID: ${SERVER_ID}. Ready for Sockets: Port ${PORT} 🔥🔥🔥`)

--- a/packages/server/postgres/getPgConfig.ts
+++ b/packages/server/postgres/getPgConfig.ts
@@ -8,7 +8,8 @@ const getPgConfig = () => {
     database: process.env.POSTGRES_DB,
     host: process.env.POSTGRES_HOST,
     port: Number(process.env.POSTGRES_PORT),
-    max: Number(process.env.POSTGRES_POOL_SIZE) || __PRODUCTION__ ? 20 : 5
+    // this is used outside of webpack transpiled scripts, so checking NODE_ENV is required
+    max: Number(process.env.POSTGRES_POOL_SIZE) || process.env.NODE_ENV === 'production' ? 20 : 5
   }
   const ssl = getPgSSL()
   if (!ssl) return config

--- a/packages/server/postgres/getPgConfig.ts
+++ b/packages/server/postgres/getPgConfig.ts
@@ -1,4 +1,3 @@
-import PROD from '../PROD'
 // @ts-ignore
 import getPgSSL from './getPgSSL'
 
@@ -9,7 +8,7 @@ const getPgConfig = () => {
     database: process.env.POSTGRES_DB,
     host: process.env.POSTGRES_HOST,
     port: Number(process.env.POSTGRES_PORT),
-    max: Number(process.env.POSTGRES_POOL_SIZE) || PROD ? 20 : 5
+    max: Number(process.env.POSTGRES_POOL_SIZE) || __PRODUCTION__ ? 20 : 5
   }
   const ssl = getPgSSL()
   if (!ssl) return config

--- a/packages/server/postgres/migrations/1692638249976_isOneOnOneTeam.ts
+++ b/packages/server/postgres/migrations/1692638249976_isOneOnOneTeam.ts
@@ -6,7 +6,7 @@ export async function up() {
   await client.connect()
   await client.query(`
     ALTER TABLE "Team"
-    ADD COLUMN "isOneOnOneTeam" BOOLEAN NOT NULL DEFAULT FALSE;
+    ADD COLUMN IF NOT EXISTS "isOneOnOneTeam" BOOLEAN NOT NULL DEFAULT FALSE;
   `)
   await client.end()
 }
@@ -16,7 +16,7 @@ export async function down() {
   await client.connect()
   await client.query(`
     ALTER TABLE "Team"
-    DROP COLUMN "isOneOnOneTeam";
+    DROP COLUMN IF EXISTS "isOneOnOneTeam";
   `)
   await client.end()
 }

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -2,7 +2,6 @@ import tracer from 'dd-trace'
 import {r} from 'rethinkdb-ts'
 import uws, {SHARED_COMPRESSOR} from 'uWebSockets.js'
 import ICSHandler from './ICSHandler'
-import PROD from './PROD'
 import PWAHandler from './PWAHandler'
 import stripeWebhookHandler from './billing/stripeWebhookHandler'
 import createSSR from './createSSR'
@@ -31,13 +30,13 @@ tracer.init({
 })
 tracer.use('ioredis').use('http').use('pg')
 
-if (!PROD) {
+if (!__PRODUCTION__) {
   process.on('SIGINT', async () => {
     r.getPoolMaster()?.drain()
   })
 }
 
-const PORT = Number(PROD ? process.env.PORT : process.env.SOCKET_PORT)
+const PORT = Number(__PRODUCTION__ ? process.env.PORT : process.env.SOCKET_PORT)
 uws
   .App()
   .get('/favicon.ico', PWAHandler)

--- a/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
+++ b/packages/server/utils/analytics/amplitude/AmplitudeAnalytics.ts
@@ -1,7 +1,6 @@
 import {identify, Identify, init, track} from '@amplitude/analytics-node'
-import {AnalyticsEvent, IdentifyOptions} from '../analytics'
-import PROD from '../../../PROD'
 import {CacheWorker, DataLoaderBase} from '../../../graphql/DataLoaderCache'
+import {AnalyticsEvent, IdentifyOptions} from '../analytics'
 
 const {AMPLITUDE_WRITE_KEY} = process.env
 
@@ -13,7 +12,7 @@ export class AmplitudeAnalytics {
     // used as a failsafe for PPMIs
     if (!AMPLITUDE_WRITE_KEY) return
     init(AMPLITUDE_WRITE_KEY, {
-      flushQueueSize: PROD ? 20 : 1,
+      flushQueueSize: __PRODUCTION__ ? 20 : 1,
       optOut: !AMPLITUDE_WRITE_KEY
     })
   }

--- a/packages/server/utils/segmentIo.ts
+++ b/packages/server/utils/segmentIo.ts
@@ -1,12 +1,11 @@
 import SegmentIo from 'analytics-node'
-import PROD from '../PROD'
-import getDataLoader from '../graphql/getDataLoader'
 import {CacheWorker, DataLoaderBase} from '../graphql/DataLoaderCache'
+import getDataLoader from '../graphql/getDataLoader'
 
 const {SEGMENT_WRITE_KEY} = process.env
 
 const segmentIo = new SegmentIo(SEGMENT_WRITE_KEY || 'x', {
-  flushAt: PROD ? 20 : 1,
+  flushAt: __PRODUCTION__ ? 20 : 1,
   enable: !!SEGMENT_WRITE_KEY
 }) as any
 segmentIo._track = segmentIo.track

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -6,7 +6,8 @@ const getProjectRoot = require('./webpack/utils/getProjectRoot')
 const fs = require('fs')
 
 const startMigration = async (direction = 'up') => {
-
+  // since this gets called outside of webpack we mock the webpack global var here
+  global.__PRODUCTION__ = process.env.NODE_ENV
   // migrating up goes all the way, migrating down goes down by 1
   const all = direction === 'up'
   if (process.env.NODE_ENV === 'test') {
@@ -21,7 +22,8 @@ const startMigration = async (direction = 'up') => {
   process.env.r = process.cwd()
   if (direction === 'up') {
     const files = fs.readdirSync(path.join(DB_ROOT, 'migrations'))
-    if (files.length !== 154) throw new Error('New migrations must live in the postgres/migrations directory')
+    if (files.length !== 154)
+      throw new Error('New migrations must live in the postgres/migrations directory')
   }
 
   try {

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -6,8 +6,6 @@ const getProjectRoot = require('./webpack/utils/getProjectRoot')
 const fs = require('fs')
 
 const startMigration = async (direction = 'up') => {
-  // since this gets called outside of webpack we mock the webpack global var here
-  global.__PRODUCTION__ = process.env.NODE_ENV
   // migrating up goes all the way, migrating down goes down by 1
   const all = direction === 'up'
   if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
# Description

fix #8627

`__PRODUCTION__` is a webpack variable that is calculated at build time. 
Since this var is a constant at runtime, webpack can tree shake conditional branches & remove bits of unreachable code, e.g. `if (!__PRODUCTION__) doThing()` gets removed entirely & `doThing()` may also get removed if it is not used elsewhere.


## Demo

If CI passes it works!
