### PR TITLE
fix(billing): Stop updating Enterprise Stripe subscription quantities to AU count

### DIFF
--- a/packages/server/billing/helpers/updateSubscriptionQuantity.ts
+++ b/packages/server/billing/helpers/updateSubscriptionQuantity.ts
@@ -15,8 +15,8 @@ const updateSubscriptionQuantity = async (orgId: string, logMismatch?: boolean) 
   const org = await r.table('Organization').get(orgId).run()
 
   if (!org) throw new Error(`org not found for invoice`)
-  const {stripeSubscriptionId} = org
-  if (!stripeSubscriptionId) return
+  const {stripeSubscriptionId, tier} = org
+  if (!stripeSubscriptionId || tier === 'enterprise') return
 
   // Hold the lock for 5s max and try to acquire the lock for 10s.
   // If there are lots of changes for the same orgId, then this can result in some of the updates timing out.

--- a/packages/server/graphql/private/mutations/stripeCreateInvoice.ts
+++ b/packages/server/graphql/private/mutations/stripeCreateInvoice.ts
@@ -30,10 +30,7 @@ const stripeCreateInvoice: MutationResolvers['stripeCreateInvoice'] = async (
   } = stripeCustomer
   if (!orgId) throw new Error(`orgId not found on metadata for invoice ${invoiceId}`)
 
-  const isTierModeVolume = stripeLineItems.every(({plan}) => plan?.tiers_mode === 'volume')
-  if (!isTierModeVolume) {
-    await updateSubscriptionQuantity(orgId, true)
-  }
+  await updateSubscriptionQuantity(orgId, true)
 
   await Promise.all([
     generateInvoice(invoice, stripeLineItems, orgId, invoiceId, dataLoader),


### PR DESCRIPTION
# Description

Fixes #8104.

The fix introduced by #8105 didn't catch all cases, and we've continued to see some enterprise subscriptions updated with AU counts over the last few months.  This change moves the check to the `updateSubscriptionQuantity` function itself, and early exits if the tier of the org we are asking to update is an enterprise org.  It also removes the now unnecessary check introduced in #8105 in `stripeCreateInvoice.ts`.

## Testing scenarios

Repeat testing steps from #8105.