### PR TITLE
fix: Allow multiple "*New Template"

### DIFF
--- a/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
+++ b/packages/client/components/ActivityLibrary/CreateNewActivity/CreateNewActivity.tsx
@@ -169,10 +169,6 @@ export const CreateNewActivity = (props: Props) => {
       onError(new Error('You may only have 20 templates per team. Please remove one first.'))
       return
     }
-    if (teamTemplates.find((template) => template.node.name === '*New Template')) {
-      onError(new Error('You already have a new template. Try renaming that one first.'))
-      return
-    }
 
     submitMutation()
     AddReflectTemplateMutation(
@@ -205,10 +201,6 @@ export const CreateNewActivity = (props: Props) => {
 
     if (teamTemplates.length >= Threshold.MAX_POKER_TEAM_TEMPLATES) {
       onError(new Error('You may only have 20 templates per team. Please remove one first.'))
-      return
-    }
-    if (teamTemplates.find((template) => template.node.name === '*New Template')) {
-      onError(new Error('You already have a new template. Try renaming that one first.'))
       return
     }
 

--- a/packages/client/modules/meeting/components/AddNewPokerTemplate.tsx
+++ b/packages/client/modules/meeting/components/AddNewPokerTemplate.tsx
@@ -90,7 +90,7 @@ const AddNewPokerTemplate = (props: Props) => {
       }, 8000)
       return
     }
