### PR TITLE
fix: too long reflect prompt ids broke the retro

### DIFF
--- a/packages/server/postgres/migrations/1685721573097_addPrePostMortemTemplates.ts
+++ b/packages/server/postgres/migrations/1685721573097_addPrePostMortemTemplates.ts
@@ -965,6 +965,7 @@ const NEW_TEMPLATE_CONFIGS: Template[] = [
 const createdAt = new Date()
 
 const makeId = (name: string, type: 'template' | 'prompt') => {
+  // FIXME truncate to 100 characters
   const cleanedName = name
     .replace(/[^0-9a-zA-Z ]/g, '') // remove emojis, apostrophes, and dashes
     .split(' ')

--- a/packages/server/postgres/migrations/1693991480688_truncateReflectPromptIds.ts
+++ b/packages/server/postgres/migrations/1693991480688_truncateReflectPromptIds.ts
@@ -1,0 +1,29 @@
+import {Client} from 'pg'
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+/**
+ * The prompt id is used as a foreign key in the ReflectionGroup table and thus should not be excessively long => truncate it to 100 characters.
+ */
+export async function up() {
+  await connectRethinkDB()
+  await r
+    .table('ReflectPrompt')
+    .insert(
+      r
+        .table('ReflectPrompt')
+        .filter((row) => row('id').count().gt(100))
+        .map((row) => row.merge({id: row('id').slice(0, 100)}))
+    )
+    .run()
+  await r
+    .table('ReflectPrompt')
+    .filter((row) => row('id').count().gt(100))
+    .delete()
+    .run()
+  await r.getPoolMaster()?.drain()
+}
+
+export async function down() {
+  // no down migration, as long as ids are unique, we're fine
+}


### PR DESCRIPTION
# Description

Fixes #8772 
The templates
* incidentResponsePostmortemTemplate
* stakeholderSatisfactionPostmortemTemplate
* timeManagementPostmortemTemplate wouldn't allow to add reflections to all prompts because the prompt id we generated was too long. Instead of increasing the maximum for the id, I opted to truncate the existing prompt ids so they fit.

## Demo

https://www.loom.com/share/12d65982939e42e7b0486cc6d01cb075?sid=638ffb69-6357-4c22-933f-bb6fedd9a9f4

## Testing scenarios

- run a retro with all 3 affected templates (needs activity library) and test adding reflections to each prompt

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
