### PR TITLE
fix: handle all types of errors in sendToSentry

### DIFF
--- a/packages/server/utils/sendToSentry.ts
+++ b/packages/server/utils/sendToSentry.ts
@@ -15,7 +15,7 @@ export interface SentryOptions {
 const sendToSentry = async (error: Error, options: SentryOptions = {}) => {
   console.trace(
     'SEND TO SENTRY',
-    error.message,
+    error.message || error?.toString() || JSON.stringify(error),
     JSON.stringify(options.tags),
     JSON.stringify(options.extras)
   )


### PR DESCRIPTION
# Description

fix #9386 by stringifying the error in any way possible 
