### PR TITLE
fix: increases integration icon visibility

### DIFF
--- a/packages/client/components/IconLabel.tsx
+++ b/packages/client/components/IconLabel.tsx
@@ -17,7 +17,6 @@ import {
   MoreVert,
   OpenInNew,
   PersonPin,
-  Publish,
   RemoveCircle,
   Reply,
   Search,
@@ -25,7 +24,8 @@ import {
   TaskAlt,
   Tune,
   UnfoldMore,
-  WebAsset
+  WebAsset,
+  Widgets
 } from '@mui/icons-material'
 import React, {forwardRef, ReactNode} from 'react'
 
@@ -97,9 +97,9 @@ const IconLabel = forwardRef((props: Props, ref: any) => {
             arrow_forward: <ArrowForward />,
             archive: <Archive />,
             close: <Close />,
-            publish: <Publish />,
             tune: <Tune />,
-            task_alt: <TaskAlt />
+            task_alt: <TaskAlt />,
+            widgets: <Widgets />
           }[icon]
         }
       </StyledIcon>

--- a/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
@@ -21,6 +21,7 @@ import isTempId from '../../../../utils/relay/isTempId'
 import {taskStatusLabels} from '../../../../utils/taskStatus'
 import TaskFooter from '../OutcomeCardFooter/TaskFooter'
 import OutcomeCardStatusIndicator from '../OutcomeCardStatusIndicator/OutcomeCardStatusIndicator'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
 
 const RootCard = styled('div')<{
   isTaskHovered: boolean
@@ -89,6 +90,9 @@ const OutcomeCard = memo((props: Props) => {
     graphql`
       fragment OutcomeCard_task on Task @argumentDefinitions(meetingId: {type: "ID"}) {
         ...IntegratedTaskContent_task
+        editors {
+          userId
+        }
         id
         integration {
           __typename
@@ -110,7 +114,11 @@ const OutcomeCard = memo((props: Props) => {
   )
   const isPrivate = isTaskPrivate(task.tags)
   const isArchived = isTaskArchived(task.tags)
-  const {integration, status, id: taskId, team, isHighlighted} = task
+  const {integration, status, id: taskId, team, isHighlighted, editors} = task
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
+  const otherEditors = editors.filter((editor) => editor.userId !== viewerId)
+  const isEditing = editors.length > otherEditors.length
   const {addTaskChild, removeTaskChild} = useTaskChildFocus(taskId)
   const {id: teamId} = team
   const type = integration?.__typename
@@ -165,7 +173,7 @@ const OutcomeCard = memo((props: Props) => {
         <TaskFooter
           dataCy={`${dataCy}`}
           area={area}
-          cardIsActive={isTaskFocused || isTaskHovered}
+          cardIsActive={isTaskFocused || isTaskHovered || isEditing}
           editorState={editorState}
           isAgenda={isAgenda}
           task={task}

--- a/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
@@ -128,6 +128,7 @@ const OutcomeCard = memo((props: Props) => {
   const statusIndicatorTitle = `${statusTitle}${isPrivate ? privateTitle : ''}${
     isArchived ? archivedTitle : ''
   }`
+  // force commit
   return (
     <RootCard
       isTaskHovered={isTaskHovered}

--- a/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
@@ -128,7 +128,6 @@ const OutcomeCard = memo((props: Props) => {
   const statusIndicatorTitle = `${statusTitle}${isPrivate ? privateTitle : ''}${
     isArchived ? archivedTitle : ''
   }`
-  // force commit
   return (
     <RootCard
       isTaskHovered={isTaskHovered}

--- a/packages/client/modules/outcomeCard/components/OutcomeCardFooter/TaskFooterIntegrateToggle.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCardFooter/TaskFooterIntegrateToggle.tsx
@@ -45,7 +45,7 @@ const TaskFooterIntegrateToggle = (props: Props) => {
         dataCy={`${dataCy}-button`}
       >
         <IconLabel
-          icon='publish'
+          icon='widgets'
           onMouseEnter={openTooltip}
           onMouseLeave={closeTooltip}
           onClick={closeTooltip}


### PR DESCRIPTION
## Description

This is intended as a small UX improvement to increase visibility of the integration button on task cards.

## Demo

![2023-11-09 14 27 54](https://github.com/ParabolInc/parabol/assets/307286/8a57601f-be53-4a31-9b8a-90bfa4c6bd0a)

## Testing scenarios

- [ ] the task card footer actions show while editing (no need to hover)
- [ ] the task card integration button icon is updated to add weight and represent integration icons even over the push action