### PR TITLE
feat(your-work): Product analytics

### DIFF
--- a/packages/client/components/ScopingSearchInput.tsx
+++ b/packages/client/components/ScopingSearchInput.tsx
@@ -5,7 +5,7 @@ import {commitLocalUpdate} from 'react-relay'
 import useAtmosphere from '../hooks/useAtmosphere'
 import SendClientSegmentEventMutation from '../mutations/SendClientSegmentEventMutation'
 import {PALETTE} from '../styles/paletteV3'
-import {TaskServiceEnum} from '../__generated__/SendClientSegmentEventMutation.graphql'
+import {ServiceEnum} from '../__generated__/SendClientSegmentEventMutation.graphql'
 
 const SearchInput = styled('input')({
   appearance: 'none',
@@ -38,7 +38,7 @@ interface Props {
   queryString: string
   meetingId: string
   linkedRecordName: string
-  service: TaskServiceEnum
+  service: ServiceEnum
   defaultInput?: string
 }
 

--- a/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDrawer.tsx
@@ -11,6 +11,7 @@ import TeamPromptDiscussionDrawer from './TeamPromptDiscussionDrawer'
 import TeamPromptWorkDrawer from './TeamPromptWorkDrawer'
 import useBreakpoint from '../../hooks/useBreakpoint'
 import findStageById from '../../utils/meetings/findStageById'
+import SendClientSegmentEventMutation from '../../mutations/SendClientSegmentEventMutation'
 
 const Drawer = styled('div')<{isDesktop: boolean; isMobile: boolean; isOpen: boolean}>(
   ({isDesktop, isMobile, isOpen}) => ({
@@ -55,6 +56,7 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
         ...TeamPromptDiscussionDrawer_meeting
         ...TeamPromptWorkDrawer_meeting
         id
+        teamId
         isRightDrawerOpen
         localStageId
         phases {
@@ -77,15 +79,6 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
   const atmosphere = useAtmosphere()
   const {id: meetingId, isRightDrawerOpen} = meeting
 
-  const onToggleDrawer = () => {
-    commitLocalUpdate(atmosphere, (store) => {
-      const meeting = store.get(meetingId)
-      if (!meeting) return
-      const isRightDrawerOpen = meeting.getValue('isRightDrawerOpen')
-      meeting.setValue(!isRightDrawerOpen, 'isRightDrawerOpen')
-    })
-  }
-
   const shouldRenderDiscussionDrawer = () => {
     const {localStageId} = meeting
     if (!localStageId) return false
@@ -97,6 +90,28 @@ const TeamPromptDrawer = ({meetingRef, isDesktop}: Props) => {
     if (!discussionId || !teamMember) return false
 
     return true
+  }
+
+  const onToggleDrawer = () => {
+    commitLocalUpdate(atmosphere, (store) => {
+      const meetingProxy = store.get(meetingId)
+      if (!meetingProxy) return
+      const isRightDrawerOpen = meetingProxy.getValue('isRightDrawerOpen')
+
+      if (!shouldRenderDiscussionDrawer()) {
+        SendClientSegmentEventMutation(
+          atmosphere,
+          isRightDrawerOpen ? 'Your Work Drawer Closed' : 'Your Work Drawer Opened',
+          {
+            teamId: meeting.teamId,
+            meetingId: meeting.id,
+            source: 'drawer'
+          }
+        )
+      }
+
+      meetingProxy.setValue(!isRightDrawerOpen, 'isRightDrawerOpen')
+    })
   }
 
   return (

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -19,6 +19,7 @@ import {TeamPromptMeetingStatus} from './TeamPromptMeetingStatus'
 import TeamPromptOptions from './TeamPromptOptions'
 import {KeyboardArrowLeft, KeyboardArrowRight} from '@mui/icons-material'
 import IconLabel from '../IconLabel'
+import SendClientSegmentEventMutation from '../../mutations/SendClientSegmentEventMutation'
 
 const TeamPromptLogoBlock = styled(LogoBlock)({
   marginRight: '8px',
@@ -95,6 +96,7 @@ const TeamPromptTopBar = (props: Props) => {
       fragment TeamPromptTopBar_meeting on TeamPromptMeeting {
         id
         name
+        teamId
         isRightDrawerOpen
         showWorkSidebar
         facilitatorUserId
@@ -139,13 +141,25 @@ const TeamPromptTopBar = (props: Props) => {
 
   const onOpenWorkSidebar = () => {
     if (meeting.isRightDrawerOpen && meeting.showWorkSidebar && !meeting.localStageId) {
-      // If we're selecting a discussion that's already open, just close the drawer.
+      // If we're clicking on 'Your Work' when it's already open, just close the drawer.
+      SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Closed', {
+        teamId: meeting.teamId,
+        meetingId: meeting.id,
+        source: 'top bar'
+      })
+
       commitLocalUpdate(atmosphere, (store) => {
         const meetingProxy = store.get(meetingId)
         if (!meetingProxy) return
         meetingProxy.setValue(false, 'isRightDrawerOpen')
       })
     } else {
+      SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Opened', {
+        teamId: meeting.teamId,
+        meetingId: meeting.id,
+        source: 'top bar'
+      })
+
       commitLocalUpdate(atmosphere, (store) => {
         const meetingProxy = store.get(meetingId)
         if (!meetingProxy) return

--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -142,30 +142,30 @@ const TeamPromptTopBar = (props: Props) => {
   const onOpenWorkSidebar = () => {
     if (meeting.isRightDrawerOpen && meeting.showWorkSidebar && !meeting.localStageId) {
       // If we're clicking on 'Your Work' when it's already open, just close the drawer.
-      SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Closed', {
-        teamId: meeting.teamId,
-        meetingId: meeting.id,
-        source: 'top bar'
-      })
-
       commitLocalUpdate(atmosphere, (store) => {
         const meetingProxy = store.get(meetingId)
         if (!meetingProxy) return
         meetingProxy.setValue(false, 'isRightDrawerOpen')
+
+        SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Closed', {
+          teamId: meeting.teamId,
+          meetingId: meeting.id,
+          source: 'top bar'
+        })
       })
     } else {
-      SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Opened', {
-        teamId: meeting.teamId,
-        meetingId: meeting.id,
-        source: 'top bar'
-      })
-
       commitLocalUpdate(atmosphere, (store) => {
         const meetingProxy = store.get(meetingId)
         if (!meetingProxy) return
         meetingProxy.setValue(null, 'localStageId')
         meetingProxy.setValue(true, 'showWorkSidebar')
         meetingProxy.setValue(true, 'isRightDrawerOpen')
+
+        SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Opened', {
+          teamId: meeting.teamId,
+          meetingId: meeting.id,
+          source: 'top bar'
+        })
       })
     }
   }

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -58,22 +58,23 @@ const TeamPromptWorkDrawer = (props: Props) => {
   const baseTabs = [
     {
       icon: <ParabolLogoSVG />,
-      service: 'parabol',
+      service: 'PARABOL',
       label: 'Parabol',
       Component: ParabolTasksPanel
     },
-    {icon: <GitHubSVG />, label: 'GitHub', Component: GitHubIntegrationPanel},
-    {icon: <JiraSVG />, label: 'Jira', Component: JiraIntegrationPanel},
+    {icon: <GitHubSVG />, service: 'github', label: 'GitHub', Component: GitHubIntegrationPanel},
+    {icon: <JiraSVG />, service: 'jira', label: 'Jira', Component: JiraIntegrationPanel},
     ...(meeting.viewerMeetingMember?.user.featureFlags.gcal
-      ? [
+      ? ([
           {
             icon: <img className='h-6 w-6' src={gcalLogo} />,
+            service: 'gcal',
             label: 'Google Calendar',
             Component: GCalIntegrationPanel
           }
-        ]
+        ] as const)
       : [])
-  ].filter((tab) => !!tab)
+  ] as const
 
   const {Component} = baseTabs[activeIdx]!
 
@@ -98,7 +99,7 @@ const TeamPromptWorkDrawer = (props: Props) => {
                   SendClientSegmentEventMutation(atmosphere, 'Your Work Integration Clicked', {
                     teamId: meeting.teamId,
                     meetingId: meeting.id,
-                    integrationLabel: baseTabs[idx]?.label
+                    service: baseTabs[idx]?.service
                   })
                   setActiveIdx(idx)
                 }}

--- a/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptWorkDrawer.tsx
@@ -46,10 +46,9 @@ const TeamPromptWorkDrawer = (props: Props) => {
   const atmosphere = useAtmosphere()
 
   useEffect(() => {
-    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Opened', {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Impression', {
       teamId: meeting.teamId,
-      meetingId: meeting.id,
-      source: 'impression'
+      meetingId: meeting.id
     })
   }, [])
 

--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalEventCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalEventCard.tsx
@@ -109,13 +109,13 @@ const GCalEventCard = (props: Props) => {
 
   const trackLinkClick = () => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Link Clicked', {
-      integrationLabel: 'Google Calendar'
+      service: 'gcal'
     })
   }
 
   const trackCopy = () => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Copied', {
-      integrationLabel: 'Google Calendar'
+      service: 'gcal'
     })
   }
 

