### PR TITLE
fix: Show correct template owner for ex-team members

### DIFF
--- a/packages/server/graphql/public/types/MeetingTemplate.ts
+++ b/packages/server/graphql/public/types/MeetingTemplate.ts
@@ -22,8 +22,8 @@ const MeetingTemplate: MeetingTemplateResolvers = {
     if (teamId === 'aGhostTeam') return 'PUBLIC'
     const viewerId = getUserId(authToken)
     const teamMemberId = TeamMemberId.join(teamId, viewerId)
-    const team = await dataLoader.get('teamMembers').load(teamMemberId)
-    const isViewerOnOwningTeam = !!team
+    const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
+    const isViewerOnOwningTeam = teamMember && teamMember.isNotRemoved
     // public user-defined templates are not visible outside their org
     return isViewerOnOwningTeam ? 'TEAM' : 'ORGANIZATION'
   }


### PR DESCRIPTION
Without this fix the edit controls were shown but did not work.

## Demo

https://www.loom.com/share/f9b2a3765b7945b092414fd0791b58dc?sid=43577910-cf01-447e-8285-731d76ee0817

## Testing scenarios

- have a team A with user Hannibal
- create a template in team A which is shared with the org automatically
- remove Hannibal from team A
- check that Hannibal can still see the template, but the edit controls are hidden

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
