### PR TITLE
feat: remove unnecessary github oauth scopes

### DIFF
--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -294,7 +294,7 @@ export const enum Providers {
   GCAL_NAME = 'Google Calendar',
   GCAL_DESC = 'Create Google Calendar events from within Parabol',
   GITHUB_DESC = 'Use GitHub Issues from within Parabol',
-  GITHUB_SCOPE = 'admin:org_hook,read:org,repo,user,write:repo_hook',
+  GITHUB_SCOPE = 'read:org,repo',
   GITLAB_SCOPE = 'api',
   MATTERMOST_NAME = 'Mattermost',
   MATTERMOST_DESC = 'Push notifications to Mattermost',


### PR DESCRIPTION
# Description

No issue, just a simple change to remove unnecessary github oauth2 scopes. The further improvement would be to do https://github.com/ParabolInc/parabol/issues/6208

## Demo

![screenshot_2023-09-05_at_17 14 16](https://github.com/ParabolInc/parabol/assets/1017620/d7fd6c01-86a0-4e32-b15b-436c1acfb29b)
instead of 
![screenshot_2023-08-08_at_18 45 13](https://github.com/ParabolInc/parabol/assets/1017620/8cbad176-8aae-49e3-a3f8-3e471c3b7e29)

## Testing scenarios

- [ ] Remove old github auth, auth again
- [ ] Open poker meeting, see if reading/writing labels, comments works as expected
- [ ] See if creating a new issue via Parabol task works as expected

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
