### PR TITLE
feat(slack): Send certain notifications via slack DM

### DIFF
--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -40,6 +40,7 @@ import TemplateDimension from './types/TemplateDimension'
 import TemplateScale from './types/TemplateScale'
 import TimelineEvent from './types/TimelineEvent'
 import User from './types/User'
+import NotificationResponseReplied from './types/NotificationResponseReplied'
 
 export type RethinkSchema = {
   AgendaItem: {
@@ -113,6 +114,7 @@ export type RethinkSchema = {
       | NotificationPromoteToBillingLeader
       | NotificationTeamInvitation
       | NotificationResponseMentioned
+      | NotificationResponseReplied
     index: 'userId'
   }
   Organization: {

--- a/packages/server/database/types/Notification.ts
+++ b/packages/server/database/types/Notification.ts
@@ -26,7 +26,7 @@ export default abstract class Notification {
   id = generateUID()
   status: NotificationStatusEnumType = 'UNREAD'
   createdAt = new Date()
-  type: NotificationEnum
+  readonly type: NotificationEnum
   userId: string
 
   constructor({type, userId}: NotificationInput) {

--- a/packages/server/database/types/NotificationDiscussionMentioned.ts
+++ b/packages/server/database/types/NotificationDiscussionMentioned.ts
@@ -9,7 +9,7 @@ interface Input {
 }
 
 export default class NotificationDiscussionMentioned extends Notification {
-  type: 'DISCUSSION_MENTIONED'
+  readonly type = 'DISCUSSION_MENTIONED'
   meetingId: string
   authorId: string
   commentId: string
@@ -18,7 +18,6 @@ export default class NotificationDiscussionMentioned extends Notification {
   constructor(input: Input) {
     const {meetingId, authorId, userId, commentId, discussionId} = input
     super({userId, type: 'DISCUSSION_MENTIONED'})
-    this.type = 'DISCUSSION_MENTIONED'
     this.meetingId = meetingId
     this.authorId = authorId
     this.commentId = commentId

--- a/packages/server/database/types/NotificationDiscussionMentioned.ts
+++ b/packages/server/database/types/NotificationDiscussionMentioned.ts
@@ -9,6 +9,7 @@ interface Input {
 }
 
 export default class NotificationDiscussionMentioned extends Notification {
+  type: 'DISCUSSION_MENTIONED'
   meetingId: string
   authorId: string
   commentId: string
@@ -17,6 +18,7 @@ export default class NotificationDiscussionMentioned extends Notification {
   constructor(input: Input) {
     const {meetingId, authorId, userId, commentId, discussionId} = input
     super({userId, type: 'DISCUSSION_MENTIONED'})
+    this.type = 'DISCUSSION_MENTIONED'
     this.meetingId = meetingId
     this.authorId = authorId
     this.commentId = commentId

--- a/packages/server/database/types/NotificationKickedOut.ts
+++ b/packages/server/database/types/NotificationKickedOut.ts
@@ -7,13 +7,12 @@ interface Input {
 }
 
 export default class NotificationKickedOut extends Notification {
-  type: 'KICKED_OUT'
+  readonly type = 'KICKED_OUT'
   teamId: string
   evictorUserId: string
   constructor(input: Input) {
     const {evictorUserId, teamId, userId} = input
     super({userId, type: 'KICKED_OUT'})
-    this.type = 'KICKED_OUT'
     this.teamId = teamId
     this.evictorUserId = evictorUserId
   }

--- a/packages/server/database/types/NotificationKickedOut.ts
+++ b/packages/server/database/types/NotificationKickedOut.ts
@@ -7,11 +7,13 @@ interface Input {
 }
 
 export default class NotificationKickedOut extends Notification {
+  type: 'KICKED_OUT'
   teamId: string
   evictorUserId: string
   constructor(input: Input) {
     const {evictorUserId, teamId, userId} = input
     super({userId, type: 'KICKED_OUT'})
+    this.type = 'KICKED_OUT'
     this.teamId = teamId
     this.evictorUserId = evictorUserId
   }

--- a/packages/server/database/types/NotificationMeetingStageTimeLimitEnd.ts
+++ b/packages/server/database/types/NotificationMeetingStageTimeLimitEnd.ts
@@ -6,10 +6,12 @@ interface Input {
 }
 
 export default class NotificationMeetingStageTimeLimitEnd extends Notification {
+  type: 'MEETING_STAGE_TIME_LIMIT_END'
   meetingId: string
   constructor(input: Input) {
     const {meetingId, userId} = input
     super({userId, type: 'MEETING_STAGE_TIME_LIMIT_END'})
+    this.type = 'MEETING_STAGE_TIME_LIMIT_END'
     this.meetingId = meetingId
   }
 }

--- a/packages/server/database/types/NotificationMeetingStageTimeLimitEnd.ts
+++ b/packages/server/database/types/NotificationMeetingStageTimeLimitEnd.ts
@@ -6,12 +6,11 @@ interface Input {
 }
 
 export default class NotificationMeetingStageTimeLimitEnd extends Notification {
-  type: 'MEETING_STAGE_TIME_LIMIT_END'
+  readonly type = 'MEETING_STAGE_TIME_LIMIT_END'
   meetingId: string
   constructor(input: Input) {
     const {meetingId, userId} = input
     super({userId, type: 'MEETING_STAGE_TIME_LIMIT_END'})
-    this.type = 'MEETING_STAGE_TIME_LIMIT_END'
     this.meetingId = meetingId
   }
 }

--- a/packages/server/database/types/NotificationPaymentRejected.ts
+++ b/packages/server/database/types/NotificationPaymentRejected.ts
@@ -8,7 +8,7 @@ interface Input {
 }
 
 export default class NotificationPaymentRejected extends Notification {
-  type: 'PAYMENT_REJECTED'
+  readonly type = 'PAYMENT_REJECTED'
   orgId: string
   last4: string
   brand: string
@@ -16,7 +16,6 @@ export default class NotificationPaymentRejected extends Notification {
   constructor(input: Input) {
     const {orgId, last4, brand, userId} = input
     super({userId, type: 'PAYMENT_REJECTED'})
-    this.type = 'PAYMENT_REJECTED'
     this.orgId = orgId
     this.last4 = last4
     this.brand = brand

--- a/packages/server/database/types/NotificationPaymentRejected.ts
+++ b/packages/server/database/types/NotificationPaymentRejected.ts
@@ -8,6 +8,7 @@ interface Input {
 }
 
 export default class NotificationPaymentRejected extends Notification {
+  type: 'PAYMENT_REJECTED'
   orgId: string
   last4: string
   brand: string
@@ -15,6 +16,7 @@ export default class NotificationPaymentRejected extends Notification {
   constructor(input: Input) {
     const {orgId, last4, brand, userId} = input
     super({userId, type: 'PAYMENT_REJECTED'})
+    this.type = 'PAYMENT_REJECTED'
     this.orgId = orgId
     this.last4 = last4
     this.brand = brand

--- a/packages/server/database/types/NotificationPromoteToBillingLeader.ts
+++ b/packages/server/database/types/NotificationPromoteToBillingLeader.ts
@@ -6,11 +6,13 @@ interface Input {
 }
 
 export default class NotificationPromoteToBillingLeader extends Notification {
+  type: 'PROMOTE_TO_BILLING_LEADER'
   orgId: string
 
   constructor(input: Input) {
     const {orgId, userId} = input
     super({userId, type: 'PROMOTE_TO_BILLING_LEADER'})
+    this.type = 'PROMOTE_TO_BILLING_LEADER'
     this.orgId = orgId
   }
 }

--- a/packages/server/database/types/NotificationPromoteToBillingLeader.ts
+++ b/packages/server/database/types/NotificationPromoteToBillingLeader.ts
@@ -6,13 +6,12 @@ interface Input {
 }
 
 export default class NotificationPromoteToBillingLeader extends Notification {
-  type: 'PROMOTE_TO_BILLING_LEADER'
+  readonly type = 'PROMOTE_TO_BILLING_LEADER'
   orgId: string
 
   constructor(input: Input) {
     const {orgId, userId} = input
     super({userId, type: 'PROMOTE_TO_BILLING_LEADER'})
-    this.type = 'PROMOTE_TO_BILLING_LEADER'
     this.orgId = orgId
   }
 }

--- a/packages/server/database/types/NotificationPromptToJoinOrg.ts
+++ b/packages/server/database/types/NotificationPromptToJoinOrg.ts
@@ -6,12 +6,11 @@ interface Input {
 }
 
 export default class NotificationPromptToJoinOrg extends Notification {
-  type: 'PROMPT_TO_JOIN_ORG'
+  readonly type = 'PROMPT_TO_JOIN_ORG'
   activeDomain: string
   constructor(input: Input) {
     const {userId, activeDomain} = input
     super({userId, type: 'PROMPT_TO_JOIN_ORG'})
-    this.type = 'PROMPT_TO_JOIN_ORG'
     this.activeDomain = activeDomain
   }
 }

--- a/packages/server/database/types/NotificationPromptToJoinOrg.ts
+++ b/packages/server/database/types/NotificationPromptToJoinOrg.ts
@@ -6,10 +6,12 @@ interface Input {
 }
 
 export default class NotificationPromptToJoinOrg extends Notification {
+  type: 'PROMPT_TO_JOIN_ORG'
   activeDomain: string
   constructor(input: Input) {
     const {userId, activeDomain} = input
     super({userId, type: 'PROMPT_TO_JOIN_ORG'})
+    this.type = 'PROMPT_TO_JOIN_ORG'
     this.activeDomain = activeDomain
   }
 }

--- a/packages/server/database/types/NotificationRequestToJoinOrg.ts
+++ b/packages/server/database/types/NotificationRequestToJoinOrg.ts
@@ -10,6 +10,7 @@ interface Input {
 }
 
 export default class NotificationRequestToJoinOrg extends Notification {
+  type: 'REQUEST_TO_JOIN_ORG'
   domainJoinRequestId: number
   email: string
   name: string
@@ -18,6 +19,7 @@ export default class NotificationRequestToJoinOrg extends Notification {
   constructor(input: Input) {
     const {domainJoinRequestId, requestCreatedBy, email, name, picture, userId} = input
     super({userId, type: 'REQUEST_TO_JOIN_ORG'})
+    this.type = 'REQUEST_TO_JOIN_ORG'
     this.domainJoinRequestId = domainJoinRequestId
     this.email = email
     this.name = name

--- a/packages/server/database/types/NotificationRequestToJoinOrg.ts
+++ b/packages/server/database/types/NotificationRequestToJoinOrg.ts
@@ -10,7 +10,7 @@ interface Input {
 }
 
 export default class NotificationRequestToJoinOrg extends Notification {
-  type: 'REQUEST_TO_JOIN_ORG'
+  readonly type = 'REQUEST_TO_JOIN_ORG'
   domainJoinRequestId: number
   email: string
   name: string
@@ -19,7 +19,6 @@ export default class NotificationRequestToJoinOrg extends Notification {
   constructor(input: Input) {
     const {domainJoinRequestId, requestCreatedBy, email, name, picture, userId} = input
     super({userId, type: 'REQUEST_TO_JOIN_ORG'})
-    this.type = 'REQUEST_TO_JOIN_ORG'
     this.domainJoinRequestId = domainJoinRequestId
     this.email = email
     this.name = name

--- a/packages/server/database/types/NotificationResponseMentioned.ts
+++ b/packages/server/database/types/NotificationResponseMentioned.ts
@@ -7,14 +7,13 @@ interface Input {
 }
 
 export default class NotificationResponseMentioned extends Notification {
-  type: 'RESPONSE_MENTIONED'
+  readonly type = 'RESPONSE_MENTIONED'
   responseId: string
   meetingId: string
 
   constructor(input: Input) {
     const {responseId, meetingId, userId} = input
     super({userId, type: 'RESPONSE_MENTIONED'})
-    this.type = 'RESPONSE_MENTIONED'
     this.responseId = responseId
     this.meetingId = meetingId
   }

--- a/packages/server/database/types/NotificationResponseMentioned.ts
+++ b/packages/server/database/types/NotificationResponseMentioned.ts
@@ -7,12 +7,14 @@ interface Input {
 }
 
 export default class NotificationResponseMentioned extends Notification {
+  type: 'RESPONSE_MENTIONED'
   responseId: string
   meetingId: string
 
   constructor(input: Input) {
     const {responseId, meetingId, userId} = input
     super({userId, type: 'RESPONSE_MENTIONED'})
+    this.type = 'RESPONSE_MENTIONED'
     this.responseId = responseId
     this.meetingId = meetingId
   }

--- a/packages/server/database/types/NotificationResponseReplied.ts
+++ b/packages/server/database/types/NotificationResponseReplied.ts
@@ -8,6 +8,7 @@ interface Input {
 }
 
 export default class NotificationResponseReplied extends Notification {
+  type: 'RESPONSE_REPLIED'
   meetingId: string
   authorId: string
   commentId: string
@@ -15,6 +16,7 @@ export default class NotificationResponseReplied extends Notification {
   constructor(input: Input) {
     const {meetingId, authorId, userId, commentId} = input
     super({userId, type: 'RESPONSE_REPLIED'})
+    this.type = 'RESPONSE_REPLIED'
     this.meetingId = meetingId
     this.authorId = authorId
     this.commentId = commentId

--- a/packages/server/database/types/NotificationResponseReplied.ts
+++ b/packages/server/database/types/NotificationResponseReplied.ts
@@ -8,7 +8,7 @@ interface Input {
 }
 
 export default class NotificationResponseReplied extends Notification {
-  type: 'RESPONSE_REPLIED'
+  readonly type = 'RESPONSE_REPLIED'
   meetingId: string
   authorId: string
   commentId: string
@@ -16,7 +16,6 @@ export default class NotificationResponseReplied extends Notification {
   constructor(input: Input) {
     const {meetingId, authorId, userId, commentId} = input
     super({userId, type: 'RESPONSE_REPLIED'})
-    this.type = 'RESPONSE_REPLIED'
     this.meetingId = meetingId
     this.authorId = authorId
     this.commentId = commentId

--- a/packages/server/database/types/NotificationTaskInvolves.ts
+++ b/packages/server/database/types/NotificationTaskInvolves.ts
@@ -11,6 +11,7 @@ interface Input {
 }
 
 export default class NotificationTaskInvolves extends Notification {
+  type: 'TASK_INVOLVES'
   changeAuthorId: string
   involvement: TaskInvolvement
   taskId: string
@@ -19,6 +20,7 @@ export default class NotificationTaskInvolves extends Notification {
   constructor(input: Input) {
     const {teamId, changeAuthorId, involvement, taskId, userId} = input
     super({userId, type: 'TASK_INVOLVES'})
+    this.type = 'TASK_INVOLVES'
     this.changeAuthorId = changeAuthorId
     this.involvement = involvement
     this.taskId = taskId

--- a/packages/server/database/types/NotificationTaskInvolves.ts
+++ b/packages/server/database/types/NotificationTaskInvolves.ts
@@ -11,7 +11,7 @@ interface Input {
 }
 
 export default class NotificationTaskInvolves extends Notification {
-  type: 'TASK_INVOLVES'
+  readonly type = 'TASK_INVOLVES'
   changeAuthorId: string
   involvement: TaskInvolvement
   taskId: string
@@ -20,7 +20,6 @@ export default class NotificationTaskInvolves extends Notification {
   constructor(input: Input) {
     const {teamId, changeAuthorId, involvement, taskId, userId} = input
     super({userId, type: 'TASK_INVOLVES'})
-    this.type = 'TASK_INVOLVES'
     this.changeAuthorId = changeAuthorId
     this.involvement = involvement
     this.taskId = taskId

--- a/packages/server/database/types/NotificationTeamArchived.ts
+++ b/packages/server/database/types/NotificationTeamArchived.ts
@@ -7,13 +7,12 @@ interface Input {
 }
 
 export default class NotificationTeamArchived extends Notification {
-  type: 'TEAM_ARCHIVED'
+  readonly type = 'TEAM_ARCHIVED'
   archivorUserId: string
   teamId: string
   constructor(input: Input) {
     const {archivorUserId, teamId, userId} = input
     super({userId, type: 'TEAM_ARCHIVED'})
-    this.type = 'TEAM_ARCHIVED'
     this.archivorUserId = archivorUserId
     this.teamId = teamId
   }

--- a/packages/server/database/types/NotificationTeamArchived.ts
+++ b/packages/server/database/types/NotificationTeamArchived.ts
@@ -7,11 +7,13 @@ interface Input {
 }
 
 export default class NotificationTeamArchived extends Notification {
+  type: 'TEAM_ARCHIVED'
   archivorUserId: string
   teamId: string
   constructor(input: Input) {
     const {archivorUserId, teamId, userId} = input
     super({userId, type: 'TEAM_ARCHIVED'})
+    this.type = 'TEAM_ARCHIVED'
     this.archivorUserId = archivorUserId
     this.teamId = teamId
   }

--- a/packages/server/database/types/NotificationTeamInvitation.ts
+++ b/packages/server/database/types/NotificationTeamInvitation.ts
@@ -7,13 +7,12 @@ interface Input {
 }
 
 export default class NotificationTeamInvitation extends Notification {
-  type: 'TEAM_INVITATION'
+  readonly type = 'TEAM_INVITATION'
   invitationId: string
   teamId: string
   constructor(input: Input) {
     const {invitationId, teamId, userId} = input
     super({userId, type: 'TEAM_INVITATION'})
-    this.type = 'TEAM_INVITATION'
     this.invitationId = invitationId
     this.teamId = teamId
   }

--- a/packages/server/database/types/NotificationTeamInvitation.ts
+++ b/packages/server/database/types/NotificationTeamInvitation.ts
@@ -7,11 +7,13 @@ interface Input {
 }
 
 export default class NotificationTeamInvitation extends Notification {
+  type: 'TEAM_INVITATION'
   invitationId: string
   teamId: string
   constructor(input: Input) {
     const {invitationId, teamId, userId} = input
     super({userId, type: 'TEAM_INVITATION'})
+    this.type = 'TEAM_INVITATION'
     this.invitationId = invitationId
     this.teamId = teamId
   }

--- a/packages/server/database/types/NotificationTeamsLimitExceeded.ts
+++ b/packages/server/database/types/NotificationTeamsLimitExceeded.ts
@@ -8,12 +8,14 @@ interface Input {
 }
 
 export default class NotificationTeamsLimitExceeded extends Notification {
+  type: 'TEAMS_LIMIT_EXCEEDED'
   orgId: string
   orgName: string
   orgPicture?: string
   constructor(input: Input) {
     const {userId, orgId, orgName, orgPicture} = input
     super({userId, type: 'TEAMS_LIMIT_EXCEEDED'})
+    this.type = 'TEAMS_LIMIT_EXCEEDED'
     this.orgId = orgId
     this.orgName = orgName
     this.orgPicture = orgPicture

--- a/packages/server/database/types/NotificationTeamsLimitExceeded.ts
+++ b/packages/server/database/types/NotificationTeamsLimitExceeded.ts
@@ -8,14 +8,13 @@ interface Input {
 }
 
 export default class NotificationTeamsLimitExceeded extends Notification {
-  type: 'TEAMS_LIMIT_EXCEEDED'
+  readonly type = 'TEAMS_LIMIT_EXCEEDED'
   orgId: string
   orgName: string
   orgPicture?: string
   constructor(input: Input) {
     const {userId, orgId, orgName, orgPicture} = input
     super({userId, type: 'TEAMS_LIMIT_EXCEEDED'})
-    this.type = 'TEAMS_LIMIT_EXCEEDED'
     this.orgId = orgId
     this.orgName = orgName
     this.orgPicture = orgPicture

--- a/packages/server/database/types/NotificationTeamsLimitReminder.ts
+++ b/packages/server/database/types/NotificationTeamsLimitReminder.ts
@@ -9,6 +9,7 @@ interface Input {
 }
 
 export default class NotificationTeamsLimitReminder extends Notification {
+  type: 'TEAMS_LIMIT_REMINDER'
   orgId: string
   orgName: string
   orgPicture?: string
@@ -16,6 +17,7 @@ export default class NotificationTeamsLimitReminder extends Notification {
   constructor(input: Input) {
     const {userId, orgId, orgName, orgPicture, scheduledLockAt} = input
     super({userId, type: 'TEAMS_LIMIT_REMINDER'})
+    this.type = 'TEAMS_LIMIT_REMINDER'
     this.orgId = orgId
     this.scheduledLockAt = scheduledLockAt
     this.orgName = orgName

--- a/packages/server/database/types/NotificationTeamsLimitReminder.ts
+++ b/packages/server/database/types/NotificationTeamsLimitReminder.ts
@@ -9,7 +9,7 @@ interface Input {
 }
 
 export default class NotificationTeamsLimitReminder extends Notification {
-  type: 'TEAMS_LIMIT_REMINDER'
+  readonly type = 'TEAMS_LIMIT_REMINDER'
   orgId: string
   orgName: string
   orgPicture?: string
@@ -17,7 +17,6 @@ export default class NotificationTeamsLimitReminder extends Notification {
   constructor(input: Input) {
     const {userId, orgId, orgName, orgPicture, scheduledLockAt} = input
     super({userId, type: 'TEAMS_LIMIT_REMINDER'})
-    this.type = 'TEAMS_LIMIT_REMINDER'
     this.orgId = orgId
     this.scheduledLockAt = scheduledLockAt
     this.orgName = orgName

--- a/packages/server/graphql/mutations/addComment.ts
+++ b/packages/server/graphql/mutations/addComment.ts
@@ -20,7 +20,7 @@ import {GQLContext} from '../graphql'
 import publishNotification from '../public/mutations/helpers/publishNotification'
 import AddCommentInput from '../types/AddCommentInput'
 import AddCommentPayload from '../types/AddCommentPayload'
-import {SlackNotifier} from './helpers/notifications/SlackNotifier'
+import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 
 type AddCommentMutationVariables = {
   comment: {
@@ -136,7 +136,11 @@ const addComment = {
 
         await r.table('Notification').insert(notification).run()
 
-        SlackNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
+        IntegrationNotifier.sendNotificationToUser?.(
+          dataLoader,
+          notification.id,
+          notification.userId
+        )
         publishNotification(notification, subOptions)
       }
     }

--- a/packages/server/graphql/mutations/addComment.ts
+++ b/packages/server/graphql/mutations/addComment.ts
@@ -20,6 +20,7 @@ import {GQLContext} from '../graphql'
 import publishNotification from '../public/mutations/helpers/publishNotification'
 import AddCommentInput from '../types/AddCommentInput'
 import AddCommentPayload from '../types/AddCommentPayload'
+import {SlackNotifier} from './helpers/notifications/SlackNotifier'
 
 type AddCommentMutationVariables = {
   comment: {
@@ -135,6 +136,7 @@ const addComment = {
 
         await r.table('Notification').insert(notification).run()
 
+        SlackNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
         publishNotification(notification, subOptions)
       }
     }

--- a/packages/server/graphql/mutations/helpers/notifications/IntegrationNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/IntegrationNotifier.ts
@@ -44,5 +44,12 @@ export const IntegrationNotifier: Notifier = {
         notifier.standupResponseSubmitted(dataLoader, meetingId, teamId, userId)
       )
     )
+  },
+  async sendNotificationToUser(dataLoader, notificationId, userId) {
+    await Promise.allSettled(
+      notifiers.map(async (notifier) =>
+        notifier.sendNotificationToUser?.(dataLoader, notificationId, userId)
+      )
+    )
   }
 }

--- a/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/Notifier.ts
@@ -22,6 +22,11 @@ export type Notifier = {
     stageIndex: number,
     channelId: string
   ): Promise<NotifyResponse>
+  sendNotificationToUser?(
+    dataLoader: DataLoaderWorker,
+    notificationId: string,
+    userId: string
+  ): Promise<void>
   standupResponseSubmitted(
     dataLoader: DataLoaderWorker,
     meetingId: string,

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -255,21 +255,21 @@ const getSlackMessageForNotification = async (
     if (!responseId) {
       return null
     }
-    const user = await dataLoader.get('users').loadNonNull(notification.authorId)
+    const author = await dataLoader.get('users').loadNonNull(notification.authorId)
     const comment = await dataLoader.get('comments').load(notification.commentId)
     return {
       responseId,
-      title: `*${user.preferredName}* replied to your response in *${meeting.name}*`,
+      title: `*${author.preferredName}* replied to your response in *${meeting.name}*`,
       body: `> ${comment.plaintextContent}`,
       buttonText: 'See the discussion'
     }
   } else if (notification.type === 'RESPONSE_MENTIONED') {
     const responseId = notification.responseId
     const response = await dataLoader.get('teamPromptResponses').loadNonNull(responseId)
-    const user = await dataLoader.get('users').loadNonNull(response.userId)
+    const author = await dataLoader.get('users').loadNonNull(response.userId)
     return {
       responseId,
-      title: `*${user.preferredName}* mentioned you in their response in *${meeting.name}*`,
+      title: `*${author.preferredName}* mentioned you in their response in *${meeting.name}*`,
       buttonText: 'See their response'
     }
   }

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -688,7 +688,7 @@ export const SlackNotifier: Notifier = {
       const responses = await getTeamPromptResponsesByMeetingId(notification.meetingId)
       responseId = responses.find(({userId: responseUserId}) => responseUserId === userId)?.id
       const user = await dataLoader.get('users').loadNonNull(notification.authorId)
-      title = `${user.preferredName} replied to your response in ${meeting.name}`
+      title = `*${user.preferredName}* replied to your response in *${meeting.name}*`
       const comment = await dataLoader.get('comments').load(notification.commentId)
       body = `> ${comment.plaintextContent}`
       buttonText = 'See the discussion'
@@ -696,7 +696,7 @@ export const SlackNotifier: Notifier = {
       responseId = notification.responseId
       const response = await dataLoader.get('teamPromptResponses').loadNonNull(responseId)
       const user = await dataLoader.get('users').loadNonNull(response.userId)
-      title = `${user.preferredName} mentioned you in their response in ${meeting.name}`
+      title = `*${user.preferredName}* mentioned you in their response in *${meeting.name}*`
       buttonText = 'See their response'
     }
 

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -682,12 +682,15 @@ export const SlackNotifier: Notifier = {
     let responseId: string | undefined
     let title: string | undefined
     let buttonText: string | undefined
+    let body: string | undefined
 
     if (notification.type === 'RESPONSE_REPLIED') {
       const responses = await getTeamPromptResponsesByMeetingId(notification.meetingId)
       responseId = responses.find(({userId: responseUserId}) => responseUserId === userId)?.id
       const user = await dataLoader.get('users').loadNonNull(notification.authorId)
       title = `${user.preferredName} replied to your response in ${meeting.name}`
+      const comment = await dataLoader.get('comments').load(notification.commentId)
+      body = `> ${comment.plaintextContent}`
       buttonText = 'See the discussion'
     } else {
       responseId = notification.responseId
@@ -713,6 +716,7 @@ export const SlackNotifier: Notifier = {
     const responseUrl = makeAppURL(appOrigin, `meet/${notification.meetingId}/responses`, options)
     const blocks: Array<{type: string}> = [
       makeSection(title),
+      ...(body ? [makeSection(body)] : []),
       makeButtons([{text: buttonText, url: responseUrl, type: 'primary'}])
     ]
 

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -12,7 +12,6 @@ import {MutationResolvers} from '../resolverTypes'
 import publishNotification from './helpers/publishNotification'
 import createTeamPromptMentionNotifications from './helpers/publishTeamPromptMentions'
 import {IntegrationNotifier} from '../../mutations/helpers/notifications/IntegrationNotifier'
-import {SlackNotifier} from '../../mutations/helpers/notifications/SlackNotifier'
 
 const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = async (
   _source,
@@ -94,7 +93,7 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
   }
 
   notifications.forEach((notification) => {
-    SlackNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
+    IntegrationNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
     publishNotification(notification, subOptions)
   })
 

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -12,6 +12,7 @@ import {MutationResolvers} from '../resolverTypes'
 import publishNotification from './helpers/publishNotification'
 import createTeamPromptMentionNotifications from './helpers/publishTeamPromptMentions'
 import {IntegrationNotifier} from '../../mutations/helpers/notifications/IntegrationNotifier'
+import {SlackNotifier} from '../../mutations/helpers/notifications/SlackNotifier'
 
 const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = async (
   _source,
@@ -93,6 +94,7 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
   }
 
   notifications.forEach((notification) => {
+    SlackNotifier.sendNotificationToUser?.(dataLoader, notification.id, notification.userId)
     publishNotification(notification, subOptions)
   })
 


### PR DESCRIPTION
# Description
For standup mentions + replies, send the user a slack DM if they have slack integrated on some team.

When finding a slack integration for the user, we'll prioritize integration on the team > team within the org > any team for that user.

In the future, we may support mapping parabol users to slack users, such that users don't need to integrate slack on a team in order to receive these DM notifications. This may simply be a user-level slack integration that's not connected to any particular team.

Based on the [POC PR](https://github.com/ParabolInc/parabol/pull/8653), and re-inspired by Gareth's [terrible idea](https://parabol.slack.com/archives/C03NGEJUKCN/p1697195167936709).

## Demo
<img width="471" alt="Screen Shot 2023-10-17 at 3 19 51 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/2c3d08c8-87ef-482b-97a1-6f495971cfab">
<img width="513" alt="Screen Shot 2023-10-17 at 3 19 55 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/93372366-080b-42f0-94bb-eef9bf12313c">


## Testing scenarios
- [ ] As a user A with no slack integrations, open a standup meeting, and connect slack for that team
- [ ] As user B, trigger the response replied and response mentioned notifications for user A in the standup meeting
- [ ] Confirm user A receives a slack DM for each
- [ ] Remove user A's slack integration for that team
- [ ] Connect slack for a different team in the same org
- [ ] Trigger the notifications, and confirm user A receives the slack DMs
- [ ] Remove user A's slack integration for that team
- [ ] Connect slack for a team in a *different* org
- [ ] Trigger the notifications, and confirm user A receives the slack DMs

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
