### PR TITLE
feat(Prompt to join org): reverse feature flag

### DIFF
--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -301,7 +301,7 @@ const initDemoOrg = () => {
       zoomTranscription: false,
       suggestGroups: false,
       teamsLimit: false,
-      promptToJoinOrg: false,
+      noPromptToJoinOrg: false,
       AIGeneratedDiscussionPrompt: false
     },
     showConversionModal: false

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -5,7 +5,7 @@ enum OrganizationFeatureFlagsEnum {
   noAISummary
   AIGeneratedDiscussionPrompt
   standupAISummary
-  promptToJoinOrg
+  noPromptToJoinOrg
   suggestGroups
   zoomTranscription
   shareSummary

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -181,7 +181,7 @@ type OrganizationFeatureFlags {
   noAISummary: Boolean!
   AIGeneratedDiscussionPrompt: Boolean!
   standupAISummary: Boolean!
-  promptToJoinOrg: Boolean!
+  noPromptToJoinOrg: Boolean!
   suggestGroups: Boolean!
   zoomTranscription: Boolean!
   shareSummary: Boolean!

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -3,7 +3,7 @@ import {OrganizationFeatureFlagsResolvers} from '../resolverTypes'
 const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   noAISummary: ({noAISummary}) => !!noAISummary,
   standupAISummary: ({standupAISummary}) => !!standupAISummary,
-  promptToJoinOrg: ({promptToJoinOrg}) => !!promptToJoinOrg,
+  noPromptToJoinOrg: ({noPromptToJoinOrg}) => !!noPromptToJoinOrg,
   AIGeneratedDiscussionPrompt: ({AIGeneratedDiscussionPrompt}) => !!AIGeneratedDiscussionPrompt,
   zoomTranscription: ({zoomTranscription}) => !!zoomTranscription,
   shareSummary: ({shareSummary}) => !!shareSummary,

--- a/packages/server/utils/isRequestToJoinDomainAllowed.ts
+++ b/packages/server/utils/isRequestToJoinDomainAllowed.ts
@@ -21,6 +21,7 @@ export const getEligibleOrgIdsByDomain = async (
   const orgs = await r
     .table('Organization')
     .getAll(activeDomain, {index: 'activeDomain'})
+    .filter((org: RDatum) => org('featureFlags').contains('noPromptToJoinOrg').not())
     .merge((org: RDatum) => ({
       members: r
         .table('OrganizationUser')


### PR DESCRIPTION
# Description

Fixes #8274 

Reverse the feature flag and include checking the feature flag when finding eligible orgs.
The check was accidentally removed previously in #8798 

## Demo

no demo

## Testing scenarios

- check with eligible org without feature flag
- see prompt to join org request
- add feature flag
- recheck

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
