### PR TITLE
fix: do not fail installing service worker on fetch fail

### DIFF
--- a/packages/client/serviceWorker/sw.ts
+++ b/packages/client/serviceWorker/sw.ts
@@ -27,11 +27,12 @@ const onInstall = async (_event: ExtendableEvent) => {
   const cacheNames = await caches.keys()
   const oldStaticCacheName = cacheNames.find((cacheName) => cacheName.startsWith('parabol-static'))
   const newCache = await caches.open(STATIC_CACHE)
+  const fetchCachedFiles = async (urls: string[]) => Promise.all(urls.map((url) => newCache.add(url)))
 
   // if this is their first service worker, fetch it all
   if (!oldStaticCacheName) {
     console.log('Installing service worker')
-    return newCache.addAll(urls).catch(console.error)
+    return fetchCachedFiles(urls).catch(console.error)
   }
 
   // if they already have some assets, forward them over to the new cache & fetch the rest
@@ -45,7 +46,7 @@ const onInstall = async (_event: ExtendableEvent) => {
       newCache.put(urls[idx], res)
     })
   )
-  return newCache.addAll(urls).catch(console.error)
+  return fetchCachedFiles(newUrls).catch(console.error)
 }
 
 const onActivate = async (_event: ExtendableEvent) => {

--- a/packages/client/serviceWorker/sw.ts
+++ b/packages/client/serviceWorker/sw.ts
@@ -31,7 +31,7 @@ const onInstall = async (_event: ExtendableEvent) => {
   // if this is their first service worker, fetch it all
   if (!oldStaticCacheName) {
     console.log('Installing service worker')
-    return newCache.addAll(urls)
+    return newCache.addAll(urls).catch(console.error)
   }
 
   // if they already have some assets, forward them over to the new cache & fetch the rest
@@ -45,7 +45,7 @@ const onInstall = async (_event: ExtendableEvent) => {
       newCache.put(urls[idx], res)
     })
   )
-  return newCache.addAll(newUrls)
+  return newCache.addAll(urls).catch(console.error)
 }
 
 const onActivate = async (_event: ExtendableEvent) => {


### PR DESCRIPTION
If we fail to fetch a file for the static cache, we previously failed to install the new service worker. Now we're just catching this error. If the file is missing from the static cache, it will be fetched from the dynamic one later.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

- run production `yarn build && yarn predeploy && yarn start`
- add a failing file, like 'https://parabol.fun/invalid' to the cache and see installation not failing

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
