### PR TITLE
chore: change gcal creds to google creds

### DIFF
--- a/packages/server/graphql/mutations/helpers/createGcalEvent.ts
+++ b/packages/server/graphql/mutations/helpers/createGcalEvent.ts
@@ -33,7 +33,6 @@ const createGcalEvent = async (input: Input) => {
     return standardError(new Error('Could not retrieve Google Calendar auth'), {userId: viewerId})
   }
   const {accessToken: access_token, refreshToken: refresh_token, expiresAt} = gcalAuth
-
   const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID
   const CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET
   const REDIRECT_URI = appOrigin

--- a/packages/server/graphql/mutations/helpers/createGcalEvent.ts
+++ b/packages/server/graphql/mutations/helpers/createGcalEvent.ts
@@ -34,8 +34,8 @@ const createGcalEvent = async (input: Input) => {
   }
   const {accessToken: access_token, refreshToken: refresh_token, expiresAt} = gcalAuth
 
-  const CLIENT_ID = process.env.GCAL_CLIENT_ID
-  const CLIENT_SECRET = process.env.GCAL_CLIENT_SECRET
+  const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID
+  const CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET
   const REDIRECT_URI = appOrigin
 
   const startDateTime = new Date(startTimestamp * 1000).toISOString()

--- a/scripts/toolboxSrc/primeIntegrations.ts
+++ b/scripts/toolboxSrc/primeIntegrations.ts
@@ -29,8 +29,8 @@ const upsertGlobalIntegrationProvidersFromEnv = async () => {
       scope: 'global',
       teamId: 'aGhostTeam',
       serverBaseUrl: 'https://www.googleapis.com/calendar/v3',
-      clientId: process.env.GCAL_CLIENT_ID,
-      clientSecret: process.env.GCAL_CLIENT_SECRET
+      clientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET
     }
   ] as const
 


### PR DESCRIPTION
Use the Google oauth credentials instead of gcal.

While building the Gcal integration, I initially created a new Gcal Project and used those credentials. Now we're using the existing Parabol project, so we can use those credentials instead.

### To test

- [ ] Create a meeting using the gcal integration and see the gcal event in your calendar