-    if (pokerTemplates.find((template) => template.name === '*New Template')) {
+    if (pokerTemplates.find((template) => template.name.startsWith('*New Template'))) {
       onError(new Error('You already have a new template. Try renaming that one first.'))
       errorTimerId.current = window.setTimeout(() => {
         onCompleted()
@@ -102,7 +102,9 @@ const AddNewPokerTemplate = (props: Props) => {
     gotoTeamTemplates()
   }
 
-  const containsNewTemplate = pokerTemplates.find((template) => template.name === '*New Template')
+  const containsNewTemplate = pokerTemplates.find((template) =>
+    template.name.startsWith('*New Template')
+  )
 
   if (pokerTemplates.length > Threshold.MAX_POKER_TEAM_TEMPLATES || containsNewTemplate) return null
   return (

--- a/packages/client/modules/meeting/components/AddNewReflectTemplate.tsx
+++ b/packages/client/modules/meeting/components/AddNewReflectTemplate.tsx
@@ -86,7 +86,7 @@ const AddNewReflectTemplate = (props: Props) => {
       }, 8000)
       return
     }
-    if (reflectTemplates.find((template) => template.name === '*New Template')) {
+    if (reflectTemplates.find((template) => template.name.startsWith('*New Template'))) {
       onError(new Error('You already have a new template. Try renaming that one first.'))
       errorTimerId.current = window.setTimeout(() => {
         onCompleted()
@@ -98,7 +98,9 @@ const AddNewReflectTemplate = (props: Props) => {
     gotoTeamTemplates()
   }
 
-  const containsNewTemplate = reflectTemplates.find((template) => template.name === '*New Template')
+  const containsNewTemplate = reflectTemplates.find((template) =>
+    template.name.startsWith('*New Template')
+  )
 
   if (reflectTemplates.length > Threshold.MAX_RETRO_TEAM_TEMPLATES || containsNewTemplate)
     return null

--- a/packages/client/modules/meeting/components/EditableTemplateName.tsx
+++ b/packages/client/modules/meeting/components/EditableTemplateName.tsx
@@ -25,7 +25,7 @@ const EditableTemplateName = (props: Props) => {
   const {name, templateId, isOwner, className} = props
   const atmosphere = useAtmosphere()
   const {onError, error, onCompleted, submitMutation, submitting} = useMutationProps()
-  const autoFocus = name === '*New Template' || name.endsWith(' Copy')
+  const autoFocus = name.startsWith('*New Template') || name.endsWith(' Copy')
 
   const handleSubmit = (rawName: string) => {
     if (submitting) return

--- a/packages/client/mutations/AddPokerTemplateMutation.ts
+++ b/packages/client/mutations/AddPokerTemplateMutation.ts
@@ -62,7 +62,7 @@ const AddPokerTemplateMutation: StandardMutation<TAddPokerTemplateMutation> = (
       const nowISO = new Date().toJSON()
       const team = store.get(teamId)!
       const parentTemplate = parentTemplateId ? store.get(parentTemplateId) : null
-      const name = parentTemplate ? parentTemplate.getValue('name') + ' Copy' : '*New Template'
+      const name = parentTemplate ? parentTemplate.getValue('name') + ' Copy' : '*New Template ##'
 
       const proxyTemplate = createProxyRecord(store, 'PokerTemplate', {
         name,

--- a/packages/client/mutations/AddReflectTemplateMutation.ts
+++ b/packages/client/mutations/AddReflectTemplateMutation.ts
@@ -61,7 +61,7 @@ const AddReflectTemplateMutation: StandardMutation<TAddReflectTemplateMutation> 
       const nowISO = new Date().toJSON()
       const team = store.get(teamId)!
       const parentTemplate = parentTemplateId ? store.get(parentTemplateId) : null
-      const name = parentTemplate ? parentTemplate.getValue('name') + ' Copy' : '*New Template'
+      const name = parentTemplate ? parentTemplate.getValue('name') + ' Copy' : '*New Template ##'
 
       const proxyTemplate = createProxyRecord(store, 'ReflectTemplate', {
         name,

--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -114,7 +114,7 @@ const addPokerTemplate = {
 
       const templateCount = allTemplates.length
       const newTemplate = new PokerTemplate({
-        name: `*New Template #${templateCount}`,
+        name: `*New Template #${templateCount + 1}`,
         teamId,
         orgId,
         mainCategory: 'estimation',

--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -110,9 +110,6 @@ const addPokerTemplate = {
       analytics.templateMetrics(viewer, newTemplate, 'Template Cloned')
       data = {templateId: newTemplate.id}
     } else {
-      if (allTemplates.find((template) => template.name === '*New Template')) {
-        return standardError(new Error('Template already created'), {userId: viewerId})
-      }
       const {orgId} = viewerTeam
 
       const newTemplate = new PokerTemplate({

--- a/packages/server/graphql/mutations/addPokerTemplate.ts
+++ b/packages/server/graphql/mutations/addPokerTemplate.ts
@@ -112,8 +112,9 @@ const addPokerTemplate = {
     } else {
       const {orgId} = viewerTeam
 
+      const templateCount = allTemplates.length
       const newTemplate = new PokerTemplate({
-        name: '*New Template',
+        name: `*New Template #${templateCount}`,
         teamId,
         orgId,
         mainCategory: 'estimation',

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -110,9 +110,6 @@ const addReflectTemplate = {
       analytics.templateMetrics(viewer, newTemplate, 'Template Cloned')
       data = {templateId: newTemplate.id}
     } else {
-      if (allTemplates.find((template) => template.name === '*New Template')) {
-        return standardError(new Error('Template already created'), {userId: viewerId})
-      }
       const {orgId} = viewerTeam
       // RESOLUTION
       const base = {

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -112,8 +112,9 @@ const addReflectTemplate = {
     } else {
       const {orgId} = viewerTeam
       // RESOLUTION
+      const templateCount = allTemplates.length
       const base = {
-        '*New Template': [
+        [`*New Template #${templateCount}`]: [
           {
             question: 'New prompt',
             description: '',

--- a/packages/server/graphql/mutations/addReflectTemplate.ts
+++ b/packages/server/graphql/mutations/addReflectTemplate.ts
@@ -114,7 +114,7 @@ const addReflectTemplate = {
       // RESOLUTION
       const templateCount = allTemplates.length
       const base = {
-        [`*New Template #${templateCount}`]: [
+        [`*New Template #${templateCount + 1}`]: [
           {
             question: 'New prompt',
             description: '',

--- a/packages/server/graphql/public/types/ReflectTemplate.ts
+++ b/packages/server/graphql/public/types/ReflectTemplate.ts
@@ -42,7 +42,7 @@ const ReflectTemplate: ReflectTemplateResolvers = {
   subCategories: async ({id, name}, _args, {dataLoader, authToken}) => {
     // :TODO: (jmtaber129): Refactor this to be a bit cleaner if decide to use subcategories
     // long-term.
-    if (name === '*New Template') {
+    if (name.startsWith('*New Template')) {
       return []
     }
 


### PR DESCRIPTION
Let's just allow duplicate names until the UX enforces proper naming of new templates

## Demo

https://www.loom.com/share/4499f45d4a134977954db3cb5326cae9?sid=e8d5b5f3-1902-4b62-8172-3133662e7884

## Testing scenarios

- create a new retro template without renaming it
- repeat

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
