### PR TITLE
feat: create ironbank s3 artifacts manual GH

### DIFF
--- a/.github/workflows/ironbank.yml
+++ b/.github/workflows/ironbank.yml
@@ -42,10 +42,9 @@ jobs:
         run: |
           docker cp temp-container:/parabol/dist ./dist
           docker cp temp-container:/parabol/build ./build
-          docker cp temp-container:/parabol/static ./static
 
       - name: Zip the files
-        run: zip -r ${{ github.event.inputs.version_number }}.zip dist build static
+        run: zip -r ${{ github.event.inputs.version_number }}.zip dist build
 
       - name: Set up AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ironbank.yml
+++ b/.github/workflows/ironbank.yml
@@ -1,0 +1,59 @@
+name: Ironbank S3 Upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number of the Parabol image to process'
+        required: true
+
+jobs:
+  pull-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{ secrets.GCP_WI_PROVIDER_NAME }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+
+      - uses: "docker/login-action@v2"
+        with:
+          registry: ${{ secrets.GCP_DOCKER_REGISTRY }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.auth.outputs.access_token }}"
+
+      - name: Pull Docker image from GCP
+        run: docker pull ${{ env.DOCKER_REPOSITORY_FOR_REF }}:v${{ github.event.inputs.version_number }}
+
+      - name: Create temporary container
+        run: |
+          docker create --name temp-container ${{ env.DOCKER_REPOSITORY_FOR_REF }}:v${{ github.event.inputs.version_number }}
+
+      - name: Copy files from container
+        run: |
+          docker cp temp-container:/parabol/dist ./dist
+          docker cp temp-container:/parabol/build ./build
+          docker cp temp-container:/parabol/static ./static
+
+      - name: Zip the files
+        run: zip -r ${{ github.event.inputs.version_number }}.zip dist build static
+
+      - name: Set up AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.IRONBANK_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.IRONBANK_AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp ${{ github.event.inputs.version_number }}.zip s3://ironbank-proving-ground-action-files.parabol.co/${{ github.event.inputs.version_number }}.zip


### PR DESCRIPTION
Adds a manual workflow that can be triggered to pull a prebuilt parabol image, copy build, dist, and static assets. Then zip the assets, and upload them to S3 for use in Ironbank.