### PR TITLE
fix(demo): Don't show top bar or sidebar on demo summary

### DIFF
--- a/packages/client/modules/summary/components/NewMeetingSummary.tsx
+++ b/packages/client/modules/summary/components/NewMeetingSummary.tsx
@@ -67,13 +67,17 @@ const NewMeetingSummary = (props: Props) => {
 
   return (
     <>
-      <div className='hidden print:hidden lg:block'>
-        <DashTopBar queryRef={data} toggle={toggle} />
-      </div>
-      <div className='flex min-h-screen bg-slate-200'>
+      {!isDemoRoute() && (
         <div className='hidden print:hidden lg:block'>
-          <DashSidebar viewerRef={viewer} isOpen={isOpen} />
+          <DashTopBar queryRef={data} toggle={toggle} />
         </div>
+      )}
+      <div className='flex min-h-screen bg-slate-200'>
+        {!isDemoRoute() && (
+          <div className='hidden print:hidden lg:block'>
+            <DashSidebar viewerRef={viewer} isOpen={isOpen} />
+          </div>
+        )}
         <div className='w-full'>
           <MeetingSummaryEmail
             appOrigin={window.location.origin}


### PR DESCRIPTION
# Description

Fixes https://parabol.slack.com/archives/C836NA350/p1698080641122759

When we moved meeting summaries to be inside the dashboard sidebar+topbar, demo summaries were included as well. This means users on the demo summary could do things like click the "Add Meeting" button that's supposed to only be accessible for logged-in users.

I tried to restrict the sidebar+topbar to only logged-in users, but because the `DemoSummary` uses the stubbed local demo atmosphere, we can't easily render these components, even for logged-in users.

Instead, simply don't render the sidebar+topbar for demo summaries.

## Demo
N/A

## Testing scenarios
- [ ] Smoke test demo summary
- [ ] Smoke test real summary

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
