### PR TITLE
feat: adds MoSCoW and RICE prioritization templates

### DIFF
--- a/packages/server/postgres/migrations/1698263155574_addPrioritizationTemplates.ts
+++ b/packages/server/postgres/migrations/1698263155574_addPrioritizationTemplates.ts
@@ -58,7 +58,9 @@ const MOSCOW_SCALE_CONFIG: TemplateScale = {
     {label: 'M', color: PALETTE.TOMATO_500},
     {label: 'S', color: PALETTE.TERRA_300},
     {label: 'C', color: PALETTE.GOLD_300},
-    {label: 'W', color: PALETTE.GRASS_300}
+    {label: 'W', color: PALETTE.GRASS_300},
+    {label: '?', color: PALETTE.ROSE_500},
+    {label: 'Pass', color: PALETTE.GRAPE_500}
   ]
 }
 

--- a/packages/server/postgres/migrations/1698263155574_addPrioritizationTemplates.ts
+++ b/packages/server/postgres/migrations/1698263155574_addPrioritizationTemplates.ts
@@ -46,56 +46,6 @@ const getTemplateIllustrationUrl = (filename: string) => {
   throw new Error('Mssing Env: FILE_STORE_PROVIDER')
 }
 
-// MeetingTemplate fields
-// "id",
-// "createdAt",
-// "isActive",
-// "name",
-// "teamId",
-// "updatedAt",
-// "scope",
-// "orgId",
-// "parentTemplateId",
-// "lastUsedAt",
-// "type",
-// "isStarter",
-// "isFree",
-// "illustrationUrl",
-// "hideStartingAt",
-// "hideEndingAt",
-// "mainCategory"
-
-// {
-//   "createdAt": Thu Oct 26 2023 20:21:08 GMT+00:00 ,
-//   "id": "rxCt74471C" ,
-//   "name": "Test Scale Fields" ,
-//   "sortOrder": 0.9999999999999996 ,
-//   "teamId": "pAlPfYEr73" ,
-//   "updatedAt": Thu Oct 26 2023 20:21:20 GMT+00:00 ,
-//   "values": [
-//   {
-//   "color": "#FD6157" ,
-//   "label": "11"
-//   } ,
-//   {
-//   "color": "#FE975D" ,
-//   "label": "22"
-//   } ,
-//   {
-//   "color": "#FFCC63" ,
-//   "label": "33"
-//   } ,
-//   {
-//   "color": "#DB70DB" ,
-//   "label": "?"
-//   } ,
-//   {
-//   "color": "#A06BD6" ,
-//   "label": "Pass"
-//   }
-//   ]
-//   }
-
 const MOSCOW_SCALE_CONFIG: TemplateScale = {
   createdAt,
   id: 'moscowScale',
@@ -173,18 +123,6 @@ const makeTemplate = (template: Template) => ({
 })
 
 const templates = NEW_TEMPLATE_CONFIGS.map((templateConfig) => makeTemplate(templateConfig))
-
-// {
-//   "createdAt": Thu Oct 26 2023 20:21:00 GMT+00:00 ,
-//   "description": "" ,
-//   "id": "rxCsyZUU9y" ,
-//   "name": "Test Dimension Fields" ,
-//   "scaleId": "rxCt74471C" ,
-//   "sortOrder": 1.0000000000000002 ,
-//   "teamId": "pAlPfYEr73" ,
-//   "templateId": "rxCsl0b9wk" ,
-//   "updatedAt": Thu Oct 26 2023 20:21:28 GMT+00:00
-//   }
 
 type DimensionInfo = {
   id: string

--- a/packages/server/postgres/migrations/1698263155574_addPrioritizationTemplates.ts
+++ b/packages/server/postgres/migrations/1698263155574_addPrioritizationTemplates.ts
@@ -1,0 +1,272 @@
+import {PALETTE} from 'parabol-client/styles/paletteV3'
+import {Client} from 'pg'
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+import TemplateDimension from '../../database/types/TemplateDimension'
+import TemplateScale from '../../database/types/TemplateScale'
+import getPgConfig from '../getPgConfig'
+import getPgp from '../getPgp'
+
+const createdAt = new Date()
+
+interface ScaleValue {
+  color: string
+  label: string
+}
+
+interface Scale {
+  id: string
+  name: string
+  values: ScaleValue[]
+}
+
+interface Dimension {
+  id: string
+  name: string
+  scaleId: string
+}
+
+interface Template {
+  id: string
+  name: string
+  dimensions: Dimension[]
+}
+
+const getTemplateIllustrationUrl = (filename: string) => {
+  const cdnType = process.env.FILE_STORE_PROVIDER
+  const partialPath = `Organization/aGhostOrg/template/${filename}`
+  if (cdnType === 'local') {
+    return `/self-hosted/${partialPath}`
+  } else if (cdnType === 's3') {
+    const {CDN_BASE_URL} = process.env
+    if (!CDN_BASE_URL) throw new Error('Missng Env: CDN_BASE_URL')
+    const hostPath = CDN_BASE_URL.replace(/^\/+/, '')
+    return `https://${hostPath}/store/${partialPath}`
+  }
+  throw new Error('Mssing Env: FILE_STORE_PROVIDER')
+}
+
+// MeetingTemplate fields
+// "id",
+// "createdAt",
+// "isActive",
+// "name",
+// "teamId",
+// "updatedAt",
+// "scope",
+// "orgId",
+// "parentTemplateId",
+// "lastUsedAt",
+// "type",
+// "isStarter",
+// "isFree",
+// "illustrationUrl",
+// "hideStartingAt",
+// "hideEndingAt",
+// "mainCategory"
+
+// {
+//   "createdAt": Thu Oct 26 2023 20:21:08 GMT+00:00 ,
+//   "id": "rxCt74471C" ,
+//   "name": "Test Scale Fields" ,
+//   "sortOrder": 0.9999999999999996 ,
+//   "teamId": "pAlPfYEr73" ,
+//   "updatedAt": Thu Oct 26 2023 20:21:20 GMT+00:00 ,
+//   "values": [
+//   {
+//   "color": "#FD6157" ,
+//   "label": "11"
+//   } ,
+//   {
+//   "color": "#FE975D" ,
+//   "label": "22"
+//   } ,
+//   {
+//   "color": "#FFCC63" ,
+//   "label": "33"
+//   } ,
+//   {
+//   "color": "#DB70DB" ,
+//   "label": "?"
+//   } ,
+//   {
+//   "color": "#A06BD6" ,
+//   "label": "Pass"
+//   }
+//   ]
+//   }
+
+const MOSCOW_SCALE_CONFIG: TemplateScale = {
+  createdAt,
+  id: 'moscowScale',
+  isStarter: true,
+  name: 'MoSCoW',
+  sortOrder: 4,
+  teamId: 'aGhostTeam',
+  updatedAt: createdAt,
+  values: [
+    {label: 'M', color: PALETTE.TOMATO_500},
+    {label: 'S', color: PALETTE.TERRA_300},
+    {label: 'C', color: PALETTE.GOLD_300},
+    {label: 'W', color: PALETTE.GRASS_300}
+  ]
+}
+
+const NEW_TEMPLATE_CONFIGS: Template[] = [
+  {
+    id: 'moscowPrioritizationTemplate',
+    name: 'MoSCoW Prioritization',
+    dimensions: [
+      {
+        id: 'moscowPriorityDimension',
+        name: 'Priority? Must/Should/Could/Won’t Have',
+        scaleId: 'moscowScale'
+      }
+    ]
+  },
+  {
+    id: 'ricePrioritizationTemplate',
+    name: 'RICE Prioritization',
+    dimensions: [
+      {
+        id: 'riceReachDimension',
+        name: 'Reach',
+        scaleId: 'fiveFingersScale'
+      },
+      {
+        id: 'riceImpactDimension',
+        name: 'Impact',
+        scaleId: 'fiveFingersScale'
+      },
+      {
+        id: 'riceConfidenceDimension',
+        name: 'Confidence',
+        scaleId: 'fiveFingersScale'
+      },
+      {
+        id: 'riceEffortDimension',
+        name: 'Effort',
+        scaleId: 'fiveFingersScale'
+      }
+    ]
+  }
+]
+
+const scales = [MOSCOW_SCALE_CONFIG]
+
+const makeTemplate = (template: Template) => ({
+  createdAt,
+  id: template.id,
+  isActive: true,
+  name: template.name,
+  orgId: 'aGhostOrg',
+  scope: 'PUBLIC',
+  teamId: 'aGhostTeam',
+  type: 'poker',
+  updatedAt: createdAt,
+  isStarter: true,
+  isFree: true,
+  illustrationUrl: getTemplateIllustrationUrl('newTemplate.png'),
+  mainCategory: 'strategy',
+  lastUsedAt: null,
+  parentTemplateId: null
+})
+
+const templates = NEW_TEMPLATE_CONFIGS.map((templateConfig) => makeTemplate(templateConfig))
+
+// {
+//   "createdAt": Thu Oct 26 2023 20:21:00 GMT+00:00 ,
+//   "description": "" ,
+//   "id": "rxCsyZUU9y" ,
+//   "name": "Test Dimension Fields" ,
+//   "scaleId": "rxCt74471C" ,
+//   "sortOrder": 1.0000000000000002 ,
+//   "teamId": "pAlPfYEr73" ,
+//   "templateId": "rxCsl0b9wk" ,
+//   "updatedAt": Thu Oct 26 2023 20:21:28 GMT+00:00
+//   }
+
+type DimensionInfo = {
+  id: string
+  name: string
+  scaleId: string
+  sortOrder: number
+  templateId: string
+}
+
+const makeDimension = (dimensionInfo: DimensionInfo): TemplateDimension => {
+  const {id, name, scaleId, sortOrder, templateId} = dimensionInfo
+  return {
+    createdAt,
+    description: '',
+    id,
+    name,
+    scaleId,
+    sortOrder,
+    teamId: 'aGhostTeam',
+    templateId,
+    updatedAt: createdAt
+  }
+}
+
+const dimensions = NEW_TEMPLATE_CONFIGS.map((templateConfig) => {
+  return templateConfig.dimensions.map((dimension, idx) => {
+    return makeDimension({
+      id: dimension.id,
+      name: dimension.name,
+      scaleId: dimension.scaleId,
+      sortOrder: idx,
+      templateId: templateConfig.id
+    })
+  })
+}).flat()
+
+export async function up() {
+  const {pgp, pg} = getPgp()
+  const columnSet = new pgp.helpers.ColumnSet(
+    [
+      'id',
+      'createdAt',
+      'isActive',
+      'name',
+      'teamId',
+      'updatedAt',
+      'scope',
+      'orgId',
+      'type',
+      'illustrationUrl',
+      'mainCategory',
+      {name: 'isStarter', def: false},
+      {name: 'isFree', def: false}
+    ],
+    {table: 'MeetingTemplate'}
+  )
+  const insert = pgp.helpers.insert(templates, columnSet)
+  await pg.none(insert)
+  try {
+    await connectRethinkDB()
+    await r.table('TemplateDimension').insert(dimensions).run()
+    await r.table('TemplateScale').insert(scales).run()
+    await r.getPoolMaster()?.drain()
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+export async function down() {
+  const templateIds = templates.map(({id}) => id)
+  const dimensionIds = dimensions.map(({id}) => id)
+  const scaleIds = scales.map(({id}) => id)
+  try {
+    await connectRethinkDB()
+    await r.table('TemplateDimension').getAll(r.args(dimensionIds)).delete().run()
+    await r.table('TemplateScale').getAll(r.args(scaleIds)).delete().run()
+    await r.getPoolMaster()?.drain()
+  } catch (e) {
+    console.log(e)
+  }
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`DELETE FROM "MeetingTemplate" WHERE id = ANY($1);`, [templateIds])
+  await client.end()
+}


### PR DESCRIPTION
# Description

Adds MoSCoW and RICE prioritization templates using the poker meeting and scales

## Demo

![2023-10-27 12 33 09](https://github.com/ParabolInc/parabol/assets/307286/ffef9b67-56a6-44f5-8460-b21407694249)

## Testing scenarios

- Run a test meeting using each new template (under the strategy category)
- Add Parabol tasks to estimate. Estimate the items. Add a final score per dimension
- End the meeting. See that the CSV has the items with their estimates for each dimension of the template