### PR TITLE
fix: default to empty instead of null

### DIFF
--- a/.github/workflows/release-to-staging.yml
+++ b/.github/workflows/release-to-staging.yml
@@ -84,9 +84,9 @@ jobs:
               --request POST \
               --header 'PRIVATE-TOKEN: ${{ secrets.GITLAB_API_TOKEN }}')
             echo $RES
-            JOB_ID_DONE=$(echo $RES | jq .id)
+            JOB_ID_DONE=$(echo $RES | jq '.id // empty')
             echo $JOB_ID_DONE
-            [ -z "$JOB_ID_DONE" ] && echo null || echo "not null"
+            [ -z "$JOB_ID_DONE" ] && echo nully || echo "not null"
             [ -z "$JOB_ID_DONE" ] && exit 1 || exit 0
       - name: Open PR to Push to Prod
         env:


### PR DESCRIPTION
# Description

jq returns `null` as a string & not actually a null value. this confused me.