### PR TITLE
feat: add support for multi-replica deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,10 @@ jobs:
           path: test-results/
           retention-days: 7
 
+      - name: Cleanup Predeploy for Docker Image
+        if: env.DOCKERIZE == 'true'
+        run: rm build/index.html build/sw.js build/manifest.json
+
       - name: Set up Docker Buildx
         if: env.DOCKERIZE == 'true'
         uses: docker/setup-buildx-action@v2

--- a/scripts/toolboxSrc/applyEnvVarsToClientAssets.ts
+++ b/scripts/toolboxSrc/applyEnvVarsToClientAssets.ts
@@ -98,3 +98,5 @@ const rewriteIndexHTML = async () => {
 export const applyEnvVarsToClientAssets = async () => {
   return Promise.all([rewriteServiceWorker(), rewriteIndexHTML(), writeManifest()])
 }
+
+if (require.main === module) applyEnvVarsToClientAssets()

--- a/scripts/toolboxSrc/applyEnvVarsToClientAssets.ts
+++ b/scripts/toolboxSrc/applyEnvVarsToClientAssets.ts
@@ -14,13 +14,13 @@ const getCDNURL = () => {
   return CDN_BASE_URL ? `${CDN_BASE_URL}/build` : '/static'
 }
 
-const rewriteServiceWorker = async () => {
-  const skeleton = await fs.promises.readFile(path.join(clientDir, 'swSkeleton.js'), 'utf-8')
+const rewriteServiceWorker = () => {
+  const skeleton = fs.readFileSync(path.join(clientDir, 'swSkeleton.js'), 'utf-8')
   const deploySpecificServiceWorker = skeleton.replaceAll('__PUBLIC_PATH__', getCDNURL())
-  await fs.promises.writeFile(path.join(clientDir, 'sw.js'), deploySpecificServiceWorker)
+  fs.writeFileSync(path.join(clientDir, 'sw.js'), deploySpecificServiceWorker)
 }
 
-const writeManifest = async () => {
+const writeManifest = () => {
   // If src is relative, then it will be relative to the manifest location, so manifest.json must be at root /
   const cdn = getCDNURL()
   const manifest = {
@@ -45,17 +45,13 @@ const writeManifest = async () => {
     theme_color: '#493272'
   }
   const manifestPath = path.join(clientDir, 'manifest.json')
-
-  await Promise.all([
-    fs.promises.writeFile(manifestPath, JSON.stringify(manifest)),
-    // move the referenced icons into the client build
-    [logo192, logo512].map((name) => {
-      return fs.promises.copyFile(path.join(serverDir, name), path.join(clientDir, name))
-    })
-  ])
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest))
+  // move the referenced icons into the client build
+  fs.copyFileSync(path.join(serverDir, logo192), path.join(clientDir, logo192))
+  fs.copyFileSync(path.join(serverDir, logo512), path.join(clientDir, logo512))
 }
 
-const rewriteIndexHTML = async () => {
+const rewriteIndexHTML = () => {
   const clientKeys = {
     atlassian: process.env.ATLASSIAN_CLIENT_ID,
     datadogClientToken: process.env.DD_CLIENTTOKEN,
@@ -76,8 +72,7 @@ const rewriteIndexHTML = async () => {
     AUTH_SSO_ENABLED: process.env.AUTH_SSO_DISABLED !== 'true'
   }
 
-  const skeleton = await fs.promises.readFile(path.join(clientDir, 'skeleton.html'), 'utf8')
-
+  const skeleton = fs.readFileSync(path.join(clientDir, 'skeleton.html'), 'utf8')
   // Hide staging & PPMIs from search engines
   const noindex =
     process.env.HOST === 'action.parabol.co' ? '' : `<meta name="robots" content="noindex"/>`
@@ -92,11 +87,16 @@ const rewriteIndexHTML = async () => {
     removeScriptTypeAttributes: true,
     removeComments: true
   })
-  await fs.promises.writeFile(path.join(clientDir, 'index.html'), minifiedHTML)
+  fs.writeFileSync(path.join(clientDir, 'index.html'), minifiedHTML)
 }
 
-export const applyEnvVarsToClientAssets = async () => {
-  return Promise.all([rewriteServiceWorker(), rewriteIndexHTML(), writeManifest()])
+export const applyEnvVarsToClientAssets = () => {
+  // When web.js starts, serveStatic generates a whitelist of all valid built assets
+  // so users cannot trigger a disk read by requesting an asset that may not exist (0days often involve disk reads)
+  // That means this script must run synchronusly and complete before web.js starts
+  rewriteServiceWorker()
+  rewriteIndexHTML()
+  writeManifest()
 }
 
 if (require.main === module) applyEnvVarsToClientAssets()

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -24,7 +24,12 @@ module.exports = ({noDeps}) => ({
   },
   entry: {
     chronos: [DOTENV, path.join(PROJECT_ROOT, 'packages/chronos/chronos.ts')],
-    web: [DOTENV, path.join(SERVER_ROOT, 'server.ts')],
+    web: [
+      DOTENV,
+      // each instance of web needs to generate its own index.html to use on startup
+      path.join(PROJECT_ROOT, 'scripts/toolboxSrc/applyEnvVarsToClientAssets.ts'),
+      path.join(SERVER_ROOT, 'server.ts')
+    ],
     gqlExecutor: [DOTENV, path.join(GQL_ROOT, 'gqlExecutor.ts')],
     preDeploy: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/preDeploy.ts')],
     pushToCDN: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/pushToCDN.ts')],


### PR DESCRIPTION
# Description

fix #8834

since index.html doesn't exist in the docker image, we need to generate it wherever `node dist/web.js` is called.

## Demo

N/A

## Testing scenarios

- [x] check our CI, it works!
- [ ] locally, run `yarn build --no-deps && node dist/preDeploy && node dist/web`
- [ ] locally, run `yarn build --no-deps && node dist/web`