### PR TITLE
chore: Users with noTemplateLimit flag can use paid templates

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/TemplateDetails.tsx
@@ -154,6 +154,7 @@ export const TemplateDetails = (props: Props) => {
         teams {
           ...TeamPickerModal_teams
         }
+        ...useTemplateDescription_viewer
       }
     `,
     viewerRef
@@ -217,7 +218,7 @@ export const TemplateDetails = (props: Props) => {
 
   const isOwner = viewerLowestScope === 'TEAM'
 
-  const description = useTemplateDescription(viewerLowestScope, activity, tier)
+  const description = useTemplateDescription(viewerLowestScope, activity, tier, viewer)
 
   useEffect(() => {
     setIsEditing(!!history.location.state?.edit)

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -72,6 +72,7 @@ const ActivityDetailsSidebar = (props: Props) => {
         featureFlags {
           gcal
           adHocTeams
+          noTemplateLimit
         }
         ...AdhocTeamMultiSelect_viewer
         organizations {
@@ -342,7 +343,9 @@ const ActivityDetailsSidebar = (props: Props) => {
             />
           )}
 
-          {selectedTeam.tier === 'starter' && !selectedTemplate.isFree ? (
+          {selectedTeam.tier === 'starter' &&
+          !viewer.featureFlags.noTemplateLimit &&
+          !selectedTemplate.isFree ? (
             <div className='flex grow flex-col'>
               <div className='my-auto text-center'>
                 Upgrade to the <b>Team Plan</b> to create custom activities unlocking your team’s

--- a/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
+++ b/packages/client/modules/meeting/components/ReflectTemplateDetails.tsx
@@ -95,6 +95,14 @@ const ReflectTemplateDetails = (props: Props) => {
           id
           orgId
           tier
+          viewerTeamMember {
+            user {
+              id
+              featureFlags {
+                noTemplateLimit
+              }
+            }
+          }
         }
       }
     `,
@@ -103,7 +111,8 @@ const ReflectTemplateDetails = (props: Props) => {
   const {teamTemplates, team} = settings
   const activeTemplate = settings.activeTemplate ?? settings.selectedTemplate
   const {id: templateId, name: templateName, prompts, illustrationUrl} = activeTemplate
-  const {id: teamId, orgId, tier} = team
+  const {id: teamId, orgId, tier, viewerTeamMember} = team
+  const noTemplateLimit = viewerTeamMember?.user?.featureFlags?.noTemplateLimit
   const lowestScope = getTemplateList(teamId, orgId, activeTemplate)
   const isOwner = activeTemplate.teamId === teamId
   const description = useTemplateDescription(lowestScope, activeTemplate, tier)
@@ -158,6 +167,7 @@ const ReflectTemplateDetails = (props: Props) => {
           template={activeTemplate}
           teamId={teamId}
           tier={tier}
+          noTemplateLimit={noTemplateLimit}
           orgId={orgId}
         />
       )}

--- a/packages/client/modules/meeting/components/SelectTemplate.tsx
+++ b/packages/client/modules/meeting/components/SelectTemplate.tsx
@@ -54,11 +54,12 @@ interface Props {
   template: SelectTemplate_template$key
   teamId: string
   tier?: TierEnum
+  noTemplateLimit?: boolean
   orgId?: string
 }
 
 const SelectTemplate = (props: Props) => {
-  const {template: templateRef, closePortal, teamId, tier, orgId} = props
+  const {template: templateRef, closePortal, teamId, tier, noTemplateLimit, orgId} = props
   const template = useFragment(
     graphql`
       fragment SelectTemplate_template on MeetingTemplate {
@@ -90,7 +91,7 @@ const SelectTemplate = (props: Props) => {
     })
     history.push(`/me/organizations/${orgId}`)
   }
-  const showUpgradeCTA = !isFree && tier === 'starter' && scope === 'PUBLIC'
+  const showUpgradeCTA = !isFree && tier === 'starter' && scope === 'PUBLIC' && !noTemplateLimit
   if (showUpgradeCTA) {
     return (
       <ButtonBlock>

--- a/packages/client/utils/useTemplateDescription.ts
+++ b/packages/client/utils/useTemplateDescription.ts
@@ -1,13 +1,15 @@
 import graphql from 'babel-plugin-relay/macro'
 import {readInlineData} from 'react-relay'
 import {useTemplateDescription_template$key} from '../__generated__/useTemplateDescription_template.graphql'
+import {useTemplateDescription_viewer$key} from '../__generated__/useTemplateDescription_viewer.graphql'
 import {TierEnum} from '../__generated__/NewMeetingQuery.graphql'
 import relativeDate from './date/relativeDate'
 
 const useTemplateDescription = (
   lowestScope: string,
   templateRef?: useTemplateDescription_template$key,
-  tier?: TierEnum
+  tier?: TierEnum,
+  viewerRef?: useTemplateDescription_viewer$key
 ) => {
   if (!templateRef) {
     return null
@@ -27,10 +29,26 @@ const useTemplateDescription = (
     templateRef
   )
 
+  const viewer = readInlineData(
+    graphql`
+      fragment useTemplateDescription_viewer on User @inline {
+        id
+        featureFlags {
+          noTemplateLimit
+        }
+      }
+    `,
+    viewerRef ?? null
+  )
+
   const {lastUsedAt, team, isFree} = template
   const {name: teamName} = team
   if (lowestScope === 'PUBLIC') {
-    return isFree ? 'Free template' : `Premium template ${tier === 'starter' ? '🔒' : '✨'}`
+    return isFree
+      ? 'Free template'
+      : `Premium template ${
+          tier === 'starter' && !viewer?.featureFlags?.noTemplateLimit ? '🔒' : '✨'
+        }`
   }
   if (lowestScope === 'TEAM')
     return lastUsedAt


### PR DESCRIPTION
# Description

Fixes #8972 

## Demo

https://www.loom.com/share/b9d8fd64a68b4babbcbf13f703052c7c?sid=67d8350a-8811-42b0-af95-e82c34f264e9

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- with the `noTemplateLimit` flag applied to your user and a `starter` org
- start a premium retro meeting from the activity library
- repeat with the legacy dialog
- mark a poker template non-free in the database
- start a meeting with a premium poker template from the activity library
- repeat with the legacy dialog

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
