### PR TITLE
fix: render activity library tooltip

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityGrid.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityGrid.tsx
@@ -31,6 +31,7 @@ const ActivityGrid = ({templates, selectedCategory}: ActivityGridProps) => {
               theme={CATEGORY_THEMES[template.category as CategoryID]}
               title={template.name}
               type={template.type}
+              templateRef={template}
               badge={
                 !template.isFree ? (
                   <ActivityBadge className='m-2 bg-gold-300 text-grape-700'>Premium</ActivityBadge>


### PR DESCRIPTION
In production, the tooltip with the prompt details isn't showing up when you hover over the activity library card.

### To test

- [ ] Hover over the activity library card and see that the tooltip shows up