--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalEventCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalEventCard.tsx
@@ -9,6 +9,8 @@ import {mergeRefs} from '../../../utils/react/mergeRefs'
 import clsx from 'clsx'
 import {ContentCopy} from '@mui/icons-material'
 import ms from 'ms'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
+import useAtmosphere from '../../../hooks/useAtmosphere'
 
 interface Props {
   eventRef: GCalEventCard_event$key
@@ -81,6 +83,8 @@ const GCalEventCard = (props: Props) => {
     eventRef
   )
 
+  const atmosphere = useAtmosphere()
+
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER
   )
@@ -94,6 +98,7 @@ const GCalEventCard = (props: Props) => {
 
   const handleCopy = () => {
     openCopiedTooltip()
+    trackCopy()
     setTimeout(() => {
       closeCopiedTooltip()
     }, 2000)
@@ -101,6 +106,18 @@ const GCalEventCard = (props: Props) => {
 
   const startDate = result.startDate ? new Date(result.startDate) : null
   const endDate = result.endDate ? new Date(result.endDate) : null
+
+  const trackLinkClick = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Link Clicked', {
+      integrationLabel: 'Google Calendar'
+    })
+  }
+
+  const trackCopy = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Copied', {
+      integrationLabel: 'Google Calendar'
+    })
+  }
 
   return (
     <div className='group'>
@@ -113,6 +130,7 @@ const GCalEventCard = (props: Props) => {
             href={result.link ?? undefined}
             target='_blank'
             rel='noreferrer'
+            onClick={trackLinkClick}
           >
             {result.summary}
           </a>

--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationPanel.tsx
@@ -8,6 +8,7 @@ import GCalIntegrationResultsRoot from './GCalIntegrationResultsRoot'
 import GcalClientManager from '../../../utils/GcalClientManager'
 import gcalSVG from '../../../styles/theme/images/graphics/google-calendar.svg'
 import clsx from 'clsx'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 
 const GCAL_QUERY_TABS = [
   {
@@ -33,6 +34,8 @@ const GCalPanel = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment GCalIntegrationPanel_meeting on TeamPromptMeeting {
+        id
+        teamId
         viewerMeetingMember {
           teamMember {
             teamId
@@ -73,6 +76,19 @@ const GCalPanel = (props: Props) => {
     }
     const {clientId, id: providerId} = gcal.cloudProvider
     GcalClientManager.openOAuth(atmosphere, providerId, clientId, teamMember.teamId, mutationProps)
+
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Integration Connected', {
+      teamId: meeting.teamId,
+      meetingId: meeting.id,
+      integrationLabel: 'Google Calendar'
+    })
+  }
+
+  const trackTabNavigated = (label: string) => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Tag Navigated', {
+      integrationLabel: 'Google Calendar',
+      buttonLabel: label
+    })
   }
 
   return (
@@ -89,7 +105,10 @@ const GCalPanel = (props: Props) => {
                     ? 'bg-grape-700 font-semibold text-white focus:text-white'
                     : 'border border-slate-300 bg-white'
                 )}
-                onClick={() => setEventRangeKey(tab.key)}
+                onClick={() => {
+                  trackTabNavigated(tab.label)
+                  setEventRangeKey(tab.key)
+                }}
               >
                 {tab.label}
               </div>

--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationPanel.tsx
@@ -80,13 +80,13 @@ const GCalPanel = (props: Props) => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Integration Connected', {
       teamId: meeting.teamId,
       meetingId: meeting.id,
-      integrationLabel: 'Google Calendar'
+      service: 'gcal'
     })
   }
 
   const trackTabNavigated = (label: string) => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Tag Navigated', {
