### PR TITLE
feat(standups): Add slack configuration link to standup options

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled'
-import {Flag, Link, Replay} from '@mui/icons-material'
+import {Flag, Link as MuiLink, OpenInNew, Replay} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
+import {Link} from 'react-router-dom'
 import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {MenuProps} from '~/hooks/useMenu'
@@ -15,8 +16,9 @@ import makeAppURL from '../../utils/makeAppURL'
 import Menu from '../Menu'
 import MenuItem from '../MenuItem'
 import {MenuItemLabelStyle} from '../MenuItemLabel'
+import SlackSVG from '../SlackSVG'
 
-const LinkIcon = styled(Link)({
+const LinkIcon = styled(MuiLink)({
   color: PALETTE.SLATE_600,
   marginRight: 8
 })
@@ -128,6 +130,28 @@ const TeamPromptOptionsMenu = (props: Props) => {
         onClick={() => {
           menuProps.closePortal()
           openRecurrenceSettingsModal()
+        }}
+      />
+      <MenuItem
+        key='slack'
+        label={
+          <Link
+            to={`/team/${team.id}/settings/integrations`}
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            <OptionMenuItem>
+              <SlackSVG />
+              <span className='ml-2'>Configure slack</span>
+              <OpenInNew className='ml-1 text-base text-slate-600' />
+            </OptionMenuItem>
+          </Link>
+        }
+        onClick={() => {
+          SendClientSegmentEventMutation(atmosphere, 'Configure Slack Standup Clicked', {
+            teamId: team?.id,
+            meetingId: meetingId
+          })
         }}
       />
       <MenuItem

--- a/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptOptionsMenu.tsx
@@ -142,8 +142,8 @@ const TeamPromptOptionsMenu = (props: Props) => {
           >
             <OptionMenuItem>
               <SlackSVG />
-              <span className='ml-2'>Configure slack</span>
-              <OpenInNew className='ml-1 text-base text-slate-600' />
+              <span className='ml-2'>Configure Slack</span>
+              <OpenInNew className='ml-auto text-base text-slate-600' />
             </OptionMenuItem>
           </Link>
         }


### PR DESCRIPTION
# Description
See [slack discussion](https://parabol.slack.com/archives/C042HTVBH8D/p1695159030945889) 🔒 

Add a standup meeting option menu item for "slack configuration" that links to the team's integrations page.

Also add metrics for when this option is clicked (note: this won't fire if the user specifically opens the link in a new tab instead of clicking)

## Demo
<img width="374" alt="Screen Shot 2023-09-21 at 1 45 40 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/7ffd4b2f-3ad9-4875-a478-cffb27361086">



## Testing scenarios
- [ ] UI makes sense
- [ ] Clicking sends the user to integration options in a new tab and sends a metric
- [ ] User can open the link by manually opening in new tab

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
