### PR TITLE
feat(standups): Response permalink sharing

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -4,6 +4,7 @@ import {JSONContent} from '@tiptap/react'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
 import {commitLocalUpdate, useFragment} from 'react-relay'
+import CopyToClipboard from 'react-copy-to-clipboard'
 import useAnimatedCard from '~/hooks/useAnimatedCard'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useEventCallback from '~/hooks/useEventCallback'
@@ -22,6 +23,12 @@ import {ResponseCardDimensions, ResponsesGridBreakpoints} from './TeamPromptGrid
 import TeamPromptLastUpdatedTime from './TeamPromptLastUpdatedTime'
 import TeamPromptRepliesAvatarList from './TeamPromptRepliesAvatarList'
 import {TeamPromptResponseEmojis} from './TeamPromptResponseEmojis'
+import makeAppURL from '../../utils/makeAppURL'
+import SendClientSegmentEventMutation from '../../mutations/SendClientSegmentEventMutation'
+import {mergeRefs} from '../../utils/react/mergeRefs'
+import useTooltip from '../../hooks/useTooltip'
+import {MenuPosition} from '../../hooks/useCoords'
+import {Link} from '@mui/icons-material'
 
 const twoColumnResponseMediaQuery = `@media screen and (min-width: ${ResponsesGridBreakpoints.TWO_RESPONSE_COLUMN}px)`
 const threeColumnResponseMediaQuery = `@media screen and (min-width: ${ResponsesGridBreakpoints.THREE_RESPONSE_COLUMNS}px)`
@@ -210,6 +217,35 @@ const TeamPromptResponseCard = (props: Props) => {
 
   const ref = useAnimatedCard(displayIdx, status)
 
+  const responsePermalink = makeAppURL(window.location.origin, `/meet/${meetingId}/responses`, {
+    searchParams: {
+      source: 'sharing',
+      responseId: response?.id
+    }
+  })
+
+  const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
+    MenuPosition.UPPER_CENTER
+  )
+
+  const {
+    tooltipPortal: copiedTooltipPortal,
+    openTooltip: openCopiedTooltip,
+    closeTooltip: closeCopiedTooltip,
+    originRef: copiedTooltipRef
+  } = useTooltip<HTMLDivElement>(MenuPosition.LOWER_CENTER)
+
+  const handleCopy = () => {
+    openCopiedTooltip()
+    SendClientSegmentEventMutation(atmosphere, 'Copied Standup Response Link', {
+      teamId: teamId,
+      meetingId: meetingId
+    })
+    setTimeout(() => {
+      closeCopiedTooltip()
+    }, 2000)
+  }
+
   return (
     <ResponseWrapper
       ref={ref}
@@ -228,6 +264,18 @@ const TeamPromptResponseCard = (props: Props) => {
             />
           )}
         </TeamMemberName>
+        {response && (
+          <CopyToClipboard text={responsePermalink} onCopy={handleCopy}>
+            <div
+              className='ml-auto h-7 rounded-full bg-transparent p-0 text-slate-500 hover:bg-slate-300 hover:text-slate-600'
+              onMouseEnter={openTooltip}
+              onMouseLeave={closeTooltip}
+              ref={mergeRefs(originRef, copiedTooltipRef)}
+            >
+              <Link className='h-7 w-7 cursor-pointer p-0.5' />
+            </div>
+          </CopyToClipboard>
+        )}
       </ResponseHeader>
       <ResponseCard
         isEmpty={isEmptyResponse}
@@ -264,6 +312,8 @@ const TeamPromptResponseCard = (props: Props) => {
           </>
         )}
       </ResponseCard>
+      {tooltipPortal('Copy permalink')}
+      {copiedTooltipPortal('Copied!')}
     </ResponseWrapper>
   )
 }

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -219,7 +219,7 @@ const TeamPromptResponseCard = (props: Props) => {
 
   const responsePermalink = makeAppURL(window.location.origin, `/meet/${meetingId}/responses`, {
     searchParams: {
-      source: 'sharing',
+      utm_source: 'sharing',
       responseId: response?.id
     }
   })

--- a/packages/client/utils/makeAppURL.ts
+++ b/packages/client/utils/makeAppURL.ts
@@ -1,12 +1,17 @@
+interface UTMParams {
+  utm_source: string
+  utm_medium: string
+  utm_campaign: string
+}
+
 interface Options {
+  // Don't require UTMs, but if one UTM param is present, the others should be present, too.
   searchParams?: {
-    utm_source: string
-    utm_medium: string
-    utm_campaign: string
+    source?: string
     openNotifs?: string
     responseId?: string
     redirectTo?: string
-  }
+  } & (UTMParams | Partial<Record<keyof UTMParams, never>>)
 }
 
 const makeAppURL = (appOrigin: string, pathname: string, options?: Options) => {

--- a/packages/client/utils/makeAppURL.ts
+++ b/packages/client/utils/makeAppURL.ts
@@ -1,13 +1,12 @@
 interface UTMParams {
   utm_source: string
-  utm_medium: string
-  utm_campaign: string
+  utm_medium?: string
+  utm_campaign?: string
 }
 
 interface Options {
   // Don't require UTMs, but if one UTM param is present, the others should be present, too.
   searchParams?: {
-    source?: string
     openNotifs?: string
     responseId?: string
     redirectTo?: string


### PR DESCRIPTION
# Description
Fixes https://github.com/ParabolInc/parabol/issues/8955

Support copying permalinks of standup responses.

## Demo
https://www.loom.com/share/407d84a2400c4bc1b371b7cbc6db28b8?sid=20ed10d4-0c08-4646-b3a7-77645604eef0

## Testing scenarios
- [ ] Link button not present for responses that haven't been submitted
- [ ] Link button is present for responses that have been submitted
- [ ] Clicking link button copies the response permalink to the clipboard

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
