### PR TITLE
fix: grab auth token before await

### DIFF
--- a/packages/server/graphql/uWSAsyncHandler.ts
+++ b/packages/server/graphql/uWSAsyncHandler.ts
@@ -7,6 +7,7 @@ export type uWSHandler = (res: HttpResponse, req: HttpRequest) => void
 const uWSAsyncHandler =
   (handler: uWSHandler, ignoreDone?: boolean) => async (res: HttpResponse, req: HttpRequest) => {
     safetyPatchRes(res)
+    const authToken = getReqAuth(req)
     try {
       await handler(res, req)
       if (!ignoreDone && !res.done) {
@@ -15,7 +16,6 @@ const uWSAsyncHandler =
     } catch (e) {
       res.writeStatus('503').end()
       const error = e instanceof Error ? e : new Error('uWSAsyncHandler failed')
-      const authToken = getReqAuth(req)
       sendToSentry(error, {userId: authToken.sub})
     }
   }


### PR DESCRIPTION
# Description

fixes #9289

`req` may only be accessed before the first `await` call, it gets GC'd on next tick, which is one of the sneaky ways uWS keeps memory consumption so low.

This was introduced about 2 months ago, i just didn't catch it: https://github.com/ParabolInc/parabol/pull/9023/files