-      integrationLabel: 'Google Calendar',
+      service: 'gcal',
       buttonLabel: label
     })
   }

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationPanel.tsx
@@ -67,13 +67,13 @@ const GitHubIntegrationPanel = (props: Props) => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Integration Connected', {
       teamId: meeting.teamId,
       meetingId: meeting.id,
-      integrationLabel: 'GitHub'
+      service: 'github'
     })
   }
 
   const trackTabNavigated = (label: string) => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Tag Navigated', {
-      integrationLabel: 'GitHub',
+      service: 'github',
       buttonLabel: label
     })
   }
@@ -89,7 +89,7 @@ const GitHubIntegrationPanel = (props: Props) => {
               SendClientSegmentEventMutation(atmosphere, 'Your Work Filter Changed', {
                 teamId: meeting.teamId,
                 meetingId: meeting.id,
-                integrationLabel: 'GitHub'
+                service: 'github'
               })
               setSelectedRepos(repos)
             }}

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationPanel.tsx
@@ -9,6 +9,7 @@ import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import GitHubIntegrationResultsRoot from './GitHubIntegrationResultsRoot'
 import GitHubRepoFilterBar from './GitHubRepoFilterBar'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 
 const GITHUB_QUERY_TABS: {key: 'issue' | 'pullRequest'; label: string}[] = [
   {
@@ -30,6 +31,8 @@ const GitHubIntegrationPanel = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment GitHubIntegrationPanel_meeting on TeamPromptMeeting {
+        teamId
+        id
         viewerMeetingMember {
           teamMember {
             teamId
@@ -60,6 +63,19 @@ const GitHubIntegrationPanel = (props: Props) => {
       return onError(new Error('Could not find team member'))
     }
     teamMember && GitHubClientManager.openOAuth(atmosphere, teamMember.teamId, mutationProps)
+
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Integration Connected', {
+      teamId: meeting.teamId,
+      meetingId: meeting.id,
+      integrationLabel: 'GitHub'
+    })
+  }
+
+  const trackTabNavigated = (label: string) => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Tag Navigated', {
+      integrationLabel: 'GitHub',
+      buttonLabel: label
+    })
   }
 
   return (
@@ -69,7 +85,14 @@ const GitHubIntegrationPanel = (props: Props) => {
           <GitHubRepoFilterBar
             teamMemberRef={teamMember}
             selectedRepos={selectedRepos}
-            setSelectedRepos={setSelectedRepos}
+            setSelectedRepos={(repos) => {
+              SendClientSegmentEventMutation(atmosphere, 'Your Work Filter Changed', {
+                teamId: meeting.teamId,
+                meetingId: meeting.id,
+                integrationLabel: 'GitHub'
+              })
+              setSelectedRepos(repos)
+            }}
           />
           <div className='mb-4 flex w-full gap-2 px-4'>
             {GITHUB_QUERY_TABS.map((tab) => (
@@ -81,7 +104,10 @@ const GitHubIntegrationPanel = (props: Props) => {
                     ? 'bg-grape-700 font-semibold text-white focus:text-white'
                     : 'border border-slate-300 bg-white'
                 )}
-                onClick={() => setGithubType(tab.key)}
+                onClick={() => {
+                  trackTabNavigated(tab.label)
+                  setGithubType(tab.key)
+                }}
               >
                 {tab.label}
               </div>

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubObjectCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubObjectCard.tsx
@@ -15,6 +15,8 @@ import {useFragment} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import {GitHubObjectCard_result$key} from '../../../__generated__/GitHubObjectCard_result.graphql'
 import {mergeRefs} from '../../../utils/react/mergeRefs'
+import useAtmosphere from '../../../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 
 const ISSUE_STATUS_MAP: Record<string, any> = {
   OPEN: githubIssueOpen,
@@ -73,6 +75,8 @@ const GitHubObjectCard = (props: Props) => {
     resultRef
   )
 
+  const atmosphere = useAtmosphere()
+
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER
   )
@@ -84,8 +88,21 @@ const GitHubObjectCard = (props: Props) => {
     originRef: copiedTooltipRef
   } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
 
+  const trackLinkClick = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Link Clicked', {
+      integrationLabel: 'GitHub'
+    })
+  }
+
+  const trackCopy = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Copied', {
+      integrationLabel: 'GitHub'
+    })
+  }
+
   const handleCopy = () => {
     openCopiedTooltip()
+    trackCopy()
     setTimeout(() => {
       closeCopiedTooltip()
     }, 2000)
@@ -112,13 +129,25 @@ const GitHubObjectCard = (props: Props) => {
     <div className='rounded border border-solid border-slate-300 p-4 hover:border-slate-600'>
       <div className='flex gap-2 text-xs text-slate-600'>
         {statusImg && <img src={statusImg} />}
-        <a href={url} target='_blank' className='font-medium hover:underline' rel='noreferrer'>
+        <a
+          href={url}
+          target='_blank'
+          className='font-medium hover:underline'
+          rel='noreferrer'
+          onClick={trackLinkClick}
+        >
           #{number}
         </a>
         <div>Updated {relativeDate(updatedAt)}</div>
       </div>
       <div className='my-2 text-sm'>
-        <a href={url} target='_blank' className='hover:underline' rel='noreferrer'>
+        <a
+          href={url}
+          target='_blank'
+          className='hover:underline'
+          rel='noreferrer'
+          onClick={trackLinkClick}
+        >
           {title}
         </a>
       </div>
@@ -132,6 +161,7 @@ const GitHubObjectCard = (props: Props) => {
             target='_blank'
             className='text-xs text-slate-600 hover:underline'
             rel='noreferrer'
+            onClick={trackLinkClick}
           >
             {repoName}
           </a>

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubObjectCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubObjectCard.tsx
@@ -90,13 +90,13 @@ const GitHubObjectCard = (props: Props) => {
 
   const trackLinkClick = () => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Link Clicked', {
-      integrationLabel: 'GitHub'
+      service: 'github'
     })
   }
 
   const trackCopy = () => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Copied', {
-      integrationLabel: 'GitHub'
+      service: 'github'
     })
   }
 

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationPanel.tsx
@@ -6,6 +6,7 @@ import AtlassianClientManager from '../../../utils/AtlassianClientManager'
 import useAtmosphere from '../../../hooks/useAtmosphere'
 import useMutationProps from '../../../hooks/useMutationProps'
 import JiraIntegrationResultsRoot from './JiraIntegrationResultsRoot'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 
 interface Props {
   meetingRef: JiraIntegrationPanel_meeting$key
@@ -16,6 +17,8 @@ const JiraIntegrationPanel = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment JiraIntegrationPanel_meeting on TeamPromptMeeting {
+        id
+        teamId
         viewerMeetingMember {
           teamMember {
             teamId
@@ -42,6 +45,12 @@ const JiraIntegrationPanel = (props: Props) => {
       return onError(new Error('Could not find team member'))
     }
     AtlassianClientManager.openOAuth(atmosphere, teamMember.teamId, mutationProps)
+
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Integration Connected', {
+      teamId: meeting.teamId,
+      meetingId: meeting.id,
+      integrationLabel: 'Jira'
+    })
   }
 
   return (

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationPanel.tsx
@@ -49,7 +49,7 @@ const JiraIntegrationPanel = (props: Props) => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Integration Connected', {
       teamId: meeting.teamId,
       meetingId: meeting.id,
-      integrationLabel: 'Jira'
+      service: 'jira'
     })
   }
 

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraObjectCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraObjectCard.tsx
@@ -53,13 +53,13 @@ const JiraObjectCard = (props: Props) => {
 
   const trackLinkClick = () => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Link Clicked', {
-      integrationLabel: 'Jira'
+      service: 'jira'
     })
   }
 
   const trackCopy = () => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Copied', {
