### PR TITLE
feat(your-work): Provide link to integration settings on error + no data

### DIFF
--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationResults.tsx
@@ -100,7 +100,7 @@ const GCalIntegrationResults = (props: Props) => {
               to={`/team/${teamId}/settings/integrations`}
               className='mt-4 font-semibold text-sky-500 hover:text-sky-400'
             >
-              Configure Google Calendar
+              Review your Google Calendar configuration
             </Link>
           </div>
         )}

--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationResults.tsx
@@ -5,14 +5,16 @@ import {GCalIntegrationResultsQuery} from '../../../__generated__/GCalIntegratio
 import halloweenRetrospectiveTemplate from '../../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 import GCalEventCard from './GCalEventCard'
 import {OpenInNew} from '@mui/icons-material'
+import {Link} from 'react-router-dom'
 
 interface Props {
   queryRef: PreloadedQuery<GCalIntegrationResultsQuery>
   order: 'DESC' | 'ASC'
+  teamId: string
 }
 
 const GCalIntegrationResults = (props: Props) => {
-  const {queryRef, order} = props
+  const {queryRef, order, teamId} = props
   const query = usePreloadedQuery(
     graphql`
       query GCalIntegrationResultsQuery($teamId: ID!, $startDate: DateTime!, $endDate: DateTime!) {
@@ -94,6 +96,12 @@ const GCalIntegrationResults = (props: Props) => {
             <div className='mt-7 w-2/3 text-center'>
               Looks like you don’t have any events to display
             </div>
+            <Link
+              to={`/team/${teamId}/settings/integrations`}
+              className='mt-4 font-semibold text-sky-500 hover:text-sky-400'
+            >
+              Configure Google Calendar
+            </Link>
           </div>
         )}
       </div>

--- a/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationResultsRoot.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GCalIntegrationResultsRoot.tsx
@@ -44,7 +44,9 @@ const GCalIntegrationResultsRoot = (props: Props) => {
   return (
     <ErrorBoundary>
       <Suspense fallback={<Loader />}>
-        {queryRef && <GCalIntegrationResults queryRef={queryRef} order={eventRange.order} />}
+        {queryRef && (
+          <GCalIntegrationResults queryRef={queryRef} order={eventRange.order} teamId={teamId} />
+        )}
       </Suspense>
     </ErrorBoundary>
   )

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationResults.tsx
@@ -8,14 +8,16 @@ import useLoadNextOnScrollBottom from '../../../hooks/useLoadNextOnScrollBottom'
 import halloweenRetrospectiveTemplate from '../../../../../static/images/illustrations/halloweenRetrospectiveTemplate.png'
 import GitHubObjectCard from './GitHubObjectCard'
 import Ellipsis from '../../Ellipsis/Ellipsis'
+import {Link} from 'react-router-dom'
 
 interface Props {
   queryRef: PreloadedQuery<GitHubIntegrationResultsQuery>
   queryType: 'issue' | 'pullRequest'
+  teamId: string
 }
 
 const GitHubIntegrationResults = (props: Props) => {
-  const {queryRef, queryType} = props
+  const {queryRef, queryType, teamId} = props
   const query = usePreloadedQuery(
     graphql`
       query GitHubIntegrationResultsQuery($teamId: ID!, $searchQuery: String!) {
@@ -99,6 +101,12 @@ const GitHubIntegrationResults = (props: Props) => {
                     queryType === 'issue' ? 'issues' : 'pull requests'
                   } to display.`}
             </div>
+            <Link
+              to={`/team/${teamId}/settings/integrations`}
+              className='mt-4 font-semibold text-sky-500 hover:text-sky-400'
+            >
+              Configure GitHub
+            </Link>
           </div>
         )}
         {lastItem}

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationResults.tsx
@@ -105,7 +105,7 @@ const GitHubIntegrationResults = (props: Props) => {
               to={`/team/${teamId}/settings/integrations`}
               className='mt-4 font-semibold text-sky-500 hover:text-sky-400'
             >
-              Configure GitHub
+              Review your GitHub configuration
             </Link>
           </div>
         )}

--- a/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationResultsRoot.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/GitHubIntegrationResultsRoot.tsx
@@ -28,7 +28,9 @@ const GitHubIntegrationResultsRoot = (props: Props) => {
   return (
     <ErrorBoundary>
       <Suspense fallback={<Loader />}>
-        {queryRef && <GitHubIntegrationResults queryRef={queryRef} queryType={queryType} />}
+        {queryRef && (
+          <GitHubIntegrationResults queryRef={queryRef} queryType={queryType} teamId={teamId} />
+        )}
       </Suspense>
     </ErrorBoundary>
   )

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
@@ -8,13 +8,15 @@ import halloweenRetrospectiveTemplate from '../../../../../static/images/illustr
 import JiraObjectCard from './JiraObjectCard'
 import useLoadNextOnScrollBottom from '../../../hooks/useLoadNextOnScrollBottom'
 import Ellipsis from '../../Ellipsis/Ellipsis'
+import {Link} from 'react-router-dom'
 
 interface Props {
   queryRef: PreloadedQuery<JiraIntegrationResultsQuery>
+  teamId: string
 }
 
 const JiraIntegrationResults = (props: Props) => {
-  const {queryRef} = props
+  const {queryRef, teamId} = props
   const query = usePreloadedQuery(
     graphql`
       query JiraIntegrationResultsQuery($teamId: ID!) {
@@ -91,6 +93,12 @@ const JiraIntegrationResults = (props: Props) => {
             <div className='mt-7 w-2/3 text-center'>
               {error?.message ? error.message : `Looks like you don’t have any issues to display.`}
             </div>
+            <Link
+              to={`/team/${teamId}/settings/integrations`}
+              className='mt-4 font-semibold text-sky-500 hover:text-sky-400'
+            >
+              Configure Jira
+            </Link>
           </div>
         )}
         {lastItem}

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResults.tsx
@@ -97,7 +97,7 @@ const JiraIntegrationResults = (props: Props) => {
               to={`/team/${teamId}/settings/integrations`}
               className='mt-4 font-semibold text-sky-500 hover:text-sky-400'
             >
-              Configure Jira
+              Review your Jira configuration
             </Link>
           </div>
         )}

--- a/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResultsRoot.tsx
+++ b/packages/client/components/TeamPrompt/WorkDrawer/JiraIntegrationResultsRoot.tsx
@@ -19,7 +19,7 @@ const JiraIntegrationResultsRoot = (props: Props) => {
   return (
     <ErrorBoundary>
       <Suspense fallback={<Loader />}>
-        {queryRef && <JiraIntegrationResults queryRef={queryRef} />}
+        {queryRef && <JiraIntegrationResults queryRef={queryRef} teamId={teamId} />}
       </Suspense>
     </ErrorBoundary>
   )


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/8881

On error or no data, show the user a link to integration settings.

## Demo
<img width="372" alt="Screen Shot 2023-10-23 at 1 12 47 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/b16e8919-f3a7-4846-b737-d4000f8e1815">
<img width="384" alt="Screen Shot 2023-10-23 at 1 14 13 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/839e4ad0-af43-4f6d-a343-221fd2f7fcfb">
<img width="368" alt="Screen Shot 2023-10-23 at 1 14 05 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/f3155d0e-952e-4e8e-8f6b-e47d3ff97d69">


## Testing scenarios
For each of GitHub, Jira, and gCal:
- [ ] Trigger a no data and/or error scenario
- [ ] Confirm a link to "Configure <Integration>" is shown
- [ ] Confirm link goes to the team's integration settings page.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
