### PR TITLE
chore(Team Insights): Limit most used retro templates

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TopRetroTemplatesCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TopRetroTemplatesCard.tsx
@@ -4,6 +4,7 @@ import {useFragment} from 'react-relay'
 import {TopRetroTemplatesCard_insights$key} from '~/__generated__/TopRetroTemplatesCard_insights.graphql'
 import Tooltip from '../../../../components/Tooltip'
 import TeamInsightsCard from './TeamInsightsCard'
+import plural from '../../../../utils/plural'
 
 interface Props {
   teamInsightsRef: TopRetroTemplatesCard_insights$key
@@ -38,7 +39,7 @@ const TopRetroTemplatesCard = (props: Props) => {
     <TeamInsightsCard
       teamInsightsRef={insights}
       title='Top Templates'
-      tooltip='The most frequently used retrospective templates on your team for the last 12 months'
+      tooltip='The most used retro templates on your team in the last 12 months'
     >
       <div className='flex w-full flex-col'>
         {topRetroTemplates.map((template, index) => {
@@ -46,7 +47,7 @@ const TopRetroTemplatesCard = (props: Props) => {
           const {name, illustrationUrl} = reflectTemplate
           return (
             <Tooltip
-              text={`Used ${count} times in the last 12 months`}
+              text={`Used ${plural(count, 'once', `${count} times`)} in the last 12 months`}
               className='my-2 flex items-center rounded border-2 border-grape-500 bg-fuscia-100 text-sm font-semibold text-slate-700'
               key={index}
             >

--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TopRetroTemplatesCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TopRetroTemplatesCard.tsx
@@ -2,6 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {TopRetroTemplatesCard_insights$key} from '~/__generated__/TopRetroTemplatesCard_insights.graphql'
+import Tooltip from '../../../../components/Tooltip'
 import TeamInsightsCard from './TeamInsightsCard'
 
 interface Props {
@@ -21,6 +22,7 @@ const TopRetroTemplatesCard = (props: Props) => {
             name
             illustrationUrl
           }
+          count
         }
       }
     `,
@@ -36,20 +38,21 @@ const TopRetroTemplatesCard = (props: Props) => {
     <TeamInsightsCard
       teamInsightsRef={insights}
       title='Top Templates'
-      tooltip='The most frequently used retrospective templates on your team'
+      tooltip='The most frequently used retrospective templates on your team for the last 12 months'
     >
       <div className='flex w-full flex-col'>
         {topRetroTemplates.map((template, index) => {
-          const {reflectTemplate} = template
+          const {reflectTemplate, count} = template
           const {name, illustrationUrl} = reflectTemplate
           return (
-            <div
+            <Tooltip
+              text={`Used ${count} times in the last 12 months`}
               className='my-2 flex items-center rounded border-2 border-grape-500 bg-fuscia-100 text-sm font-semibold text-slate-700'
               key={index}
             >
               <img className='m-1 h-10 w-10' src={illustrationUrl} />
               {name}
-            </div>
+            </Tooltip>
           )
         })}
         {topRetroTemplates.length === 1 && (


### PR DESCRIPTION
# Description

Fixes #8887 

## Demo

https://www.loom.com/share/516fc5120015449e81c5a38076c5880b?sid=77d5cf4f-68af-4048-8072-7b54fc13aadb

## Testing scenarios

- with the feature flag enabled and insights shown, use 4 different retro templates and see only 3 show up

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
