### PR TITLE
fix: await last migration

### DIFF
--- a/packages/server/postgres/migrations/1697477646986_swot-typo.ts
+++ b/packages/server/postgres/migrations/1697477646986_swot-typo.ts
@@ -11,7 +11,8 @@ const connectRethinkDB = async () => {
 
 export async function up() {
   await connectRethinkDB()
-  r.table('ReflectPrompt')
+  await r
+    .table('ReflectPrompt')
     .get('sWOTAnalysisTemplate:stengthsPrompt')
     .update({question: 'Strengths'})
     .run()


### PR DESCRIPTION
# Description

adds `await` to the last migration so it completes before the connection is terminated after migrations complete.