### PR TITLE
chore: Allow google to index /create-account

### DIFF
--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -99,7 +99,7 @@ server {
 
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 

--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -182,7 +182,7 @@ server {
   }
   location = /robots.txt {
     add_header Content-Type text/plain;
-    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
+    return 200 "User-agent: *\nDisallow: /\nAllow: /$dollar\nAllow: /create-account\nAllow: /signin\nAllow: /retrospective-demo\n";
   }
   include {{ $.DOKKU_ROOT }}/{{ $.APP }}/nginx.conf.d/*.conf;
 


### PR DESCRIPTION
# Description

Right now, https://action.parabol.co/robots.txt has `Allow: create-account` instead of `Allow: /create-account`, which is blocking the create account page from being indexed by Google (and other search engines).  Fixing this should help drive more organic search signups.

## Testing scenarios

N/A, I believe we only run NGINX on dokku, not when developing locally.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
