### PR TITLE
fix: dockerize ignores git tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Setup environment variables
         run: |
           echo "NODE_VERSION=$(jq -r -j '.engines.node|ltrimstr("^")' package.json)" >> $GITHUB_ENV
-          IS_RELEASE= ${{ startsWith(github.event.head_commit.message, 'chore(release): release') }}
-          IS_MANUAL_BUILD= ${{ startsWith(github.event.head_commit.message, 'dockerize') }}
+          IS_RELEASE=${{ startsWith(github.event.head_commit.message, 'chore(release): release') }}
+          IS_MANUAL_BUILD=${{ startsWith(github.event.head_commit.message, 'dockerize') }}
           echo IS_RELEASE=$IS_RELEASE
           echo IS_MANUAL_BUILD=$IS_MANUAL_BUILD
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,20 +38,25 @@ jobs:
       - name: Setup environment variables
         run: |
           echo "NODE_VERSION=$(jq -r -j '.engines.node|ltrimstr("^")' package.json)" >> $GITHUB_ENV
+          IS_RELEASE= ${{ startsWith(github.event.head_commit.message, 'chore(release): release') }}
+          IS_MANUAL_BUILD= ${{ startsWith(github.event.head_commit.message, 'dockerize') }}
+          echo IS_RELEASE=$IS_RELEASE
+          echo IS_MANUAL_BUILD=$IS_MANUAL_BUILD
 
-          if [ ${{github.ref_type}} = "tag" ]; then
+          if [ $IS_RELEASE = true ]; then
+            echo IS_RELEASE_TRUE
             DOCKER_REPOSITORY_FOR_REF=${{ secrets.GCP_AR_PARABOL }}
           else
             DOCKER_REPOSITORY_FOR_REF=${{ secrets.GCP_AR_PARABOL_DEV }}
           fi
+          echo DOCKER_REPOSITORY_FOR_REF=$DOCKER_REPOSITORY_FOR_REF
 
           echo "DOCKER_REPOSITORY_FOR_REF=${DOCKER_REPOSITORY_FOR_REF}" >> $GITHUB_ENV
 
-          GITHUB_REF_NAME_NORMALIZED=$(echo ${{github.ref_name}} | tr / -)
-          echo "GITHUB_REF_NAME_NORMALIZED=${GITHUB_REF_NAME_NORMALIZED}" >> $GITHUB_ENV
-
-          DOCKERIZE=${{ github.ref_type == 'tag' || contains(fromJSON('["master", "release", "staging", "production"]'), github.ref_name) || startsWith(github.event.head_commit.message, 'dockerize')}}
+          DOCKERIZE=$IS_RELEASE || $IS_MANUAL_BUILD
+          echo DOCKERIZE=$DOCKERIZE
           echo "DOCKERIZE=${DOCKERIZE}" >> $GITHUB_ENV
+          echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_ENV
 
           ACTION_VERSION=$(grep '"version":' package.json | cut -d\" -f4)
           echo "ACTION_VERSION=${ACTION_VERSION}" >> $GITHUB_ENV
@@ -188,9 +193,9 @@ jobs:
           push: true
           tags: |
             "${{ secrets.GCP_AR_PARABOL_DEV }}:${{github.sha}}"
-            "${{ env.DOCKER_REPOSITORY_FOR_REF }}:${{ env.GITHUB_REF_NAME_NORMALIZED }}"
+            "${{ env.DOCKER_REPOSITORY_FOR_REF }}:v${{ env.ACTION_VERSION }}"
       - name: Push Artifacts to Sentry
-        if: github.ref_type == 'tag'
+        if: env.IS_RELEASE == 'true'
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: "${{secrets.SENTRY_AUTH_TOKEN}}"
@@ -201,7 +206,7 @@ jobs:
           sourcemaps: "./build"
           version: ${{env.ACTION_VERSION}}
       - name: Push Artifacts to Datadog
-        if: github.ref_type == 'tag'
+        if: env.IS_RELEASE == 'true'
         env:
           DATADOG_API_KEY: "${{secrets.DATADOG_API_KEY}}"
           CDN_BUILD_URL: "https://action-files.parabol.co/production/build/"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,3 +11,4 @@ jobs:
         with:
           command: manifest
           default-branch: release
+          release-type: node

--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -270,6 +270,8 @@ export default class Atmosphere extends Environment {
           'Cannot establish connection. Behind a firewall? Reach out for support: love@parabol.co'
       })
       console.error('Cannot connect!')
