### PR TITLE
fix: activity library colour imports

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -129,7 +129,7 @@ export const ActivityCard = (props: ActivityCardProps) => {
       {title && category && (
         <div className='mt-2 px-2 pb-2'>
           <div className='truncate pb-1 text-lg leading-5 text-slate-800'>{title}</div>
-          <div className={clsx('font-semibold italic', `text-${theme.primary}`)}>
+          <div className={clsx('font-semibold italic', `${theme.text}`)}>
             {upperFirst(category)}
           </div>
         </div>

--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -101,7 +101,7 @@ export const ActivityCard = (props: ActivityCardProps) => {
       <div
         className={twMerge(
           'relative flex h-full min-w-0 flex-col overflow-hidden rounded-lg',
-          `bg-${theme.secondary}`,
+          theme.secondary,
           className
         )}
       >

--- a/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetailsCategoryBadge.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetailsCategoryBadge.tsx
@@ -39,7 +39,7 @@ const ActivityDetailsCategoryBadge = (props: Props) => {
       <DropdownMenu.Trigger asChild disabled={!isEditing}>
         <PlainButton className={clsx(!isEditing && 'cursor-default', 'flex')} disabled={false}>
           <ActivityDetailsBadge
-            className={clsx(`bg-${CATEGORY_THEMES[category].primary}`, 'select-none text-white')}
+            className={clsx(`${CATEGORY_THEMES[category].primary}`, 'select-none text-white')}
           >
             {CATEGORY_ID_TO_NAME[category]}
           </ActivityDetailsBadge>
@@ -60,7 +60,7 @@ const ActivityDetailsCategoryBadge = (props: Props) => {
                 >
                   <span
                     className={clsx(
-                      `bg-${CATEGORY_THEMES[categoryId].primary}`,
+                      `${CATEGORY_THEMES[categoryId].primary}`,
                       'h-5 w-5 rounded-full'
                     )}
                   ></span>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -125,7 +125,7 @@ const getTemplateDocumentValue = (
     .join('-')
 
 const CategoryIDToColorClass = {
-  [QUICK_START_CATEGORY_ID]: 'grape-700',
+  [QUICK_START_CATEGORY_ID]: 'bg-grape-700',
   ...Object.fromEntries(
     Object.entries(CATEGORY_THEMES).map(([key, value]) => {
       return [key, value.primary]
@@ -336,7 +336,7 @@ export const ActivityLibrary = (props: Props) => {
                     'flex-shrink-0 cursor-pointer rounded-full py-2 px-4 text-sm text-slate-800',
                     category === selectedCategory && searchQuery.length === 0
                       ? [
-                          `bg-${CategoryIDToColorClass[category]}`,
+                          `${CategoryIDToColorClass[category]}`,
                           'font-semibold text-white focus:text-white'
                         ]
                       : 'border border-slate-300 bg-white'

--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -295,7 +295,7 @@ export const CreateNewActivity = (props: Props) => {
                   {activity.includedCategories.map((badge) => (
                     <ActivityBadge
                       key={badge}
-                      className={clsx('text-white', `bg-${CATEGORY_THEMES[badge].primary}`)}
+                      className={clsx('text-white', `${CATEGORY_THEMES[badge].primary}`)}
                     >
                       {CATEGORY_ID_TO_NAME[badge]}
                     </ActivityBadge>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9276

Perhaps there was a merge conflict that went wrong as the text colours and the background colours weren't imported correctly from `CATEGORY_THEMES`.

On master, the meeting type tabs don't have the correct background colours. This is now fixed and looks like this:
![Screenshot 2023-12-06 at 18 03 11](https://github.com/ParabolInc/parabol/assets/39854876/d6f5fc1f-28aa-419f-953c-8a69a220e8e9)

### AC

- [ ] Category titles have the colours outlined in the linked issue
- [ ] Meeting type tabs have the expected background colours