### PR TITLE
fix: e-mail love@parabol.com replaced by love@parabol.co

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,7 +21,7 @@ from Parabol, you must contact The Company.
 
 If you have any questions regarding our licensing policy, please contact us:
 
-    love@parabol.com (via email)
+    love@parabol.co (via email)
 
     Parabol
     8605 Santa Monica Blvd

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parabol-client",
   "description": "An open-source app for building smarter, more agile teams.",
-  "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
+  "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
   "version": "7.3.0",
   "repository": {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
+  "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
   "version": "7.3.0",
   "description": "",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parabol-server",
   "description": "An open-source app for building smarter, more agile teams.",
-  "author": "Parabol Inc. <love@parabol.com> (http://github.com/ParabolInc)",
+  "author": "Parabol Inc. <love@parabol.co> (http://github.com/ParabolInc)",
   "license": "AGPL-3.0",
   "version": "7.3.0",
   "repository": {


### PR DESCRIPTION
# Description

The e-mail love@parabol.com was found multiple times on the code base. It is replaced now with the actual e-mail love@parabol.co