### PR TITLE
fix: reference to SendClientSideEvent

### DIFF
--- a/packages/client/components/RequestToJoin.tsx
+++ b/packages/client/components/RequestToJoin.tsx
@@ -1,11 +1,11 @@
 import {Lock, MailOutline} from '@mui/icons-material'
 import React, {useState} from 'react'
 import {useRouteMatch} from 'react-router'
+import {PushInvitationMutation$data} from '../__generated__/PushInvitationMutation.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import PushInvitationMutation from '../mutations/PushInvitationMutation'
-import SendClientSideEvent from '../mutations/SendClientSideEvent'
-import {PushInvitationMutation$data} from '../__generated__/PushInvitationMutation.graphql'
+import SendClientSideEvent from '../utils/SendClientSideEvent'
 import PrimaryButton from './PrimaryButton'
 
 const RequestToJoinComponent = () => {


### PR DESCRIPTION
# Description

fixes borked master

From slack rant:

> master is broken right now! It looks like our GitHub strategy is to blame:
The error is Can't resolve '../mutations/SendClientSideEvent'
This is because https://github.com/ParabolInc/parabol/pull/9067 changed the location of that file
And https://github.com/ParabolInc/parabol/pull/9057 referenced the old location
The root cause is that we don’t require PRs be brought up to date before we allow them to be merged. For example, I open a PR, the checks pass, someone else’s PR gets merged which would cause my PR to break, but since my checks already passed, I can merge & break master