### PR TITLE
feat(Team Insights): add meeting engagement insights

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/MeetingEngagementCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/MeetingEngagementCard.tsx
@@ -1,0 +1,62 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {MeetingEngagementCard_insights$key} from '~/__generated__/MeetingEngagementCard_insights.graphql'
+import TeamInsightsCard from './TeamInsightsCard'
+
+// We need to tune this once we have some data on real teams
+const HIGH_ENGAGEMENT_THRESHOLD = 0.7
+const LOW_ENGAGEMENT_THRESHOLD = 0.3
+
+const getDescription = (engagement: number) => {
+  if (engagement >= HIGH_ENGAGEMENT_THRESHOLD) {
+    return 'Great job! Your meetings have a higher engagement rate than the average team using Parabol. Keep it up!'
+  }
+  if (engagement <= LOW_ENGAGEMENT_THRESHOLD) {
+    return 'Your engagement rate is lower than other Parabol teams. Try starting with an icebreaker to get everyone talking or discuss why people don’t feel like contributing to your meeting.'
+  }
+  return 'You have an average meeting engagement rate, but there’s always room for improvement! Try mixing things up with a new template.'
+}
+
+interface Props {
+  teamInsightsRef: MeetingEngagementCard_insights$key
+}
+
+const MeetingEngagementCard = (props: Props) => {
+  const {teamInsightsRef} = props
+  const insights = useFragment(
+    graphql`
+      fragment MeetingEngagementCard_insights on TeamInsights {
+        ...TeamInsightsCard_insights
+        meetingEngagement {
+          all
+        }
+      }
+    `,
+    teamInsightsRef
+  )
+
+  const {meetingEngagement} = insights
+  const all = meetingEngagement?.all
+  if (all === undefined) {
+    return null
+  }
+
+  const percent = `${Math.round(all * 100)}%`
+  const description = getDescription(all)
+
+  return (
+    <TeamInsightsCard
+      teamInsightsRef={insights}
+      title='Meeting Engagement'
+      tooltip='Reflections, groups, comments and emoji reactions created in your last meetings, relative to the number of participants'
+    >
+      <div className='flex flex-col p-4'>
+        <div className='flex justify-center pb-6 text-5xl text-grape-500'>{percent}</div>
+        <div className='text-sm'>{description}</div>
+      </div>
+    </TeamInsightsCard>
+  )
+}
+
+export default MeetingEngagementCard

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/MeetingEngagementCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/MeetingEngagementCard.tsx
@@ -4,12 +4,12 @@ import {useFragment} from 'react-relay'
 import {MeetingEngagementCard_insights$key} from '~/__generated__/MeetingEngagementCard_insights.graphql'
 import TeamInsightsCard from './TeamInsightsCard'
 
