### PR TITLE
fix(gcal): handle Zoom add-on conflict

### DIFF
--- a/packages/client/modules/userDashboard/components/GcalModal/DateTimePickers.tsx
+++ b/packages/client/modules/userDashboard/components/GcalModal/DateTimePickers.tsx
@@ -82,7 +82,7 @@ const DateTimePickers = (props: Props) => {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <div className='w flex flex-col justify-between space-y-4 pt-3'>
+      <div className='w flex flex-col justify-between space-y-6 pt-3'>
         <div className='flex space-x-2' onMouseDown={handleMouseDown}>
           <DatePicker
             label={`Meeting Start Date`}

--- a/packages/client/modules/userDashboard/components/GcalModal/GcalModal.tsx
+++ b/packages/client/modules/userDashboard/components/GcalModal/GcalModal.tsx
@@ -104,9 +104,6 @@ const GcalModal = (props: Props) => {
   const {fields, onChange} = useForm({
     title: {
       getDefault: () => ''
-    },
-    description: {
-      getDefault: () => ''
     }
   })
   const titleErr = fields.title.error
@@ -120,11 +117,9 @@ const GcalModal = (props: Props) => {
     }
     const startTimestamp = start.unix()
     const endTimestamp = end.unix()
-    const description = fields.description.value
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
     const input = {
       title,
-      description,
       startTimestamp,
       endTimestamp,
       timeZone,
@@ -189,13 +184,18 @@ const GcalModal = (props: Props) => {
   return (
     <StyledDialogContainer>
       <DialogTitle>
-        {'Schedule Your Meeting'}
+        <div className='flex flex-col'>
+          <div className='text-lg'>{'Schedule Your Meeting'}</div>
+          <div className='text-gray-500 mt-1 text-sm font-normal'>
+            We'll include a link to the Parabol meeting in the description
+          </div>
+        </div>
         <StyledCloseButton onClick={closeModal}>
           <CloseIcon />
         </StyledCloseButton>
       </DialogTitle>
       <DialogContent>
-        <div className='space-y-1'>
+        <div className='space-y-2'>
           <div>
             <StyledInput
               autoFocus
@@ -207,13 +207,7 @@ const GcalModal = (props: Props) => {
             />
             {titleErr && <ErrorMessage>{titleErr}</ErrorMessage>}
           </div>
-          <StyledInput
-            maxLength={100}
-            name='description'
-            onChange={onChange}
-            placeholder='Enter your meeting description (optional)'
-          />
-          <div className='pt-2'>
+          <div className='pt-1'>
             <DateTimePickers
               startValue={start}
               endValue={end}

--- a/packages/server/graphql/mutations/helpers/createGcalEvent.ts
+++ b/packages/server/graphql/mutations/helpers/createGcalEvent.ts
@@ -26,7 +26,7 @@ const createGcalEvent = async (input: Input) => {
   if (!featureFlags.includes('gcal')) {
     return standardError(new Error('Does not have gcal feature flag'), {userId: viewerId})
   }
-  const {startTimestamp, endTimestamp, title, description, timeZone, invitees} = gcalInput
+  const {startTimestamp, endTimestamp, title, timeZone, invitees} = gcalInput
 
   const gcalAuth = await dataLoader.get('freshGcalAuth').load({teamId, userId: viewerId})
   if (!gcalAuth) {
@@ -48,9 +48,12 @@ const createGcalEvent = async (input: Input) => {
   const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`)
   const attendeesWithEmailObjects = invitees?.map((email) => ({email}))
 
+  const description = `Here's the link to your Parabol meeting: ${meetingUrl}
+
+` // add a newline to separate the link from the rest of the description
+
   const event = {
     summary: title,
-    location: meetingUrl,
     description,
     start: {
       dateTime: startDateTime,

--- a/packages/server/graphql/mutations/helpers/createGcalEvent.ts
+++ b/packages/server/graphql/mutations/helpers/createGcalEvent.ts
@@ -47,7 +47,6 @@ const createGcalEvent = async (input: Input) => {
   const calendar = google.calendar({version: 'v3', auth: oauth2Client})
   const meetingUrl = makeAppURL(appOrigin, `meet/${meetingId}`)
   const attendeesWithEmailObjects = invitees?.map((email) => ({email}))
-
   const description = `Here's the link to your Parabol meeting: ${meetingUrl}
 
 ` // add a newline to separate the link from the rest of the description

--- a/packages/server/graphql/public/typeDefs/startTeamPrompt.graphql
+++ b/packages/server/graphql/public/typeDefs/startTeamPrompt.graphql
@@ -44,10 +44,6 @@ input CreateGcalEventInput {
   """
   title: String!
   """
-  The description of the event
-  """
-  description: String!
-  """
   The start timestamp of the event
   """
   startTimestamp: Int!

--- a/packages/server/graphql/public/types/CreateGcalEventInput.ts
+++ b/packages/server/graphql/public/types/CreateGcalEventInput.ts
@@ -14,10 +14,6 @@ const CreateGcalEventInput = new GraphQLInputObjectType({
       type: new GraphQLNonNull(GraphQLString),
       description: 'The title of the meeting'
     },
-    description: {
-      type: GraphQLString,
-      description: 'The description of the meeting'
-    },
     startTimestamp: {
       type: new GraphQLNonNull(GraphQLInt),
       description: 'The start dateTime of the meeting'
@@ -40,7 +36,6 @@ const CreateGcalEventInput = new GraphQLInputObjectType({
 
 export type CreateGcalEventInputType = {
   title: string
-  description: string
   startTimestamp: number
   endTimestamp: number
   timeZone: string


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8714

Demo: https://www.loom.com/share/9923a47d690d4e26ad5369faaa6fc94c

### To test

- [ ] Create a Parabol meeting using the gcal modal
- [ ] See that the Parabol meeting link is added to the description field, not the location field