### PR TITLE
fix: autoJoin needs refresh

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -95,6 +95,7 @@ const bootstrapNewUser = async (
     await Promise.all(
       teamsWithAutoJoin.map((team) => {
         const teamId = team.id
+        tms.push(teamId)
         return Promise.all([
           acceptTeamInvitation(team, userId, dataLoader),
           isOrganic


### PR DESCRIPTION
Demo: https://www.loom.com/share/e0b1d96c4c5f4a10975fe02399845b90

This fixes a bug where you need to refresh the page to see the auto joined teams.

### To test (or trust my Loom)

- [ ] Add `autoJoin` to a team with the `updateAutoJoin` mutation
- [ ] Make sure the team has a founder or billing leader with a verified email
- [ ] Run the `addApprovedOrganizationDomains` mutation so that new emails with `parabol.co` require verification
- [ ] Create an account with email & password `igor+test@parabol.co`
- [ ] Open your emails, click verify, and see that your account has been created and you now have the autoJoin teams