### PR TITLE
fix(standups): 'Your tasks' -> 'Your work'

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -162,7 +162,7 @@ const TeamPromptTopBar = (props: Props) => {
         onClick={onOpenWorkSidebar}
       >
         <IconLabel icon='task_alt' iconLarge />
-        <div className='text-slate-700 group-hover:text-slate-900'>Your tasks</div>
+        <div className='text-slate-700 group-hover:text-slate-900'>Your work</div>
       </button>
       <TeamPromptOptions
         meetingRef={meeting}


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8869

## Demo
<img width="350" alt="Screen Shot 2023-09-21 at 1 48 51 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/e5613575-09e8-4603-94e8-58356730a565">

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
