### PR TITLE
chore: Restrict prompt to join org to a smaller set of orgs

### DIFF
--- a/packages/server/utils/isRequestToJoinDomainAllowed.ts
+++ b/packages/server/utils/isRequestToJoinDomainAllowed.ts
@@ -5,6 +5,7 @@ import User from '../database/types/User'
 import {DataLoaderWorker} from '../graphql/graphql'
 import isValid from '../graphql/isValid'
 import TeamMember from '../database/types/TeamMember'
+import Organization from '../database/types/Organization'
 
 export const getEligibleOrgIdsByDomain = async (
   activeDomain: string,
@@ -39,7 +40,8 @@ export const getEligibleOrgIdsByDomain = async (
     )
     .run()
 
-  const eligibleOrgs = await Promise.all(
+  type OrgWithActiveMembers = Organization & {activeMembers: number}
+  const eligibleOrgs = (await Promise.all(
     orgs.map(async (org) => {
       const {founder} = org
       const importantMembers = org.billingLeads.slice() as TeamMember[]
@@ -57,8 +59,33 @@ export const getEligibleOrgIdsByDomain = async (
       }
       return org
     })
+  )) as OrgWithActiveMembers[]
+
+  const highestTierOrgs = eligibleOrgs.filter(isValid).reduce((acc, org) => {
+    if (acc.length === 0) {
+      return [org]
+    }
+    const highestTier = acc[0]!.tier
+    if (org.tier === highestTier) {
+      return [...acc, org]
+    }
+    if (org.tier === 'enterprise') {
+      return [org]
+    }
+    if (highestTier === 'starter' && org.tier === 'team') {
+      return [org]
+    }
+    return acc
+  }, [] as OrgWithActiveMembers[])
+
+  const biggestSize = highestTierOrgs.reduce(
+    (acc, org) => (org.activeMembers > acc ? org.activeMembers : acc),
+    0
   )
-  return eligibleOrgs.filter(isValid).map(({id}) => id)
+
+  return highestTierOrgs
+    .filter(({activeMembers}) => activeMembers === biggestSize)
+    .map(({id}) => id)
 }
 
 const isRequestToJoinDomainAllowed = async (


### PR DESCRIPTION
Prefer higher tiers and bigger over smaller orgs.

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
