### PR TITLE
chore: Prettify "Time's up" Slack message

### DIFF
--- a/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/MattermostNotifier.ts
@@ -277,12 +277,38 @@ const MattermostNotificationHelper: NotificationIntegrationHelper<MattermostNoti
     )
   },
   async endTimeLimit(meeting, team, user) {
+    const {name: meetingName} = meeting
     const {webhookUrl} = notificationChannel
-
+    const {name: teamName} = team
     const meetingUrl = makeAppURL(appOrigin, `meet/${meeting.id}`)
-    const messageText = `Time’s up! Advance your meeting to the next phase: ${meetingUrl}`
 
-    return notifyMattermost('MEETING_STAGE_TIME_LIMIT_END', webhookUrl, user, team.id, messageText)
+    const attachments = [
+      makeFieldsAttachment(
+        [
+          {
+            short: true,
+            title: 'Team',
+            value: teamName
+          },
+          {
+            short: true,
+            title: 'Meeting',
+            value: meetingName
+          },
+          {
+            short: false,
+            value: makeHackedFieldButtonValue({label: 'Open meeting', link: meetingUrl})
+          }
+        ],
+        {
+          fallback: `Time’s up! Advance your meeting to the next phase: ${meetingUrl}`,
+          title: `Time’s up! Advance your meeting to the next phase ⏰`,
+          title_link: meetingUrl
+        }
+      )
+    ]
+
+    return notifyMattermost('MEETING_STAGE_TIME_LIMIT_END', webhookUrl, user, team.id, attachments)
   },
   async integrationUpdated(user) {
     const message = `Integration webhook configuration updated`

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -420,14 +420,21 @@ export const SlackSingleChannelNotifier: NotificationIntegrationHelper<SlackNoti
 
   async endTimeLimit(meeting, team, user) {
     const meetingUrl = makeAppURL(appOrigin, `meet/${meeting.id}`)
-    // TODO now is a good time to make the message nice with the `meetingName`
-    const slackText = `Time’s up! Advance your meeting to the next phase: ${meetingUrl}`
+    const title = `Time’s up! Advance your meeting to the next phase :alarm_clock:`
+    const button = {text: 'Open meeting', url: meetingUrl, type: 'primary'} as const
+    const blocks = [
+      makeSection(title),
+      makeSections([createTeamSectionContent(team), createMeetingSectionContent(meeting)]),
+      makeButtons([button])
+    ]
+
     const res = await notifySlack(
       notificationChannel,
       'MEETING_STAGE_TIME_LIMIT_END',
       team.id,
       user,
-      slackText
+      blocks,
+      title
     )
 
     if ('error' in res) {


### PR DESCRIPTION
Format the "Time's up" message similar to the rest of the messages. MSTeams seems to have a nicely formatted message already.

## Demo
Before:
<img width="565" alt="Screenshot 2024-01-18 at 15 35 26" src="https://github.com/ParabolInc/parabol/assets/7331043/21e8b230-e935-46cc-ac74-83b2c6cb7470">
Now:
<img width="469" alt="Screenshot 2024-01-18 at 15 34 18" src="https://github.com/ParabolInc/parabol/assets/7331043/b5e4a5ca-5421-41b4-a947-d016e7ca40d0">
<img width="794" alt="Screenshot 2024-01-18 at 15 36 45" src="https://github.com/ParabolInc/parabol/assets/7331043/fcbe7129-a5b8-4bbb-8e8f-7758d1afdfd3">


## Testing scenarios

For ease of testing I replaced
https://github.com/ParabolInc/parabol/blob/35121827ea3eb8a34f839367fa8480c7727d1241/packages/server/graphql/public/mutations/startCheckIn.ts#L113
with
```
  IntegrationNotifier.endTimeLimit(dataLoader, meetingId, teamId)
```
and just started a check-in

- check Slack
- check Mattermost

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
