### PR TITLE
chore: webpack client and server in parallel

### DIFF
--- a/scripts/prod.js
+++ b/scripts/prod.js
@@ -1,33 +1,26 @@
-const webpack = require('webpack')
 const generateGraphQLArtifacts = require('./generateGraphQLArtifacts')
 const cp = require('child_process')
+
+const runChild = (cmd) => {
+  return new Promise((resolve) => {
+    const build = cp.exec(cmd).on('exit', resolve)
+    build.stderr.pipe(process.stderr)
+  })
+}
 
 const prod = async (isDeploy, noDeps) => {
   console.log('🙏🙏🙏      Building Production Server      🙏🙏🙏')
   await generateGraphQLArtifacts()
-  const buildServers = new Promise((resolve) => {
-    const serverBuild = cp
-      .exec(
-        `yarn webpack --config ./scripts/webpack/prod.servers.config.js --no-stats --env=noDeps=${noDeps}`
-      )
-      .on('exit', () => {
-        resolve()
-      })
-    serverBuild.stderr.pipe(process.stderr)
-  })
-  const buildClient = new Promise((resolve) => {
-    const clientBuild = cp
-      .exec(
-        `yarn webpack --config ./scripts/webpack/prod.client.config.js --no-stats --env=isDeploy=${
-          isDeploy || noDeps
-        }`
-      )
-      .on('exit', () => {
-        resolve()
-      })
-    clientBuild.stderr.pipe(process.stderr)
-  })
-  await Promise.all([buildServers, buildClient])
+  await Promise.all([
+    runChild(
+      `yarn webpack --config ./scripts/webpack/prod.servers.config.js --no-stats --env=noDeps=${noDeps}`
+    ),
+    runChild(
+      `yarn webpack --config ./scripts/webpack/prod.client.config.js --no-stats --env=isDeploy=${
+        isDeploy || noDeps
+      }`
+    )
+  ])
 }
 
 if (require.main === module) {

--- a/scripts/webpack/prod.client.config.js
+++ b/scripts/webpack/prod.client.config.js
@@ -33,185 +33,189 @@ const babelPresets = [
   ]
 ]
 
