### PR TITLE
feat(your-work): Jira Integration pagination

### DIFF
--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import graphql from 'babel-plugin-relay/macro'
-import {PreloadedQuery, useFragment, usePreloadedQuery} from 'react-relay'
+import {PreloadedQuery, usePaginationFragment, usePreloadedQuery} from 'react-relay'
 import {JiraIntegrationResultsQuery} from '../../../__generated__/JiraIntegrationResultsQuery.graphql'
-import {JiraIntegrationResults_search$data} from '../../../__generated__/JiraIntegrationResults_search.graphql'
+import {JiraIntegrationResultsSearchPaginationQuery} from '../../../__generated__/JiraIntegrationResultsSearchPaginationQuery.graphql'
+import {JiraIntegrationResults_search$key} from '../../../__generated__/JiraIntegrationResults_search.graphql'
 import halloweenRetrospectiveTemplate from '../../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 import JiraObjectCard from './JiraObjectCard'
+import useLoadNextOnScrollBottom from '../../../hooks/useLoadNextOnScrollBottom'
+import Ellipsis from '../../Ellipsis/Ellipsis'
 
 interface Props {
   queryRef: PreloadedQuery<JiraIntegrationResultsQuery>
@@ -21,16 +24,25 @@ const JiraIntegrationResults = (props: Props) => {
     queryRef
   )
 
-  // :TODO: (jmtaber129): Implement pagination
-  const queryFrag = useFragment(
+  const paginationRes = usePaginationFragment<
+    JiraIntegrationResultsSearchPaginationQuery,
+    JiraIntegrationResults_search$key
+  >(
     graphql`
-      fragment JiraIntegrationResults_search on Query @argumentDefinitions(teamId: {type: "ID!"}) {
+      fragment JiraIntegrationResults_search on Query
+      @argumentDefinitions(
+        cursor: {type: "String"}
+        count: {type: "Int", defaultValue: 2}
+        teamId: {type: "ID!"}
+      )
+      @refetchable(queryName: "JiraIntegrationResultsSearchPaginationQuery") {
         viewer {
           teamMember(teamId: $teamId) {
             integrations {
               atlassian {
                 issues(
-                  first: 20
+                  first: $count
+                  after: $cursor
                   isJQL: true
                   queryString: "assignee = currentUser() order by updated DESC"
                 ) @connection(key: "JiraScopingSearchResults_issues") {
@@ -56,9 +68,10 @@ const JiraIntegrationResults = (props: Props) => {
     query
   )
 
-  const jira = (queryFrag as JiraIntegrationResults_search$data).viewer.teamMember?.integrations
-    .atlassian
+  const lastItem = useLoadNextOnScrollBottom(paginationRes, {}, 2)
+  const {data, hasNext} = paginationRes
 
+  const jira = data.viewer.teamMember?.integrations.atlassian
   const jiraResults = jira?.issues.edges.map((edge) => edge.node)
   const error = jira?.issues.error ?? null
 
@@ -78,6 +91,12 @@ const JiraIntegrationResults = (props: Props) => {
             <div className='mt-7 w-2/3 text-center'>
               {error?.message ? error.message : `Looks like you don’t have any issues to display.`}
             </div>
+          </div>
+        )}
+        {lastItem}
+        {hasNext && (
+          <div className='mx-auto mb-4 -mt-4 h-8 text-2xl' key={'loadingNext'}>
+            <Ellipsis />
           </div>
         )}
       </div>

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
@@ -32,7 +32,7 @@ const JiraIntegrationResults = (props: Props) => {
       fragment JiraIntegrationResults_search on Query
       @argumentDefinitions(
         cursor: {type: "String"}
-        count: {type: "Int", defaultValue: 2}
+        count: {type: "Int", defaultValue: 20}
         teamId: {type: "ID!"}
       )
       @refetchable(queryName: "JiraIntegrationResultsSearchPaginationQuery") {
@@ -68,7 +68,7 @@ const JiraIntegrationResults = (props: Props) => {
     query
   )
 
-  const lastItem = useLoadNextOnScrollBottom(paginationRes, {}, 2)
+  const lastItem = useLoadNextOnScrollBottom(paginationRes, {}, 20)
   const {data, hasNext} = paginationRes
 
   const jira = data.viewer.teamMember?.integrations.atlassian

--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -617,7 +617,9 @@ export default abstract class AtlassianManager {
   async getIssues(
     queryString: string | null,
     isJQL: boolean,
-    projectFiltersByCloudId: {[cloudId: string]: string[]}
+    projectFiltersByCloudId: {[cloudId: string]: string[]},
+    maxResults: number,
+    startAt?: number
   ) {
     const allIssues = [] as JiraGQLFields[]
     let firstError: Error | undefined
@@ -626,7 +628,8 @@ export default abstract class AtlassianManager {
       const jql = composeJQL(queryString, isJQL, projectKeys)
       const payload = {
         jql,
-        maxResults: 100,
+        maxResults,
+        startAt,
         fields: ['summary', 'description', 'issuetype', 'created'],
         expand: ['renderedFields,changelog']
       }

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -912,9 +912,9 @@ A connection to a list of items.
 """
 type JiraIssueConnection {
   """
-  Page info with cursors coerced to ISO8601 dates
+  Page info with cursors
   """
-  pageInfo: PageInfoDateCursor
+  pageInfo: PageInfo
 
   """
   A list of edges.
@@ -935,7 +935,7 @@ type JiraIssueEdge {
   The item at the end of the edge
   """
   node: JiraIssue!
-  cursor: DateTime
+  cursor: String
 }
 
 interface TaskIntegration {

--- a/packages/server/graphql/public/typeDefs/AtlassianIntegration.graphql
+++ b/packages/server/graphql/public/typeDefs/AtlassianIntegration.graphql
@@ -6,9 +6,9 @@ extend type AtlassianIntegration {
     first: Int = 100
 
     """
-    the datetime cursor
+    the index cursor
     """
-    after: DateTime
+    after: String
 
     """
     A string of text to search for, or JQL if isJQL is true

--- a/packages/server/graphql/public/typeDefs/JiraIssue.graphql
+++ b/packages/server/graphql/public/typeDefs/JiraIssue.graphql
@@ -113,9 +113,9 @@ A connection to a list of items.
 """
 type JiraIssueConnection {
   """
-  Page info with cursors coerced to ISO8601 dates
+  Page info with cursors
   """
-  pageInfo: PageInfoDateCursor
+  pageInfo: PageInfo
 
   """
   A list of edges.
@@ -136,5 +136,5 @@ type JiraIssueEdge {
   The item at the end of the edge
   """
   node: JiraIssue!
-  cursor: DateTime
+  cursor: String
 }

--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -2,17 +2,23 @@ import {downloadAndCacheImages, updateJiraImageUrls} from '../../../utils/atlass
 import AtlassianServerManager from '../../../utils/AtlassianServerManager'
 import {getUserId} from '../../../utils/authorization'
 import standardError from '../../../utils/standardError'
-import connectionFromTasks from '../../queries/helpers/connectionFromTasks'
 import {AtlassianIntegrationResolvers} from '../resolverTypes'
 
 const AtlassianIntegration: AtlassianIntegrationResolvers = {
   issues: async ({teamId, userId, accessToken, cloudIds}, args, {authToken}) => {
-    const {first, queryString, isJQL, projectKeyFilters} = args
+    const {first, queryString, isJQL, projectKeyFilters, after} = args
     const viewerId = getUserId(authToken)
     if (viewerId !== userId || !accessToken) {
       const err = new Error('Cannot access another team members issues')
       standardError(err, {tags: {teamId, userId}, userId: viewerId})
-      return connectionFromTasks([], 0, err)
+      return {
+        error: {message: err.message},
+        edges: [],
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false
+        }
+      }
     }
     const manager = new AtlassianServerManager(accessToken)
     const projectKeyFiltersByCloudId = {} as {[cloudId: string]: string[]}
@@ -28,7 +34,18 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
         projectKeyFiltersByCloudId[cloudId] = []
       })
     }
-    const issueRes = await manager.getIssues(queryString ?? null, isJQL, projectKeyFiltersByCloudId)
+    // Request one extra item to see if there are more results
+    const maxResults = first + 1
+    // Relay requires the cursor to be a string
+    const afterInt = parseInt(after ?? '-1', 10)
+    const startAt = afterInt + 1
+    const issueRes = await manager.getIssues(
+      queryString ?? null,
+      isJQL,
+      projectKeyFiltersByCloudId,
+      maxResults,
+      startAt
+    )
     const {error, issues} = issueRes
     const mappedIssues = issues.map((issue) => {
       const {updatedDescription, imageUrlToHash} = updateJiraImageUrls(
@@ -42,10 +59,25 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
         teamId,
         userId,
         descriptionHTML: updatedDescription,
-        updatedAt: new Date()
+        updatedAt: new Date(issue.lastUpdated)
       }
     })
-    return connectionFromTasks(mappedIssues, first, error ? {message: error.message} : undefined)
+    const nodes = mappedIssues.slice(0, first)
+    const edges = nodes.map((node, index) => ({
+      cursor: `${index + (afterInt ?? 0)}`,
+      node
+    }))
+    const firstEdge = edges[0]
+    return {
+      error: error ? {message: error.message} : undefined,
+      edges,
+      pageInfo: {
+        startCursor: firstEdge && firstEdge.cursor,
+        endCursor: firstEdge ? edges[edges.length - 1]!.cursor : null,
+        hasNextPage: mappedIssues.length > nodes.length,
+        hasPreviousPage: false
+      }
+    }
   }
 }
 

--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -58,16 +58,18 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
         ...issue,
         teamId,
         userId,
-        descriptionHTML: updatedDescription,
-        updatedAt: new Date(issue.lastUpdated)
+        descriptionHTML: updatedDescription
       }
     })
+
     const nodes = mappedIssues.slice(0, first)
     const edges = nodes.map((node, index) => ({
       cursor: `${index + startAt}`,
       node
     }))
+
     const firstEdge = edges[0]
+
     return {
       error: error ? {message: error.message} : undefined,
       edges,

--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -64,7 +64,7 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
     })
     const nodes = mappedIssues.slice(0, first)
     const edges = nodes.map((node, index) => ({
-      cursor: `${index + (afterInt ?? 0)}`,
+      cursor: `${index + startAt}`,
       node
     }))
     const firstEdge = edges[0]

--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -38,7 +38,7 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
     const maxResults = first + 1
     // Relay requires the cursor to be a string
     const afterInt = parseInt(after ?? '-1', 10)
-    const startAt = Number.isNaN(afterInt) ? -1 : afterInt + 1
+    const startAt = Number.isNaN(afterInt) ? 0 : afterInt + 1
     const issueRes = await manager.getIssues(
       queryString ?? null,
       isJQL,

--- a/packages/server/graphql/public/types/AtlassianIntegration.ts
+++ b/packages/server/graphql/public/types/AtlassianIntegration.ts
@@ -38,7 +38,7 @@ const AtlassianIntegration: AtlassianIntegrationResolvers = {
     const maxResults = first + 1
     // Relay requires the cursor to be a string
     const afterInt = parseInt(after ?? '-1', 10)
-    const startAt = afterInt + 1
+    const startAt = Number.isNaN(afterInt) ? -1 : afterInt + 1
     const issueRes = await manager.getIssues(
       queryString ?? null,
       isJQL,


### PR DESCRIPTION
# Description
Fixes https://github.com/ParabolInc/parabol/issues/8917

Pagination for Your Work - Jira.

Note that because this modifies the Jira GQL API (both pagination args and behavior) there is a risk of regression in the Jira integration for Sprint Poker, so that should be smoke tested more rigorously than usual.

Needs rebase once https://github.com/ParabolInc/parabol/pull/8907 lands

## Demo
Multiple pages (2 per page):
https://www.loom.com/share/83e737abb0bc4c30a1b61f9d20bd29f3?sid=469f4e61-0ecb-44a4-9c40-f7e1dc92cdc2

Paginate on scroll to bottom (7 per page):
https://www.loom.com/share/7dcf95f1fe6249faad5d9fac9f6609ec?sid=112a19e7-eecd-4a06-96a5-1468a95fd8a2

## Testing scenarios
- [ ] Connect a team to Jira, and open a standup meeting on that team
- [ ] Assign several issues to yourself in Jira
- [ ] Set the page size to a number less than the number of assigned issues
- [ ] Confirm that when the end of the list is seen by the user, the next page of issues is loaded.
- [ ] Confirm that when there are no more assigned issues, the end of the list does not show a loading animation.
- [ ] Smoke test sprint poker for Jira.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