-      integrationLabel: 'Jira'
+      service: 'jira'
     })
   }
 

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraObjectCard.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraObjectCard.tsx
@@ -9,6 +9,8 @@ import {useFragment} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
 import {JiraObjectCard_result$key} from '../../../__generated__/JiraObjectCard_result.graphql'
 import {mergeRefs} from '../../../utils/react/mergeRefs'
+import useAtmosphere from '../../../hooks/useAtmosphere'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 
 interface Props {
   resultRef: JiraObjectCard_result$key
@@ -36,6 +38,8 @@ const JiraObjectCard = (props: Props) => {
     resultRef
   )
 
+  const atmosphere = useAtmosphere()
+
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER
   )
@@ -47,8 +51,21 @@ const JiraObjectCard = (props: Props) => {
     originRef: copiedTooltipRef
   } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
 
+  const trackLinkClick = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Link Clicked', {
+      integrationLabel: 'Jira'
+    })
+  }
+
+  const trackCopy = () => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Card Copied', {
+      integrationLabel: 'Jira'
+    })
+  }
+
   const handleCopy = () => {
     openCopiedTooltip()
+    trackCopy()
     setTimeout(() => {
       closeCopiedTooltip()
     }, 2000)
@@ -65,13 +82,20 @@ const JiraObjectCard = (props: Props) => {
           target='_blank'
           className='font-semibold text-slate-600 hover:underline'
           rel='noreferrer'
+          onClick={trackLinkClick}
         >
           {issueKey}
         </a>
         <div>Updated {relativeDate(lastUpdated)}</div>
       </div>
       <div className='my-2 text-sm'>
-        <a href={url} target='_blank' className='hover:underline' rel='noreferrer'>
+        <a
+          href={url}
+          target='_blank'
+          className='hover:underline'
+          rel='noreferrer'
+          onClick={trackLinkClick}
+        >
           {summary}
         </a>
       </div>
@@ -86,6 +110,7 @@ const JiraObjectCard = (props: Props) => {
               target='_blank'
               className='text-xs text-slate-600 hover:underline'
               rel='noreferrer'
+              onClick={trackLinkClick}
             >
               {project.name}
             </a>

--- a/packages/client/components/TeamPrompt/WorkDrawer/ParabolTasksPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/ParabolTasksPanel.tsx
@@ -12,6 +12,7 @@ import dndNoise from '../../../utils/dndNoise'
 import AddTaskButton from '../../AddTaskButton'
 import ParabolTasksResultsRoot from './ParabolTasksResultsRoot'
 import clsx from 'clsx'
+import SendClientSegmentEventMutation from '../../../mutations/SendClientSegmentEventMutation'
 
 interface Props {
   meetingRef: ParabolTasksPanel_meeting$key
@@ -49,6 +50,13 @@ const ParabolTasksPanel = (props: Props) => {
     )
   }
 
+  const trackTabNavigated = (label: string) => {
+    SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Tag Navigated', {
+      integrationLabel: 'Parabol',
+      buttonLabel: label
+    })
+  }
+
   return (
     <>
       <div>
@@ -62,7 +70,10 @@ const ParabolTasksPanel = (props: Props) => {
                   ? 'bg-grape-700 font-semibold text-white focus:text-white'
                   : 'border border-slate-300 bg-white'
               )}
-              onClick={() => setSelectedStatus(status)}
+              onClick={() => {
+                trackTabNavigated(taskStatusLabels[status])
+                setSelectedStatus(status)
+              }}
             >
               {taskStatusLabels[status]}
             </div>

--- a/packages/client/components/TeamPrompt/WorkDrawer/ParabolTasksPanel.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/ParabolTasksPanel.tsx
@@ -52,7 +52,7 @@ const ParabolTasksPanel = (props: Props) => {
 
   const trackTabNavigated = (label: string) => {
     SendClientSegmentEventMutation(atmosphere, 'Your Work Drawer Tag Navigated', {
-      integrationLabel: 'Parabol',
+      service: 'PARABOL',
       buttonLabel: label
     })
   }

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -8571,6 +8571,8 @@ input SegmentEventTrackOptions {
   reflectionId: ID
   viewerId: ID
   reflectionsCount: Int
+  integrationLabel: String
+  buttonLabel: String
 }
 
 type SelectTemplatePayload {

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -7719,6 +7719,17 @@ enum TaskServiceEnum {
   PARABOL
 }
 
+enum ServiceEnum {
+  PARABOL
+  github
+  jira
+  gitlab
+  mattermost
+  jiraServer
+  gcal
+  azureDevOps
+}
+
 """
 The part of the site that is calling the mutation
 """
@@ -8571,7 +8582,6 @@ input SegmentEventTrackOptions {
   reflectionId: ID
   viewerId: ID
   reflectionsCount: Int
-  integrationLabel: String
   buttonLabel: String
 }
 

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -54,7 +54,9 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     teamIds: {type: GraphQLList(GraphQLID)},
     insightTitle: {type: GraphQLString},
     isHelpfulInsight: {type: GraphQLBoolean},
-    selectionLocation: {type: GraphQLString}
+    selectionLocation: {type: GraphQLString},
+    integrationLabel: {type: GraphQLString},
+    buttonLabel: {type: GraphQLString}
   })
 })
 

