### PR TITLE
feat(admin): Base Org Admin role

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -25,6 +25,7 @@ import lazyPreload from '../../../../utils/lazyPreload'
 import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
 import {OrgMemberRow_organization$key} from '../../../../__generated__/OrgMemberRow_organization.graphql'
 import {OrgMemberRow_organizationUser$key} from '../../../../__generated__/OrgMemberRow_organizationUser.graphql'
+import BaseTag from '../../../../components/Tag/BaseTag'
 
 const AvatarBlock = styled('div')({
   display: 'none',
@@ -132,6 +133,7 @@ const OrgMemberRow = (props: Props) => {
   const {orgId, isViewerBillingLeader} = organization
   const {newUserUntil, user, role} = organizationUser
   const isBillingLeader = role === 'BILLING_LEADER'
+  const isOrgAdmin = role === 'ORG_ADMIN'
   const {email, inactive, picture, preferredName, userId} = user
   const isViewerLastBillingLeader =
     isViewerBillingLeader && isBillingLeader && billingLeaderCount === 1
@@ -159,7 +161,8 @@ const OrgMemberRow = (props: Props) => {
         <RowInfoHeader>
           <RowInfoHeading>{preferredName}</RowInfoHeading>
           {isBillingLeader && <RoleTag>{'Billing Leader'}</RoleTag>}
-          {inactive && !isBillingLeader && <InactiveTag>{'Inactive'}</InactiveTag>}
+          {isOrgAdmin && <BaseTag className='bg-gold-500 text-white'>{'Org Admin'}</BaseTag>}
+          {inactive && !isBillingLeader && !isOrgAdmin && <InactiveTag>{'Inactive'}</InactiveTag>}
           {new Date(newUserUntil) > new Date() && <EmphasisTag>{'New'}</EmphasisTag>}
         </RowInfoHeader>
         <RowInfoLink href={`mailto:${email}`} title='Send an email'>
@@ -168,7 +171,7 @@ const OrgMemberRow = (props: Props) => {
       </StyledRowInfo>
       <RowActions>
         <ActionsBlock>
-          {!isBillingLeader && viewerId === userId && (
+          {!isBillingLeader && !isOrgAdmin && viewerId === userId && (
             <StyledFlatButton onClick={toggleLeave} onMouseEnter={LeaveOrgModal.preload}>
               Leave Organization
             </StyledFlatButton>

--- a/packages/server/database/types/OrganizationUser.ts
+++ b/packages/server/database/types/OrganizationUser.ts
@@ -1,7 +1,7 @@
 import generateUID from '../../generateUID'
 import {TierEnum} from './Invoice'
 
-export type OrgUserRole = 'BILLING_LEADER'
+export type OrgUserRole = 'BILLING_LEADER' | 'ORG_ADMIN'
 interface Input {
   orgId: string
   userId: string

--- a/packages/server/graphql/types/OrgUserRole.ts
+++ b/packages/server/graphql/types/OrgUserRole.ts
@@ -5,7 +5,8 @@ const OrgUserRole = new GraphQLEnumType({
   description: 'The role of the org user',
   values: {
     // graphql only supports enum values at runtime, the value here is the text value
-    BILLING_LEADER: {}
+    BILLING_LEADER: {},
+    ORG_ADMIN: {}
   }
 })
 


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/9181

Add the base `ORG_ADMIN` org role, and who which user(s) are an admin in the members list.

Doesn't do anything around permissions (see https://github.com/ParabolInc/parabol/issues/9183)

## Demo

<img width="1053" alt="Screen Shot 2023-11-14 at 4 30 51 PM" src="https://github.com/ParabolInc/parabol/assets/9013217/e4699659-f414-49d8-b9dd-da241315dc2f">

## Testing scenarios
Give an `OrganizationUser` the `ORG_ADMIN` role via rethink query:
```
r.db('actionDevelopment').table('OrganizationUser')
  .get('<org user id>')
  .update({role: 'ORG_ADMIN'})
```
Confirm the user is shown as an Org Admin in the UI.

## Final checklist

- [X] I checked the [code review guidelines](../docs/codeReview.md)
- [X] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [X] I have performed a self-review of my code, the same way I'd do it for any other team member
- [X] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [X] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [X] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [X] PR title is human readable and could be used in changelog
