### PR TITLE
chore: upgrade openai

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -122,7 +122,7 @@
     "node-pg-migrate": "^5.9.0",
     "nodemailer": "^6.4.6",
     "oauth-1.0a": "^2.2.6",
-    "openai": "^3.3.0",
+    "openai": "^4.9.0",
     "oy-vey": "^0.11.0",
     "parabol-client": "^6.121.0",
     "pg": "^8.5.1",

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -3,7 +3,7 @@ import sendToSentry from './sendToSentry'
 import Reflection from '../database/types/Reflection'
 
 class OpenAIServerManager {
-  private openAIApi: OpenAI | null
+  private openAIApi
   constructor() {
     if (!process.env.OPEN_AI_API_KEY) {
       this.openAIApi = null

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -4,7 +4,6 @@ import Reflection from '../database/types/Reflection'
 
 class OpenAIServerManager {
   private openAIApi: OpenAI | null
-
   constructor() {
     if (!process.env.OPEN_AI_API_KEY) {
       this.openAIApi = null

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -1,20 +1,19 @@
-import {Configuration, OpenAIApi} from 'openai'
+import OpenAI from 'openai'
 import sendToSentry from './sendToSentry'
 import Reflection from '../database/types/Reflection'
 
 class OpenAIServerManager {
-  private openAIApi: OpenAIApi | null
+  private openAIApi: OpenAI | null
 
   constructor() {
     if (!process.env.OPEN_AI_API_KEY) {
       this.openAIApi = null
       return
     }
-    const configuration = new Configuration({
+    this.openAIApi = new OpenAI({
       apiKey: process.env.OPEN_AI_API_KEY,
       organization: process.env.OPEN_AI_ORG_ID
     })
-    this.openAIApi = new OpenAIApi(configuration)
   }
 
   async getStandupSummary(plaintextResponses: string[], meetingPrompt: string) {
@@ -33,7 +32,7 @@ class OpenAIServerManager {
     ${plaintextResponses.join('\nNEW_RESPONSE\n')}
     """`
     try {
-      const response = await this.openAIApi.createChatCompletion({
+      const response = await this.openAIApi.chat.completions.create({
         model: 'gpt-3.5-turbo',
         messages: [
           {
@@ -47,7 +46,7 @@ class OpenAIServerManager {
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      return (response.data.choices[0]?.message?.content?.trim() as string) ?? null
+      return (response.choices[0]?.message?.content?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)
@@ -68,7 +67,7 @@ class OpenAIServerManager {
     ${textStr}
     """`
     try {
-      const response = await this.openAIApi.createChatCompletion({
+      const response = await this.openAIApi.chat.completions.create({
         model: 'gpt-3.5-turbo',
         messages: [
           {
@@ -82,7 +81,7 @@ class OpenAIServerManager {
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      return (response.data.choices[0]?.message?.content?.trim() as string) ?? null
+      return (response.choices[0]?.message?.content?.trim() as string) ?? null
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to getSummary')
       sendToSentry(error)
@@ -118,7 +117,7 @@ class OpenAIServerManager {
       .map(({plaintextContent}) => plaintextContent.trim().replace(/\n/g, '\t'))
       .join('\n')}`
     try {
-      const response = await this.openAIApi.createChatCompletion({
+      const response = await this.openAIApi.chat.completions.create({
         model: 'gpt-3.5-turbo',
         messages: [
           {
@@ -130,7 +129,7 @@ class OpenAIServerManager {
         max_tokens: 80
       })
       const question =
-        (response.data.choices[0]?.message?.content?.trim() as string).replace(
+        (response.choices[0]?.message?.content?.trim() as string).replace(
           /^[Qq]uestion:*\s*/gi,
           ''
         ) ?? null
@@ -155,7 +154,7 @@ class OpenAIServerManager {
     )}. Each theme should be no longer than a few words. There should be roughly ${suggestedThemeCountMin} to ${suggestedThemeCountMax} themes. Return the themes as a comma-separated list.`
 
     try {
-      const response = await this.openAIApi.createChatCompletion({
+      const response = await this.openAIApi.chat.completions.create({
         model: 'gpt-4',
         messages: [
           {
@@ -168,7 +167,7 @@ class OpenAIServerManager {
         frequency_penalty: 0,
         presence_penalty: 0
       })
-      const themes = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
+      const themes = (response.choices[0]?.message?.content?.trim() as string) ?? null
       return themes.split(', ')
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to generate themes')
@@ -189,7 +188,7 @@ class OpenAIServerManager {
         ', '
       )}, and the following reflection: "${reflection}", classify the reflection into the theme it fits in best. The reflection can only be added to one theme. Do not edit the reflection text. Your output should just be the theme name, and must be one of the themes I've provided.`
 
-      const response = await this.openAIApi!.createChatCompletion({
+      const response = await this.openAIApi!.chat.completions.create({
         model: 'gpt-4',
         messages: [
           {
@@ -203,7 +202,7 @@ class OpenAIServerManager {
         presence_penalty: 0
       })
 
-      const theme = (response.data.choices[0]?.message?.content?.trim() as string) ?? null
+      const theme = (response.choices[0]?.message?.content?.trim() as string) ?? null
       if (!theme || !themes.includes(theme)) {
         if (!retry) {
           return getThemeForReflection(reflection, true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8054,6 +8054,14 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
+"@types/node-fetch@^2.6.4":
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.5.tgz#972756a9a0fe354b2886bf3defe667ddb4f0d30a"
+  integrity sha512-OZsUlr2nxvkqUFLSaY2ZbA+P1q22q+KrlxWOn/38RX+u5kTkYL2mTujEpzUhGkS+K/QCYp9oagfXG39XOzyySg==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node@*", "@types/node@>=13.7.0":
   version "17.0.38"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
@@ -8068,6 +8076,11 @@
   version "16.11.62"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.62.tgz#bab2e6208531321d147eda20c38e389548cd5ffc"
   integrity sha512-K/ggecSdwAAy2NUW4WKmF4Rc03GKbsfP+k326UWgckoS+Rzd2PaWbjk76dSmqdLQvLTJAO9axiTUJ6488mFsYQ==
+
+"@types/node@^18.11.18":
+  version "18.17.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.18.tgz#acae19ad9011a2ab3d792232501c95085ba1838f"
+  integrity sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==
 
 "@types/nodemailer@^6.4.4":
   version "6.4.4"
@@ -8744,6 +8757,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -9310,13 +9330,6 @@ axios@^0.21.0, axios@^0.21.4:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.26.0:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
-  dependencies:
-    follow-redirects "^1.14.8"
-
 axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
@@ -9533,6 +9546,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==
 
 base-64@^1.0.0:
   version "1.0.0"
@@ -11326,6 +11344,14 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+digest-fetch@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/digest-fetch/-/digest-fetch-1.3.0.tgz#898e69264d00012a23cf26e8a3e40320143fc661"
+  integrity sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==
+  dependencies:
+    base-64 "^0.1.0"
+    md5 "^2.3.0"
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -12065,6 +12091,11 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter-asyncresource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz#734ff2e44bf448e627f7748f905d6bdd57bdb65b"
@@ -12513,7 +12544,7 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
-follow-redirects@^1.14.8, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
+follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -12525,6 +12556,11 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data-encoder@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
+  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
 
 form-data-encoder@^1.7.2:
   version "1.9.0"
@@ -15777,7 +15813,7 @@ marked@^4.3.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
-md5@^2.2.1:
+md5@^2.2.1, md5@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
@@ -17031,13 +17067,19 @@ open@^8.0.9, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openai@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-3.3.0.tgz#a6408016ad0945738e1febf43f2fccca83a3f532"
-  integrity sha512-uqxI/Au+aPRnsaQRe8CojU0eCR7I0mBiKjD3sNMzY6DaC1ZVrc85u98mtJW6voDug8fgGN+DIZmTDxTthxb7dQ==
+openai@^4.9.0:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/openai/-/openai-4.9.1.tgz#fe5c11a61f298d2d70cfd6163e146307581c71bc"
+  integrity sha512-R+ahYXaBYcDvyBrFpor2WZcNqh/0/+3rtCLy0/m2nriBuB9UecpKxllk6kfrwNkkLryCi1cs8tWjvCX2Ny27Gw==
   dependencies:
-    axios "^0.26.0"
-    form-data "^4.0.0"
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    digest-fetch "^1.3.0"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
 
 openapi-types@^12.1.0:
   version "12.1.1"


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8737

https://github.com/ParabolInc/parabol/issues/8737 mentions that during a meeting, some of the AI features were showing up and some weren't. I agree with @tianrunhe that there may have been a timeout issue. There are plenty of threads (like [this one](https://community.openai.com/t/resolved-is-gpt3-5-api-timing-out-a-known-issue/106094)) where people report performance issues.

Looking at the [usage data](https://platform.openai.com/account/usage), I don't see us hitting any rate limits. I also don't see any recent 429 errors in Sentry. 

I don't see why any potential timeouts would be connected to the meeting crashing, though, as we're handling errors safely. 

Upgrading to the latest version of `openai` may help with the AI performance issues as v4 has improved latency through reusing TCP connections: https://github.com/openai/openai-node/discussions/182

### To test

- [ ] Run a Retro and see that Suggest Groups, AI Summaries, and Discussion Prompts work as expected
- [ ] Run a Standup and see the AI Summary works as expected
