### PR TITLE
feat(standups): Display responses in single column (feature flagged)

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -30,23 +30,26 @@ const fiveColumnResponseMediaQuery = `@media screen and (min-width: ${ResponsesG
 
 const ResponseWrapper = styled('div')<{
   status: TransitionStatus
-}>(({status}) => ({
+  isSingleColumn: boolean
+}>(({status, isSingleColumn}) => ({
   opacity: status === TransitionStatus.MOUNTED || status === TransitionStatus.EXITING ? 0 : 1,
   transition: `box-shadow 100ms ${BezierCurve.DECELERATE}, opacity 300ms ${BezierCurve.DECELERATE}`,
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
+  maxWidth: isSingleColumn ? '850px' : undefined,
+  margin: isSingleColumn ? '0 auto' : undefined,
   [twoColumnResponseMediaQuery]: {
-    width: `calc(100% / 2 - ${ResponseCardDimensions.GAP}px)`
+    width: isSingleColumn ? undefined : `calc(100% / 2 - ${ResponseCardDimensions.GAP}px)`
   },
   [threeColumnResponseMediaQuery]: {
-    width: `calc(100% / 3 - ${ResponseCardDimensions.GAP}px)`
+    width: isSingleColumn ? undefined : `calc(100% / 3 - ${ResponseCardDimensions.GAP}px)`
   },
   [fourColumnResponseMediaQuery]: {
-    width: `calc(100% / 4 - ${ResponseCardDimensions.GAP}px)`
+    width: isSingleColumn ? undefined : `calc(100% / 4 - ${ResponseCardDimensions.GAP}px)`
   },
   [fiveColumnResponseMediaQuery]: {
-    width: `calc(100% / 5 - ${ResponseCardDimensions.GAP}px)`
+    width: isSingleColumn ? undefined : `calc(100% / 5 - ${ResponseCardDimensions.GAP}px)`
   }
 }))
 
@@ -105,11 +108,12 @@ interface Props {
   stageRef: TeamPromptResponseCard_stage$key
   status: TransitionStatus
   displayIdx: number
+  isSingleColumn: boolean
   onTransitionEnd: () => void
 }
 
 const TeamPromptResponseCard = (props: Props) => {
-  const {stageRef, status, onTransitionEnd, displayIdx} = props
+  const {stageRef, status, onTransitionEnd, displayIdx, isSingleColumn} = props
   const responseStage = useFragment(
     graphql`
       fragment TeamPromptResponseCard_stage on TeamPromptResponseStage {
@@ -207,7 +211,12 @@ const TeamPromptResponseCard = (props: Props) => {
   const ref = useAnimatedCard(displayIdx, status)
 
   return (
-    <ResponseWrapper ref={ref} status={status} onTransitionEnd={onTransitionEnd}>
+    <ResponseWrapper
+      ref={ref}
+      status={status}
+      onTransitionEnd={onTransitionEnd}
+      isSingleColumn={isSingleColumn}
+    >
       <ResponseHeader>
         <Avatar picture={picture} size={48} />
         <TeamMemberName>

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -37,7 +37,7 @@ const ResponseWrapper = styled('div')<{
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  maxWidth: isSingleColumn ? '850px' : undefined,
+  maxWidth: isSingleColumn ? '600px' : undefined,
   margin: isSingleColumn ? '0 auto' : undefined,
   [twoColumnResponseMediaQuery]: {
     width: isSingleColumn ? undefined : `calc(100% / 2 - ${ResponseCardDimensions.GAP}px)`

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -86,11 +86,18 @@ const TeamPromptMeeting = (props: Props) => {
             }
           }
         }
+        organization {
+          featureFlags {
+            singleColumnStandups
+          }
+        }
       }
     `,
     meetingRef
   )
-  const {phases} = meeting
+  const {phases, organization} = meeting
+  const {featureFlags} = organization
+  const {singleColumnStandups} = featureFlags
   const atmosphere = useAtmosphere()
   const {viewerId} = atmosphere
 
@@ -172,6 +179,7 @@ const TeamPromptMeeting = (props: Props) => {
                           onTransitionEnd={onTransitionEnd}
                           displayIdx={displayIdx}
                           stageRef={stage}
+                          isSingleColumn={singleColumnStandups}
                         />
                       )
                     })}

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -37,13 +37,14 @@ const ResponsesGridContainer = styled('div')({
   }
 })
 
-const ResponsesGrid = styled('div')({
+const ResponsesGrid = styled('div')<{isSingleColumn: boolean}>(({isSingleColumn}) => ({
   flex: 1,
   display: 'flex',
   flexWrap: 'wrap',
+  flexDirection: isSingleColumn ? 'column' : 'row',
   position: 'relative',
   gap: 32
-})
+}))
 
 interface Props {
   meeting: TeamPromptMeeting_meeting$key
@@ -167,7 +168,7 @@ const TeamPromptMeeting = (props: Props) => {
               <TeamPromptEditablePrompt meetingRef={meeting} />
               <ErrorBoundary>
                 <ResponsesGridContainer>
-                  <ResponsesGrid>
+                  <ResponsesGrid isSingleColumn={singleColumnStandups}>
                     {transitioningStages.map((transitioningStage) => {
                       const {child: stage, onTransitionEnd, status} = transitioningStage
                       const {key, displayIdx} = stage

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -12,6 +12,7 @@ enum OrganizationFeatureFlagsEnum {
   teamsLimit
   teamInsights
   oneOnOne
+  singleColumnStandups
 }
 
 extend type Mutation {

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -188,4 +188,5 @@ type OrganizationFeatureFlags {
   teamsLimit: Boolean!
   teamInsights: Boolean!
   oneOnOne: Boolean!
+  singleColumnStandups: Boolean!
 }

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -10,7 +10,8 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   suggestGroups: ({suggestGroups}) => !!suggestGroups,
   teamsLimit: ({teamsLimit}) => !!teamsLimit,
   teamInsights: ({teamInsights}) => !!teamInsights,
-  oneOnOne: ({oneOnOne}) => !!oneOnOne
+  oneOnOne: ({oneOnOne}) => !!oneOnOne,
+  singleColumnStandups: ({singleColumnStandups}) => !!singleColumnStandups
 }
 
 export default OrganizationFeatureFlags


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8865

Standup responses are pretty narrow for our own internal Friday Ship updates, leading to updates that can take up the entire height of the screen (or more), which can be annoying.

Add a feature flag for showing these responses in a single column. We'll use this internally, and roll out to everyone if we decide that's what we want to do. Alternatively, we could potentially add a "grid vs. list" option for each user, persisted on the client-side.

## Demo
<img width="1719" alt="Screen Shot 2023-09-21 at 2 05 51 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/a5c41fbd-87e9-4d5a-b9cd-b52d6e78dcec">
<img width="464" alt="Screen Shot 2023-09-21 at 2 06 15 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/512140e5-a44f-4569-82ec-fb3d0cabedd3">
<img width="1131" alt="Screen Shot 2023-09-21 at 2 05 58 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/2268a2eb-9d7e-44fd-9939-79736bf4e59d">


## Testing scenarios

- [ ] Smoke test the grid view without the feature flag
- [ ] Add the `singleColumnStandups` org feature flag, and test the response list.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
