### PR TITLE
fix: create release branch as head

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,25 @@
+name: Ironbank S3 Upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: "Version number of the Parabol image to process"
+        required: true
+
+jobs:
+  make-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "write"
+      id-token: "write"
+      pull-requests: "write"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create release branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git checkout -b "release/${{ github.event.inputs.version_number }}"
+          git push


### PR DESCRIPTION
testing how a github workflow can create a new branch