### PR TITLE
fix: Fix service worker static cache base url

### DIFF
--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -114,7 +114,10 @@ module.exports = ({isDeploy, isStats}) => ({
     new InjectManifest({
       swSrc: path.join(PROJECT_ROOT, 'packages/client/serviceWorker/sw.ts'),
       swDest: 'swSkeleton.js',
-      exclude: [/GraphqlContainer/, /\.map$/, /^manifest.*\.js$/, /index.html$/]
+      exclude: [/GraphqlContainer/, /\.map$/, /^manifest.*\.js$/, /index.html$/],
+      modifyURLPrefix: {
+        '': 'https:__PUBLIC_PATH__/'
+      }
     }),
     isStats && new BundleAnalyzerPlugin({generateStatsFile: true})
   ].filter(Boolean),

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -116,7 +116,7 @@ module.exports = ({isDeploy, isStats}) => ({
       swDest: 'swSkeleton.js',
       exclude: [/GraphqlContainer/, /\.map$/, /^manifest.*\.js$/, /index.html$/],
       modifyURLPrefix: {
-        '': 'https:__PUBLIC_PATH__/'
+        '': '__PUBLIC_PATH__/'
       }
     }),
     isStats && new BundleAnalyzerPlugin({generateStatsFile: true})


### PR DESCRIPTION
# Description

Fixes #8948 
Prefix static file URLs with `__PUBLIC_PATH__` so they're loaded from CDN.

## Demo

https://www.loom.com/share/0a6cbcbe2161499bb2d8f2a9053bf733?sid=06fcf923-afb8-487b-ab90-f5e9cf35412f

## Testing scenarios

- run a production build `yarn build && yarn predeploy && yarn start`
- inspect the static cache with dev tools and see files are valid

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
