### PR TITLE
feat(SAML): Support attributes with namespace

### DIFF
--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -19,6 +19,11 @@ import standardError from '../../../utils/standardError'
 const serviceProvider = samlify.ServiceProvider({})
 samlify.setSchemaValidator(samlXMLValidator)
 
+const CLAIM_SPEC = {
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'email',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'displayname'
+}
+
 const getRelayState = (body: querystring.ParsedUrlQuery) => {
   let relayState = {} as SSORelayState
   try {
@@ -71,13 +76,13 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
 
   const {extract} = loginResponse
   const {attributes, nameID: name} = extract
-  const caseInsensitiveAttributes = {} as Record<string, string | undefined>
-  Object.keys(attributes).forEach((key) => {
-    const lowercaseKey = key.toLowerCase()
-    const value = attributes[key]
-    caseInsensitiveAttributes[lowercaseKey] = String(value)
-  })
-  const {email: inputEmail, emailaddress, displayname} = caseInsensitiveAttributes
+  const normalizedAttributes = Object.fromEntries(
+    Object.entries(attributes).map(([key, value]) => {
+      const normalizedKey = CLAIM_SPEC[key as keyof typeof CLAIM_SPEC] ?? key.toLowerCase()
+      return [normalizedKey, String(value)]
+    })
+  )
+  const {email: inputEmail, emailaddress, displayname} = normalizedAttributes
   const preferredName = displayname || name
   const email = inputEmail?.toLowerCase() || emailaddress?.toLowerCase()
   if (!email) {


### PR DESCRIPTION
# Description

Support Microsoft Entra ID (formaly Azure Active Directory) out of the box. They're sending `emailaddress` and `name` prefixed with the http://schemas.xmlsoap.org/ws/2005/05/identity/claims/ namespace. Map those to values we expect.

Instead of stripping all URI prefixes, I decided to just map these explicitly to avoid cases where there could be duplicate values in different namespaces (although extremely unlikely)

## Demo

https://www.loom.com/share/6d23e89c31d84ef0b2784e2139d781fb?sid=d850e510-ba6c-47be-b85f-ca665a5edad9

## Testing scenarios

- set up Microsoft Entra ID and test...
- https://www.loom.com/share/37ef6f0bccc742358987df3ce0c00a96?sid=d77edb31-6d35-4d4a-a6e7-a32f0012699b

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
