### PR TITLE
feat(kudos): show snackbar when reflection with kudos created

### DIFF
--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -125,7 +125,6 @@ const PhaseItemEditor = (props: Props) => {
   const {disableAnonymity, viewerMeetingMember, teamId} = meeting
 
   const handleSubmit = (content: string) => {
-    console.log('HANDLE SUBMIT')
     const input = {
       content,
       meetingId,

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -125,6 +125,7 @@ const PhaseItemEditor = (props: Props) => {
   const {disableAnonymity, viewerMeetingMember, teamId} = meeting
 
   const handleSubmit = (content: string) => {
+    console.log('HANDLE SUBMIT')
     const input = {
       content,
       meetingId,

--- a/packages/client/mutations/CreateReflectionMutation.ts
+++ b/packages/client/mutations/CreateReflectionMutation.ts
@@ -15,6 +15,7 @@ import SendClientSideEvent from '../utils/SendClientSideEvent'
 
 graphql`
   fragment CreateReflectionMutation_meeting on CreateReflectionPayload {
+    reflectionId
     reflectionGroup {
       meetingId
       sortOrder
@@ -72,7 +73,7 @@ const CreateReflectionMutation: StandardMutation<TCreateReflectionMutation> = (
           .map((kudos) => kudos.receiverUser.preferredName)
           .join(', ')
         atmosphere.eventEmitter.emit('addSnackbar', {
-          key: 'youGaveKudos',
+          key: `youGaveKudos:${res.createReflection.reflectionId}`,
           message: `${preferredNames} will receive kudos at the end ot the meeting ${draftKudoses[0]?.emojiUnicode}`,
           autoDismiss: 5,
           onShow: () => {

--- a/packages/client/mutations/CreateReflectionMutation.ts
+++ b/packages/client/mutations/CreateReflectionMutation.ts
@@ -11,6 +11,7 @@ import clientTempId from '../utils/relay/clientTempId'
 import createProxyRecord from '../utils/relay/createProxyRecord'
 import {CreateReflectionMutation as TCreateReflectionMutation} from '../__generated__/CreateReflectionMutation.graphql'
 import handleAddReflectionGroups from './handlers/handleAddReflectionGroups'
+import SendClientSideEvent from '../utils/SendClientSideEvent'
 
 graphql`
   fragment CreateReflectionMutation_meeting on CreateReflectionPayload {
@@ -31,6 +32,12 @@ graphql`
     unlockedStages {
       id
       isNavigableByFacilitator
+    }
+    draftKudoses {
+      receiverUser {
+        preferredName
+      }
+      emojiUnicode
     }
   }
 `
@@ -58,7 +65,30 @@ const CreateReflectionMutation: StandardMutation<TCreateReflectionMutation> = (
   return commitMutation<TCreateReflectionMutation>(atmosphere, {
     mutation,
     variables,
-    onCompleted,
+    onCompleted: (res, errors) => {
+      const draftKudoses = res.createReflection?.draftKudoses
+      if (draftKudoses && draftKudoses.length) {
+        const preferredNames = draftKudoses
+          .map((kudos) => kudos.receiverUser.preferredName)
+          .join(', ')
+        atmosphere.eventEmitter.emit('addSnackbar', {
+          key: 'youGaveKudos',
+          message: `${preferredNames} will receive kudos at the end ot the meeting ${draftKudoses[0]?.emojiUnicode}`,
+          autoDismiss: 5,
+          onShow: () => {
+            SendClientSideEvent(atmosphere, 'Snackbar Viewed', {
+              snackbarType: 'kudosSent'
+            })
+          },
+          onManualDismiss: () => {
+            SendClientSideEvent(atmosphere, 'Snackbar Clicked', {
+              snackbarType: 'kudosSent'
+            })
+          }
+        })
+      }
+      onCompleted(res, errors)
+    },
     onError,
     updater: (store) => {
       const payload = store.getRootField('createReflection')

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -6779,6 +6779,11 @@ type CreateReflectionPayload {
   The stages that were unlocked by navigating
   """
   unlockedStages: [NewMeetingStage!]
+
+  """
+  Kudoses that might be sent by the end of the retro
+  """
+  draftKudoses: [Kudos!]
 }
 
 input CreateReflectionInput {


### PR DESCRIPTION
**How to test:**

- Start a retro and add a reflection with kudos
- See snackbar appearing:

<img width="825" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/d661d373-5e6f-4569-8ee6-5796bddbcef3">
