### PR TITLE
chore: update deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,8 @@
 
 - When a commit is pushed to a branch named `master` or `hotfix*`, our [release-please action](../.github/workflows/release-please.yml) creates a new PR that increments the version number and creates a changelog based on the commit messages.
 
+- The app is then docerized & the image is sent to our development artifact registry
+
 - The default commit message for that PR is `chore(release): release vX.Y.Z`
 
-- When the release-please PR gets merged, our [GitHub Build Action](../.github/workflows/build.yml) determines that it is a release, dockerizes the build and pushes it to our docker registry.
+- When the release-please PR gets merged, our [GitHub Release Action](../.github/workflows/release.yml) tags the pre-built image with the version number and moves it to our production repository


### PR DESCRIPTION
# Description

release.yml is not running, I assume because the release-please bot opened the PR so it can't trigger a GH workflow.
Testing it again with GH App credentials