### PR TITLE
fix: removed default button background from your tasks button

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -158,7 +158,7 @@ const TeamPromptTopBar = (props: Props) => {
   const buttons = (
     <ButtonContainer>
       <button
-        className='group flex h-max w-max cursor-pointer flex-col items-center px-2 text-sm font-semibold text-sky-500 hover:text-sky-600'
+        className='group flex h-max w-max cursor-pointer flex-col items-center bg-transparent px-2 text-sm font-semibold text-sky-500 hover:text-sky-600'
         onClick={onOpenWorkSidebar}
       >
         <IconLabel icon='task_alt' iconLarge />


### PR DESCRIPTION
# Description

Fixes `Your tasks` btn bg on standups meetings

## Demo

before
<img width="250" alt="Screenshot 2023-09-08 at 15 45 12" src="https://github.com/ParabolInc/parabol/assets/1017620/32307c37-c251-4d51-ae7c-58049d72b7f0">
after
<img width="292" alt="Screenshot 2023-09-08 at 15 45 00" src="https://github.com/ParabolInc/parabol/assets/1017620/d3591294-31d4-478e-a8d5-4ee10106e0fc">


## Testing scenarios

nothing to test

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
