### PR TITLE
feat: Allow retro meeting series naming

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetailsRecurrenceSettings.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsRecurrenceSettings.tsx
@@ -8,10 +8,11 @@ import DialogContainer from '../DialogContainer'
 interface Props {
   onRecurrenceSettingsUpdated: (recurrenceSettings: RecurrenceSettings) => void
   recurrenceSettings: RecurrenceSettings
+  placeholder: string
 }
 
 export const ActivityDetailsRecurrenceSettings = (props: Props) => {
-  const {onRecurrenceSettingsUpdated, recurrenceSettings} = props
+  const {onRecurrenceSettingsUpdated, recurrenceSettings, placeholder} = props
   const {togglePortal, modalPortal} = useModal({
     id: 'activityDetailsRecurrenceSettings'
   })
@@ -32,6 +33,7 @@ export const ActivityDetailsRecurrenceSettings = (props: Props) => {
           <RecurrenceSettings
             onRecurrenceSettingsUpdated={onRecurrenceSettingsUpdated}
             recurrenceSettings={recurrenceSettings}
+            placeholder={placeholder}
           />
         </DialogContainer>
       )}

--- a/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetailsSidebar.tsx
@@ -408,6 +408,7 @@ const ActivityDetailsSidebar = (props: Props) => {
                         <ActivityDetailsRecurrenceSettings
                           onRecurrenceSettingsUpdated={setRecurrenceSettings}
                           recurrenceSettings={recurrenceSettings}
+                          placeholder='Retro'
                         />
                       )}
                     </>
@@ -422,6 +423,7 @@ const ActivityDetailsSidebar = (props: Props) => {
                     <ActivityDetailsRecurrenceSettings
                       onRecurrenceSettingsUpdated={setRecurrenceSettings}
                       recurrenceSettings={recurrenceSettings}
+                      placeholder='Standup'
                     />
                   )}
                 </>

--- a/packages/client/components/NewMeeting.tsx
+++ b/packages/client/components/NewMeeting.tsx
@@ -215,6 +215,7 @@ const NewMeeting = (props: Props) => {
               <NewMeetingRecurrenceSettings
                 onRecurrenceSettingsUpdated={setRecurrenceSettings}
                 recurrenceSettings={recurrenceSettings}
+                placeholder='Standup'
               />
             )}
           </SettingsRow>

