### PR TITLE
fix: restore missing pm2.config.js

### DIFF
--- a/pm2.config.js
+++ b/pm2.config.js
@@ -1,0 +1,49 @@
+module.exports = {
+  apps: [
+    {
+      name: 'Chronos',
+      script: 'dist/chronos.js',
+      instances: 1, // there can only be 1
+      increment_var: 'SERVER_ID',
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '4096M',
+      env: {
+        SERVER_ID: 1
+      },
+      env_production: {
+        NODE_ENV: 'production'
+      }
+    },
+    {
+      name: 'Web Server',
+      script: 'dist/web.js',
+      instances: 2,
+      increment_var: 'SERVER_ID',
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '8192M',
+      env: {
+        SERVER_ID: 2
+      },
+      env_production: {
+        NODE_ENV: 'production'
+      }
+    },
+    {
+      name: 'GQL Executor',
+      script: 'dist/gqlExecutor.js',
+      instances: 2,
+      increment_var: 'SERVER_ID',
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '24576M',
+      env: {
+        SERVER_ID: 5
+      },
+      env_production: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Github build action was broken since yesterday after merging the PR to remove old Dokku artifacts due to missing pm2.config.js. This PR restores the pm2.config.js and gets the tests working again.

- [Action failing on the PR before merging](https://github.com/ParabolInc/parabol/actions/runs/6724538961)
- [Master action failing after merging the PR](https://github.com/ParabolInc/parabol/actions/runs/6724558476)

## Testing scenarios

- [x] [Github action](https://github.com/ParabolInc/parabol/actions/runs/6730053340) for this PR works
