### PR TITLE
chore(ci): adding release branch to the build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           GITHUB_REF_NAME_NORMALIZED=$(echo ${{github.ref_name}} | tr / -)
           echo "GITHUB_REF_NAME_NORMALIZED=${GITHUB_REF_NAME_NORMALIZED}" >> $GITHUB_ENV
 
-          DOCKERIZE=${{ github.ref_type == 'tag' || contains(fromJSON('["master", "staging", "production"]'), github.ref_name) || startsWith(github.event.head_commit.message, 'dockerize')}}
+          DOCKERIZE=${{ github.ref_type == 'tag' || contains(fromJSON('["master", "release", "staging", "production"]'), github.ref_name) || startsWith(github.event.head_commit.message, 'dockerize')}}
           echo "DOCKERIZE=${DOCKERIZE}" >> $GITHUB_ENV
 
       - name: Setup Node


### PR DESCRIPTION
# Description

Adds the branch `release` to the build pipeline so it will build the Docker image for that branch as well.

Later, once in the new environment, branches production and staging should be removed from the build action and from the repository.
