### PR TITLE
chore: Check SERVER_ID in generateUID

### DIFF
--- a/packages/server/generateUID.ts
+++ b/packages/server/generateUID.ts
@@ -10,6 +10,10 @@ const MID_OFFSET = BigInt(SEQ_BIT_LEN)
 const BIG_ZERO = BigInt(0)
 const MAX_SEQ = 2 ** SEQ_BIT_LEN - 1
 
+if (MID < 0 || MID > 2 ** MACHINE_ID_BIT_LEN - 1) {
+  throw new Error('SERVER_ID must be between 0 and 1023')
+}
+
 let seq = 0
 let lastTime = Date.now()
 const generateUID = () => {


### PR DESCRIPTION
If the server id is out of range, we potentially generate duplicate ids, so it's better to throw immediately.

## Testing scenarios

- set the `SERVER_ID` environment variable in range and see it working
- set the variable out of range and see it throwing

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
