### PR TITLE
feat: added meeting link to a meeting summary

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryHeader.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryHeader.tsx
@@ -8,7 +8,7 @@ import {useFragment} from 'react-relay'
 import {ExternalLinks} from '../../../../../types/constEnums'
 import {CorsOptions} from '../../../../../types/cors'
 
-const meetingSummaryLabel = {
+const meetingSummaryLabel: React.CSSProperties = {
   color: PALETTE.SLATE_600,
   fontFamily: FONT_FAMILY.SANS_SERIF,
   textTransform: 'uppercase',
@@ -16,41 +16,47 @@ const meetingSummaryLabel = {
   fontWeight: 600,
   paddingTop: 8,
   textAlign: 'center'
-} as React.CSSProperties
+}
 
-const teamNameLabel = {
+const teamNameLabel: React.CSSProperties = {
   color: PALETTE.SLATE_700,
   fontFamily: FONT_FAMILY.SANS_SERIF,
   fontSize: 36,
   fontWeight: 600,
   paddingTop: 16
-} as React.CSSProperties
+}
 
-const dateLabel = {
+const dateLabel: React.CSSProperties = {
   color: PALETTE.SLATE_600,
   fontFamily: FONT_FAMILY.SANS_SERIF,
   fontSize: '15px',
   fontWeight: 400,
   paddingTop: 8
-} as React.CSSProperties
+}
 
-const teamLink = {
+const teamLink: React.CSSProperties = {
   color: PALETTE.SKY_500,
   fontFamily: FONT_FAMILY.SANS_SERIF,
   fontWeight: 600,
   fontSize: '15px',
   paddingTop: 8
-} as React.CSSProperties
+}
+
+const meetingLink: React.CSSProperties = {
+  textDecoration: 'underline',
+  color: 'inherit'
+}
 
 interface Props {
   meeting: SummaryHeader_meeting$key
   isDemo?: boolean
   corsOptions: CorsOptions
   teamDashUrl: string
+  meetingUrl: string
 }
 
 const SummaryHeader = (props: Props) => {
-  const {meeting: meetingRef, isDemo, corsOptions, teamDashUrl} = props
+  const {meeting: meetingRef, isDemo, corsOptions, teamDashUrl, meetingUrl} = props
   const meeting = useFragment(
     graphql`
       fragment SummaryHeader_meeting on NewMeeting {
@@ -87,7 +93,9 @@ const SummaryHeader = (props: Props) => {
         </tr>
         <tr>
           <td align='center' style={teamNameLabel}>
-            {meetingName}
+            <a href={meetingUrl} style={meetingLink} rel='noopener noreferrer'>
+              {meetingName}
+            </a>
           </td>
         </tr>
         <tr>

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -39,6 +39,7 @@ interface Props {
   referrer: MeetingSummaryReferrer
   referrerUrl?: string
   teamDashUrl: string
+  meetingUrl: string
   urlAction?: 'csv'
   corsOptions: CorsOptions
 }
@@ -55,6 +56,7 @@ const SummarySheet = (props: Props) => {
     meeting: meetingRef,
     referrer,
     teamDashUrl,
+    meetingUrl,
     appOrigin,
     corsOptions
   } = props
@@ -108,7 +110,12 @@ const SummarySheet = (props: Props) => {
       <tbody>
         <tr>
           <td>
-            <SummaryHeader meeting={meeting} corsOptions={corsOptions} teamDashUrl={teamDashUrl} />
+            <SummaryHeader
+              meeting={meeting}
+              corsOptions={corsOptions}
+              teamDashUrl={teamDashUrl}
+              meetingUrl={meetingUrl}
+            />
             <QuickStats meeting={meeting} />
             <TeamHealthSummary meeting={meeting} />
           </td>


### PR DESCRIPTION
# Description

Implements @avivapinchas's [idea 🔒](https://parabol.slack.com/archives/C03NGEJUKCN/p1695749810137199)

## Demo

<img width="657" alt="Screenshot 2023-09-27 at 09 39 18" src="https://github.com/ParabolInc/parabol/assets/1017620/39b10630-adfc-4ae9-9c5c-20bcb04e8f7c">


## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Test if clicking the meeting title from the meeting summary navigates to the meeting
- [ ] Test if clicking the meeting title from the meeting summary email navigates to the meeting

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
