### PR TITLE
feat(al): Show standup meeting type first in all views

### DIFF
--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -138,6 +138,7 @@ const User: UserResolvers = {
       })
     }
     const getScore = (activity: MeetingTemplate, teamIds: string[]) => {
+      const IS_STANDUP = 1 << 9 // prioritize standups (see https://github.com/ParabolInc/parabol/issues/8848)
       const SEASONAL = 1 << 8 // put seasonal templates at the top
       const USED_LAST_90 = 1 << 7 // next, show all templates used within the last 90 days
       const ON_TEAM = 1 << 6 // tiebreak by putting team templates first
@@ -145,12 +146,14 @@ const User: UserResolvers = {
       const IS_FREE = 1 << 4 // then free parabol templates
       const USED_LAST_30 = 1 << 3 // tiebreak on being used in last 30
       const {hideStartingAt, teamId, orgId, lastUsedAt, isFree} = activity
+      const isStandup = activity.type === 'teamPrompt'
       const isSeasonal = !!hideStartingAt
       const isOnTeam = teamIds.includes(teamId)
       const isOnOrg = orgId !== 'aGhostOrg' && !isOnTeam
       const isUsedLast30 = lastUsedAt && lastUsedAt > new Date(Date.now() - ms('30d'))
       const isUsedLast90 = lastUsedAt && lastUsedAt > new Date(Date.now() - ms('90d'))
       let score = 0
+      if (isStandup) score += IS_STANDUP
       if (isSeasonal) score += SEASONAL
       if (isUsedLast90) score += USED_LAST_90
       if (isOnTeam) score += ON_TEAM


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8848

Move the "standup" meeting type to the top of the quick start view in the activity library.

## Demo
<img width="1397" alt="Screen Shot 2023-09-20 at 5 58 03 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/fc171725-c8bf-413b-a8c5-5eb7e49664bf">


## Testing scenarios
- [ ] Confirm standup is first in quick start

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
