### PR TITLE
fix: highlight team dash in sidebar regardless of tab

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -112,7 +112,12 @@ const DashSidebar = (props: Props) => {
         <Nav isOpen={isOpen}>
           <Contents>
             <NavItemsWrap>
-              <NavItem icon={'arrowBack'} href={'/me/organizations'} label={'Organizations'} />
+              <NavItem
+                icon={'arrowBack'}
+                href={'/me/organizations'}
+                label={'Organizations'}
+                exact
+              />
               <OrgName>{name}</OrgName>
               <NavItem
                 icon={'creditScore'}
@@ -157,7 +162,7 @@ const DashSidebar = (props: Props) => {
         <Contents>
           <NavItemsWrap>
             <NavItem icon={'forum'} href={'/meetings'} label={'Meetings'} />
-            <NavItem icon={'timeline'} href={'/me'} label={'History'} />
+            <NavItem icon={'timeline'} href={'/me'} label={'History'} exact />
             <NavItem icon={'playlist_add_check'} href={'/me/tasks'} label={'Tasks'} />
           </NavItemsWrap>
           <DashHR />

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -82,6 +82,7 @@ interface Props {
   navState?: unknown
   //FIXME 6062: change to React.ComponentType
   icon: keyof typeof iconLookup
+  exact?: boolean
 }
 
 const LeftDashNavItem = (props: Props) => {
@@ -93,7 +94,11 @@ const LeftDashNavItem = (props: Props) => {
     onClick?.()
   }
   return (
-    <NavItem className={className} onClick={handleClick} isActive={!!match?.isExact}>
+    <NavItem
+      className={className}
+      onClick={handleClick}
+      isActive={!!match && (match?.isExact || !props.exact)}
+    >
       <StyledIcon>{iconLookup[icon]}</StyledIcon>
       <Label>{label}</Label>
     </NavItem>

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -125,6 +125,7 @@ const MobileDashSidebar = (props: Props) => {
                 icon={'arrowBack'}
                 href={'/me/organizations'}
                 label={'Organizations'}
+                exact
               />
               <OrgName>{name}</OrgName>
               <LeftDashNavItem

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -191,6 +191,7 @@ const MobileDashSidebar = (props: Props) => {
               icon={'timeline'}
               href={'/me'}
               label={'History'}
+              exact
             />
             <LeftDashNavItem
               onClick={handleMenuClick}


### PR DESCRIPTION
Highlight in the sidebar vanished when navigating from the main team dash to a subtab, like tasks or activity.

## Demo

https://www.loom.com/share/5b29e927ef3247f194b5b88757f02293?sid=badb2cf4-f713-4473-9a1c-254a8045f820

## Testing scenarios

- navigate through the pages and check the highlight in the sidebar
- repeat with mobile sidebar

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label `One Review Required` if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