-module.exports = ({isDeploy, isStats}) => ({
-  stats: {
-    assets: false
-  },
-  devtool: 'source-map',
-  mode: 'production',
-  entry: {
-    app: [path.join(CLIENT_ROOT, 'polyfills.ts'), path.join(CLIENT_ROOT, 'client.tsx')]
-  },
-  output: {
-    path: buildPath,
-    publicPath: 'auto',
-    filename: '[name]_[contenthash].js',
-    chunkFilename: '[name]_[contenthash].js',
-    crossOriginLoading: 'anonymous'
-  },
-  resolve: {
-    alias: {
-      '~': CLIENT_ROOT,
-      'parabol-client': CLIENT_ROOT,
-      static: STATIC_ROOT
+module.exports = (config) => {
+  const isDeploy = config.isDeploy === 'true'
+  const isStats = config.isStats === 'true'
+  return {
+    stats: {
+      assets: false
     },
-    extensions: ['.js', '.json', '.ts', '.tsx', '.graphql'],
-    fallback: {
-      assert: path.join(PROJECT_ROOT, 'scripts/webpack/assert.js'),
-      os: false
+    devtool: 'source-map',
+    mode: 'production',
+    entry: {
+      app: [path.join(CLIENT_ROOT, 'polyfills.ts'), path.join(CLIENT_ROOT, 'client.tsx')]
     },
-    modules: [path.resolve(CLIENT_ROOT, '../node_modules'), 'node_modules']
-  },
-  resolveLoader: {
-    modules: [path.resolve(CLIENT_ROOT, '../node_modules'), 'node_modules']
-  },
-  optimization: {
-    minimize: Boolean(isDeploy || isStats),
-    minimizer: [
-      new TerserPlugin({
-        parallel: isDeploy ? 2 : true,
-        terserOptions: {
-          output: {
-            comments: false,
-            ecma: 6
-          },
-          compress: {
-            ecma: 6
+    output: {
+      path: buildPath,
+      publicPath: 'auto',
+      filename: '[name]_[contenthash].js',
+      chunkFilename: '[name]_[contenthash].js',
+      crossOriginLoading: 'anonymous'
+    },
+    resolve: {
+      alias: {
+        '~': CLIENT_ROOT,
+        'parabol-client': CLIENT_ROOT,
+        static: STATIC_ROOT
+      },
+      extensions: ['.js', '.json', '.ts', '.tsx', '.graphql'],
+      fallback: {
+        assert: path.join(PROJECT_ROOT, 'scripts/webpack/assert.js'),
+        os: false
+      },
+      modules: [path.resolve(CLIENT_ROOT, '../node_modules'), 'node_modules']
+    },
+    resolveLoader: {
+      modules: [path.resolve(CLIENT_ROOT, '../node_modules'), 'node_modules']
+    },
+    optimization: {
+      minimize: Boolean(isDeploy || isStats),
+      minimizer: [
+        new TerserPlugin({
+          parallel: isDeploy ? 2 : true,
+          terserOptions: {
+            output: {
+              comments: false,
+              ecma: 6
+            },
+            compress: {
+              ecma: 6
+            }
+            // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
           }
-          // https://github.com/webpack-contrib/terser-webpack-plugin#terseroptions
+        })
+      ]
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        // persist across builds, only emit 1 file per entry
+        filename: '[contenthash].css'
+      }),
+      new CopyPlugin({
+        patterns: [
+          {
+            from: path.join(PROJECT_ROOT, 'static/favicon.ico')
+          }
+        ]
+      }),
+      new HtmlWebpackPlugin({
+        inject: false,
+        filename: 'skeleton.html',
+        template: path.join(PROJECT_ROOT, 'template.html'),
+        title: 'Free Online Retrospectives | Parabol',
+        // we'll overwrite this in preDeploy since it depends on process.env.{HOST,CDN_BASE_URL}
+        publicPath: '__PUBLIC_PATH__'
+      }),
+      new CleanWebpackPlugin(),
+      new webpack.DefinePlugin({
+        __CLIENT__: true,
+        __PRODUCTION__: true,
+        __APP_VERSION__: JSON.stringify(process.env.npm_package_version)
+        // Environment variables go in applyEnvVarsToClientAssets.ts, not here
+        // This build may be deployed to many different environments
+      }),
+      new InjectManifest({
+        swSrc: path.join(PROJECT_ROOT, 'packages/client/serviceWorker/sw.ts'),
+        swDest: 'swSkeleton.js',
+        exclude: [/GraphqlContainer/, /\.map$/, /^manifest.*\.js$/, /index.html$/],
+        modifyURLPrefix: {
+          '': '__PUBLIC_PATH__/'
         }
-      })
-    ]
-  },
-  plugins: [
-    new MiniCssExtractPlugin({
-      // persist across builds, only emit 1 file per entry
-      filename: '[contenthash].css'
-    }),
-    new CopyPlugin({
-      patterns: [
+      }),
+      isStats && new BundleAnalyzerPlugin({generateStatsFile: true})
+    ].filter(Boolean),
+    module: {
+      rules: [
         {
-          from: path.join(PROJECT_ROOT, 'static/favicon.ico')
+          test: /\.tsx?$/,
+          // things that need the relay plugin
+          include: [path.join(CLIENT_ROOT)],
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                cacheDirectory: true,
+                babelrc: false,
+                presets: babelPresets,
+                plugins: [
+                  [
+                    'macros',
+                    {
+                      relay: {
+                        artifactDirectory: path.join(CLIENT_ROOT, '__generated__')
+                      }
+                    }
+                  ]
+                ]
+              }
+            },
+            {
+              loader: '@sucrase/webpack-loader',
+              options: {
+                production: true,
+                transforms: ['jsx', 'typescript']
+              }
+            }
+          ]
+        },
+        {
+          test: /\.js$/,
+          include: [path.join(CLIENT_ROOT)],
+          use: [
+            {
+              loader: 'babel-loader',
+              options: {
+                cacheDirectory: true,
+                babelrc: false,
+                presets: babelPresets,
+                plugins: [
+                  [
+                    'macros',
+                    {
+                      relay: {
+                        artifactDirectory: path.join(CLIENT_ROOT, '__generated__')
+                      }
+                    }
+                  ]
+                ]
+              }
+            },
+            {
+              loader: '@sucrase/webpack-loader',
+              options: {
+                production: true,
+                transforms: ['jsx']
+              }
+            }
+          ]
+        },
+        {test: /\.flow$/, loader: 'ignore-loader'},
+        {
+          test: /\.css$/,
+          use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader']
+        },
+        {
+          test: /\.(png|jpg|jpeg|gif|svg)$/,
+          use: [
+            {
+              loader: 'url-loader',
+              options: {
+                limit: 4096
+              }
+            }
+          ]
+        },
+        // for graphiql, since graphql uses mjs files to run in the server
+        {
+          test: /\.mjs$/,
+          include: /node_modules/,
+          type: 'javascript/auto'
+        },
+        {
+          test: /\.(eot|ttf|wav|mp3|woff|woff2|otf)$/,
+          use: ['file-loader']
         }
       ]
-    }),
-    new HtmlWebpackPlugin({
-      inject: false,
-      filename: 'skeleton.html',
-      template: path.join(PROJECT_ROOT, 'template.html'),
-      title: 'Free Online Retrospectives | Parabol',
-      // we'll overwrite this in preDeploy since it depends on process.env.{HOST,CDN_BASE_URL}
-      publicPath: '__PUBLIC_PATH__'
-    }),
-    new CleanWebpackPlugin(),
-    new webpack.DefinePlugin({
-      __CLIENT__: true,
-      __PRODUCTION__: true,
-      __APP_VERSION__: JSON.stringify(process.env.npm_package_version)
-      // Environment variables go in applyEnvVarsToClientAssets.ts, not here
-      // This build may be deployed to many different environments
-    }),
-    new InjectManifest({
-      swSrc: path.join(PROJECT_ROOT, 'packages/client/serviceWorker/sw.ts'),
-      swDest: 'swSkeleton.js',
-      exclude: [/GraphqlContainer/, /\.map$/, /^manifest.*\.js$/, /index.html$/],
-      modifyURLPrefix: {
-        '': '__PUBLIC_PATH__/'
-      }
-    }),
-    isStats && new BundleAnalyzerPlugin({generateStatsFile: true})
-  ].filter(Boolean),
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        // things that need the relay plugin
-        include: [path.join(CLIENT_ROOT)],
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
-              babelrc: false,
-              presets: babelPresets,
-              plugins: [
-                [
-                  'macros',
-                  {
-                    relay: {
-                      artifactDirectory: path.join(CLIENT_ROOT, '__generated__')
-                    }
-                  }
-                ]
-              ]
-            }
-          },
-          {
-            loader: '@sucrase/webpack-loader',
-            options: {
-              production: true,
-              transforms: ['jsx', 'typescript']
-            }
-          }
-        ]
-      },
-      {
-        test: /\.js$/,
-        include: [path.join(CLIENT_ROOT)],
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
-              babelrc: false,
-              presets: babelPresets,
-              plugins: [
-                [
-                  'macros',
-                  {
-                    relay: {
-                      artifactDirectory: path.join(CLIENT_ROOT, '__generated__')
-                    }
-                  }
-                ]
-              ]
-            }
-          },
-          {
-            loader: '@sucrase/webpack-loader',
-            options: {
-              production: true,
-              transforms: ['jsx']
-            }
-          }
-        ]
-      },
-      {test: /\.flow$/, loader: 'ignore-loader'},
-      {
-        test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader']
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif|svg)$/,
-        use: [
-          {
-            loader: 'url-loader',
-            options: {
-              limit: 4096
-            }
-          }
-        ]
-      },
-      // for graphiql, since graphql uses mjs files to run in the server
-      {
-        test: /\.mjs$/,
-        include: /node_modules/,
-        type: 'javascript/auto'
-      },
-      {
-        test: /\.(eot|ttf|wav|mp3|woff|woff2|otf)$/,
-        use: ['file-loader']
-      }
-    ]
+    }
   }
