### PR TITLE
fix: unable to create org

### DIFF
--- a/packages/client/mutations/fragments/PublicTeamsFrag.ts
+++ b/packages/client/mutations/fragments/PublicTeamsFrag.ts
@@ -10,6 +10,9 @@ graphql`
       allTeams {
         id
       }
+      viewerTeams {
+        id
+      }
     }
   }
 `


### PR DESCRIPTION
`viewerTeams` are undefined after creating a new org on master. The app crashes and the user needs to refresh the page to see their org. 

### To test

- [ ] Create a new org and see the app no longer crashes