### PR TITLE
chore(dx): allow any branch with hotfix prefix to build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@ on:
   push:
     branches:
       - master
-      - hotfix-*
+      - hotfix*
 name: release-please
 jobs:
   release-please:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - hotfix-*
+      - hotfix*
     types: [closed]
 jobs:
   release:


### PR DESCRIPTION
# Description

I named my hotfix branch `hotfix/` instead of `hotfix-` and thought the whole release process was broken because the build didn't happen.

As long as the branch starts with `hotfix`, it should create a release, no matter the delimiter.