### PR TITLE
chore: don't lock org in case of failed payment

### DIFF
--- a/packages/server/billing/helpers/terminateSubscription.ts
+++ b/packages/server/billing/helpers/terminateSubscription.ts
@@ -1,6 +1,5 @@
 import getRethink from '../../database/rethinkDriver'
 import Organization from '../../database/types/Organization'
-import updateTeamByOrgId from '../../postgres/queries/updateTeamByOrgId'
 import {getStripeManager} from '../../utils/stripe'
 
 const terminateSubscription = async (orgId: string) => {
@@ -21,8 +20,7 @@ const terminateSubscription = async (orgId: string) => {
           {returnChanges: true}
         )('changes')(0)('old_val')
         .default(null) as unknown as Organization
-    }).run(),
-    updateTeamByOrgId({isPaid: false}, orgId)
+    }).run()
   ])
   const {organization} = rethinkResult
   const {stripeSubscriptionId} = organization

--- a/packages/server/graphql/private/mutations/stripeFailPayment.ts
+++ b/packages/server/graphql/private/mutations/stripeFailPayment.ts
@@ -7,7 +7,6 @@ import {isSuperUser} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import {getStripeManager} from '../../../utils/stripe'
 import {MutationResolvers} from '../resolverTypes'
-import updateTeamByOrgId from '../../../postgres/queries/updateTeamByOrgId'
 
 export type StripeFailPaymentPayloadSource =
   | {
@@ -75,9 +74,6 @@ const stripeFailPayment: MutationResolvers['stripeFailPayment'] = async (
     // After 23 hours subscription updates to incomplete_expired and the invoice becomes void.
     // Not to handle this particular case in 23 hours, we do it now
     await terminateSubscription(orgId)
-  } else {
-    // Keep subscription, but disable teams
-    await updateTeamByOrgId({isPaid: false}, orgId)
   }
 
   const billingLeaderUserIds = (await r


### PR DESCRIPTION
fixes #8341

**How to test:**

- Run: `stripe listen --forward-to localhost:3000/stripe` (Do `stripe login` if you see an error)
- Upgrade starter org to team plan using "Decline after attaching" test card number: 4000000000000341
- Wait few seconds, refresh page. See that org is not locked
- See that it i upgraded to team tier
- See that card rejected notification is added in the notification center