--- a/packages/server/graphql/types/SegmentEventTrackOptions.ts
+++ b/packages/server/graphql/types/SegmentEventTrackOptions.ts
@@ -11,10 +11,10 @@ import NewMeetingPhaseTypeEnum from './NewMeetingPhaseTypeEnum'
 import NotificationEnum from './NotificationEnum'
 import SharingScopeEnum from './SharingScopeEnum'
 import SnackbarTypeEnum from './SnackbarTypeEnum'
-import TaskServiceEnum from './TaskServiceEnum'
 import TierEnum from './TierEnum'
 import UpgradeCTALocationEnum from './UpgradeCTALocationEnum'
 import DowngradeCTALocationEnum from './DowngradeCTALocationEnum'
+import ServiceEnum from './ServiceEnum'
 
 const SegmentEventTrackOptions = new GraphQLInputObjectType({
   name: 'SegmentEventTrackOptions',
@@ -30,7 +30,7 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     reflectionsCount: {type: GraphQLInt},
     action: {type: GraphQLString},
     searchQueryString: {type: GraphQLString},
-    service: {type: TaskServiceEnum},
+    service: {type: ServiceEnum},
     searchQueryFilters: {type: GraphQLList(GraphQLID)},
     projectId: {type: GraphQLID},
     selectedAll: {type: GraphQLBoolean},
@@ -55,7 +55,6 @@ const SegmentEventTrackOptions = new GraphQLInputObjectType({
     insightTitle: {type: GraphQLString},
     isHelpfulInsight: {type: GraphQLBoolean},
     selectionLocation: {type: GraphQLString},
-    integrationLabel: {type: GraphQLString},
     buttonLabel: {type: GraphQLString}
   })
 })

