### PR TITLE
feat(ad-hoc): allow to create team from teams dropdown

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -71,6 +71,7 @@ const ActivityDetailsSidebar = (props: Props) => {
       fragment ActivityDetailsSidebar_viewer on User {
         featureFlags {
           gcal
+          adHocTeams
         }
         ...AdhocTeamMultiSelect_viewer
         organizations {
@@ -323,6 +324,7 @@ const ActivityDetailsSidebar = (props: Props) => {
               selectedTeamRef={selectedTeam}
               teamsRef={availableTeams}
               customPortal={teamScopePopover}
+              allowAddTeam={viewer.featureFlags.adHocTeams}
             />
           )}
 

--- a/packages/client/components/NewMeetingTeamPicker.tsx
+++ b/packages/client/components/NewMeetingTeamPicker.tsx
@@ -26,10 +26,12 @@ interface Props {
   onSelectTeam: (teamId: string) => void
   positionOverride?: MenuPosition
   customPortal?: React.ReactNode
+  allowAddTeam?: boolean
 }
 
 const NewMeetingTeamPicker = (props: Props) => {
-  const {selectedTeamRef, teamsRef, onSelectTeam, positionOverride, customPortal} = props
+  const {selectedTeamRef, teamsRef, onSelectTeam, positionOverride, customPortal, allowAddTeam} =
+    props
   const {togglePortal, menuPortal, originRef, menuProps, portalStatus} = useMenu<HTMLDivElement>(
     positionOverride ?? MenuPosition.LOWER_RIGHT,
     {
@@ -86,6 +88,13 @@ const NewMeetingTeamPicker = (props: Props) => {
             menuProps={menuProps}
             teams={teams}
             teamHandleClick={handleSelectTeam}
+            onAddTeamClick={
+              allowAddTeam
+                ? () => {
+                    window.open(`/newteam/1`, '_blank', 'noreferrer')
+                  }
+                : undefined
+            }
           />
         )
       )}

--- a/packages/client/components/SelectTeamDropdown.tsx
+++ b/packages/client/components/SelectTeamDropdown.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import {Add} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
@@ -13,6 +14,7 @@ interface Props {
   menuProps: MenuProps
   teamHandleClick: (teamId: string, e: React.MouseEvent) => void
   teams: SelectTeamDropdown_teams$key
+  onAddTeamClick?: () => void
 }
 
 const TeamMenu = styled(Menu)({
@@ -20,7 +22,7 @@ const TeamMenu = styled(Menu)({
 })
 
 const SelectTeamDropdown = (props: Props) => {
-  const {teams: teamsRef, menuProps, teamHandleClick} = props
+  const {teams: teamsRef, menuProps, teamHandleClick, onAddTeamClick} = props
   const teams = useFragment(
     graphql`
       fragment SelectTeamDropdown_teams on Team @relay(plural: true) {
@@ -32,7 +34,21 @@ const SelectTeamDropdown = (props: Props) => {
   )
   return (
     <TeamMenu ariaLabel={'Select the team associated with the new task'} {...menuProps}>
-      <DropdownMenuLabel>Select Team:</DropdownMenuLabel>
+      {onAddTeamClick ? (
+        <MenuItem
+          label={
+            <div
+              className='text-md flex w-full items-center px-2 font-semibold leading-8 text-sky-500'
+              onClick={onAddTeamClick}
+            >
+              <Add className='mr-1' />
+              Add Team
+            </div>
+          }
+        />
+      ) : (
+        <DropdownMenuLabel>Select Team:</DropdownMenuLabel>
+      )}
       {teams.map((team) => {
         return (
           <MenuItem

--- a/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
+++ b/packages/server/graphql/public/typeDefs/updateFeatureFlag.graphql
@@ -12,6 +12,7 @@ enum UserFlagEnum {
   checkoutFlow
   retrosInDisguise
   gcal
+  adHocTeams
 }
 
 """
@@ -28,6 +29,7 @@ type UserFeatureFlags {
   checkoutFlow: Boolean!
   retrosInDisguise: Boolean!
   gcal: Boolean!
+  adHocTeams: Boolean!
 }
 
 extend type Mutation {

--- a/packages/server/graphql/public/types/UserFeatureFlags.ts
+++ b/packages/server/graphql/public/types/UserFeatureFlags.ts
@@ -8,7 +8,8 @@ const UserFeatureFlags: UserFeatureFlagsResolvers = {
   noMeetingHistoryLimit: ({noMeetingHistoryLimit}) => !!noMeetingHistoryLimit,
   checkoutFlow: ({checkoutFlow}) => !!checkoutFlow,
   retrosInDisguise: ({retrosInDisguise}) => !!retrosInDisguise,
-  gcal: ({gcal}) => !!gcal
+  gcal: ({gcal}) => !!gcal,
+  adHocTeams: ({adHocTeams}) => !!adHocTeams
 }
 
 export default UserFeatureFlags

--- a/packages/server/graphql/types/UserFlagEnum.ts
+++ b/packages/server/graphql/types/UserFlagEnum.ts
@@ -9,7 +9,8 @@ const UserFlagEnum = new GraphQLEnumType({
     noAISummary: {},
     noMeetingHistoryLimit: {},
     checkoutFlow: {},
-    gcal: {}
+    gcal: {},
+    adHocTeams: {}
   }
 })
 


### PR DESCRIPTION
Fixes: #8824
Fixes: #8826

<img width="421" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/c82f903e-1aca-42cc-a281-a6aba33bb5d9">

How to test:
- add `adHocTeam` user-level feature flag
- go to any meeting in activity library, see that now you can add a team from teams dropdown
- Currently, it just opens a new tab with new team screen