### PR TITLE
chore: build bumps version in gitlab

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Bump version in GitLab
         run: |
-          curl  "https://gitlab.com/api/v4/projects/${{ env.GITLAB_PROJECT_ID }}/repository/files/version%2Eyaml" \
+          curl  "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/repository/files/version%2Eyaml" \
             --request PUT \
             --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
             --form "branch=main" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,21 @@ jobs:
           # Caching yarn dir & running yarn install is too slow
           # Instead, we aggressively cache node_modules below to avoid calling install
 
+      - name: Bump version in GitLab
+        run: |
+          curl  "https://gitlab.com/api/v4/projects/${{ env.GITLAB_PROJECT_ID }}/repository/files/version%2Eyaml" \
+            --request PUT \
+            --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
+            --form "branch=main" \
+            --form "commit_message=release v${{ env.ACTION_VERSION }}" \
+            --form "content=
+          # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
+          applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}
+
+          global:
+            image:
+              tag: *applicationVersion"
+
       - name: Get cached node modules
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,21 +64,6 @@ jobs:
           # Caching yarn dir & running yarn install is too slow
           # Instead, we aggressively cache node_modules below to avoid calling install
 
-      - name: Bump version in GitLab
-        run: |
-          curl  "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/repository/files/version%2Eyaml" \
-            --request PUT \
-            --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
-            --form "branch=main" \
-            --form "commit_message=release v${{ env.ACTION_VERSION }}" \
-            --form "content=
-          # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
-          applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}
-
-          global:
-            image:
-              tag: *applicationVersion"
-
       - name: Get cached node modules
         id: cache
         uses: actions/cache@v3
@@ -206,6 +191,23 @@ jobs:
           tags: |
             "${{ secrets.GCP_AR_PARABOL_DEV }}:${{github.sha}}"
             "${{ env.DOCKER_REPOSITORY_FOR_REF }}:v${{ env.ACTION_VERSION }}"
+
+      - name: Bump version in GitLab
+        if: env.IS_RELEASE == 'true'
+        run: |
+          curl  "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/repository/files/version%2Eyaml" \
+            --request PUT \
+            --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
+            --form "branch=main" \
+            --form "commit_message=release v${{ env.ACTION_VERSION }}" \
+            --form "content=
+          # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
+          applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}
+
+          global:
+            image:
+              tag: *applicationVersion"
+
       - name: Push Artifacts to Sentry
         if: env.IS_RELEASE == 'true'
         uses: getsentry/action-release@v1


### PR DESCRIPTION
# Description

When a release-please PR is merged to `release`, the build.yml will push a docker image to our registry.
Now, it will also add a commit message to gitlab that increments the version, which kicks off the pipeline diff.
This removes 1 more step from the release process. Now all that remains is a dev going to the pipeline & clicking Play.

## Demo

Tested without the IS_RELEASE conditional here: https://github.com/ParabolInc/parabol/actions/runs/6644516359/job/18053839586

You can see that it worked on the staging repo here: https://gitlab.com/parabol1/saas/staging/parabol/-/blob/main/version.yaml?ref_type=heads

