### PR TITLE
feat(your-work): Open your work drawer by default

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptTopBar.tsx
@@ -98,6 +98,7 @@ const TeamPromptTopBar = (props: Props) => {
         isRightDrawerOpen
         showWorkSidebar
         facilitatorUserId
+        localStageId
         prevMeeting {
           id
         }
@@ -137,7 +138,7 @@ const TeamPromptTopBar = (props: Props) => {
   const isRecurrenceEnabled = meetingSeries && !meetingSeries.cancelledAt
 
   const onOpenWorkSidebar = () => {
-    if (meeting.isRightDrawerOpen && meeting.showWorkSidebar) {
+    if (meeting.isRightDrawerOpen && meeting.showWorkSidebar && !meeting.localStageId) {
       // If we're selecting a discussion that's already open, just close the drawer.
       commitLocalUpdate(atmosphere, (store) => {
         const meetingProxy = store.get(meetingId)

--- a/packages/client/components/TeamPromptMeeting.tsx
+++ b/packages/client/components/TeamPromptMeeting.tsx
@@ -70,6 +70,7 @@ const TeamPromptMeeting = (props: Props) => {
         id
         isRightDrawerOpen
         endedAt
+        localStageId
         phases {
           ... on TeamPromptResponsesPhase {
             __typename
@@ -133,7 +134,7 @@ const TeamPromptMeeting = (props: Props) => {
   const transitioningStages = useTransition(stages)
   const {safeRoute, isDesktop} = useMeeting(meeting)
   const history = useHistory()
-  const {isRightDrawerOpen, id: meetingId} = meeting
+  const {isRightDrawerOpen, id: meetingId, localStageId} = meeting
   const params = new URLSearchParams(history.location.search)
   const responseId = params.get('responseId')
   useEffect(() => {
@@ -150,9 +151,23 @@ const TeamPromptMeeting = (props: Props) => {
       const meetingProxy = store.get(meetingId)
       if (!meetingProxy) return
       meetingProxy.setValue(stage.id, 'localStageId')
+      meetingProxy.setValue(false, 'showWorkSidebar')
       meetingProxy.setValue(true, 'isRightDrawerOpen')
     })
   }, [responseId])
+
+  useEffect(() => {
+    if (localStageId || !!meeting?.endedAt) {
+      return
+    }
+    commitLocalUpdate(atmosphere, (store) => {
+      const meetingProxy = store.get(meetingId)
+      if (!meetingProxy) return
+      meetingProxy.setValue(true, 'showWorkSidebar')
+      meetingProxy.setValue(true, 'isRightDrawerOpen')
+    })
+  }, [])
+
   if (!safeRoute) return null
 
   return (


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8940

Open the your work drawer by default to attempt to increase feature adoption.

## Demo
N/A - see tests

## Testing scenarios
- [ ] Open an active standup meeting, and confirm that the your work drawer is open
- [ ] Confirm that clicking either the 'X' or the 'Your work' icon in the top bar closes the drawer
- [ ] Open an ended standup meeting, and confirm that the your work drawer does not open
- [ ] Open a permalinked standup discussion thread (looks like http://localhost:3000/meet/pgc4zNn4go/responses?responseId=teamPromptResponse%3A374, you can get this from a standup notification, such as a mention), and confirm the discussion drawer opens.
- [ ] Confirm that clicking the 'Your work' icon switches the drawer to the your work drawer.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
