### PR TITLE
chore: update gcal modal description

### DIFF
--- a/packages/client/modules/userDashboard/components/GcalModal/GcalModal.tsx
+++ b/packages/client/modules/userDashboard/components/GcalModal/GcalModal.tsx
@@ -187,7 +187,7 @@ const GcalModal = (props: Props) => {
         <div className='flex flex-col'>
           <div className='text-lg'>{'Schedule Your Meeting'}</div>
           <div className='text-gray-500 mt-1 text-sm font-normal'>
-            We'll include a link to the Parabol meeting in the description
+            Create a Google Calendar event with a link to the Parabol meeting in the description
           </div>
         </div>
         <StyledCloseButton onClick={closeModal}>

--- a/packages/server/graphql/mutations/helpers/createGcalEvent.ts
+++ b/packages/server/graphql/mutations/helpers/createGcalEvent.ts
@@ -33,7 +33,6 @@ const createGcalEvent = async (input: Input) => {
     return standardError(new Error('Could not retrieve Google Calendar auth'), {userId: viewerId})
   }
   const {accessToken: access_token, refreshToken: refresh_token, expiresAt} = gcalAuth
-
   const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID
   const CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET
   const REDIRECT_URI = appOrigin

--- a/packages/server/graphql/mutations/helpers/createGcalEvent.ts
+++ b/packages/server/graphql/mutations/helpers/createGcalEvent.ts
@@ -34,8 +34,8 @@ const createGcalEvent = async (input: Input) => {
   }
   const {accessToken: access_token, refreshToken: refresh_token, expiresAt} = gcalAuth
 
-  const CLIENT_ID = process.env.GCAL_CLIENT_ID
-  const CLIENT_SECRET = process.env.GCAL_CLIENT_SECRET
+  const CLIENT_ID = process.env.GOOGLE_OAUTH_CLIENT_ID
+  const CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET
   const REDIRECT_URI = appOrigin
 
   const startDateTime = new Date(startTimestamp * 1000).toISOString()

--- a/scripts/toolboxSrc/primeIntegrations.ts
+++ b/scripts/toolboxSrc/primeIntegrations.ts
@@ -29,8 +29,8 @@ const upsertGlobalIntegrationProvidersFromEnv = async () => {
       scope: 'global',
       teamId: 'aGhostTeam',
       serverBaseUrl: 'https://www.googleapis.com/calendar/v3',
-      clientId: process.env.GCAL_CLIENT_ID,
-      clientSecret: process.env.GCAL_CLIENT_SECRET
+      clientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET
     }
   ] as const
 


### PR DESCRIPTION
This PR updates the Google calendar modal description to make it clearer that we'll create a Google Calendar event. 

![Screenshot 2023-09-27 at 19 09 49](https://github.com/ParabolInc/parabol/assets/39854876/2857ba0b-471e-45be-a5bb-6c879d236eba)


### To test

- [ ] Open the Google calendar modal and view the new description 