### PR TITLE
chore: rename services in datadog trace

### DIFF
--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -9,9 +9,10 @@ import RedisInstance from '../server/utils/RedisInstance'
 import RedisStream from './RedisStream'
 
 tracer.init({
-  service: `GQLExecutor ${process.env.SERVER_ID}`,
+  service: `gql`,
   appsec: process.env.DD_APPSEC_ENABLED === 'true',
-  plugins: false
+  plugins: false,
+  version: process.env.npm_package_version
 })
 tracer.use('ioredis').use('http').use('pg')
 

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -24,9 +24,10 @@ import staticFileHandler from './staticFileHandler'
 import SAMLHandler from './utils/SAMLHandler'
 
 tracer.init({
-  service: `Web ${process.env.SERVER_ID}`,
+  service: `web`,
   appsec: process.env.DD_APPSEC_ENABLED === 'true',
-  plugins: false
+  plugins: false,
+  version: process.env.npm_package_version
 })
 tracer.use('ioredis').use('http').use('pg')
 


### PR DESCRIPTION
# Description

When analyzing traces, we want all of our replicas to appear as the same service instead of each replica representing its own unique service.

https://app.datadoghq.com/apm/services?env=production&service=gqlexecutor_74&start=1698246317423&end=1698249917423&paused=false

## Demo

Queue up dd in staging & see that there are only 2 services: web & gql.