+      // this may be reached if the auth token was deemed invalid by the server
+      this.setAuthToken(null)
       return
     }
     this.transport = new GQLTrebuchetClient(trebuchet)

--- a/packages/server/listenHandler.ts
+++ b/packages/server/listenHandler.ts
@@ -1,6 +1,5 @@
 import {us_listen_socket} from 'uWebSockets.js'
 import getGraphQLExecutor from './utils/getGraphQLExecutor'
-import serverHealthChecker from './utils/serverHealthChecker'
 
 const listenHandler = (listenSocket: us_listen_socket) => {
   const PORT = Number(__PRODUCTION__ ? process.env.PORT : process.env.SOCKET_PORT)
@@ -9,7 +8,7 @@ const listenHandler = (listenSocket: us_listen_socket) => {
     console.log(`\n🔥🔥🔥 Server ID: ${SERVER_ID}. Ready for Sockets: Port ${PORT} 🔥🔥🔥`)
     getGraphQLExecutor().subscribe()
     // Cleaning on startup because shutdowns may be abrupt
-    serverHealthChecker.cleanUserPresence()
+    // serverHealthChecker.cleanUserPresence()
   } else {
     console.log(`❌❌❌    Port ${PORT} is in use!    ❌❌❌`)
   }

--- a/packages/server/listenHandler.ts
+++ b/packages/server/listenHandler.ts
@@ -1,5 +1,6 @@
 import {us_listen_socket} from 'uWebSockets.js'
 import getGraphQLExecutor from './utils/getGraphQLExecutor'
+import serverHealthChecker from './utils/serverHealthChecker'
 
 const listenHandler = (listenSocket: us_listen_socket) => {
   const PORT = Number(__PRODUCTION__ ? process.env.PORT : process.env.SOCKET_PORT)
@@ -8,7 +9,7 @@ const listenHandler = (listenSocket: us_listen_socket) => {
     console.log(`\n🔥🔥🔥 Server ID: ${SERVER_ID}. Ready for Sockets: Port ${PORT} 🔥🔥🔥`)
     getGraphQLExecutor().subscribe()
     // Cleaning on startup because shutdowns may be abrupt
-    // serverHealthChecker.cleanUserPresence()
+    serverHealthChecker.cleanUserPresence()
   } else {
     console.log(`❌❌❌    Port ${PORT} is in use!    ❌❌❌`)
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "release-as": "6.125.0",
   "packages": {
     ".": {
-      "release-type": "node"
+      "release-type": "node",
+      "pull-request-title-pattern": "chore${scope}: release ${version}"
     }
   },
   "changelog-sections": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,12 @@
 {
   "bootstrap-sha": "12396933718e23275a48550e8665f92015b55029",
   "release-as": "6.125.0",
+  "extra-label": "release",
   "packages": {
     ".": {
       "release-type": "node",
-      "pull-request-title-pattern": "chore${scope}: release ${version}"
+      "pull-request-title-pattern": "chore${scope}: release ${version}",
+      "include-component-in-tag": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
# Description

we've been building 3 docker images when we should only be building 1.
- one for branch production
- one for branch release
- one for the tag e.g. v6.124.0

to do away with this, we'll only build when the release-please PR gets merged.
if you absolutely have to, you can make a commit start with "dockerize" to trigger this manually, but that's not recommended. that build will supercede the previous, taking its version tag.