### PR TITLE
fix: release to staging debug #4

### DIFF
--- a/.github/workflows/release-to-staging.yml
+++ b/.github/workflows/release-to-staging.yml
@@ -69,20 +69,32 @@ jobs:
             JOBS=$(curl "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/pipelines/$PIPELINE_ID/jobs" \
               --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}')
             JOB_ID=$(echo $JOBS | jq '.[] | select(.name == "${{ env.STAGING_JOB }}")' | jq .id)
-            curl "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/$JOB_ID/play" \
-              --request POST \
-              --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}'
             PROD_JOB_ID=$(echo $JOBS | jq '.[] | select(.name == "${{ env.PRODUCTION_JOB}}")' | jq .id)
             echo "JOB_ID=${JOB_ID}" >> $GITHUB_ENV
             echo "PROD_JOB_ID=${PROD_JOB_ID}" >> $GITHUB_ENV
+      - name: Push to staging
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 1
+          max_attempts: 20
+          retry_wait_seconds: 5
+          # If the job isn't created yet, will return {"message":"400 Bad request - Unplayable Job"}
+          command: |
+            RES=$(curl "https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}/play" \
+              --request POST \
+              --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}')
+            JOB_ID_DONE=$(echo $RES | jq .id)
+            [ -z "$JOB_ID_DONE" ] && exit 1
       - name: Open PR to Push to Prod
         env:
           GH_TOKEN: ${{ github.token }}
+        # gh cli does not interpret \n, so we first write to a file
         run: |
           BACKLINK="Production Job Id: $PROD_JOB_ID\nStaging Job Id: $JOB_ID"
           TEMPLATE=$(tail -n +12 .github/ISSUE_TEMPLATE/release_test.md)
           CHANGES=$(perl -0777ne 'print "$1\n" and exit if m/\n##\s[^\n]*\n+(.*?\n)##?\s|$/gs;' CHANGELOG.md)
-          BODY="${BACKLINK}\n\n${TEMPLATE}\n\n\n${CHANGES}"
+          echo -e "${BACKLINK}\n\n${TEMPLATE}\n\n\n${CHANGES}" > BODY
+          export BODY=$(cat BODY)
           gh pr create \
             --assignee ${{ github.actor }} \
             --base production \
@@ -91,7 +103,7 @@ jobs:
       - name: Poll Staging Release
         uses: artiz/poll-endpoint@1.0.2
         with:
-          url: https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}
+          url: https://gitlab.com/api/v4/projects/${{ vars.GITLAB_PROJECT_ID }}/jobs/${{ env.JOB_ID }}?access_token=${{ secrets.GITLAB_API_TOKEN }}
           method: GET
           expect-status: 200
           expect-response-regex: '"status":"success"'

--- a/.github/workflows/release-to-staging.yml
+++ b/.github/workflows/release-to-staging.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      pull-requests: "write"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

more CI debugging:
- gitlab creates pipelines before the jobs inside the pipelines, so we have to wait for the job, not just the pipeline
- gh cli doesn't interpret \n, so we handle that
- checking the status of deployment requires an auth_token