### PR TITLE
chore: test sentry and dd uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           echo "DOCKERIZE=${DOCKERIZE}" >> $GITHUB_ENV
 
           ACTION_VERSION=$(grep '"version":' package.json | cut -d\" -f4)
-          echo "ACTION_VERSION=6.122.0-exotic" >> $GITHUB_ENV
+          echo "ACTION_VERSION=${ACTION_VERSION}" >> $GITHUB_ENV
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -95,6 +95,17 @@ jobs:
 
       - name: Verify source is clean
         run: git diff --quiet HEAD || (echo "Changes in generated files detected"; git diff; exit 1)
+
+      - name: Push Artifacts to Datadog
+        #if: github.ref_type == 'tag'
+        env:
+          DATADOG_API_KEY: "${{secrets.DATADOG_API_KEY}}"
+        run: |
+
+          yarn datadog-ci sourcemaps upload ./build \
+            --service=parabol-saas-production \
+            --release-version=${{env.ACTION_VERSION}} \
+            --minified-path-prefix=https://action-files.parabol.co/production/build/
 
       - name: Check Code Quality
         run: yarn codecheck
@@ -205,11 +216,3 @@ jobs:
           environment: "production"
           sourcemaps: "./build"
           version: ${{env.ACTION_VERSION}}
-      - name: Push Artifacts to Datadog
-        #if: github.ref_type == 'tag'
-        run: |
-          yarn add @datadog/datadog-ci -W
-          yarn datadog-ci sourcemaps upload ./build \
-            --service=parabol-saas-production \
-            --release-version=${{env.ACTION_VERSION}} \
-            --minified-path-prefix=https://action-files.parabol.co/production/build/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           node-version-file: package.json
           # Caching yarn dir & running yarn install is too slow
           # Instead, we aggressively cache node_modules below to avoid calling install
+
       - name: Get cached node modules
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,10 +209,10 @@ jobs:
         if: github.ref_type == 'tag'
         env:
           DATADOG_API_KEY: "${{secrets.DATADOG_API_KEY}}"
+          CDN_BUILD_URL: "https://action-files.parabol.co/production/build/"
         run: |
-          echo "$DATADOG_API_KEY"
           yarn add @datadog/datadog-ci -W
           yarn datadog-ci sourcemaps upload ./build \
             --service=parabol-saas-production \
             --release-version=${{env.ACTION_VERSION}} \
-            --minified-path-prefix=https://action-files.parabol.co/production/build/
+            --minified-path-prefix=${{env.CDN_BUILD_URL}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,7 @@ jobs:
       - name: Push Artifacts to Datadog
         #if: github.ref_type == 'tag'
         run: |
+          yarn add @datadog/datadog-ci -W
           yarn datadog-ci sourcemaps upload ./build \
             --service=parabol-saas-production \
             --release-version=${{env.ACTION_VERSION}} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,8 @@ jobs:
         env:
           DATADOG_API_KEY: "${{secrets.DATADOG_API_KEY}}"
         run: |
-
+          echo "$DATADOG_API_KEY"
+          yarn add @datadog/datadog-ci -W
           yarn datadog-ci sourcemaps upload ./build \
             --service=parabol-saas-production \
             --release-version=${{env.ACTION_VERSION}} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,13 +53,15 @@ jobs:
           DOCKERIZE=${{ github.ref_type == 'tag' || contains(fromJSON('["master", "release", "staging", "production"]'), github.ref_name) || startsWith(github.event.head_commit.message, 'dockerize')}}
           echo "DOCKERIZE=${DOCKERIZE}" >> $GITHUB_ENV
 
+          ACTION_VERSION=$(grep '"version":' package.json | cut -d\" -f4)
+          echo "ACTION_VERSION=6.122.0-exotic" >> $GITHUB_ENV
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version-file: package.json
           # Caching yarn dir & running yarn install is too slow
           # Instead, we aggressively cache node_modules below to avoid calling install
-
       - name: Get cached node modules
         id: cache
         uses: actions/cache@v3
@@ -176,11 +178,6 @@ jobs:
           registry: ${{ secrets.GCP_DOCKER_REGISTRY }}
           username: "oauth2accesstoken"
           password: "${{ steps.auth.outputs.access_token }}"
-      #
-      # Multi-platform build. Uncomment to be able t build multi-platform images.
-      #
-      # - name: Set up QEMU
-      #   uses: docker/setup-qemu-action@v2
       - name: Build and push
         if: env.DOCKERIZE == 'true'
         uses: docker/build-push-action@v4
@@ -196,4 +193,21 @@ jobs:
           tags: |
             "${{ secrets.GCP_AR_PARABOL_DEV }}:${{github.sha}}"
             "${{ env.DOCKER_REPOSITORY_FOR_REF }}:${{ env.GITHUB_REF_NAME_NORMALIZED }}"
-          # platforms: linux/amd64,linux/arm64 # Uncomment to be able to build multi-platform images.
+      - name: Push Artifacts to Sentry
+        #if: github.ref_type == 'tag'
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: "${{secrets.SENTRY_AUTH_TOKEN}}"
+          SENTRY_ORG: "parabol"
+          SENTRY_PROJECT: "action-production"
+        with:
+          environment: "production"
+          sourcemaps: "./build"
+          version: ${{env.ACTION_VERSION}}
+      - name: Push Artifacts to Datadog
+        #if: github.ref_type == 'tag'
+        run: |
+          yarn datadog-ci sourcemaps upload ./build \
+            --service=parabol-saas-production \
+            --release-version=${{env.ACTION_VERSION}} \
+            --minified-path-prefix=https://action-files.parabol.co/production/build/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,18 +96,6 @@ jobs:
       - name: Verify source is clean
         run: git diff --quiet HEAD || (echo "Changes in generated files detected"; git diff; exit 1)
 
-      - name: Push Artifacts to Datadog
-        #if: github.ref_type == 'tag'
-        env:
-          DATADOG_API_KEY: "${{secrets.DATADOG_API_KEY}}"
-        run: |
-          echo "$DATADOG_API_KEY"
-          yarn add @datadog/datadog-ci -W
-          yarn datadog-ci sourcemaps upload ./build \
-            --service=parabol-saas-production \
-            --release-version=${{env.ACTION_VERSION}} \
-            --minified-path-prefix=https://action-files.parabol.co/production/build/
-
       - name: Check Code Quality
         run: yarn codecheck
 
@@ -207,7 +195,7 @@ jobs:
             "${{ secrets.GCP_AR_PARABOL_DEV }}:${{github.sha}}"
             "${{ env.DOCKER_REPOSITORY_FOR_REF }}:${{ env.GITHUB_REF_NAME_NORMALIZED }}"
       - name: Push Artifacts to Sentry
-        #if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag'
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: "${{secrets.SENTRY_AUTH_TOKEN}}"
@@ -217,3 +205,14 @@ jobs:
           environment: "production"
           sourcemaps: "./build"
           version: ${{env.ACTION_VERSION}}
+      - name: Push Artifacts to Datadog
+        if: github.ref_type == 'tag'
+        env:
+          DATADOG_API_KEY: "${{secrets.DATADOG_API_KEY}}"
+        run: |
+          echo "$DATADOG_API_KEY"
+          yarn add @datadog/datadog-ci -W
+          yarn datadog-ci sourcemaps upload ./build \
+            --service=parabol-saas-production \
+            --release-version=${{env.ACTION_VERSION}} \
+            --minified-path-prefix=https://action-files.parabol.co/production/build/

--- a/packages/client/components/Action/Action.tsx
+++ b/packages/client/components/Action/Action.tsx
@@ -86,6 +86,6 @@ const Action = memo(() => {
   )
 })
 
-Action.displayName = 'Action'
+Action.displayName = 'Action!'
 
 export default Action

--- a/packages/client/components/Action/Action.tsx
+++ b/packages/client/components/Action/Action.tsx
@@ -86,6 +86,6 @@ const Action = memo(() => {
   )
 })
 
-Action.displayName = 'Action!'
+Action.displayName = 'Action'
 
 export default Action


### PR DESCRIPTION
# Description

fixes #8925


## Demo

Demo was performed stubbing in `v6.1220.0-exotic` for version & removing the `if:` clause in the yml

- [x] Can upload to Sentry: https://parabol.sentry.io/settings/projects/action-production/source-maps/release-bundles/6.122.0-exotic/
- [x] Can upload to Datadog: `✅ Uploaded 234 sourcemaps in 7.214 seconds.` (can't confirm in datadog UI 😠 )
