### PR TITLE
feat(redis): upgrade to use Redis 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
           POSTGRES_DB: "parabol-saas"
           POSTGRES_HOST: "localhost"
           POSTGRES_PORT: "5432"
-      - image: redis:6.2.6-alpine
+      - image: redis:7.0-alpine
         environment:
           TERM: xterm
     environment:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           - 28015:28015
           - 29015:29015
       redis:
-        image: redis:6.2.6
+        image: redis:7.0-alpine
         ports:
           - 6379:6379
     steps:

--- a/certs/README.md
+++ b/certs/README.md
@@ -6,7 +6,27 @@ The certs that are checked into version control are self-signed and safe to shar
 ### Env Vars
 
 All env vars should correspond with the vars in the redis instance.
-In development, that means vars in .env should match the vars in dev.yml.
+
+In development, that means:
+- In the `docker/dev.yml`, add a volume: `bitnami-redis-data: {}`
+- In the `docker/dev.yml`, replace the Redis container sections with the following:
+  ```yaml
+  image: bitnami/redis:7.0-debian-11
+  environment:
+    - ALLOW_EMPTY_PASSWORD=yes
+    - REDIS_PASSWORD=''
+    - REDIS_TLS_ENABLED=no
+    - REDIS_TLS_AUTH_CLIENTS=no
+    - REDIS_TLS_CERT_FILE=/opt/bitnami/redis/certs/redis.crt
+    - REDIS_TLS_KEY_FILE=/opt/bitnami/redis/certs/redis.key
+    - REDIS_TLS_CA_FILE=/opt/bitnami/redis/certs/redisCA.crt
+  volumes:
+    - bitnami-redis-data:/bitnami/redis/data
+    - ../certs:/opt/bitnami/redis/certs
+  ```
+
+- Vars in .env should match the vars in dev.yml
+
 Any changes to dev.yml require running `yarn db:start`
 
 REDIS_PASSWORD: Use this if you'd like our app to connect to redis using a password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     networks:
       - parabol-network
   redis:
-    image: redis:6
+    image: redis:7.0-alpine
     ports:
       - "6379:6379"
     volumes:

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -51,21 +51,12 @@ services:
       - parabol-network
     restart: unless-stopped
   redis:
-    image: bitnami/redis:7.0-alpine
+    image: redis:7.0-alpine
     restart: unless-stopped
-    environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - REDIS_PASSWORD=''
-      - REDIS_TLS_ENABLED=no
-      - REDIS_TLS_AUTH_CLIENTS=no
-      - REDIS_TLS_CERT_FILE=/opt/bitnami/redis/certs/redis.crt
-      - REDIS_TLS_KEY_FILE=/opt/bitnami/redis/certs/redis.key
-      - REDIS_TLS_CA_FILE=/opt/bitnami/redis/certs/redisCA.crt
     ports:
       - "6379:6379"
     volumes:
-      - bitnami-redis-data:/bitnami/redis/data
-      - ../certs:/opt/bitnami/redis/certs
+      - redis-data:/data
     networks:
       - parabol-network
   redis-commander:
@@ -82,7 +73,7 @@ services:
 networks:
   parabol-network:
 volumes:
-  bitnami-redis-data: {}
+  redis-data: {}
   rethink-data: {}
   postgres-data: {}
   pgadmin-data: {}

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -51,7 +51,7 @@ services:
       - parabol-network
     restart: unless-stopped
   redis:
-    image: bitnami/redis:7.0-debian-11
+    image: bitnami/redis:7.0-alpine
     restart: unless-stopped
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -51,7 +51,7 @@ services:
       - parabol-network
     restart: unless-stopped
   redis:
-    image: bitnami/redis:6.2
+    image: bitnami/redis:7.0-debian-11
     restart: unless-stopped
     environment:
       - ALLOW_EMPTY_PASSWORD=yes

--- a/docker/parabol-ubi/docker-build/README.md
+++ b/docker/parabol-ubi/docker-build/README.md
@@ -29,7 +29,7 @@ Recommended:
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------- |
 | `postgresql_tag`     | PostgreSQL version from the [Docker image](https://hub.docker.com/_/postgres)                                           | `Any tag`                                             | `12.10-alpine`                                                      |
 | `rethinkdb_tag`      | RethinkDB version from the [Docker image](https://hub.docker.com/_/rethinkdb)                                           | `Any tag`                                             | `2.4.2`                                                             |
-| `redis_tag`          | Redis version from the [Docker image](https://hub.docker.com/_/redis)                                                   | `Any tag`                                             | `6.2.6`                                                             |
+| `redis_tag`          | Redis version from the [Docker image](https://hub.docker.com/_/redis)                                                   | `Any tag`                                             | `7.0-alpine`                                                             |
 | `_BUILD_ENV_PATH`    | File `.env` used by the application during the build process                                                            | `Relative path from the root level of the repository` | `docker/parabol-ubi/docker-build/environments/pipeline`             |
 | `_NODE_VERSION`      | Node version, used by Docker to use the Docker image node:\_NODE_VERSION as base image to build                         | `Same as in root package.json`                        |                                                                     |
 | `_DOCKERFILE`        | Dockerfile used to build the image                                                                                      | `Relative path from the root level of the repository` | `./docker/parabol-ubi/docker-build/dockerfiles/pipeline.dockerfile` |
@@ -42,7 +42,7 @@ Example of variables:
 ```commandLine
 export postgresql_tag=12.10-alpine; \
 export rethinkdb_tag=2.4.2; \
-export redis_tag=6.2.6; \
+export redis_tag=7.0-alpine; \
 export _BUILD_ENV_PATH=docker/parabol-ubi/docker-build/environments/pipeline; \
 export _NODE_VERSION=$(jq -r -j '.engines.node|ltrimstr("^")' package.json); \
 export _DOCKERFILE=./docker/parabol-ubi/docker-build/dockerfiles/pipeline.dockerfile; \
@@ -133,7 +133,7 @@ Modify the version export below e.g. update vX.X.X and run the export command an
 ```commandLine
 export postgresql_tag=12.10-alpine; \
 export rethinkdb_tag=2.4.2; \
-export redis_tag=6.2.6; \
+export redis_tag=7.0-alpine; \
 export _BUILD_ENV_PATH=environments/local-buildenv \
 export _NODE_VERSION=18.17.0 \
 export _DOCKER_REPOSITORY=parabol \


### PR DESCRIPTION
# Description

We are already using Redis 7 in both Digital Ocean and GCP. This PR upgrades all Redis references to 7.0.

- It uses 7.0, without a patch version, because it is what's configured in GCP. We cannot control the patch upgrades. By definition, these images aren't inmutable, but the risk is very low and we need to test things ahead of GCP automated upgrades.
- The image  [Docker official 7.0-alpine](https://hub.docker.com/_/redis/tags?page=1&name=7.0-alpine) is used everywhere.
- Redis TLS documentation has been modified in order to ease the use of that functionality in development if required.

## Testing scenarios

- [x] Build action works and produces a Docker image.
- [x] Developers can execute their local environment without problem.