### PR TITLE
chore: remove unused filesToCache logic

### DIFF
--- a/packages/server/utils/StaticServer.ts
+++ b/packages/server/utils/StaticServer.ts
@@ -31,7 +31,6 @@ interface MetaDict {
 }
 
 interface Options {
-  filesToCache: string[]
   staticPaths: {
     [pathname: string]: boolean
   }
@@ -53,11 +52,9 @@ const makePathnames = (dirname: string, pathnames: PathNames, prefix: string) =>
 }
 export default class StaticServer {
   pathnames: PathNames = {}
-  cachedFileSet: Set<string>
   meta: MetaDict = {}
   constructor(options: Options) {
-    const {filesToCache, staticPaths} = options
-    this.cachedFileSet = new Set(filesToCache)
+    const {staticPaths} = options
     Object.keys(staticPaths).forEach((dirname) => {
       if (!staticPaths[dirname]) return
       try {

--- a/packages/server/utils/serveStatic.ts
+++ b/packages/server/utils/serveStatic.ts
@@ -22,8 +22,7 @@ const staticPaths = {
   [path.join(PROJECT_ROOT, 'static')]: !__PRODUCTION__,
   [path.join(PROJECT_ROOT, 'dev', 'dll')]: !__PRODUCTION__
 }
-const filesToCache = ['sw.js', 'favicon.ico', 'manifest.json']
-const staticServer = new StaticServer({staticPaths, filesToCache})
+const staticServer = new StaticServer({staticPaths})
 
 const serveStatic = (res: HttpResponse, fileName: string, sendCompressed?: boolean) => {
   const meta = staticServer.getMeta(fileName)


### PR DESCRIPTION
StaticServer caches all files. The array with explicitly cached files is therefore meaningless and was never read.
