### PR TITLE
chore: Apply no template limit feature flag to some new users

### DIFF
--- a/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
+++ b/packages/server/graphql/mutations/helpers/bootstrapNewUser.ts
@@ -49,6 +49,7 @@ const bootstrapNewUser = async (
 
   const experimentalFlags = [...featureFlags]
 
+  // Retros in disguise
   const domainUserHasRidFlag = usersWithDomain.some((user) =>
     user.featureFlags.includes('retrosInDisguise')
   )
@@ -62,6 +63,16 @@ const bootstrapNewUser = async (
   // Add signUpDestinationTeam feature flag to 50% of new accounts
   if (Math.random() < 0.5) {
     experimentalFlags.push('signUpDestinationTeam')
+  }
+
+  // No template limit
+  const domainUserHasNoTemplateLimitFlag = usersWithDomain.some((user) =>
+    user.featureFlags.includes('noTemplateLimit')
+  )
+  if (domainUserHasNoTemplateLimitFlag) {
+    experimentalFlags.push('noTemplateLimit')
+  } else if (Math.random() < 0.5) {
+    experimentalFlags.push('noTemplateLimit')
   }
 
   const isVerified = identities.some((identity) => identity.isEmailVerified)


### PR DESCRIPTION
# Description

Fixes #8971 
Apply the setting based on domain similar to `retrosInDisguise`. This way no additional database query is necessary.

## Demo

no demo

## Testing scenarios

- [ ] create a couple of users and see the flag applied to about half of new users
- [ ] alternatively run the server tests (`yarn workspace parabol-server test`) and see about half of new users have the flag

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
