### PR TITLE
fix: replace saas url with calculated value for PPMIs

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/LogoFooter.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/LogoFooter.tsx
@@ -3,6 +3,7 @@ import {FONT_FAMILY} from 'parabol-client/styles/typographyV2'
 import React from 'react'
 import {ExternalLinks} from '../../../../../types/constEnums'
 import {CorsOptions} from '../../../../../types/cors'
+import makeAppURL from '../../../../../utils/makeAppURL'
 
 const logoStyle = {
   paddingTop: 64
@@ -29,12 +30,13 @@ const linkStyle = {
 }
 
 interface Props {
+  appOrigin: string
   corsOptions: CorsOptions
 }
 
 const LogoFooter = (props: Props) => {
-  const {corsOptions} = props
-
+  const {appOrigin, corsOptions} = props
+  const profileUrl = makeAppURL(appOrigin, `me/profile`)
   return (
     <>
       <tr>
@@ -55,7 +57,7 @@ const LogoFooter = (props: Props) => {
       <tr>
         <td align='center' style={linkWrapperStyle}>
           <a
-            href='https://action.parabol.co/me/profile'
+            href={profileUrl}
             style={linkStyle}
             rel='noopener noreferrer'
             target='_blank'

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -232,7 +232,7 @@ const SummarySheet = (props: Props) => {
           prompt={`How’d your meeting go?`}
           tagline='We’re eager for your feedback!'
         />
-        <LogoFooter corsOptions={corsOptions} />
+        <LogoFooter corsOptions={corsOptions} appOrigin={appOrigin} />
       </tbody>
     </table>
   )


### PR DESCRIPTION
# Description

Partially Fixes #8549

when possible, we don't want to use `action.parabol.co` in the codebase because PPMIs shouldn't go there, they should go to their own instance.
There are 2 exceptions:
- for PPMIs tell robots to `noindex` so they don't show up in search engines
- for PPMIs, point to action.parabol.co as canonical so we don't hurt our SEO
