### PR TITLE
fix: author should be nullable when comment was anonymous

### DIFF
--- a/packages/client/components/DiscussionMentioned.tsx
+++ b/packages/client/components/DiscussionMentioned.tsx
@@ -10,6 +10,7 @@ import {cardShadow} from '../styles/elevation'
 import fromStageIdToUrl from '../utils/meetings/fromStageIdToUrl'
 import {DiscussionMentioned_notification$key} from '../__generated__/DiscussionMentioned_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
+import anonymousAvatar from '../styles/theme/images/anonymous-avatar.svg'
 
 const EditorWrapper = styled('div')({
   backgroundColor: '#fff',
@@ -60,7 +61,8 @@ const DiscussionMentioned = (props: Props) => {
   )
   const {history} = useRouter()
   const {meeting, author, comment, discussion} = notification
-  const {picture: authorPicture, preferredName: authorName} = author
+  const authorPicture = author ? author.picture : anonymousAvatar
+  const authorName = author ? author.preferredName : 'Anonymous'
   const {stage} = discussion
   const {id: stageId, response} = stage ?? {}
   const {id: meetingId, name: meetingName} = meeting

--- a/packages/client/components/ResponseReplied.tsx
+++ b/packages/client/components/ResponseReplied.tsx
@@ -9,6 +9,7 @@ import useRouter from '../hooks/useRouter'
 import {cardShadow} from '../styles/elevation'
 import {ResponseReplied_notification$key} from '../__generated__/ResponseReplied_notification.graphql'
 import NotificationTemplate from './NotificationTemplate'
+import anonymousAvatar from '../styles/theme/images/anonymous-avatar.svg'
 
 const EditorWrapper = styled('div')({
   backgroundColor: '#fff',
@@ -50,7 +51,8 @@ const ResponseReplied = (props: Props) => {
   )
   const {history} = useRouter()
   const {meeting, author, comment, response} = notification
-  const {picture: authorPicture, preferredName: authorName} = author
+  const authorPicture = author ? author.picture : anonymousAvatar
+  const authorName = author ? author.preferredName : 'Anonymous'
 
   const {id: meetingId, name: meetingName} = meeting
   const goThere = () => {

--- a/packages/client/modules/email/components/EmailNotifications/EmailDiscussionMentioned.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailDiscussionMentioned.tsx
@@ -11,7 +11,7 @@ import makeAppURL from '../../../../utils/makeAppURL'
 import fromStageIdToUrl from '../../../../utils/meetings/fromStageIdToUrl'
 import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
 import EmailNotificationTemplate from './EmailNotificationTemplate'
-import anonymousAvatar from '../../styles/theme/images/anonymous-avatar.svg'
+import anonymousAvatar from '../../../../styles/theme/images/anonymous-avatar.svg'
 
 const editorStyles: React.CSSProperties = {
   backgroundColor: '#FFFFFF',

--- a/packages/client/modules/email/components/EmailNotifications/EmailDiscussionMentioned.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailDiscussionMentioned.tsx
@@ -11,6 +11,7 @@ import makeAppURL from '../../../../utils/makeAppURL'
 import fromStageIdToUrl from '../../../../utils/meetings/fromStageIdToUrl'
 import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
 import EmailNotificationTemplate from './EmailNotificationTemplate'
+import anonymousAvatar from '../../styles/theme/images/anonymous-avatar.svg'
 
 const editorStyles: React.CSSProperties = {
   backgroundColor: '#FFFFFF',
@@ -66,7 +67,9 @@ const EmailDiscussionMentioned = (props: Props) => {
     notificationRef
   )
   const {meeting, author, comment, discussion} = notification
-  const {rasterPicture: authorPicture, preferredName: authorName} = author
+  const authorPicture = author ? author.rasterPicture : anonymousAvatar
+  const authorName = author ? author.preferredName : 'Anonymous'
+
   const {stage} = discussion
   const {id: meetingId, name: meetingName} = meeting
   const {id: stageId, response} = stage ?? {}

--- a/packages/client/modules/email/components/EmailNotifications/EmailResponseReplied.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailResponseReplied.tsx
@@ -10,7 +10,7 @@ import {FONT_FAMILY} from '../../../../styles/typographyV2'
 import makeAppURL from '../../../../utils/makeAppURL'
 import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
 import EmailNotificationTemplate from './EmailNotificationTemplate'
-import anonymousAvatar from '../../styles/theme/images/anonymous-avatar.svg'
+import anonymousAvatar from '../../../../styles/theme/images/anonymous-avatar.svg'
 
 const editorStyles = {
   backgroundColor: '#FFFFFF',

--- a/packages/client/modules/email/components/EmailNotifications/EmailResponseReplied.tsx
+++ b/packages/client/modules/email/components/EmailNotifications/EmailResponseReplied.tsx
@@ -10,6 +10,7 @@ import {FONT_FAMILY} from '../../../../styles/typographyV2'
 import makeAppURL from '../../../../utils/makeAppURL'
 import {notificationSummaryUrlParams} from '../NotificationSummaryEmail'
 import EmailNotificationTemplate from './EmailNotificationTemplate'
+import anonymousAvatar from '../../styles/theme/images/anonymous-avatar.svg'
 
 const editorStyles = {
   backgroundColor: '#FFFFFF',
@@ -56,7 +57,8 @@ const EmailResponseReplied = (props: Props) => {
     notificationRef
   )
   const {meeting, author, comment, response} = notification
-  const {rasterPicture: authorPicture, preferredName: authorName} = author
+  const authorPicture = author ? author.rasterPicture : anonymousAvatar
+  const authorName = author ? author.preferredName : 'Anonymous'
 
   const {id: meetingId, name: meetingName} = meeting
 

--- a/packages/client/mutations/toasts/mapDiscussionMentionedToToast.ts
+++ b/packages/client/mutations/toasts/mapDiscussionMentionedToToast.ts
@@ -46,7 +46,7 @@ const mapDiscussionMentionedToToast = (
 ): Snack | null => {
   if (!notification) return null
   const {id: notificationId, meeting, author, discussion} = notification
-  const {preferredName: authorName} = author
+  const authorName = author ? author.preferredName : 'Anonymous'
   const {id: meetingId, name: meetingName} = meeting
   const {stage} = discussion
   const {id: stageId, response} = stage ?? {}

--- a/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
+++ b/packages/client/mutations/toasts/mapResponseRepliedToToast.ts
@@ -27,7 +27,7 @@ const mapResponseRepliedToToast = (
 ): Snack | null => {
   if (!notification) return null
   const {id: notificationId, meeting, author, response} = notification
-  const {preferredName: authorName} = author
+  const authorName = author ? author.preferredName : 'Anonymous'
   const {id: meetingId, name: meetingName} = meeting
 
   // :TODO: (jmtaber129): Check if we're already open to the relevant standup response discussion

--- a/packages/server/graphql/public/typeDefs/NotifyDiscussionMentioned.graphql
+++ b/packages/server/graphql/public/typeDefs/NotifyDiscussionMentioned.graphql
@@ -21,14 +21,14 @@ type NotifyDiscussionMentioned implements Notification {
   userId: ID!
 
   """
-  The id of the user that replied to the response
+  The id of the user that replied to the response, null if anonymous
   """
-  authorId: ID!
+  authorId: ID
 
   """
-  The user that replied to the response
+  The user that replied to the response, null if anonymous
   """
-  author: User!
+  author: User
 
   """
   The id of the meeting the response was replied to in.

--- a/packages/server/graphql/public/typeDefs/NotifyResponseReplied.graphql
+++ b/packages/server/graphql/public/typeDefs/NotifyResponseReplied.graphql
@@ -21,14 +21,14 @@ type NotifyResponseReplied implements Notification {
   userId: ID!
 
   """
-  The id of the user that replied to the response
+  The id of the user that replied to the response, null if anonymous
   """
-  authorId: ID!
+  authorId: ID
 
   """
-  The user that replied to the response
+  The user that replied to the response, null if anonymous
   """
-  author: User!
+  author: User
 
   """
   The id of the meeting the response was replied to in.

--- a/packages/server/graphql/public/types/NotifyDiscussionMentioned.ts
+++ b/packages/server/graphql/public/types/NotifyDiscussionMentioned.ts
@@ -7,7 +7,10 @@ const NotifyDiscussionMentioned: NotifyDiscussionMentionedResolvers = {
     const meeting = await dataLoader.get('newMeetings').load(meetingId)
     return meeting as MeetingTeamPrompt
   },
-  author: ({authorId}, _args: unknown, {dataLoader}) => {
+  author: async ({authorId, commentId}, _args: unknown, {dataLoader}) => {
+    const comment = await dataLoader.get('comments').load(commentId)
+    if (comment.isAnonymous) return null
+
     return dataLoader.get('users').loadNonNull(authorId)
   },
   comment: ({commentId}, _args: unknown, {dataLoader}) => {

--- a/packages/server/graphql/public/types/NotifyResponseReplied.ts
+++ b/packages/server/graphql/public/types/NotifyResponseReplied.ts
@@ -13,7 +13,10 @@ const NotifyResponseReplied: NotifyResponseRepliedResolvers = {
     const responses = await getTeamPromptResponsesByMeetingId(meetingId)
     return responses.find(({userId: responseUserId}) => responseUserId === userId)!
   },
-  author: ({authorId}, _args: unknown, {dataLoader}) => {
+  author: async ({authorId, commentId}, _args: unknown, {dataLoader}) => {
+    const comment = await dataLoader.get('comments').load(commentId)
+    if (comment.isAnonymous) return null
+
     return dataLoader.get('users').loadNonNull(authorId)
   },
   comment: ({commentId}, _args: unknown, {dataLoader}) => {


### PR DESCRIPTION
# Description

Fixes #9197 

Main issue was that we didn't check if comment was anonymous in related gql resolvers. keep in mind svg avatars in emails won't work, they _should_ work on prod, see [thread 🔒 ](https://parabol.slack.com/archives/C608QL4RH/p1701167748897159).

## Demo

<img width="2079" alt="Screenshot 2023-11-28 at 17 28 08" src="https://github.com/ParabolInc/parabol/assets/1017620/dfabbf69-0ef1-41d6-9283-3c98803b7e1c">

## Testing scenarios

- [ ] mention someone in discussion thread as anonymous and see if mentioned user see correctly notification about anonymous mention
- [ ] respond as anonymous to someone else standup response and check the notification
- [ ] do the same but for emails

## Final checklist


- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
