### PR TITLE
chore: update 3d secure card number in release_test.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_test.md
+++ b/.github/ISSUE_TEMPLATE/release_test.md
@@ -31,7 +31,7 @@ Run through this list at least once at [staging](https://action.parabol.fun):
 - [ ] Created a 2nd team
 - [ ] Created a 2nd organization
 - [ ] Upgraded to Team (Credit card number: `4242 4242 4242 4242`, expiration date: any month in the future, CVC: `123`)
-- [ ] Upgraded to Team with a 3D Secure card (Credit card number: `4000 0000 0000 3063`, expiration date: any month in the future, CVC: `123`)
+- [ ] Upgraded to Team with a 3D Secure card (Credit card number: `4000 0000 0000 3220`, expiration date: any month in the future, CVC: `123`)
 - [ ] Tried and failed to upgrade with a card with insufficient funds (Credit card number: `4000 0000 0000 9995`, expiration date: any month in the future, CVC: `123`). Error feedback is shown in the UI.
 - [ ] Smoke tested the app on a mobile device (e.g. navigate between views, smoke test a Retro meeting, etc.)
 - [ ] Test previously existed meetings to make sure that existing data is not corrupted


### PR DESCRIPTION
Previous 3d secure card number does not work anymore and I don't see it in the stripe docs https://stripe.com/docs/testing?testing-method=card-numbers#regulatory-cards

How to test:
- See that new card number triggers 3d secure window auth on staging