--- a/packages/server/graphql/types/ServiceEnum.ts
+++ b/packages/server/graphql/types/ServiceEnum.ts
@@ -1,0 +1,22 @@
+import {GraphQLEnumType} from 'graphql'
+
+const values = {
+  PARABOL: {},
+  github: {},
+  jira: {},
+  gitlab: {},
+  mattermost: {},
+  jiraServer: {},
+  gcal: {},
+  azureDevOps: {}
+} as const
+
+const ServiceEnum = new GraphQLEnumType({
+  name: 'ServiceEnum',
+  description: 'The list of services',
+  values
+})
+
+export type ServiceEnumType = keyof typeof values
+
+export default ServiceEnum


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8924

Add analytics for Your Work drawer.

Needs rebase once [gCal PR](https://github.com/ParabolInc/parabol/pull/8939) lands.

## Demo
N/A

## Testing scenarios
- [ ] Test each metric listed in the issue:
  - [ ] Open/close drawer:
    - [ ] Via impression (e.g. default open on load)
    - [ ] Via top bar
    - [ ] Via drawer (e.g. close icon + swipe-to-close on smaller screens)
  - [ ] Clicks into individual integration panels
  - [ ] Click to connect integration
  - [ ] Integration cards for GitHub, Jira, and gCal:
    - [ ] Click on links
    - [ ] Click copy
  - [ ] Change GitHub repo filter
- [ ] Does not track opens/closes for discussion drawer
- [ ] Does not track close when switching from your work to discussion

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
