### PR TITLE
feat: support SERVER_SECRET rotations gracefully

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -272,6 +272,7 @@ export default class Atmosphere extends Environment {
       console.error('Cannot connect!')
       // this may be reached if the auth token was deemed invalid by the server
       this.setAuthToken(null)
+      window.location.href = '/'
       return
     }
     this.transport = new GQLTrebuchetClient(trebuchet)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -71,7 +71,7 @@
     "@emotion/styled": "^10.0.27",
     "@mattkrick/graphql-trebuchet-client": "^2.2.1",
     "@mattkrick/sanitize-svg": "0.4.0",
-    "@mattkrick/trebuchet-client": "^3.0.1",
+    "@mattkrick/trebuchet-client": "^3.0.2",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.2",
     "@mui/x-date-pickers": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5946,10 +5946,10 @@
   resolved "https://registry.yarnpkg.com/@mattkrick/sanitize-svg/-/sanitize-svg-0.4.0.tgz#388c29614cf72aa0dd9803c77c9c9d070bd3cd2d"
   integrity sha512-TnPI97WVAxo8SQcPy8aV3OF9/2WjXB5/+pRNVudIWR7Bhi5ZjtR/ur162So08GkvsvB914AXCW2sxFh1x6KhHA==
 
-"@mattkrick/trebuchet-client@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@mattkrick/trebuchet-client/-/trebuchet-client-3.0.1.tgz#3fc49f7858652a55dca92cb0c14c0313df931619"
-  integrity sha512-5uHCldCqmVntoyujTzRfmGtjld8k4JuBdFN0SvhvRFf83FPaNeoit6Mh8VgrcxxxKujKeYCQDMQH6LWwpsshgQ==
+"@mattkrick/trebuchet-client@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@mattkrick/trebuchet-client/-/trebuchet-client-3.0.2.tgz#336d687256fb9ac7bb407f656bf2f69f35f817e1"
+  integrity sha512-JLOx8gd+cGkDeHhdnns0oor2UNv5uRZ8A/Jfw3NhQcVqQe6R+x9xIHW29M2T78TDHUWqItTgntX+cdDLqVjVvg==
   dependencies:
     "@mattkrick/fast-rtc-peer" "^0.4.1"
     eventemitter3 "^4.0.7"


### PR DESCRIPTION
# Description

support server secret rotations without our app trying to DOS us.
before the client would see it failed to connect & keep retrying forever because it had succeeded in the past.
now it realized that just because it succeeded in the past, it may not succeed now.

## Demo

https://www.loom.com/share/891a552c4f3c4e3d99d5f71d9dcdcdcb?sid=00bfa14e-60e7-406f-8ebf-68c42ebb3723

## Testing scenarios

- [ ] can rotate secret while a client is connected. they get logged out
- [ ] a client with an old token visits the app & goes to the auth page
