### PR TITLE
fix(check-in): fix navigating from first call to a new agenda item

### DIFF
--- a/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
+++ b/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
@@ -24,6 +24,10 @@ const addAgendaItemToActiveActionMeeting = async (
   const agendaItemPhase = getPhase(phases, 'agendaitems')
   if (!agendaItemPhase) return undefined
 
+  // If any of the stages are navigable, then the new one should be as well. Same goes if there are no stages yet, i.e. we're in first call
+  const isNewAgendaItemStageNavigable =
+    agendaItemPhase.stages.length === 0 ||
+    agendaItemPhase.stages.some((stage) => stage.isNavigableByFacilitator || stage.isNavigable)
   const {stages} = agendaItemPhase
   const newStage = new AgendaItemsStage({
     agendaItemId,

--- a/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
+++ b/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
@@ -31,8 +31,8 @@ const addAgendaItemToActiveActionMeeting = async (
   const {stages} = agendaItemPhase
   const newStage = new AgendaItemsStage({
     agendaItemId,
-    isNavigableByFacilitator: true,
-    isNavigable: true
+    isNavigableByFacilitator: isNewAgendaItemStageNavigable,
+    isNavigable: isNewAgendaItemStageNavigable
   })
   const {discussionId} = newStage
   stages.push(newStage)


### PR DESCRIPTION
# Description

Fixes: #8799 

Fix navigating to a newly created agenda item in "first call".

## Demo

https://www.loom.com/share/108626a1e1b8401dab8e9e7ac9a646e8?sid=6432f262-21b8-46bb-946f-0176701d2573

## Testing scenarios

- start a checkin with no agenda items
- move to first call
- add an agenda item
- see you can navigate there

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
