### PR TITLE
fix: standup meeting summary layout

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/TeamPromptResponseSummaryCard.tsx
@@ -8,7 +8,6 @@ import {PALETTE} from '~/styles/paletteV3'
 import {createEditorExtensions} from '../../../../../components/promptResponse/tiptapConfig'
 
 const responseSummaryCardStyles: React.CSSProperties = {
-  display: 'inherit',
   padding: '12px',
   width: '100%'
 }


### PR DESCRIPTION
# Description

Fixes an issue with standup summary formatting caused by #8884

The issue was caused by playing with various properties in order to improve the email layout see the wrong margin on the right here

<img width="610" alt="Screenshot 2023-10-02 at 09 20 26" src="https://github.com/ParabolInc/parabol/assets/1017620/51b8b6b6-4db1-4697-a5c4-6607fbdc1e38">

it was present before the the changes and I'll address it later. 

## Demo

No demo

## Testing scenarios

- [ ] Open standup, add multiple responses and see if the layout is one column
- [ ] Do the same as above, check the summary email

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
