### PR TITLE
feat: Update Slack message on meeting rename

### DIFF
--- a/packages/client/utils/SlackManager.ts
+++ b/packages/client/utils/SlackManager.ts
@@ -240,9 +240,11 @@ abstract class SlackManager {
 
   updateMessage(channelId: string, blocks: string | Array<{type: string}>, ts: string) {
     const newBlocks = typeof blocks === 'string' ? blocks : JSON.stringify(blocks)
-    return this.get<UpdateMessageResponse>(
-      `https://slack.com/api/chat.update?token=${this.token}&channel=${channelId}&blocks=${newBlocks}&ts=${ts}`
-    )
+    return this.post<UpdateMessageResponse>('https://slack.com/api/chat.update', {
+      channel: channelId,
+      blocks: newBlocks,
+      ts
+    })
   }
 }
 

--- a/packages/server/database/types/Meeting.ts
+++ b/packages/server/database/types/Meeting.ts
@@ -44,6 +44,7 @@ export default abstract class Meeting {
   summary?: string
   sentimentScore?: number
   usedReactjis?: Record<string, number>
+  slackTs?: string
 
   constructor(input: Input) {
     const {

--- a/packages/server/graphql/mutations/helpers/notifications/IntegrationNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/IntegrationNotifier.ts
@@ -11,6 +11,11 @@ export const IntegrationNotifier: Notifier = {
       notifiers.map(async (notifier) => notifier.startMeeting(dataLoader, meetingId, teamId))
     )
   },
+  async updateMeeting(dataLoader, meetingId, teamId) {
+    await Promise.allSettled(
+      notifiers.map(async (notifier) => notifier.updateMeeting?.(dataLoader, meetingId, teamId))
+    )
+  },
   async endMeeting(dataLoader, meetingId, teamId) {
     await Promise.allSettled(
       notifiers.map(async (notifier) => notifier.endMeeting(dataLoader, meetingId, teamId))

--- a/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/NotificationIntegrationHelper.ts
@@ -13,6 +13,7 @@ export type NotifyResponse =
 
 export type NotificationIntegration = {
   startMeeting(meeting: Meeting, team: Team): Promise<NotifyResponse>
+  updateMeeting?(meeting: Meeting, team: Team): Promise<NotifyResponse>
   endMeeting(
     meeting: Meeting,
     team: Team,

--- a/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
@@ -3,6 +3,7 @@ import {NotifyResponse} from './NotificationIntegrationHelper'
 
 export type Notifier = {
   startMeeting(dataLoader: DataLoaderWorker, meetingId: string, teamId: string): Promise<void>
+  updateMeeting?(dataLoader: DataLoaderWorker, meetingId: string, teamId: string): Promise<void>
   endMeeting(dataLoader: DataLoaderWorker, meetingId: string, teamId: string): Promise<void>
   startTimeLimit(
     dataLoader: DataLoaderWorker,

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -282,9 +282,13 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
     const {botAccessToken} = auth
     const {slackTs} = meeting
     if (!slackTs || !botAccessToken || !channelId) {
-      return handleError({ok: false, error: 'missing slackTs, botAccessToken, or channelId'}, team.id, notificationChannel)
+      return handleError(
+        {ok: false, error: 'missing slackTs, botAccessToken, or channelId'},
+        team.id,
+        notificationChannel
+      )
     }
- 
+
     const searchParams = {
       utm_source: 'slack meeting start',
       utm_medium: 'product',
@@ -300,7 +304,7 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
 
     const manager = new SlackServerManager(botAccessToken)
     const res = await manager.updateMessage(channelId, blocks, slackTs)
- 
+
     if ('error' in res) {
       return handleError(res, team.id, notificationChannel)
     }

--- a/packages/server/graphql/mutations/renameMeeting.ts
+++ b/packages/server/graphql/mutations/renameMeeting.ts
@@ -7,6 +7,7 @@ import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import RenameMeetingPayload from '../types/RenameMeetingPayload'
+import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 
 const renameMeeting = {
   type: new GraphQLNonNull(RenameMeetingPayload),
@@ -62,6 +63,7 @@ const renameMeeting = {
       .run()
 
     const data = {meetingId}
+    IntegrationNotifier.updateMeeting?.(dataLoader, meetingId, teamId)
     publish(SubscriptionChannel.TEAM, teamId, 'RenameMeetingSuccess', data, subOptions)
 
     return data

--- a/packages/server/utils/sendToSentry.ts
+++ b/packages/server/utils/sendToSentry.ts
@@ -15,7 +15,7 @@ export interface SentryOptions {
 const sendToSentry = async (error: Error, options: SentryOptions = {}) => {
   console.trace(
     'SEND TO SENTRY',
-    JSON.stringify(error),
+    error.message,
     JSON.stringify(options.tags),
     JSON.stringify(options.extras)
   )


### PR DESCRIPTION
We send the Slack message on meeting creation and only afterwards allow to rename it. Store the `ts` of the meeting started notification and update the message if a meeting is renamed.

## Demo

https://www.loom.com/share/97aac89a69444585bb7355a60d9e300b?sid=0261ca0c-a3d5-4248-83a8-3e32aa10a0da

## Testing scenarios

This only works on new meetings
- integrate with Slack
- create a meeting
- see the Slack message
- rename the meeting
- see the Slack message being updated with the new name

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