--- a/packages/client/components/NewMeetingRecurrenceSettings.tsx
+++ b/packages/client/components/NewMeetingRecurrenceSettings.tsx
@@ -9,10 +9,11 @@ import {RecurrenceSettings} from './TeamPrompt/Recurrence/RecurrenceSettings'
 interface Props {
   onRecurrenceSettingsUpdated: (recurrenceSettings: RecurrenceSettings) => void
   recurrenceSettings: RecurrenceSettings
+  placeholder: string
 }
 
 export const NewMeetingRecurrenceSettings = (props: Props) => {
-  const {onRecurrenceSettingsUpdated, recurrenceSettings} = props
+  const {onRecurrenceSettingsUpdated, recurrenceSettings, placeholder} = props
   const {togglePortal, menuPortal, originRef, portalStatus} = useMenu<HTMLDivElement>(
     MenuPosition.LOWER_RIGHT,
     {
@@ -41,6 +42,7 @@ export const NewMeetingRecurrenceSettings = (props: Props) => {
         <RecurrenceSettings
           onRecurrenceSettingsUpdated={onRecurrenceSettingsUpdated}
           recurrenceSettings={recurrenceSettings}
+          placeholder={placeholder}
         />
       )}
     </>

--- a/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/RecurrenceSettings.tsx
@@ -175,10 +175,11 @@ interface Props {
     validationErrors: string[] | undefined
   ) => void
   recurrenceSettings: RecurrenceSettings
+  placeholder: string
 }
 
 export const RecurrenceSettings = (props: Props) => {
-  const {onRecurrenceSettingsUpdated, recurrenceSettings} = props
+  const {onRecurrenceSettingsUpdated, recurrenceSettings, placeholder} = props
   const {name: meetingSeriesName, rrule: recurrenceRule} = recurrenceSettings
   const [name, setName] = React.useState(meetingSeriesName)
   const [nameError, setNameError] = React.useState<string | undefined>()
@@ -268,7 +269,7 @@ export const RecurrenceSettings = (props: Props) => {
             hasError={!!nameError}
             id='series-title'
             type='text'
-            placeholder='Standup'
+            placeholder={placeholder}
             value={meetingSeriesName}
             onChange={handleNameChange}
             min={1}
@@ -304,7 +305,7 @@ export const RecurrenceSettings = (props: Props) => {
           <Description>
             The next meeting in this series will be called{' '}
             <span className='font-semibold'>
-              "{meetingSeriesName || 'Standup'} - {dayjs(recurrenceStartTime).format('MMM DD')}"
+              "{meetingSeriesName || placeholder} - {dayjs(recurrenceStartTime).format('MMM DD')}"
             </span>
           </Description>
         )}

--- a/packages/client/components/TeamPrompt/Recurrence/UpdateRecurrenceSettingsModal.tsx
+++ b/packages/client/components/TeamPrompt/Recurrence/UpdateRecurrenceSettingsModal.tsx
@@ -90,8 +90,9 @@ export const UpdateRecurrenceSettingsModal = (props: Props) => {
 
   const meeting = useFragment(
     graphql`
-      fragment UpdateRecurrenceSettingsModal_meeting on TeamPromptMeeting {
+      fragment UpdateRecurrenceSettingsModal_meeting on NewMeeting {
         id
+        meetingType
         meetingSeries {
           id
           title
@@ -103,6 +104,13 @@ export const UpdateRecurrenceSettingsModal = (props: Props) => {
     meetingRef
   )
 
+  const {meetingType} = meeting
+  const placeholder =
+    meetingType === 'teamPrompt'
+      ? 'Standup'
+      : meetingType === 'retrospective'
+      ? 'Retrospective'
+      : 'Meeting'
   const currentRecurrenceRule = meeting.meetingSeries?.recurrenceRule
   const atmosphere = useAtmosphere()
   const isMeetingSeriesActive = meeting.meetingSeries?.cancelledAt === null
@@ -191,6 +199,7 @@ export const UpdateRecurrenceSettingsModal = (props: Props) => {
       <RecurrenceSettings
         recurrenceSettings={newRecurrenceSettings}
         onRecurrenceSettingsUpdated={handleNewRecurrenceSettings}
+        placeholder={placeholder}
       />
       <StyledCloseButton onClick={closeModal}>
         <CloseIcon />

--- a/packages/server/__tests__/startRetrospective.test.ts
+++ b/packages/server/__tests__/startRetrospective.test.ts
@@ -1,0 +1,95 @@
+import ms from 'ms'
+import {RRule} from 'rrule'
+import getRethink from '../database/rethinkDriver'
+import MeetingTeamPrompt from '../database/types/MeetingTeamPrompt'
+import TeamPromptResponsesPhase from '../database/types/TeamPromptResponsesPhase'
+import generateUID from '../generateUID'
+import {insertMeetingSeries as insertMeetingSeriesQuery} from '../postgres/queries/insertMeetingSeries'
+import {getUserTeams, sendIntranet, sendPublic, signUp} from './common'
+
+test('Retro is named Retro #1 by default', async () => {
+  const r = await getRethink()
+  const {userId, authToken} = await signUp()
+  const {id: teamId} = (await getUserTeams(userId))[0]
+
+  const newRetro = await sendPublic({
+    query: `
+      mutation StartRetrospectiveMutation($teamId: ID!, $recurrenceSettings: RecurrenceSettingsInput, $gcalInput: CreateGcalEventInput) {
+        startRetrospective(teamId: $teamId, recurrenceSettings: $recurrenceSettings, gcalInput: $gcalInput) {
+          ... on ErrorPayload {
+            error {
+              message
+            }
+          }
+          ... on StartRetrospectiveSuccess {
+            meeting {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      teamId
+    },
+    authToken
+  })
+  expect(newRetro).toMatchObject({
+    data: {
+      startRetrospective: {
+        meeting: {
+          id: expect.anything(),
+          name: 'Retro 1'
+        }
+      }
+    }
+  })
+})
+
+test('Recurring retro is named like RetroSeries Jan 1', async () => {
+  const r = await getRethink()
+  const {userId, authToken} = await signUp()
+  const {id: teamId} = (await getUserTeams(userId))[0]
+
+  const now = new Date()
+  const newRetro = await sendPublic({
+    query: `
+      mutation StartRetrospectiveMutation($teamId: ID!, $recurrenceSettings: RecurrenceSettingsInput, $gcalInput: CreateGcalEventInput) {
+        startRetrospective(teamId: $teamId, recurrenceSettings: $recurrenceSettings, gcalInput: $gcalInput) {
+          ... on ErrorPayload {
+            error {
+              message
+            }
+          }
+          ... on StartRetrospectiveSuccess {
+            meeting {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      teamId,
+      recurrenceSettings: {
+        rrule: 'DTSTART;TZID=Europe/Berlin:20240117T060000\nRRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=WE',
+        name: 'RetroSeries'
+      }
+    },
+    authToken
+  })
+
+  const formattedDate = now.toLocaleDateString('en-US', {month: 'short', day: 'numeric'}, 'UTC')
+  expect(newRetro).toMatchObject({
+    data: {
+      startRetrospective: {
+        meeting: {
+          id: expect.anything(),
+          name: `RetroSeries - ${formattedDate}`
+        }
+      }
+    }
+  })
+})

--- a/packages/server/database/types/MeetingRetrospective.ts
+++ b/packages/server/database/types/MeetingRetrospective.ts
@@ -15,7 +15,7 @@ interface Input {
   id?: string
   teamId: string
   meetingCount: number
-  name?: string
+  name: string
   phases: [GenericMeetingPhase, ...GenericMeetingPhase[]]
   facilitatorUserId: string
   showConversionModal?: boolean
@@ -84,7 +84,7 @@ export default class MeetingRetrospective extends Meeting {
       phases,
       facilitatorUserId,
       meetingType: 'retrospective',
-      name: name ?? `Retro #${meetingCount + 1}`,
+      name,
       meetingSeriesId,
       scheduledEndTime
     })

--- a/packages/server/database/types/MeetingTeamPrompt.ts
+++ b/packages/server/database/types/MeetingTeamPrompt.ts
@@ -20,20 +20,6 @@ export function isMeetingTeamPrompt(meeting: Meeting): meeting is MeetingTeamPro
   return meeting.meetingType === 'teamPrompt'
 }
 
-export function createTeamPromptTitle(
-  meetingSeriesName: string,
-  startTime: Date,
-  timeZone: string
-) {
-  const formattedDate = startTime.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    timeZone
-  })
-
-  return `${meetingSeriesName} - ${formattedDate}`
-}
-
 export default class MeetingTeamPrompt extends Meeting {
   meetingType!: 'teamPrompt'
   meetingPrompt: string

--- a/packages/server/graphql/mutations/helpers/createMeetingSeriesTitle.ts
+++ b/packages/server/graphql/mutations/helpers/createMeetingSeriesTitle.ts
@@ -1,0 +1,13 @@
+export function createMeetingSeriesTitle(
+  meetingSeriesName: string,
+  startTime: Date,
+  timeZone: string
+) {
+  const formattedDate = startTime.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone
+  })
+
+  return `${meetingSeriesName} - ${formattedDate}`
+}

--- a/packages/server/graphql/mutations/helpers/safeCreateRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeCreateRetrospective.ts
@@ -16,11 +16,12 @@ const safeCreateRetrospective = async (
     videoMeetingURL?: string
     meetingSeriesId?: number
     scheduledEndTime?: Date
+    name?: string
   },
   dataLoader: DataLoaderWorker
 ) => {
   const r = await getRethink()
-  const {teamId, facilitatorUserId} = meetingSettings
+  const {teamId, facilitatorUserId, name} = meetingSettings
   const meetingType: MeetingTypeEnum = 'retrospective'
   const [meetingCount, team] = await Promise.all([
     r
@@ -37,6 +38,7 @@ const safeCreateRetrospective = async (
   const {showConversionModal} = organization
 
   const meetingId = generateUID()
+  const meetingName = name ?? `Retro ${meetingCount + 1}`
   const phases = await createNewMeetingPhases(
     facilitatorUserId,
     teamId,
@@ -51,7 +53,8 @@ const safeCreateRetrospective = async (
     meetingCount,
     phases,
     showConversionModal,
-    ...meetingSettings
+    ...meetingSettings,
+    name: meetingName
   })
 }
 

--- a/packages/server/graphql/public/mutations/startRetrospective.ts
+++ b/packages/server/graphql/public/mutations/startRetrospective.ts
@@ -15,6 +15,7 @@ import isStartMeetingLocked from '../../mutations/helpers/isStartMeetingLocked'
 import {IntegrationNotifier} from '../../mutations/helpers/notifications/IntegrationNotifier'
 import {startNewMeetingSeries} from './updateRecurrenceSettings'
 import safeCreateRetrospective from '../../mutations/helpers/safeCreateRetrospective'
+import {createMeetingSeriesTitle} from '../../mutations/helpers/createMeetingSeriesTitle'
 
 const startRetrospective: MutationResolvers['startRetrospective'] = async (
   _source,
@@ -50,6 +51,10 @@ const startRetrospective: MutationResolvers['startRetrospective'] = async (
     videoMeetingURL
   } = meetingSettings
 
+  const name = recurrenceSettings?.name
+    ? createMeetingSeriesTitle(recurrenceSettings.name, new Date(), 'UTC')
+    : undefined
+
   const meeting = await safeCreateRetrospective(
     {
       teamId,
@@ -58,7 +63,8 @@ const startRetrospective: MutationResolvers['startRetrospective'] = async (
       maxVotesPerGroup,
       disableAnonymity,
       templateId: selectedTemplateId,
-      videoMeetingURL: videoMeetingURL ?? undefined
+      videoMeetingURL: videoMeetingURL ?? undefined,
+      name
     },
     dataLoader
   )

--- a/packages/server/graphql/public/mutations/startTeamPrompt.ts
+++ b/packages/server/graphql/public/mutations/startTeamPrompt.ts
@@ -11,8 +11,8 @@ import {IntegrationNotifier} from '../../mutations/helpers/notifications/Integra
 import safeCreateTeamPrompt from '../../mutations/helpers/safeCreateTeamPrompt'
 import {MutationResolvers} from '../resolverTypes'
 import {startNewMeetingSeries} from './updateRecurrenceSettings'
-import {createTeamPromptTitle} from '../../../database/types/MeetingTeamPrompt'
 import createGcalEvent from '../../mutations/helpers/createGcalEvent'
+import {createMeetingSeriesTitle} from '../../mutations/helpers/createMeetingSeriesTitle'
 
 const MEETING_START_DELAY_MS = 3000
 
@@ -46,7 +46,7 @@ const startTeamPrompt: MutationResolvers['startTeamPrompt'] = async (
   }
 
   //TODO: use client timezone here (requires sending it from the client and passing it via gql context most likely)
-  const meetingName = createTeamPromptTitle(
+  const meetingName = createMeetingSeriesTitle(
     recurrenceSettings?.name || 'Standup',
     new Date(),
     'UTC'


### PR DESCRIPTION
# Description

Fixes #9343
Chose the correct placeholder for the series name based on meeting type and use the same naming scheme for retro instances that we also use for standups.

## Demo

https://www.loom.com/share/1e282a34a11f425ca7eb1cb722065820?sid=76d56a91-998a-4018-a7e9-02d0a02bc71c

## Testing scenarios

- PR includes some basic test
- Set a meeting series name "MeetingSeries" when creating a series
- See the individual meeting will be named "Meeting Series Jan 23"

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
