### PR TITLE
fix: allow to set task max-width

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -112,7 +112,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
         {selectedTasks.length > 0 ? (
           selectedTasks.map((task) => (
             <NullableTask
-              className='w-full rounded border border-solid border-slate-100'
+              className='w-full'
               key={task.id}
               dataCy='foo'
               area={'userDash'}

--- a/packages/client/components/ThreadedTaskBase.tsx
+++ b/packages/client/components/ThreadedTaskBase.tsx
@@ -30,7 +30,9 @@ const HeaderActions = styled('div')({
   paddingRight: 32
 })
 
-const StyledNullableTask = styled(NullableTask)({})
+const StyledNullableTask = styled(NullableTask)({
+  maxWidth: 296
+})
 
 interface Props {
   allowedThreadables: DiscussionThreadables[]

--- a/packages/client/containers/TaskCard/DraggableTask.tsx
+++ b/packages/client/containers/TaskCard/DraggableTask.tsx
@@ -44,6 +44,7 @@ const DraggableTask = (props: Props) => {
           {...dragProvided.dragHandleProps}
         >
           <NullableTask
+            className='max-w-[296px]'
             dataCy={`draggable-task`}
             area={area}
             task={task}

--- a/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamArchive/TeamArchive.tsx
@@ -300,7 +300,13 @@ const TeamArchive = (props: Props) => {
               key={`cardBlockFor${task.id}`}
               style={{...style, width: CARD_WIDTH, padding: '1rem 0.5rem'}}
             >
-              <NullableTask dataCy={`archive-task`} key={key} area='teamDash' task={task} />
+              <NullableTask
+                className='max-w-[296px]'
+                dataCy={`archive-task`}
+                key={key}
+                area='teamDash'
+                task={task}
+              />
             </div>
           )
         }}

--- a/packages/client/styles/helpers/cardRootStyles.ts
+++ b/packages/client/styles/helpers/cardRootStyles.ts
@@ -7,7 +7,6 @@ const cardRootStyles = {
   borderRadius: Card.BORDER_RADIUS,
   boxShadow: cardShadow,
   minWidth: 256,
-  maxWidth: 296,
   position: 'relative' as const,
   width: '100%'
 }


### PR DESCRIPTION
# Description

Fixes #8807 

## Demo

<img width="2090" alt="Screenshot 2023-09-12 at 07 55 26" src="https://github.com/ParabolInc/parabol/assets/1017620/c40b32df-cb5a-42f5-815c-e824df5fdb20">

## Testing scenarios

- [ ] open standup meeting, check task styles in your tasks view
- [ ] check styles in other places where tasks are visible ie. discussions, tasks dashboard

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
