### PR TITLE
feat: handle redirect in email verification

### DIFF
--- a/packages/client/utils/makeAppURL.ts
+++ b/packages/client/utils/makeAppURL.ts
@@ -5,6 +5,7 @@ interface Options {
     utm_campaign: string
     openNotifs?: string
     responseId?: string
+    redirectTo?: string
   }
 }
 

--- a/packages/server/email/createEmailVerification.ts
+++ b/packages/server/email/createEmailVerification.ts
@@ -12,14 +12,19 @@ type SignUpWithPasswordMutationVariables = {
   password: string
   invitationToken?: string | null
   segmentId?: string | null
+  redirectTo?: string | null
 }
 
 const createEmailVerification = async (props: SignUpWithPasswordMutationVariables) => {
-  const {password, invitationToken, segmentId} = props
+  const {password, invitationToken, segmentId, redirectTo} = props
   const email = props.email.toLowerCase().trim()
   const tokenBuffer = crypto.randomBytes(48)
   const verifiedEmailToken = base64url.encode(tokenBuffer)
-  const {subject, body, html} = emailVerificationEmailCreator({verifiedEmailToken, invitationToken})
+  const {subject, body, html} = emailVerificationEmailCreator({
+    verifiedEmailToken,
+    invitationToken,
+    redirectTo
+  })
   const success = await getMailManager().sendEmail({
     to: email,
     subject,

--- a/packages/server/email/emailVerificationEmailCreator.tsx
+++ b/packages/server/email/emailVerificationEmailCreator.tsx
@@ -9,18 +9,22 @@ import emailTemplate from './emailTemplate'
 interface Props {
   verifiedEmailToken: string
   invitationToken: string | null | undefined
+  redirectTo?: string | null
 }
 
 const emailVerificationEmailCreator = (props: Props) => {
-  const {invitationToken, verifiedEmailToken} = props
+  const {invitationToken, verifiedEmailToken, redirectTo} = props
   const fullToken = invitationToken
     ? `${verifiedEmailToken}/${invitationToken}`
     : verifiedEmailToken
+
   const searchParams = {
     utm_source: 'verify account',
     utm_medium: 'email',
-    utm_campaign: 'invitations'
-  }
+    utm_campaign: 'invitations',
+    ...(redirectTo ? {redirectTo} : {})
+  } as const
+
   const options = {searchParams}
   const verificationURL = makeAppURL(appOrigin, `verify-email/${fullToken}`, options)
   const bodyContent = ReactDOMServer.renderToStaticMarkup(

--- a/packages/server/graphql/public/mutations/signUpWithPassword.ts
+++ b/packages/server/graphql/public/mutations/signUpWithPassword.ts
@@ -10,6 +10,7 @@ import isEmailVerificationRequired from '../../../utils/isEmailVerificationRequi
 import attemptLogin from '../../mutations/helpers/attemptLogin'
 import bootstrapNewUser from '../../mutations/helpers/bootstrapNewUser'
 import {MutationResolvers} from '../resolverTypes'
+import {URLSearchParams} from 'url'
 
 const signUpWithPassword: MutationResolvers['signUpWithPassword'] = async (
   _source,
@@ -56,7 +57,8 @@ const signUpWithPassword: MutationResolvers['signUpWithPassword'] = async (
     if (existingVerification) {
       return {error: {message: 'Verification email already sent'}}
     }
-    return createEmailVerification({invitationToken, password, segmentId, email})
+    const redirectTo = new URLSearchParams(params).get('redirectTo')
+    return createEmailVerification({invitationToken, password, segmentId, email, redirectTo})
   }
   const hashedPassword = await bcrypt.hash(password, Security.SALT_ROUNDS)
   const newUser = createNewLocalUser({email, hashedPassword, isEmailVerified: false, segmentId})


### PR DESCRIPTION
# Description

Fixes #8801 

## Demo

https://www.loom.com/share/405857cf937b458f91e3ddab2882ec0d?sid=792a735c-8f86-4044-9917-4ca65fa7aa04

## Testing scenarios

- [ ] open create account page with redirect param like http://localhost:3000/create-account?rid=1&redirectTo=%2Factivity-library%2Fdetails%2FincidentResponsePostmortemTemplate
- [ ] signup with email that requires verification (the easiest way to do it is to change [this method](https://github.com/ParabolInc/parabol/blob/e682da21b853abaf67681aee649e4b480c6fbe63/packages/server/utils/isEmailVerificationRequired.ts#L3) to return true on local env)
- [ ] click verify my email from verification email
- [ ] make sure you the you were redirected to the url specified in `redirectTo` param from the signup page


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