-// We need to tune this once we have some data on real teams
-const HIGH_ENGAGEMENT_THRESHOLD = 0.7
-const LOW_ENGAGEMENT_THRESHOLD = 0.3
+// TODO: We need to tune this once we have some data on real teams
+const HIGH_ENGAGEMENT_THRESHOLD = 0.8
+const LOW_ENGAGEMENT_THRESHOLD = 0.6
 
 const getDescription = (engagement: number) => {
-  if (engagement >= HIGH_ENGAGEMENT_THRESHOLD) {
+  if (engagement > HIGH_ENGAGEMENT_THRESHOLD) {
     return 'Great job! Your meetings have a higher engagement rate than the average team using Parabol. Keep it up!'
   }
   if (engagement <= LOW_ENGAGEMENT_THRESHOLD) {

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TeamDashInsights.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {useFragment} from 'react-relay'
 import {TeamDashInsights_insights$key} from '~/__generated__/TeamDashInsights_insights.graphql'
 import MostUsedEmojisCard from './MostUsedEmojisCard'
+import MeetingEngagementCard from './MeetingEngagementCard'
 
 interface Props {
   teamInsightsRef: TeamDashInsights_insights$key
@@ -15,6 +16,7 @@ const TeamDashInsights = (props: Props) => {
       fragment TeamDashInsights_insights on TeamInsights {
         id
         ...MostUsedEmojisCard_insights
+        ...MeetingEngagementCard_insights
       }
     `,
     teamInsightsRef
@@ -25,6 +27,7 @@ const TeamDashInsights = (props: Props) => {
       <h3 className='mb-0 pl-2 text-base font-semibold'>Team Insights</h3>
       <div className='flex w-full flex-wrap'>
         <MostUsedEmojisCard teamInsightsRef={insights} />
+        <MeetingEngagementCard teamInsightsRef={insights} />
       </div>
     </div>
   )

--- a/packages/server/database/types/Comment.ts
+++ b/packages/server/database/types/Comment.ts
@@ -26,6 +26,7 @@ export default class Comment {
   reactjis: Reactji[]
   updatedAt: Date
   content: string
+  // userId of the creator
   createdBy: string
   plaintextContent: string
   discussionId: string

--- a/packages/server/database/types/Meeting.ts
+++ b/packages/server/database/types/Meeting.ts
@@ -45,6 +45,7 @@ export default abstract class Meeting {
   sentimentScore?: number
   usedReactjis?: Record<string, number>
   slackTs?: string
+  engagement?: number
 
   constructor(input: Input) {
     const {

--- a/packages/server/database/types/Reflection.ts
+++ b/packages/server/database/types/Reflection.ts
@@ -23,6 +23,7 @@ export default class Reflection {
   id: string
   autoReflectionGroupId?: string
   createdAt: Date
+  // userId of the creator
   creatorId: string
   content: string
   plaintextContent: string

--- a/packages/server/database/types/ReflectionGroup.ts
+++ b/packages/server/database/types/ReflectionGroup.ts
@@ -22,6 +22,7 @@ export default class ReflectionGroup {
   promptId: string
   sortOrder: number
   updatedAt: Date
+  // userIds of the voters
   voterIds: string[]
   smartTitle: string | null
   summary: string | null

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -20,8 +20,8 @@ import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {DataLoaderWorker, GQLContext} from '../graphql'
 import EndCheckInPayload from '../types/EndCheckInPayload'
-import collectReactjis from './helpers/collectReactjis'
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
+import gatherInsights from './helpers/gatherInsights'
 import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
 import updateTeamInsights from './helpers/updateTeamInsights'
@@ -194,7 +194,7 @@ export default {
       stage.endAt = now
     }
     const phase = getMeetingPhase(phases)
-    const usedReactjis = await collectReactjis(meeting, dataLoader)
+    const insights = await gatherInsights(meeting, dataLoader)
 
     const completedCheckIn = (await r
       .table('NewMeeting')
@@ -203,7 +203,7 @@ export default {
         {
           endedAt: now,
           phases,
-          usedReactjis
+          ...insights
         },
         {returnChanges: true}
       )('changes')(0)('new_val')

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -15,7 +15,7 @@ import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import EndSprintPokerPayload from '../types/EndSprintPokerPayload'
-import collectReactjis from './helpers/collectReactjis'
+import gatherInsights from './helpers/gatherInsights'
 import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
@@ -74,7 +74,7 @@ export default {
       estimateStages.filter(({isComplete}) => isComplete).map(({taskId}) => taskId)
     ).size
     const discussionIds = estimateStages.map((stage) => stage.discussionId)
-    const usedReactjis = await collectReactjis(meeting, dataLoader)
+    const insights = await gatherInsights(meeting, dataLoader)
 
     const completedMeeting = (await r
       .table('NewMeeting')
@@ -89,7 +89,7 @@ export default {
             .count()
             .default(0) as unknown as number,
           storyCount,
-          usedReactjis
+          ...insights
         },
         {returnChanges: true, nonAtomic: true}
       )('changes')(0)('new_val')

--- a/packages/server/graphql/mutations/helpers/calculateEngagement.ts
+++ b/packages/server/graphql/mutations/helpers/calculateEngagement.ts
@@ -11,8 +11,8 @@ import isValid from '../../isValid'
  * **retro**: meeting member who did at least 1 of facilitated, added team health response, reflection, discussion, reaction, task / total meeting members
  *   - **not included**: voting, grouping
  * **check-in**: ignore as every member will have a solo update phase
- * **sprint poker**: meeting members facilitated, voted or discussed / total meeting members
- * **standup**: replied or commented / all members
+ * **sprint poker**: meeting members facilitated, voted discussed or reacted / total meeting members
+ * **standup**: replied, commented or reacted / all members
  */
 const calculateEngagement = async (meeting: Meeting, dataLoader: DataLoaderWorker) => {
   const {id: meetingId, phases, meetingType, facilitatorUserId} = meeting
@@ -57,8 +57,11 @@ const calculateEngagement = async (meeting: Meeting, dataLoader: DataLoaderWorke
   // Team prompt responses
   if (phases.find(({phaseType}) => phaseType === 'RESPONSES')) {
     const responses = await getTeamPromptResponsesByMeetingId(meetingId)
-    responses.forEach(({userId}) => {
+    responses.forEach(({userId, reactjis}) => {
       passiveMembers.delete(userId)
+      reactjis.forEach(({userId}) => {
+        passiveMembers.delete(userId)
+      })
     })
     if (passiveMembers.size === 0) return 1
   }

--- a/packages/server/graphql/mutations/helpers/calculateEngagement.ts
+++ b/packages/server/graphql/mutations/helpers/calculateEngagement.ts
@@ -1,0 +1,103 @@
+import TeamMemberId from '../../../../client/shared/gqlIds/TeamMemberId'
+import EstimatePhase from '../../../database/types/EstimatePhase'
+import Meeting from '../../../database/types/Meeting'
+import TeamHealthPhase from '../../../database/types/TeamHealthPhase'
+import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTeamPromptResponsesByMeetingIds'
+import {DataLoaderWorker} from '../../graphql'
+import isValid from '../../isValid'
+
+/**
+ * at the end of a meeting, calculate the engagement:
+ * **retro**: meeting member who did at least 1 of facilitated, added team health response, reflection, vote, discussion, task / total meeting members
+ * **check-in**: ignore as every member will have a solo update phase
+ * **sprint poker**: meeting members facilitated, voted or discussed / total meeting members
+ * **standup**: replied or commented / all members
+ */
+const calculateEngagement = async (meeting: Meeting, dataLoader: DataLoaderWorker) => {
+  const {id: meetingId, phases, meetingType, facilitatorUserId} = meeting
+
+  if (meetingType === 'action') return undefined
+
+  const meetingMembers = await dataLoader.get('meetingMembersByMeetingId').load(meetingId)
+
+  // Facilitator is never passive
+  const passiveMembers = new Set(
+    meetingMembers
+      .map(({id}) => TeamMemberId.split(id).userId)
+      .filter((id) => id !== facilitatorUserId)
+  )
+
+  console.log('GEORG passiveMembers', passiveMembers)
+
+  // Facilitator only meetings don't count
+  if (passiveMembers.size === 0) return undefined
+
+  // Team Health
+  const teamHealthPhase = phases.find(({phaseType}) => phaseType === 'TEAM_HEALTH')
+  if (teamHealthPhase) {
+    ;(teamHealthPhase as TeamHealthPhase).stages.forEach(({votes}) => {
+      votes.forEach(({userId}) => {
+        passiveMembers.delete(userId)
+      })
+    })
+    if (passiveMembers.size === 0) return 1
+  }
+  console.log('GEORG passiveMembers after team health', passiveMembers)
+
+  // Reflections and votes
+  if (phases.find(({phaseType}) => phaseType === 'reflect')) {
+    const [reflections, reflectionGroups] = await Promise.all([
+      dataLoader.get('retroReflectionsByMeetingId').load(meetingId),
+      dataLoader.get('retroReflectionGroupsByMeetingId').load(meetingId)
+    ])
+    reflections.forEach(({creatorId}) => {
+      passiveMembers.delete(creatorId)
+    })
+    reflectionGroups.forEach(({voterIds}) => {
+      voterIds.forEach((voterId) => {
+        passiveMembers.delete(voterId)
+      })
+    })
+
+    if (passiveMembers.size === 0) return 1
+  }
+  console.log('GEORG passiveMembers after reflect', passiveMembers)
+
+  // Team prompt responses
+  if (phases.find(({phaseType}) => phaseType === 'RESPONSES')) {
+    const responses = await getTeamPromptResponsesByMeetingId(meetingId)
+    responses.forEach(({userId}) => {
+      passiveMembers.delete(userId)
+    })
+    if (passiveMembers.size === 0) return 1
+  }
+
+  // Estimates in Sprint Poker
+  const estimatePhase = phases.find(({phaseType}) => phaseType === 'ESTIMATE')
+  if (estimatePhase) {
+    ;(estimatePhase as EstimatePhase).stages.forEach(({scores}) => {
+      scores.forEach(({userId}) => {
+        passiveMembers.delete(userId)
+      })
+    })
+    if (passiveMembers.size === 0) return 1
+  }
+
+  // Discussions can happen in many different stage types: discuss, ESTIMATE, reflect, RESPONSES
+  const stages = phases.flatMap(({stages}) => stages)
+  const discussionIds = stages
+    .map((stage) => 'discussionId' in stage && stage.discussionId)
+    .filter(isValid) as string[]
+  const [comments, tasks] = await Promise.all([
+    dataLoader.get('commentsByDiscussionId').loadMany(discussionIds),
+    dataLoader.get('tasksByDiscussionId').loadMany(discussionIds)
+  ])
+  const threadables = [...comments.flat(), ...tasks.flat()].filter(isValid)
+  threadables.forEach(({createdBy}) => {
+    passiveMembers.delete(createdBy)
+  })
+
+  return 1 - passiveMembers.size / meetingMembers.length
+}
+
+export default calculateEngagement

--- a/packages/server/graphql/mutations/helpers/calculateEngagement.ts
+++ b/packages/server/graphql/mutations/helpers/calculateEngagement.ts
@@ -27,8 +27,6 @@ const calculateEngagement = async (meeting: Meeting, dataLoader: DataLoaderWorke
       .filter((id) => id !== facilitatorUserId)
   )
 
-  console.log('GEORG passiveMembers', passiveMembers)
-
   // Facilitator only meetings don't count
   if (passiveMembers.size === 0) return undefined
 
@@ -42,7 +40,6 @@ const calculateEngagement = async (meeting: Meeting, dataLoader: DataLoaderWorke
     })
     if (passiveMembers.size === 0) return 1
   }
-  console.log('GEORG passiveMembers after team health', passiveMembers)
 
   // Reflections and votes
   if (phases.find(({phaseType}) => phaseType === 'reflect')) {
@@ -61,7 +58,6 @@ const calculateEngagement = async (meeting: Meeting, dataLoader: DataLoaderWorke
 
     if (passiveMembers.size === 0) return 1
   }
-  console.log('GEORG passiveMembers after reflect', passiveMembers)
 
   // Team prompt responses
   if (phases.find(({phaseType}) => phaseType === 'RESPONSES')) {

--- a/packages/server/graphql/mutations/helpers/gatherInsights.ts
+++ b/packages/server/graphql/mutations/helpers/gatherInsights.ts
@@ -1,0 +1,14 @@
+import Meeting from '../../../database/types/Meeting'
+import {DataLoaderWorker} from '../../graphql'
+import collectReactjis from './collectReactjis'
+import calculateEngagement from './calculateEngagement'
+
+const gatherInsights = async (meeting: Meeting, dataLoader: DataLoaderWorker) => {
+  const [usedReactjis, engagement] = await Promise.all([
+    collectReactjis(meeting, dataLoader),
+    calculateEngagement(meeting, dataLoader)
+  ])
+  return {usedReactjis, engagement}
+}
+
+export default gatherInsights

--- a/packages/server/graphql/mutations/helpers/gatherInsights.ts
+++ b/packages/server/graphql/mutations/helpers/gatherInsights.ts
@@ -8,6 +8,7 @@ const gatherInsights = async (meeting: Meeting, dataLoader: DataLoaderWorker) =>
     collectReactjis(meeting, dataLoader),
     calculateEngagement(meeting, dataLoader)
   ])
+  console.log('GEORG engagement', engagement)
   return {usedReactjis, engagement}
 }
 

--- a/packages/server/graphql/mutations/helpers/gatherInsights.ts
+++ b/packages/server/graphql/mutations/helpers/gatherInsights.ts
@@ -8,7 +8,6 @@ const gatherInsights = async (meeting: Meeting, dataLoader: DataLoaderWorker) =>
     collectReactjis(meeting, dataLoader),
     calculateEngagement(meeting, dataLoader)
   ])
-  console.log('GEORG engagement', engagement)
   return {usedReactjis, engagement}
 }
 

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -8,20 +8,20 @@ import {analytics} from '../../../utils/analytics/analytics'
 import publish, {SubOptions} from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
 import {InternalContext} from '../../graphql'
-import collectReactjis from './collectReactjis'
 import sendNewMeetingSummary from './endMeeting/sendNewMeetingSummary'
 import {IntegrationNotifier} from './notifications/IntegrationNotifier'
 import updateTeamInsights from './updateTeamInsights'
 import generateStandupMeetingSummary from './generateStandupMeetingSummary'
 import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
+import gatherInsights from './gatherInsights'
 
 const finishTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalContext) => {
   const {dataLoader} = context
   const r = await getRethink()
 
-  const [summary, usedReactjis] = await Promise.all([
+  const [summary, insights] = await Promise.all([
     generateStandupMeetingSummary(meeting, dataLoader),
-    collectReactjis(meeting, dataLoader)
+    gatherInsights(meeting, dataLoader)
   ])
 
   await r
@@ -29,7 +29,7 @@ const finishTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalCon
     .get(meeting.id)
     .update({
       summary,
-      usedReactjis
+      ...insights
     })
     .run()
 

--- a/packages/server/graphql/public/typeDefs/TeamInsights.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamInsights.graphql
@@ -3,6 +3,13 @@ type Emoji {
   count: Int!
 }
 
+type MeetingEngagement {
+  """
+  Engagement across retros, poker and standups
+  """
+  all: Float!
+}
+
 type TeamInsights {
   id: ID!
 
@@ -10,4 +17,9 @@ type TeamInsights {
   Most used emojis in the team, null if not enough signal
   """
   mostUsedEmojis: [Emoji!]
+
+  """
+  Meeting engagement, null if not enough signal
+  """
+  meetingEngagement: MeetingEngagement
 }

--- a/packages/server/graphql/public/types/Team.ts
+++ b/packages/server/graphql/public/types/Team.ts
@@ -4,14 +4,16 @@ import toTeamMemberId from '../../../../client/utils/relay/toTeamMemberId'
 import {getUserId} from '../../../utils/authorization'
 
 const Team: TeamResolvers = {
-  insights: async ({id, orgId, mostUsedEmojis}, _args, {dataLoader}) => {
+  insights: async ({id, orgId, mostUsedEmojis, meetingEngagement}, _args, {dataLoader}) => {
     const org = await dataLoader.get('organizations').load(orgId)
+    console.log('GEORGIA', {id, orgId, mostUsedEmojis, meetingEngagement})
     if (!org?.featureFlags?.includes('teamInsights')) return null
-    if (!mostUsedEmojis) return null
+    if (!mostUsedEmojis && !meetingEngagement) return null
 
     return {
       id: TeamInsightsId.join(id),
-      mostUsedEmojis
+      mostUsedEmojis,
+      meetingEngagement
     } as any
   },
   viewerTeamMember: async ({id: teamId}, _args, {authToken, dataLoader}) => {

--- a/packages/server/graphql/public/types/Team.ts
+++ b/packages/server/graphql/public/types/Team.ts
@@ -6,7 +6,6 @@ import {getUserId} from '../../../utils/authorization'
 const Team: TeamResolvers = {
   insights: async ({id, orgId, mostUsedEmojis, meetingEngagement}, _args, {dataLoader}) => {
     const org = await dataLoader.get('organizations').load(orgId)
-    console.log('GEORGIA', {id, orgId, mostUsedEmojis, meetingEngagement})
     if (!org?.featureFlags?.includes('teamInsights')) return null
     if (!mostUsedEmojis && !meetingEngagement) return null
 


### PR DESCRIPTION
# Description

Fixes #8468
Calculate the engagement at the end of each retro, standup and poker meeting. Show the insights for all meetings combined over the last 30 days.
The meeting engagement is stored on each meeting individually allowing us to tweak the thresholds of what can be considered low or high engagement.

I considered >80% as high engagement, <= 60% as low by imagining a 5 person team. If 2 people do not participate that's low, if 1 does not participate it's average, if all participate it's high.

## Demo

https://www.loom.com/share/35fbd6e60c594a82b79c2521bdd5223d?sid=a52120e6-d74e-4644-8bd1-cf5687ab3eb1

## Testing scenarios

* add `teamInsights` org flag

### facilitator only meetings don't have an engagement score
* run a **retro**, **standup** and **poker** with only the facilitator, see no engagement is shown

### inactive participants lower the score
* run **retro** with 1 additional participant who does nothing, see engagement as 50%
* run **retro** and 1 additional participant who only votes on a retro group, engagement still 50%
* run **standup** with 1 additional participant who does nothing, see engagement stays at 50%
* run **poker** with 1 addition participant who does nothing, engagement 50%

### discussing, reflecting, reacting increases the engagement score
* run a **retro** with 1 participant for each of the following
  * reflecting
  * discussing
  * reacting
  
  and see the engagement increasing (100% engagement for the meeting)
* run a **poker** with 1 participant for each of the following
  * voting
  * discussing
  
  and see engagement increasing

* run a **standup** with 1 participant for each of the following
  * responding
  * discussing
  * reacting
  
  and see the engagement increasing

### checkin is ignored
* run a checkin with 1 additional participant doing nothing, see engagement unchanged

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
