### PR TITLE
fix: make new agenda items accessible from first call phase

### DIFF
--- a/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
+++ b/packages/server/graphql/mutations/helpers/addAgendaItemToActiveActionMeeting.ts
@@ -24,15 +24,11 @@ const addAgendaItemToActiveActionMeeting = async (
   const agendaItemPhase = getPhase(phases, 'agendaitems')
   if (!agendaItemPhase) return undefined
 
-  // if one of the agenda item stages has been started, new item should be navigable
-  // for example, when any phase after agendaitems phase has been started or facilitator navigated back somewhere
-  // before agendaitems phase
-  const isNewAgendaItemStageNavigable = agendaItemPhase.stages.some((stage) => !!stage.startAt)
   const {stages} = agendaItemPhase
   const newStage = new AgendaItemsStage({
     agendaItemId,
-    isNavigableByFacilitator: isNewAgendaItemStageNavigable,
-    isNavigable: isNewAgendaItemStageNavigable
+    isNavigableByFacilitator: true,
+    isNavigable: true
   })
   const {discussionId} = newStage
   stages.push(newStage)


### PR DESCRIPTION
…enda items phase has not been started yet (#8799)"

This reverts commit 4ce50eeacf257b7de65d07bdaba0f34967227c09.
With #8799 adding agenda items from first call if there are none already makes the meeting non-navigatable.