### PR TITLE
feat: fix custom template border

### DIFF
--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -287,7 +287,7 @@ export const CreateNewActivity = (props: Props) => {
             return (
               <RadioGroup.Item
                 key={activity.title}
-                className='group flex cursor-pointer flex-col items-start space-y-3 rounded-lg bg-transparent p-1 focus:outline-none focus:ring-2 focus:ring-offset-8'
+                className='group flex cursor-pointer flex-col items-start space-y-3 rounded-lg bg-transparent p-1 focus:outline-none'
                 value={activity.type}
               >
                 <ActivityCard


### PR DESCRIPTION
I noticed there are two borders when you select a custom template, so I removed the outer one. See Loom demo: https://www.loom.com/share/a2246d909cc04b7b8c3e5177d85ad059

(I should have committed fix instead of feat).

### To test

- [ ] Create a custom template in the new activity library and see that there's only one border as the Loom demos