### PR TITLE
fix: sort team names alphabetically

### DIFF
--- a/packages/server/graphql/types/Organization.ts
+++ b/packages/server/graphql/types/Organization.ts
@@ -78,17 +78,15 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
           dataLoader.get('teamsByOrgIds').load(orgId),
           dataLoader.get('organizations').load(orgId)
         ])
+        const sortedTeamsOnOrg = allTeamsOnOrg.sort((a, b) => a.name.localeCompare(b.name))
         const hasPublicTeamsFlag = !!organization.featureFlags?.includes('publicTeams')
         const isBillingLeader = await isUserBillingLeader(viewerId, orgId, dataLoader)
         if (isBillingLeader || isSuperUser(authToken) || hasPublicTeamsFlag) {
-          const viewerTeams = allTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
-          const otherTeams = allTeamsOnOrg.filter((team) => !authToken.tms.includes(team.id))
-          const sortedOtherTeams = otherTeams.sort((a, b) => a.name.localeCompare(b.name))
-          return [...viewerTeams, ...sortedOtherTeams]
+          const viewerTeams = sortedTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
+          const otherTeams = sortedTeamsOnOrg.filter((team) => !authToken.tms.includes(team.id))
+          return [...viewerTeams, ...otherTeams]
         } else {
-          return allTeamsOnOrg
-            .filter((team) => authToken.tms.includes(team.id))
-            .sort((a, b) => a.name.localeCompare(b.name))
+          return sortedTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
         }
       }
     },

--- a/packages/server/graphql/types/Organization.ts
+++ b/packages/server/graphql/types/Organization.ts
@@ -86,7 +86,9 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
           const sortedOtherTeams = otherTeams.sort((a, b) => a.name.localeCompare(b.name))
           return [...viewerTeams, ...sortedOtherTeams]
         } else {
-          return allTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
+          return allTeamsOnOrg
+            .filter((team) => authToken.tms.includes(team.id))
+            .sort((a, b) => a.name.localeCompare(b.name))
         }
       }
     },
@@ -95,7 +97,9 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
       description: 'all the teams the viewer is on in the organization',
       resolve: async ({id: orgId}, _args: unknown, {dataLoader, authToken}) => {
         const allTeamsOnOrg = await dataLoader.get('teamsByOrgIds').load(orgId)
-        return allTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
+        return allTeamsOnOrg
+          .filter((team) => authToken.tms.includes(team.id))
+          .sort((a, b) => a.name.localeCompare(b.name))
       }
     },
     tier: {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9136

### To test

- [ ] Go to sidebar and see that your teams are now sorted in alphabetical order