### PR TITLE
chore(kudos): track kudos type and meeting type in kudosSent event

### DIFF
--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -159,6 +159,8 @@ const sendKudos = async (
         teamId,
         kudos.id,
         kudos.receiverUserId,
+        'mention',
+        'retrospective',
         isAnonymous
       )
     })

--- a/packages/server/graphql/public/mutations/addReactjiToReactable.ts
+++ b/packages/server/graphql/public/mutations/addReactjiToReactable.ts
@@ -213,7 +213,7 @@ const addReactjiToReactable: MutationResolvers['addReactjiToReactable'] = async 
 
     publishNotification(notificationsToInsert, subOptions)
 
-    analytics.kudosSent(viewer, teamId, addedKudosId, reactableCreatorId)
+    analytics.kudosSent(viewer, teamId, addedKudosId, reactableCreatorId, 'reaction', meetingType)
   }
 
   const data = {reactableId, reactableType, addedKudosId}

--- a/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
+++ b/packages/server/graphql/public/mutations/upsertTeamPromptResponse.ts
@@ -117,7 +117,7 @@ const upsertTeamPromptResponse: MutationResolvers['upsertTeamPromptResponse'] = 
         .execute()
 
       insertedKudoses.forEach((kudos) => {
-        analytics.kudosSent(user, teamId, kudos.id, kudos.receiverUserId)
+        analytics.kudosSent(user, teamId, kudos.id, kudos.receiverUserId, 'mention', 'teamPrompt')
       })
     }
   }

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -720,6 +720,8 @@ class Analytics {
     teamId: string,
     kudosId: number,
     receiverUserId: string,
+    kudosType: 'mention' | 'reaction',
+    meetingType: MeetingTypeEnum,
     isAnonymous = false
   ) => {
     this.track(user, 'Kudos Sent', {
@@ -727,6 +729,8 @@ class Analytics {
       teamId,
       kudosId,
       receiverUserId,
+      kudosType,
+      meetingType,
       isAnonymous
     })
   }


### PR DESCRIPTION
**How to test:**
- Add some kudos see `kudosSent` event tracked correctly