-})
+}

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -17,140 +17,143 @@ const distPath = path.join(PROJECT_ROOT, 'dist')
 
 const COMMIT_HASH = cp.execSync('git rev-parse HEAD').toString().trim()
 
-module.exports = ({noDeps}) => ({
-  mode: 'production',
-  node: {
-    __dirname: false
-  },
-  entry: {
-    chronos: [DOTENV, path.join(PROJECT_ROOT, 'packages/chronos/chronos.ts')],
-    web: [
-      DOTENV,
-      // each instance of web needs to generate its own index.html to use on startup
-      path.join(PROJECT_ROOT, 'scripts/toolboxSrc/applyEnvVarsToClientAssets.ts'),
-      path.join(SERVER_ROOT, 'server.ts')
-    ],
-    gqlExecutor: [DOTENV, path.join(GQL_ROOT, 'gqlExecutor.ts')],
-    preDeploy: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/preDeploy.ts')],
-    pushToCDN: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/pushToCDN.ts')],
-    migrate: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/standaloneMigrations.ts')]
-  },
-  output: {
-    filename: '[name].js',
-    path: distPath
-  },
-  resolve: {
-    alias: {
-      '~': CLIENT_ROOT,
-      'parabol-client': CLIENT_ROOT,
-      'parabol-server': SERVER_ROOT
+module.exports = (config) => {
+  const noDeps = config.noDeps === 'true'
+  return {
+    mode: 'production',
+    node: {
+      __dirname: false
     },
-    extensions: ['.mjs', '.js', '.json', '.ts', '.tsx', '.graphql'],
-    // this is run outside the server dir, but we want to favor using modules from the server dir
-    modules: [path.resolve(SERVER_ROOT, '../node_modules'), 'node_modules']
-  },
-  resolveLoader: {
-    modules: [path.resolve(SERVER_ROOT, '../node_modules'), 'node_modules']
-  },
-  target: 'node',
-  externals: [
-    !noDeps &&
-      nodeExternals({
-        allowlist: [/parabol-client/, /parabol-server/]
-      })
-  ].filter(Boolean),
-  optimization: {
-    // When Node exits with an uncaughtException it prints the callstack, which is the line that caused the error.
-    // We do not minify the server to prevent callstacks that can be longer than a terminal scrollback buffer
-    // Not minifying costs us ~50MB extra, but it doesn't require sourcemaps & compiles 90s faster
-    minimize: false
-  },
-  plugins: [
-    // Pro tip: comment this out along with stable entry files for quick debugging
-    new CleanWebpackPlugin(),
-    new webpack.DefinePlugin({
-      __PRODUCTION__: true,
-      __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
-      __COMMIT_HASH__: JSON.stringify(COMMIT_HASH),
-      // hardcode architecture so uWebSockets.js dynamic require becomes deterministic at build time & requires 1 binary
-      'process.platform': JSON.stringify(process.platform),
-      'process.arch': JSON.stringify(process.arch),
-      'process.versions.modules': JSON.stringify(process.versions.modules)
-    }),
-    // if we need canvas for SSR we can just install it to our own package.json
-    new webpack.IgnorePlugin({resourceRegExp: /^canvas$/, contextRegExp: /jsdom$/}),
-    // native bindings might be faster, but abandonware & not currently used
-    new webpack.IgnorePlugin({resourceRegExp: /^pg-native$/, contextRegExp: /pg\/lib/}),
-    noDeps &&
-      new CopyWebpackPlugin({
-        patterns: [
-          {
-            // copy sharp's libvips to the output
-            from: path.resolve(PROJECT_ROOT, 'node_modules', 'sharp', 'vendor'),
-            to: 'vendor'
-          }
-        ]
-      })
-  ].filter(Boolean),
-  module: {
-    rules: [
-      ...transformRules(PROJECT_ROOT, true),
-      {
-        test: /\.(png|jpg|jpeg|gif|svg)$/,
-        oneOf: [
-          {
-            // Put templates in their own directory that will get pushed to the CDN. PG Migrations will reference that URL
-            test: /Template.png$/,
-            include: [path.resolve(PROJECT_ROOT, 'static/images/illustrations')],
-            use: [
-              {
-                loader: 'file-loader',
-                options: {
-                  name: 'templates/[name].[ext]',
-                  publicPath: distPath
-                }
-              }
-            ]
-          },
-          {
-            // manifest.json icons just need the file name, we'll prefix them with the CDN in preDeploy
-            test: /mark-cropped-\d+.png$/,
-            include: [path.resolve(PROJECT_ROOT, 'static/images/brand')],
-            use: [
-              {
-                loader: 'file-loader',
-                options: {
-                  name: '[name].[ext]'
-                }
-              }
-            ]
-          },
-          {
-            use: [
-              {
-                loader: 'file-loader',
-                options: {
-                  publicPath: distPath
-                }
-              }
-            ]
-          }
-        ]
+    entry: {
+      chronos: [DOTENV, path.join(PROJECT_ROOT, 'packages/chronos/chronos.ts')],
+      web: [
+        DOTENV,
+        // each instance of web needs to generate its own index.html to use on startup
+        path.join(PROJECT_ROOT, 'scripts/toolboxSrc/applyEnvVarsToClientAssets.ts'),
+        path.join(SERVER_ROOT, 'server.ts')
+      ],
+      gqlExecutor: [DOTENV, path.join(GQL_ROOT, 'gqlExecutor.ts')],
+      preDeploy: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/preDeploy.ts')],
+      pushToCDN: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/pushToCDN.ts')],
+      migrate: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/standaloneMigrations.ts')]
+    },
+    output: {
+      filename: '[name].js',
+      path: distPath
+    },
+    resolve: {
+      alias: {
+        '~': CLIENT_ROOT,
+        'parabol-client': CLIENT_ROOT,
+        'parabol-server': SERVER_ROOT
       },
-      {
-        include: [/node_modules/],
-        test: /\.node$/,
-        use: [
-          {
-            loader: 'node-loader',
-            options: {
-              // sharp's bindings.gyp is hardcoded to look for libvips 2 directories up
-              // rather than do a custom build, we just output it 2 directories down (/node/binaries)
-              name: 'node/binaries/[name].[ext]'
+      extensions: ['.mjs', '.js', '.json', '.ts', '.tsx', '.graphql'],
+      // this is run outside the server dir, but we want to favor using modules from the server dir
+      modules: [path.resolve(SERVER_ROOT, '../node_modules'), 'node_modules']
+    },
+    resolveLoader: {
+      modules: [path.resolve(SERVER_ROOT, '../node_modules'), 'node_modules']
+    },
+    target: 'node',
+    externals: [
+      !noDeps &&
+        nodeExternals({
+          allowlist: [/parabol-client/, /parabol-server/]
+        })
+    ].filter(Boolean),
+    optimization: {
+      // When Node exits with an uncaughtException it prints the callstack, which is the line that caused the error.
+      // We do not minify the server to prevent callstacks that can be longer than a terminal scrollback buffer
+      // Not minifying costs us ~50MB extra, but it doesn't require sourcemaps & compiles 90s faster
+      minimize: false
+    },
+    plugins: [
+      // Pro tip: comment this out along with stable entry files for quick debugging
+      new CleanWebpackPlugin(),
+      new webpack.DefinePlugin({
+        __PRODUCTION__: true,
+        __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+        __COMMIT_HASH__: JSON.stringify(COMMIT_HASH),
+        // hardcode architecture so uWebSockets.js dynamic require becomes deterministic at build time & requires 1 binary
+        'process.platform': JSON.stringify(process.platform),
+        'process.arch': JSON.stringify(process.arch),
+        'process.versions.modules': JSON.stringify(process.versions.modules)
+      }),
+      // if we need canvas for SSR we can just install it to our own package.json
+      new webpack.IgnorePlugin({resourceRegExp: /^canvas$/, contextRegExp: /jsdom$/}),
+      // native bindings might be faster, but abandonware & not currently used
+      new webpack.IgnorePlugin({resourceRegExp: /^pg-native$/, contextRegExp: /pg\/lib/}),
+      noDeps &&
+        new CopyWebpackPlugin({
+          patterns: [
+            {
+              // copy sharp's libvips to the output
+              from: path.resolve(PROJECT_ROOT, 'node_modules', 'sharp', 'vendor'),
+              to: 'vendor'
             }
-          }
-        ]
-      }
-    ]
+          ]
+        })
+    ].filter(Boolean),
+    module: {
+      rules: [
+        ...transformRules(PROJECT_ROOT, true),
+        {
+          test: /\.(png|jpg|jpeg|gif|svg)$/,
+          oneOf: [
+            {
+              // Put templates in their own directory that will get pushed to the CDN. PG Migrations will reference that URL
+              test: /Template.png$/,
+              include: [path.resolve(PROJECT_ROOT, 'static/images/illustrations')],
+              use: [
+                {
+                  loader: 'file-loader',
+                  options: {
+                    name: 'templates/[name].[ext]',
+                    publicPath: distPath
+                  }
+                }
+              ]
+            },
+            {
+              // manifest.json icons just need the file name, we'll prefix them with the CDN in preDeploy
+              test: /mark-cropped-\d+.png$/,
+              include: [path.resolve(PROJECT_ROOT, 'static/images/brand')],
+              use: [
+                {
+                  loader: 'file-loader',
+                  options: {
+                    name: '[name].[ext]'
+                  }
+                }
+              ]
+            },
+            {
+              use: [
+                {
+                  loader: 'file-loader',
+                  options: {
+                    publicPath: distPath
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          include: [/node_modules/],
+          test: /\.node$/,
+          use: [
+            {
+              loader: 'node-loader',
+              options: {
+                // sharp's bindings.gyp is hardcoded to look for libvips 2 directories up
+                // rather than do a custom build, we just output it 2 directories down (/node/binaries)
+                name: 'node/binaries/[name].[ext]'
+              }
+            }
+          ]
+        }
+      ]
+    }
   }
-})
+}


### PR DESCRIPTION
# Description

I've been doing a lot of testing of the production build & I hate waiting around for 1 minute to watch it build.
By building client & server at the same time, in separate threads, it cuts that time in half 🎉 .

I used `child_process` instead of `worker_threads` because the API is a little cleaner (no need for an extra file). Plus it looks like it's more performant, too, which is a NodeJS problem: https://github.com/orgs/nodejs/discussions/44264

The webpack files hardly changed, i just wrapped the return value in `{}` & normalized the input params. The git diff makes it look much worse!
 
## Demo

Before

```
🙏🙏🙏      Building Production Server      🙏🙏🙏
✔ Parse Configuration
✔ Generate outputs
✨  Done in 58.23s.
```

After

```
🙏🙏🙏      Building Production Server      🙏🙏🙏
✔ Parse Configuration
✔ Generate outputs
✨  Done in 30.16s.
```

## Testing scenarios

`yarn build --no-deps`
