### PR TITLE
fix(checkin): prevent newly added agenda item to be accessible when `agendaitems` phase has not been started yet

### DIFF
--- a/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
+++ b/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
@@ -24,11 +24,15 @@ const addAgendaItemToActiveActionMeeting = async (
   const agendaItemPhase = getPhase(phases, 'agendaitems')
   if (!agendaItemPhase) return undefined
 
+  // if one of the agenda item stages has been started, new item should be navigable
+  // for example, when any phase after agendaitems phase has been started or facilitator navigated back somewhere
+  // before agendaitems phase
+  const isNewAgendaItemStageNavigable = agendaItemPhase.stages.some((stage) => !!stage.startAt)
   const {stages} = agendaItemPhase
   const newStage = new AgendaItemsStage({
     agendaItemId,
-    isNavigableByFacilitator: true,
-    isNavigable: true
+    isNavigableByFacilitator: isNewAgendaItemStageNavigable,
+    isNavigable: isNewAgendaItemStageNavigable
   })
   const {discussionId} = newStage
   stages.push(newStage)


### PR DESCRIPTION
# Description

Fixes #8704 

## Demo

https://www.loom.com/share/4a8ddfe7851e4bff978bfef2421e99a5?sid=3dca0e4f-7ebb-452d-ae14-0b4bdd044168

## Testing scenarios

- [ ] Open checkin meeting, during the solo updates add an agenda item and make sure you can't click on it
- [ ] When the meeting is in the last call phase, or facilitator navigated back from agenda items phase to solo updates newly added agend item should be accessible 

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
