### PR TITLE
chore: remove release branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,22 @@ jobs:
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_ENV
           echo "DOCKERIZE=${DOCKERIZE}" >> $GITHUB_ENV
           echo "DOCKER_REPOSITORY_FOR_REF=${DOCKER_REPOSITORY_FOR_REF}" >> $GITHUB_ENV
+      - name: Bump version in GitLab
+        run: |
+          curl  "https://gitlab.com/api/v4/projects/47422225/repository/commits" \
+            --request POST \
+            --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
+            --form "branch=main" \
+            --form "commit_message=release v${{ env.ACTION_VERSION }}" \
+            --form "actions[][action]=update" \
+            --form "actions[][file_path]=version.yaml" \
+            --form "actions[][content]=
+          # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
+          applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}
+
+          global:
+            image:
+              tag: *applicationVersion"
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -202,7 +218,6 @@ jobs:
             --form "commit_message=release v${{ env.ACTION_VERSION }}" \
             --form "actions[][action]=update" \
             --form "actions[][file_path]=version.yaml" \
-            --form "actions[][content]=</path/to/local2.file" \
             --form "actions[][content]=
           # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
           applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,22 +56,6 @@ jobs:
           echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_ENV
           echo "DOCKERIZE=${DOCKERIZE}" >> $GITHUB_ENV
           echo "DOCKER_REPOSITORY_FOR_REF=${DOCKER_REPOSITORY_FOR_REF}" >> $GITHUB_ENV
-      - name: Bump version in GitLab
-        run: |
-          curl  "https://gitlab.com/api/v4/projects/47422225/repository/commits" \
-            --request POST \
-            --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
-            --form "branch=main" \
-            --form "commit_message=release v${{ env.ACTION_VERSION }}" \
-            --form "actions[][action]=update" \
-            --form "actions[][file_path]=version.yaml" \
-            --form "actions[][content]=
-          # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
-          applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}
-
-          global:
-            image:
-              tag: *applicationVersion"
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup environment variables
         run: |
-          IS_RELEASE=${{ startsWith(github.event.head_commit.message, 'chore(release): release') }}
+          IS_RELEASE=${{ startsWith(github.event.head_commit.message, 'chore(release): release') && (github.ref_name == 'master' || startsWith(github.ref_name, 'hotfix')) }}
           IS_MANUAL_BUILD=${{ startsWith(github.event.head_commit.message, 'dockerize') }}
 
           DOCKER_REPOSITORY_FOR_REF=${{ secrets.GCP_AR_PARABOL_DEV }}
@@ -195,12 +195,15 @@ jobs:
       - name: Bump version in GitLab
         if: env.IS_RELEASE == 'true'
         run: |
-          curl  "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/repository/files/version%2Eyaml" \
-            --request PUT \
+          curl  "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/repository/commits" \
+            --request POST \
             --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}' \
             --form "branch=main" \
             --form "commit_message=release v${{ env.ACTION_VERSION }}" \
-            --form "content=
+            --form "actions[][action]=update" \
+            --form "actions[][file_path]=version.yaml" \
+            --form "actions[][content]=</path/to/local2.file" \
+            --form "actions[][content]=
           # Change it to use a valid docker tag, which are the same of the Github tags. Ex: v6.110.0
           applicationVersion: &applicationVersion v${{ env.ACTION_VERSION }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,8 @@
 on:
   push:
     branches:
-      - release
+      - master
+      - hotfix-*
 name: release-please
 jobs:
   release-please:
@@ -10,5 +11,5 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           command: manifest
-          default-branch: release
+          default-branch: ${{ github.ref_name}}
           release-type: node

--- a/packages/client/hooks/useServiceWorkerUpdater.ts
+++ b/packages/client/hooks/useServiceWorkerUpdater.ts
@@ -21,8 +21,7 @@ const useServiceWorkerUpdater = () => {
         action: {
           label: `See what's changed`,
           callback: () => {
-            const url =
-              'https://github.com/ParabolInc/parabol/blob/release/CHANGELOG.md#parabol-change-log'
+            const url = 'https://github.com/ParabolInc/parabol/releases'
             window.open(url, '_blank', 'noopener')?.focus()
           }
         }


### PR DESCRIPTION
# Description

Removes the `release` branch.
If you're doing a standard release, merge to `master`.
If you're doing a hotfix, just make sure the branch name starts with `hotfix` e.g. `hotfix/4022/fix-user-details`
release-please will open a PR for you. merge it & it will push a new docker image to the registry.
