### PR TITLE
fix: dailyPulse handle nulls

### DIFF
--- a/packages/server/graphql/private/queries/dailyPulse.ts
+++ b/packages/server/graphql/private/queries/dailyPulse.ts
@@ -1,14 +1,14 @@
-import {RValue} from '../../../database/stricterR'
 import getRethink from '../../../database/rethinkDriver'
+import {RValue} from '../../../database/stricterR'
 import getPg from '../../../postgres/getPg'
 import {getUserByEmail} from '../../../postgres/queries/getUsersByEmails'
-import {toEpochSeconds} from '../../../utils/epochTime'
 import SlackServerManager from '../../../utils/SlackServerManager'
+import {toEpochSeconds} from '../../../utils/epochTime'
+import {DataLoaderWorker} from '../../graphql'
+import isValid from '../../isValid'
 import {makeSection} from '../../mutations/helpers/notifications/makeSlackBlocks'
 import {QueryResolvers} from '../resolverTypes'
 import authCountByDomain from './helpers/authCountByDomain'
-import isValid from '../../isValid'
-import {DataLoaderWorker} from '../../graphql'
 
 interface TypeField {
   type: 'mrkdwn'
@@ -36,7 +36,8 @@ const filterCounts = async (domainCount: DomainCount[], dataLoader: DataLoaderWo
   const companyCounts = await Promise.all(
     domainCount.map(async (count) => {
       const {domain, total} = count
-      if (total <= 1 || !(await dataLoader.get('isCompanyDomain').load(domain))) return null
+      if (total <= 1 || !domain || !(await dataLoader.get('isCompanyDomain').load(domain)))
+        return null
       return count
     })
   )

--- a/packages/server/graphql/private/queries/helpers/authCountByDomain.ts
+++ b/packages/server/graphql/private/queries/helpers/authCountByDomain.ts
@@ -19,6 +19,7 @@ const authCountByDomain = async (
         `SELECT count(*)::float as "total", "domain" from "User"
          WHERE (NOT $1 OR "inactive" = FALSE)
          AND "${filterField}" >= $2
+         AND domain IS NOT NULL
          GROUP BY "domain"
          ORDER BY "total" DESC`,
         [countOnlyActive ?? false, after]
@@ -26,6 +27,7 @@ const authCountByDomain = async (
     : await pg.query<DomainTotal>(
         `SELECT count(*)::float as "total", "domain" from "User"
          WHERE (NOT $1 OR "inactive" = FALSE)
+         AND domain IS NOT NULL
          GROUP BY "domain"
          ORDER BY "total" DESC`,
         [countOnlyActive ?? false]


### PR DESCRIPTION
# Description

Fixes our internal daily pulse.
On Sept 25 we started using a new dataloader to determine if something is a company domain.
Dataloaders can't handle `null`. https://github.com/ParabolInc/parabol/blob/0508fad31335d0cedb324237fcb6342a83c56793/packages/server/dataloader/customLoaderMakers.ts#L709
We could make the dataloader handle nulls, or we could ensure that only non-nulls make it to the dataloader.
Since none of the other dataloders handle `null`, I figured the latter was the better option.

## Demo

This relies on prod data to verify the fix.


## Testing scenarios

In admin/graphql run this

```gql
query DailyPulse($after: DateTime!, $email: String!, $channelId: ID!) {
  dailyPulse(after: $after, email: $email, channelId: $channelId)
}
```

with these vars (replace X with what you see in the dokku prod env)

```json
{
  "after": "2023-10-15T16:05:39.810Z",
  "email": "X",
  "channelId": "X"
}
```