### PR TITLE
feat: update activity library quick start

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -135,14 +135,21 @@ const CategoryIDToColorClass = {
 
 type Template = Omit<ActivityLibrary_template$data, ' $fragmentType'>
 
-type SubCategory = 'popular' | 'recentlyUsed' | 'recentlyUsedInOrg' | 'neverTried' | 'getStarted'
+type SubCategory =
+  | 'popular'
+  | 'recentlyUsed'
+  | 'recentlyUsedInOrg'
+  | 'neverTried'
+  | 'getStarted'
+  | 'mostPopular'
 
 const subCategoryMapping: Record<SubCategory, string> = {
   popular: 'Popular templates',
   recentlyUsed: 'You used these recently',
   recentlyUsedInOrg: 'Others in your organization are using',
   neverTried: 'Try these activities',
-  getStarted: 'Activities to get you started'
+  getStarted: 'Activities to get you started',
+  mostPopular: 'Our most popular'
 }
 
 interface ActivityGridProps {
@@ -280,8 +287,6 @@ export const ActivityLibrary = (props: Props) => {
   const selectedCategory = categoryId as CategoryID | typeof QUICK_START_CATEGORY_ID
   const subCategoryTitle =
     selectedCategory === 'recommended' ? subCategoryMapping['getStarted'] : undefined
-
-  console.log('🚀 ~ subCategoryTitle:', subCategoryTitle)
 
   return (
     <div className='flex h-full w-full flex-col bg-white'>

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -135,21 +135,14 @@ const CategoryIDToColorClass = {
 
 type Template = Omit<ActivityLibrary_template$data, ' $fragmentType'>
 
-type SubCategory =
-  | 'popular'
-  | 'recentlyUsed'
-  | 'recentlyUsedInOrg'
-  | 'neverTried'
-  | 'getStarted'
-  | 'mostPopular'
+type SubCategory = 'popular' | 'recentlyUsed' | 'recentlyUsedInOrg' | 'neverTried' | 'getStarted'
 
 const subCategoryMapping: Record<SubCategory, string> = {
   popular: 'Popular templates',
   recentlyUsed: 'You used these recently',
   recentlyUsedInOrg: 'Others in your organization are using',
   neverTried: 'Try these activities',
-  getStarted: 'Activities to get you started',
-  mostPopular: 'Our most popular'
+  getStarted: 'Activities to get you started'
 }
 
 interface ActivityGridProps {

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -278,7 +278,7 @@ export const ActivityLibrary = (props: Props) => {
   }
 
   const selectedCategory = categoryId as CategoryID | typeof QUICK_START_CATEGORY_ID
-  const subCategoryTitle =
+  const quickStartTitle =
     selectedCategory === 'recommended' ? subCategoryMapping['getStarted'] : undefined
 
   return (
@@ -409,12 +409,12 @@ export const ActivityLibrary = (props: Props) => {
                 </>
               ) : (
                 <>
-                  {subCategoryTitle && (
-                    <div className='ml-4 mt-8 w-full text-xl font-bold text-slate-700'>
-                      {subCategoryTitle}
+                  {quickStartTitle && (
+                    <div className='ml-4 mt-8 text-xl font-bold text-slate-700'>
+                      {quickStartTitle}
                     </div>
                   )}
-                  <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
+                  <div className='grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4'>
                     <ActivityGrid
                       templates={templatesToRender as Template[]}
                       selectedCategory={selectedCategory}

--- a/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibrary.tsx
@@ -135,13 +135,14 @@ const CategoryIDToColorClass = {
 
 type Template = Omit<ActivityLibrary_template$data, ' $fragmentType'>
 
-type SubCategory = 'popular' | 'recentlyUsed' | 'recentlyUsedInOrg' | 'neverTried'
+type SubCategory = 'popular' | 'recentlyUsed' | 'recentlyUsedInOrg' | 'neverTried' | 'getStarted'
 
 const subCategoryMapping: Record<SubCategory, string> = {
   popular: 'Popular templates',
   recentlyUsed: 'You used these recently',
   recentlyUsedInOrg: 'Others in your organization are using',
-  neverTried: 'Try these activities'
+  neverTried: 'Try these activities',
+  getStarted: 'Activities to get you started'
 }
 
 interface ActivityGridProps {
@@ -277,6 +278,10 @@ export const ActivityLibrary = (props: Props) => {
   }
 
   const selectedCategory = categoryId as CategoryID | typeof QUICK_START_CATEGORY_ID
+  const subCategoryTitle =
+    selectedCategory === 'recommended' ? subCategoryMapping['getStarted'] : undefined
+
+  console.log('🚀 ~ subCategoryTitle:', subCategoryTitle)
 
   return (
     <div className='flex h-full w-full flex-col bg-white'>
@@ -405,12 +410,19 @@ export const ActivityLibrary = (props: Props) => {
                   )}
                 </>
               ) : (
-                <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
-                  <ActivityGrid
-                    templates={templatesToRender as Template[]}
-                    selectedCategory={selectedCategory}
-                  />
-                </div>
+                <>
+                  {subCategoryTitle && (
+                    <div className='ml-4 mt-8 w-full text-xl font-bold text-slate-700'>
+                      {subCategoryTitle}
+                    </div>
+                  )}
+                  <div className='mt-1 grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(min(40%,256px),1fr))] gap-4 p-4 md:mt-4'>
+                    <ActivityGrid
+                      templates={templatesToRender as Template[]}
+                      selectedCategory={selectedCategory}
+                    />
+                  </div>
+                </>
               )}
             </>
           )}

--- a/packages/server/graphql/public/types/FixedActivity.ts
+++ b/packages/server/graphql/public/types/FixedActivity.ts
@@ -2,7 +2,7 @@ import {FixedActivityResolvers} from '../resolverTypes'
 
 const FixedActivity: FixedActivityResolvers = {
   __isTypeOf: ({type}) => type === 'teamPrompt' || type === 'action',
-  isRecommended: () => true
+  isRecommended: ({id}) => (id === 'action' ? false : true)
 }
 
 export default FixedActivity

--- a/packages/server/graphql/public/types/MeetingTemplate.ts
+++ b/packages/server/graphql/public/types/MeetingTemplate.ts
@@ -2,13 +2,7 @@ import TeamMemberId from 'parabol-client/shared/gqlIds/TeamMemberId'
 import {getUserId} from '../../../utils/authorization'
 import {MeetingTemplateResolvers} from '../resolverTypes'
 
-const RECOMMENDED_TEMPLATES = [
-  'teamCharterTemplate',
-  'startStopContinueTemplate',
-  'estimatedEffortTemplate',
-  'incidentResponsePostmortemTemplate',
-  'successAndFailurePremortemTemplate'
-]
+const RECOMMENDED_TEMPLATES = ['startStopContinueTemplate', 'estimatedEffortTemplate']
 
 const MeetingTemplate: MeetingTemplateResolvers = {
   category: ({mainCategory}, _args, _context) => mainCategory,

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -145,8 +145,8 @@ const User: UserResolvers = {
       })
     }
     const getScore = (activity: MeetingTemplate, teamIds: string[]) => {
-      const IS_STANDUP = 1 << 9 // prioritize standups (see https://github.com/ParabolInc/parabol/issues/8848)
       const SEASONAL = 1 << 8 // put seasonal templates at the top
+      const IS_STANDUP = 1 << 7 // prioritize standups but less than seasonal
       const USED_LAST_90 = 1 << 7 // next, show all templates used within the last 90 days
       const ON_TEAM = 1 << 6 // tiebreak by putting team templates first
       const ON_ORG = 1 << 5 // then org templates


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9113

In this PR, I've added "Activities to get you started" title, the four templates from the linked issue, and updated the order to show the Retro template first.

I haven't included the "Our most popular" section as it seems repetitive. There's just one Standup and 1-1 template and two Sprint Poker templates. As we're showing a Standup and 1-1 template in the Quick Start section, we shouldn't show the same templates in the "Our most popular" section, too. 

That means the "Our most popular" section would largely just show popular retro templates, which we already do when they click on the "Retrospective" tab.

I think there's also an advantage to showing a minimal amount of info so users don't feel overwhelmed. Curious to get @acressall's thoughts. 

<img width="1512" alt="Screenshot 2024-01-17 at 16 40 38" src="https://github.com/ParabolInc/parabol/assets/39854876/46003e95-16a6-4f5f-b1d6-9f5f84c3b584">

<img width="1512" alt="Screenshot 2024-01-17 at 16 30 00" src="https://github.com/ParabolInc/parabol/assets/39854876/09a1723d-318c-4b92-afcc-cf759770b55a">


### To test

- [ ] AL looks like the images above
- [ ] You need to add the 1-1 feature flag to see 1-1s
