### PR TITLE
fix: bump versions for dependencies

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,11 @@
     },
     {
       "type": "json",
+      "path": "packages/chronos/package.json",
+      "jsonpath": "$.dependencies.parabol-server.version"
+    },
+    {
+      "type": "json",
       "path": "packages/client/package.json",
       "jsonpath": "$.version"
     },
@@ -44,6 +49,16 @@
     },
     {
       "type": "json",
+      "path": "packages/gql-executor/package.json",
+      "jsonpath": "$.dependencies.parabol-client.version"
+    },
+    {
+      "type": "json",
+      "path": "packages/gql-executor/package.json",
+      "jsonpath": "$.dependencies.parabol-server.version"
+    },
+    {
+      "type": "json",
       "path": "packages/integration-tests/package.json",
       "jsonpath": "$.version"
     },
@@ -51,6 +66,11 @@
       "type": "json",
       "path": "packages/server/package.json",
       "jsonpath": "$.version"
+    },
+    {
+      "type": "json",
+      "path": "packages/server/package.json",
+      "jsonpath": "$.dependencies.parabol-client.version"
     }
   ]
 }


### PR DESCRIPTION
# Description

release-please wasn't set to bump dependencies. now it is! (if the syntax is correct...)