### PR TITLE
chore(meeting-inception): use retrosInDisguise flag for displaying add an activity button

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -106,6 +106,9 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
     graphql`
       fragment DiscussionThreadInput_viewer on User {
         picture
+        featureFlags {
+          retrosInDisguise
+        }
       }
     `,
     viewerRef
@@ -119,22 +122,16 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
         discussionTopicType
         team {
           id
-          organization {
-            featureFlags {
-              meetingInception
-            }
-          }
         }
       }
     `,
     discussionRef
   )
-  const {picture} = viewer
+  const {picture, featureFlags} = viewer
   const isReply = !!props.isReply
   const isDisabled = !!props.isDisabled
   const {id: discussionId, meetingId, isAnonymousComment, team, discussionTopicType} = discussion
-  const {id: teamId, organization} = team
-  const {featureFlags} = organization
+  const {id: teamId} = team
   const [editorState, setEditorState] = useReplyEditorState(replyMention, setReplyMention)
   const atmosphere = useAtmosphere()
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
@@ -301,7 +298,7 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
     }
   }, [])
 
-  const allowAddActivity = featureFlags.meetingInception
+  const allowAddActivity = featureFlags.retrosInDisguise
   const isActionsContainerVisible = allowTasks || allowPolls || allowAddActivity
   const isActionsContainerDisabled = isCreatingTask || isCreatingPoll
   const avatar = isAnonymousComment ? anonymousAvatar : picture


### PR DESCRIPTION
Because "add an activity" button redirects on activity library, I will use `retrosInDisguise` flag for now for displaying this button.
After merge it will instantly be available for users with this flag

Previous PR: #8750

**How to test:**

- Add `retrosInDisguise` flag and see add an activity button in the discussion panel
- Remove `retrosInDisguise` flag and see no button