### PR TITLE
fix: gracefully handle reconnects when servers upgrade

### DIFF
--- a/packages/server/activeClients.ts
+++ b/packages/server/activeClients.ts
@@ -1,6 +1,6 @@
 import ConnectionContext from './socketHelpers/ConnectionContext'
 
-class SSEClients {
+class ActiveClients {
   store = {} as Record<string, ConnectionContext>
   get(connectionId: unknown) {
     return this.store[String(connectionId)]
@@ -13,4 +13,4 @@ class SSEClients {
   }
 }
 
-export default new SSEClients()
+export default new ActiveClients()

--- a/packages/server/graphql/httpGraphQLHandler.ts
+++ b/packages/server/graphql/httpGraphQLHandler.ts
@@ -1,10 +1,10 @@
 import {TrebuchetCloseReason} from 'parabol-client/types/constEnums'
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
+import activeClients from '../activeClients'
 import AuthToken from '../database/types/AuthToken'
 import parseBody from '../parseBody'
 import parseFormBody from '../parseFormBody'
 import StatelessContext from '../socketHelpers/StatelessContext'
-import sseClients from '../sseClients'
 import {getUserId} from '../utils/authorization'
 import checkBlacklistJWT from '../utils/checkBlacklistJWT'
 import getReqAuth from '../utils/getReqAuth'
@@ -23,7 +23,7 @@ const httpGraphQLBodyHandler = async (
   ip: string
 ) => {
   const connectionContext: any = connectionId
-    ? sseClients.get(connectionId)
+    ? activeClients.get(connectionId)
     : new StatelessContext(ip, authToken)
   if (!connectionContext) {
     const viewerId = getUserId(authToken)

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -38,7 +38,7 @@ if (!__PRODUCTION__) {
 }
 
 process.on('SIGTERM', () => {
-  const RECONNECT_WINDOW = 60 // seconds
+  const RECONNECT_WINDOW = 60_000 // ms
   Object.values(activeClients.store).forEach((connectionContext) => {
     const disconnectIn = ~~(Math.random() * RECONNECT_WINDOW)
     setTimeout(() => {

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -3,6 +3,7 @@ import {r} from 'rethinkdb-ts'
 import uws, {SHARED_COMPRESSOR} from 'uWebSockets.js'
 import ICSHandler from './ICSHandler'
 import PWAHandler from './PWAHandler'
+import activeClients from './activeClients'
 import stripeWebhookHandler from './billing/stripeWebhookHandler'
 import createSSR from './createSSR'
 import httpGraphQLHandler from './graphql/httpGraphQLHandler'
@@ -14,6 +15,7 @@ import listenHandler from './listenHandler'
 import './monkeyPatchFetch'
 import selfHostedHandler from './selfHostedHandler'
 import handleClose from './socketHandlers/handleClose'
+import handleDisconnect from './socketHandlers/handleDisconnect'
 import handleMessage from './socketHandlers/handleMessage'
 import handleOpen from './socketHandlers/handleOpen'
 import handleUpgrade from './socketHandlers/handleUpgrade'
@@ -34,6 +36,16 @@ if (!__PRODUCTION__) {
     r.getPoolMaster()?.drain()
   })
 }
+
+process.on('SIGTERM', () => {
+  const RECONNECT_WINDOW = 60 // seconds
+  Object.values(activeClients.store).forEach((connectionContext) => {
+    const disconnectIn = ~~(Math.random() * RECONNECT_WINDOW)
+    setTimeout(() => {
+      handleDisconnect(connectionContext)
+    }, disconnectIn)
+  })
+})
 
 const PORT = Number(__PRODUCTION__ ? process.env.PORT : process.env.SOCKET_PORT)
 uws

--- a/packages/server/socketHandlers/handleDisconnect.ts
+++ b/packages/server/socketHandlers/handleDisconnect.ts
@@ -1,6 +1,6 @@
-import closeTransport from '../socketHelpers/closeTransport'
+import activeClients from '../activeClients'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
-import sseClients from '../sseClients'
+import closeTransport from '../socketHelpers/closeTransport'
 import {getUserId} from '../utils/authorization'
 import publishInternalGQL from '../utils/publishInternalGQL'
 import relayUnsubscribeAll from '../utils/relayUnsubscribeAll'
@@ -30,9 +30,7 @@ const handleDisconnect = (connectionContext: ConnectionContext, options: Options
     const userId = getUserId(authToken)
     publishInternalGQL({authToken, ip, query: disconnectQuery, socketId, variables: {userId}})
   }
-  if (connectionContext.id.startsWith('sse')) {
-    sseClients.delete(connectionContext.id)
-  }
+  activeClients.delete(connectionContext.id)
   closeTransport(socket, exitCode, reason)
 }
 

--- a/packages/server/socketHandlers/handleOpen.ts
+++ b/packages/server/socketHandlers/handleOpen.ts
@@ -1,4 +1,5 @@
 import {WebSocketBehavior} from 'uWebSockets.js'
+import activeClients from '../activeClients'
 import AuthToken from '../database/types/AuthToken'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 import keepAlive from '../socketHelpers/keepAlive'
@@ -20,6 +21,7 @@ const handleOpen: WebSocketBehavior<SocketUserData>['open'] = async (socket) => 
     authToken,
     ip
   ))
+  activeClients.set(connectionContext)
   // messages will start coming in before handleConnect completes & sit in the readyQueue
   const nextAuthToken = await handleConnect(connectionContext)
   sendEncodedMessage(connectionContext, {version: APP_VERSION, authToken: nextAuthToken})

--- a/packages/server/sse/SSEConnectionHandler.ts
+++ b/packages/server/sse/SSEConnectionHandler.ts
@@ -1,13 +1,13 @@
 import {TrebuchetCloseReason} from 'parabol-client/types/constEnums'
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
+import activeClients from '../activeClients'
 import uWSAsyncHandler from '../graphql/uWSAsyncHandler'
 import handleConnect from '../socketHandlers/handleConnect'
 import handleDisconnect from '../socketHandlers/handleDisconnect'
-import closeTransport from '../socketHelpers/closeTransport'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
+import closeTransport from '../socketHelpers/closeTransport'
 import keepAlive from '../socketHelpers/keepAlive'
 import {sendEncodedMessage} from '../socketHelpers/sendEncodedMessage'
-import sseClients from '../sseClients'
 import {isAuthenticated} from '../utils/authorization'
 import checkBlacklistJWT from '../utils/checkBlacklistJWT'
 import getQueryToken from '../utils/getQueryToken'
@@ -41,7 +41,7 @@ const SSEConnectionHandler = uWSAsyncHandler(async (res: HttpResponse, req: Http
     return
   }
 
-  sseClients.set(connectionContext)
+  activeClients.set(connectionContext)
   const nextAuthToken = await handleConnect(connectionContext)
   if (res.done) return
   res.tryEnd(`retry: 1000\n`, 1e8)

--- a/packages/server/sse/SSEPingHandler.ts
+++ b/packages/server/sse/SSEPingHandler.ts
@@ -1,14 +1,14 @@
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
+import activeClients from '../activeClients'
 import AuthToken from '../database/types/AuthToken'
 import uWSAsyncHandler from '../graphql/uWSAsyncHandler'
 import parseBody from '../parseBody'
-import sseClients from '../sseClients'
 import getReqAuth from '../utils/getReqAuth'
 import handleReliableMessage from '../utils/handleReliableMessage'
 
 const SSEPingHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
   const connectionId = req.getHeader('x-correlation-id')
-  const connectionContext = sseClients.get(connectionId)
+  const connectionContext = activeClients.get(connectionId)
   if (connectionContext) {
     const authToken = getReqAuth(req)
     if ((authToken as AuthToken).sub === connectionContext.authToken.sub) {


### PR DESCRIPTION
# Description

fixes #8903 

## Demo

https://www.loom.com/share/c891b7ca7e7346ba9f6dfbfa8c138157?sid=445095fa-b1a4-4890-b091-3aa1ae7211fa

## Testing scenarios

- [ ] in handleOpen.ts, add the line `console.log('connected', process.pid)` to get the process id of the connected user
- [ ] open a browser & go to the app
- [ ] in a terminal, call `kill -SIGTERM <pid>` where <pid> is what got logged to the console
- [ ] watch the browser reconnect (it'll probably do it twice since it reconnected to the same single server since we have no load balancer locally)
