### PR TITLE
fix: gh action release switch head to version tag

### DIFF
--- a/.github/workflows/release-to-staging.yml
+++ b/.github/workflows/release-to-staging.yml
@@ -101,6 +101,7 @@ jobs:
           gh pr create \
             --assignee ${{ github.actor }} \
             --base production \
+            --head v${{ env.ACTION_VERSION }} \
             --title "chore(release): Test v${{ env.ACTION_VERSION }}" \
             --body "$BODY"
       - name: Poll Staging Release


### PR DESCRIPTION
# Description

when GH opens a PR to `production` the head should not be master because another dev could have pushed something new to master. Instead, we are pushing a specific version, so we should use that version as the tag.