### PR TITLE
fix: filter tasks that are being created by different users in your work drawer

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -38,6 +38,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
                 ...NullableTask_task
                 id
                 status
+                userId
               }
             }
           }
@@ -64,6 +65,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
   const [selectedStatus, setSelectedStatus] = useState<TaskStatusEnum>(TaskStatus.DONE)
   const selectedTasks = tasks.edges
     .map((edge) => edge.node)
+    .filter((task) => task.userId === atmosphere.viewerId)
     .filter((task) => task.status === selectedStatus)
 
   const handleAddTask = () => {


### PR DESCRIPTION
# Description

Fixes #8808 

## Demo

No demo

## Testing scenarios

- [ ] login as Alice in one browser window, login as Bob in the second browser window. open standup meeting and start creating a task as one of the users. validate Bob won't see 'Alice is creating a task' card and otherwise

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
