### PR TITLE
chore: Add more Atlassian logging

### DIFF
--- a/docker/dd-conf.d/gqlExecutor.yml
+++ b/docker/dd-conf.d/gqlExecutor.yml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/var/log/datadog/logs/gqlExecutor-1.log"
+    service: parabol-local-dev
+    source: GQL-Executor

--- a/docker/dd-conf.d/web.yml
+++ b/docker/dd-conf.d/web.yml
@@ -1,5 +1,5 @@
 logs:
   - type: file
-    path: "/var/log/datadog/logs/gqlExecutor.log"
+    path: "/var/log/datadog/logs/web.log"
     service: parabol
     source: parabol

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -14,7 +14,7 @@ services:
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
       - "./dd-conf.d:/etc/datadog-agent/conf.d/local.d/"
-      - "../logs:/var/log/datadog/logs"
+      - "../dev/logs:/var/log/datadog/logs"
   db:
     image: rethinkdb:2.4.2
     restart: unless-stopped

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -13,6 +13,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+      - "./dd-conf.d:/etc/datadog-agent/conf.d/local.d/"
+      - "../logs:/var/log/datadog/logs"
   db:
     image: rethinkdb:2.4.2
     restart: unless-stopped

--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -1,125 +1,20 @@
-import JiraIssueId from '../shared/gqlIds/JiraIssueId'
-import JiraProjectKeyId from '../shared/gqlIds/JiraProjectKeyId'
-import {SprintPokerDefaults} from '../types/constEnums'
-import composeJQL from './composeJQL'
-
-export interface JiraUser {
-  self: string
-  key: string
-  accountId: string
-  name: string
-  emailAddress: string
-  avatarUrls: {[key: string]: string}
-  displayName: string
-  active: boolean
-  timeZone: string
-}
-
-export interface AccessibleResource {
-  id: string
-  name: string
-  scopes: string[]
-  avatarUrl: string
-  url: string
-}
-
-interface AvatarURLs {
-  '48x48': string
-  '24x24': string
-  '16x16': string
-  '32x32': string
-}
-export interface JiraProject {
-  self: string
-  id: string
-  key: string
-  name: string
-  avatarUrls: AvatarURLs
-  projectCategory: {
-    self: string
-    id: string
-    name: string
-    description: string
-  }
-  simplified: boolean
-  style: string
-}
-
-export interface JiraProjectResponse {
-  self: string
-  nextPage: string
-  maxResults: number
-  startAt: number
-  total: number
-  isLast: boolean
-  values: JiraProject[]
-}
-
-export interface JiraIssueType {
-  self: string
-  id: string
-  description: string
-  iconUrl: string
-  name: string
-  subtask: boolean
-  fields?: {
-    issuetype: {
-      required: boolean
-      name: string
-      key: string
-      hasDefaultValue: false
-      operations: string[]
-    }
-  }
-}
+const MAX_REQUEST_TIME = 5000
 
 export interface AtlassianError {
   code: number
   message: string
 }
 
-interface GetProjectsResult {
-  cloudId: string
-  newProjects: JiraProject[]
-}
-
-interface Reporter {
-  id: string
-}
-
-interface Assignee {
-  id: string
-}
-
-interface CreateIssueFields {
-  assignee: Assignee
-  summary: string
-  description?: Record<any, any>
-  reporter?: Reporter // probably can't use, it throws a lot of errors
-  project?: Partial<JiraProject>
-  issuetype?: Partial<JiraIssueType>
-}
-
-interface IssueCreateMetadata {
-  projects: (Pick<JiraProject, 'self' | 'id' | 'key' | 'name' | 'avatarUrls'> & {
-    issuetypes: [JiraIssueType, ...JiraIssueType[]]
-  })[]
-}
-
-export interface JiraCreateIssueResponse {
-  id: string
-  key: string
-  self: string
-}
-
-type GetProjectsCallback = (
-  error: AtlassianError | Error | null,
-  result: GetProjectsResult | null
-) => void
-
 interface JiraNoAccessError {
   errorMessages: ['The app is not installed on this instance.']
 }
+
+export function isJiraNoAccessError<T extends object>(
+  response: T | JiraNoAccessError
+): response is JiraNoAccessError {
+  return 'errorMessages' in response && response.errorMessages.length > 0
+}
+
 interface JiraFieldError {
   errors: {
     [fieldName: string]: string
@@ -133,167 +28,8 @@ interface JiraGetError {
   message: string
   path: string
 }
+
 type JiraError = JiraNoAccessError | JiraFieldError | JiraGetError
-
-type JiraIssueProperties = any
-type JiraIssueNames = any
-type JiraIssueSchema = any
-type JiraIssueTransition = any
-type JiraOperations = any
-type JiraIssueUpdateMetadata = any
-type JiraPageOfChangelogs = any
-type JiraVersionedRepresentations = any
-type JiraIncludedFields = any
-
-interface JiraIssueBean<F = {description: any; summary: string; created: string}, R = unknown> {
-  expand: string
-  id: string
-  self: string
-  key: string
-  renderedFields: R
-  properties: JiraIssueProperties
-  names: JiraIssueNames
-  schema: JiraIssueSchema
-  transitions: JiraIssueTransition[]
-  operations: JiraOperations
-  editmeta: JiraIssueUpdateMetadata
-  changelog: JiraPageOfChangelogs
-  versionedRepresentations: JiraVersionedRepresentations
-  fieldsToInclude: JiraIncludedFields
-  fields: F
-}
-
-export type JiraIssueRaw = JiraIssueBean<
-  {description: string; summary: string; issuetype: {id: string; iconUrl: string}; created: string},
-  {description: string}
->
-
-interface JiraAuthor {
-  self: string
-  emailAddress: string
-  avatarUrls: AvatarURLs
-  displayName: string
-  active: boolean
-  timeZone: string
-  accountType: 'atlassian'
-}
-
-interface JiraAddCommentResponse {
-  self: string
-  id: string
-  author: JiraAuthor
-  body: {
-    version: 1
-    type: 'doc'
-    content: any[]
-  }
-  updateAuthor: JiraAuthor
-  created: string
-  updated: string
-  jsdPublic: true
-}
-
-export type JiraGetIssueRes = JiraIssueBean<JiraGQLFields>
-
-export interface JiraGQLFields {
-  issuetype: {
-    id: string
-    iconUrl: string
-  }
-  project?: {
-    simplified: boolean
-  }
-  cloudId: string
-  description: any
-  descriptionHTML: string
-  issueKey: string
-  summary: string
-  lastUpdated: string
-}
-interface JiraSearchResponse<
-  T = {
-    summary: string
-    description: string
-    issuetype: {id: string; iconUrl: string}
-    created: string
-  }
-> {
-  expand: string
-  startAt: number
-  maxResults: number
-  total: number
-  issues: {
-    expand: string
-    id: string
-    self: string
-    key: string
-    fields: T
-    renderedFields: {
-      description: string
-    }
-    changelog: {
-      histories: {
-        created: string
-      }[]
-    }
-  }[]
-}
-
-/*
-interface JiraField {
-  issuetype: {
-    id: string
-  }
-  clauseNames: string[]
-  custom: boolean
-  id: string
-  key: string
-  name: string
-  navigable: boolean
-  orderable: boolean
-  schema: {
-    custom: string
-    customId: number
-    type: string
-  }
-  searchable: boolean
-  untranslatedName: string
-}
-*/
-
-export interface JiraScreen {
-  id: string
-  name: string
-  description: string
-}
-
-export interface JiraScreenTab {
-  id: string
-  name: string
-}
-
-export interface JiraAddScreenFieldResponse {
-  id: string
-  name: string
-}
-
-interface JiraPageBean<T> {
-  startAt: number
-  maxResults: number
-  total: number
-  isLast: boolean
-  values: T[]
-}
-
-export function isJiraNoAccessError<T extends object>(
-  response: T | JiraNoAccessError
-): response is JiraNoAccessError {
-  return 'errorMessages' in response && response.errorMessages.length > 0
-}
-
-export type JiraScreensResponse = JiraPageBean<JiraScreen>
-
-const MAX_REQUEST_TIME = 5000
 
 export type JiraPermissionScope =
   | 'read:jira-user'
@@ -324,12 +60,12 @@ export default abstract class AtlassianManager {
   ]
   static MANAGE_SCOPE: JiraPermissionScope[] = [...AtlassianManager.SCOPE, 'manage:jira-project']
   accessToken: string
-  private headers = {
+  protected headers = {
     Authorization: '',
     Accept: 'application/json' as const,
     'Content-Type': 'application/json' as const
   }
-  private readonly fetchWithTimeout = async (url: string, options: RequestInit) => {
+  protected readonly fetchWithTimeout = async (url: string, options: RequestInit) => {
     const controller = new AbortController()
     const {signal} = controller
     const timeout = setTimeout(() => {
@@ -344,7 +80,7 @@ export default abstract class AtlassianManager {
       return new Error('Atlassian is down')
     }
   }
-  private readonly get = async <T extends object>(url: string) => {
+  protected readonly get = async <T extends object>(url: string) => {
     const res = await this.fetchWithTimeout(url, {headers: this.headers})
     if (res instanceof Error) {
       return res
@@ -373,7 +109,7 @@ export default abstract class AtlassianManager {
     }
     return json
   }
-  private readonly post = async <T extends object>(url: string, payload: any) => {
+  protected readonly post = async <T extends object>(url: string, payload: any) => {
     const res = await this.fetchWithTimeout(url, {
       method: 'POST',
       headers: this.headers,
@@ -395,7 +131,7 @@ export default abstract class AtlassianManager {
     }
     return json
   }
-  private readonly put = async (url: string, payload: any) => {
+  protected readonly put = async (url: string, payload: any) => {
     const res = await this.fetchWithTimeout(url, {
       method: 'PUT',
       headers: this.headers,
@@ -421,7 +157,7 @@ export default abstract class AtlassianManager {
     }
     return new Error(`Unknown Jira error: ${JSON.stringify(error)}`)
   }
-  private readonly delete = async (url: string) => {
+  protected readonly delete = async (url: string) => {
     const res = await this.fetchWithTimeout(url, {
       method: 'DELETE',
       headers: this.headers
@@ -451,339 +187,5 @@ export default abstract class AtlassianManager {
   constructor(accessToken: string) {
     this.accessToken = accessToken
     this.headers.Authorization = `Bearer ${accessToken}`
-  }
-
-  async getAccessibleResources() {
-    return this.get<AccessibleResource[]>(
-      'https://api.atlassian.com/oauth/token/accessible-resources'
-    )
-  }
-
-  async getMyself(cloudId: string) {
-    return this.get<JiraUser>(`https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/myself`)
-  }
-
-  async getPaginatedProjects(cloudId: string, url: string, callback: GetProjectsCallback) {
-    const res = await this.get<JiraProjectResponse>(url)
-    if (res instanceof Error || res instanceof RateLimitError) {
-      callback(res, null)
-    } else {
-      callback(null, {cloudId, newProjects: res.values})
-      if (res.nextPage) {
-        await this.getPaginatedProjects(cloudId, res.nextPage, callback).catch(console.error)
-      }
-    }
-  }
-
-  async getProjects(cloudIds: string[], callback: GetProjectsCallback) {
-    return Promise.all(
-      cloudIds.map(async (cloudId) => {
-        return this.getPaginatedProjects(
-          cloudId,
-          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`,
-          callback
-        ).catch(console.error)
-      })
-    )
-  }
-
-  async getImage(imageUrl: string) {
-    const imageRes = await this.fetchWithTimeout(imageUrl, {
-      headers: {Authorization: this.headers.Authorization}
-    })
-
-    if (!imageRes || imageRes instanceof Error) return null
-    const arrayBuffer = await imageRes.arrayBuffer()
-    return {
-      imageBuffer: Buffer.from(arrayBuffer),
-      contentType: imageRes.headers.get('content-type')
-    }
-  }
-
-  async getAllProjects(cloudIds: string[]) {
-    const projects = [] as (JiraProject & {cloudId: string})[]
-    let error: Error | undefined
-    const getProjectPage = async (cloudId: string, url: string): Promise<void> => {
-      const res = await this.get<JiraProjectResponse>(url)
-      if (res instanceof Error || res instanceof RateLimitError) {
-        error = res
-      } else {
-        const pagedProjects = res.values.map((project) => ({
-          ...project,
-          cloudId
-        }))
-        projects.push(...pagedProjects)
-        if (res.nextPage) {
-          return getProjectPage(cloudId, res.nextPage)
-        }
-      }
-    }
-    await Promise.all(
-      cloudIds.map((cloudId) =>
-        getProjectPage(
-          cloudId,
-          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`
-        )
-      )
-    )
-
-    if (error) {
-      console.log('getAllProjects ERROR:', error)
-    }
-    return projects
-  }
-
-  async getProject(cloudId: string, projectKey: string) {
-    const project = await this.get<JiraProject>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/${projectKey}`
-    )
-
-    return project
-  }
-
-  async getCreateMeta(cloudId: string, projectKeys?: string[]) {
-    let args = ''
-    if (projectKeys) {
-      args += `projectKeys=${projectKeys.join(',')}`
-    }
-    if (args.length) {
-      args = '?' + args
-    }
-    return this.get<IssueCreateMetadata>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/createmeta${args}`
-    )
-  }
-
-  async getEditMeta(cloudId: string, issueKey: string) {
-    return this.get<IssueCreateMetadata>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}/editmeta`
-    )
-  }
-
-  async createIssue(cloudId: string, projectKey: string, issueFields: CreateIssueFields) {
-    const payload = {
-      fields: {
-        project: {
-          key: projectKey
-        },
-        ...issueFields
-      } as CreateIssueFields
-    }
-    return this.post<JiraCreateIssueResponse>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue`,
-      payload
-    )
-  }
-
-  async getCloudNameLookup() {
-    const sites = await this.getAccessibleResources()
-    const cloudNameLookup = {} as {[cloudId: string]: string}
-    if (sites instanceof Error || sites instanceof RateLimitError) {
-      return sites
-    }
-    sites.forEach((site) => {
-      cloudNameLookup[site.id] = site.name
-    })
-    return cloudNameLookup
-  }
-
-  async getIssue(
-    cloudId: string,
-    issueKey: string,
-    extraFieldIds: string[] = [],
-    extraExpand: string[] = []
-  ) {
-    const reqFields = extraFieldIds.includes('*all')
-      ? '*all'
-      : ['summary', 'description', 'issuetype', 'created', ...extraFieldIds].join(',')
-    const expand = ['renderedFields', 'changelog', 'editmeta', 'names', ...extraExpand].join(',')
-    const issueRes = await this.get<JiraIssueRaw>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}?fields=${reqFields}&expand=${expand}`
-    )
-    if (issueRes instanceof Error || issueRes instanceof RateLimitError) return issueRes
-    return {
-      ...issueRes,
-      fields: {
-        ...issueRes.fields,
-        descriptionHTML: issueRes.renderedFields.description,
-        cloudId,
-        issueKey,
-        id: JiraIssueId.join(cloudId, issueKey),
-        lastUpdated: issueRes.changelog.histories[0]?.created ?? issueRes.fields.created
-      }
-    }
-  }
-
-  async getIssues(
-    queryString: string | null,
-    isJQL: boolean,
-    projectFiltersByCloudId: {[cloudId: string]: string[]},
-    maxResults: number,
-    startAt?: number
-  ) {
-    const allIssues = [] as JiraGQLFields[]
-    let firstError: Error | undefined
-    const reqs = Object.entries(projectFiltersByCloudId).map(async ([cloudId, projectKeys]) => {
-      const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search`
-      const jql = composeJQL(queryString, isJQL, projectKeys)
-      const payload = {
-        jql,
-        maxResults,
-        startAt,
-        fields: ['summary', 'description', 'issuetype', 'created'],
-        expand: ['renderedFields,changelog']
-      }
-
-      const res = await this.post<JiraSearchResponse>(url, payload)
-      if (res instanceof Error) {
-        if (!firstError) {
-          firstError = res
-          if (firstError.message.includes('not installed on this instance')) {
-            firstError.message = 'Jira access revoked. Please reintegrate with Jira.'
-          }
-        }
-        return
-      }
-      const issues = res.issues.map((issue) => {
-        const {key: issueKey, fields, renderedFields, changelog} = issue
-        const {description, summary, issuetype, created} = fields
-        const {description: descriptionHTML} = renderedFields
-        return {
-          issuetype,
-          summary,
-          description,
-          descriptionHTML,
-          cloudId,
-          issueKey,
-          lastUpdated: changelog.histories[0]?.created ?? created
-        }
-      })
-      allIssues.push(...issues)
-    })
-    await Promise.all(reqs)
-    return {error: firstError, issues: allIssues}
-  }
-
-  async getComments(cloudId: string, issueKey: string) {
-    return this.get(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}/comment`
-    ) as any
-  }
-
-  async getFieldScreens(cloudId: string, fieldId: string) {
-    return this.get(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/field/${fieldId}/screens`
-    ) as any
-  }
-
-  async addComment(cloudId: string, issueKey: string, body: any) {
-    const payload = {
-      body
-    }
-    return this.post<JiraAddCommentResponse>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}/comment`,
-      payload
-    )
-  }
-
-  async updateStoryPoints(
-    cloudId: string,
-    issueKey: string,
-    storyPoints: string | number,
-    fieldId: string
-  ) {
-    // according to Jira docs fields related to the time tracking have to be set in a different way than other fields
-    // https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put
-    // more context: https://github.com/ParabolInc/parabol/issues/5705#issuecomment-1007501068
-    let payload: Record<string, any>
-    const timeTrackingFieldId = 'timetracking'
-    const timeTrackingFieldLookup = {
-      timeoriginalestimate: 'originalEstimate',
-      timeestimate: 'remainingEstimate'
-    } as const
-    const timeTrackingFieldName =
-      timeTrackingFieldLookup[fieldId as keyof typeof timeTrackingFieldLookup]
-    if (!!timeTrackingFieldName) {
-      payload = {
-        update: {
-          [timeTrackingFieldId]: [
-            {
-              set: {
-                // time tracking fields have to be set in time format, we're setting them in (h)ours
-                [timeTrackingFieldName]: `${storyPoints}h`
-              }
-            }
-          ]
-        }
-      }
-    } else {
-      payload = {
-        fields: {
-          [fieldId]: storyPoints
-        }
-      }
-    }
-    const res = await this.put(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}`,
-      payload
-    )
-    if (res === null) return
-    if (res.message.includes('The app is not installed on this instance')) {
-      throw new Error(
-        'The user who added this issue was removed from Jira. Please remove & re-add the issue'
-      )
-    }
-    if (
-      res.message.startsWith(timeTrackingFieldName ? timeTrackingFieldId : fieldId) &&
-      res.message.includes('is not on the appropriate screen')
-    ) {
-      const projectKey = JiraProjectKeyId.join(issueKey)
-      const project = await this.getProject(cloudId, projectKey)
-
-      if (project instanceof RateLimitError || project instanceof Error) {
-        throw project
-      }
-
-      if (project.simplified) {
-        if (timeTrackingFieldName) {
-          throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR_ESTIMATION_TIMETRACKING)
-        }
-        throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR_ESTIMATION)
-      }
-
-      throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR)
-    }
-    throw res
-  }
-
-  async getScreens(cloudId: string, maxResults: number, startAt = 0) {
-    return this.get<JiraScreensResponse>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens?maxResults=${maxResults}&startAt=${startAt}`
-    )
-  }
-
-  async getScreenTabs(cloudId: string, screenId: string) {
-    // a screen has at least 1 tab
-    return this.get<[JiraScreenTab, ...JiraScreenTab[]]>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens/${screenId}/tabs`
-    )
-  }
-
-  async addFieldToScreenTab(cloudId: string, screenId: string, tabId: string, fieldId: string) {
-    return this.post<JiraAddScreenFieldResponse>(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/`,
-      {fieldId}
-    )
-  }
-
-  async removeFieldFromScreenTab(
-    cloudId: string,
-    screenId: string,
-    tabId: string,
-    fieldId: string
-  ) {
-    return this.delete(
-      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/${fieldId}`
-    )
   }
 }

--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -9,12 +9,6 @@ interface JiraNoAccessError {
   errorMessages: ['The app is not installed on this instance.']
 }
 
-export function isJiraNoAccessError<T extends object>(
-  response: T | JiraNoAccessError
-): response is JiraNoAccessError {
-  return 'errorMessages' in response && response.errorMessages.length > 0
-}
-
 interface JiraFieldError {
   errors: {
     [fieldName: string]: string
@@ -30,6 +24,12 @@ interface JiraGetError {
 }
 
 type JiraError = JiraNoAccessError | JiraFieldError | JiraGetError
+
+export function isJiraNoAccessError<T extends object>(
+  response: T | JiraNoAccessError
+): response is JiraNoAccessError {
+  return 'errorMessages' in response && response.errorMessages.length > 0
+}
 
 export type JiraPermissionScope =
   | 'read:jira-user'

--- a/packages/server/dataloader/atlassianLoaders.ts
+++ b/packages/server/dataloader/atlassianLoaders.ts
@@ -3,12 +3,7 @@ import {decode} from 'jsonwebtoken'
 import JiraIssueId from 'parabol-client/shared/gqlIds/JiraIssueId'
 import JiraProjectId from 'parabol-client/shared/gqlIds/JiraProjectId'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import {
-  JiraGetIssueRes,
-  JiraGQLFields,
-  JiraProject,
-  RateLimitError
-} from 'parabol-client/utils/AtlassianManager'
+import {RateLimitError} from 'parabol-client/utils/AtlassianManager'
 import {JiraIssueMissingEstimationFieldHintEnum} from '../graphql/private/resolverTypes'
 import {AtlassianAuth} from '../postgres/queries/getAtlassianAuthByUserIdTeamId'
 import getAtlassianAuthsByUserId from '../postgres/queries/getAtlassianAuthsByUserId'
@@ -21,7 +16,11 @@ import upsertAtlassianAuths from '../postgres/queries/upsertAtlassianAuths'
 import {hasDefaultEstimationField, isValidEstimationField} from '../utils/atlassian/jiraFields'
 import {downloadAndCacheImages, updateJiraImageUrls} from '../utils/atlassian/jiraImages'
 import {getIssue} from '../utils/atlassian/jiraIssues'
-import AtlassianServerManager from '../utils/AtlassianServerManager'
+import AtlassianServerManager, {
+  JiraGetIssueRes,
+  JiraGQLFields,
+  JiraProject
+} from '../utils/AtlassianServerManager'
 import publish from '../utils/publish'
 import sendToSentry from '../utils/sendToSentry'
 import RootDataLoader from './RootDataLoader'

--- a/packages/server/graphql/types/JiraRemoteProject.ts
+++ b/packages/server/graphql/types/JiraRemoteProject.ts
@@ -1,12 +1,11 @@
 import {GraphQLBoolean, GraphQLID, GraphQLNonNull, GraphQLObjectType, GraphQLString} from 'graphql'
 import JiraProjectId from 'parabol-client/shared/gqlIds/JiraProjectId'
-import {JiraProject} from 'parabol-client/utils/AtlassianManager'
 import {
   createImageUrlHash,
   createParabolImageUrl,
   downloadAndCacheImage
 } from '../../utils/atlassian/jiraImages'
-import AtlassianServerManager from '../../utils/AtlassianServerManager'
+import AtlassianServerManager, {JiraProject} from '../../utils/AtlassianServerManager'
 import {GQLContext} from '../graphql'
 import IntegrationProviderServiceEnum from './IntegrationProviderServiceEnum'
 import JiraRemoteAvatarUrls from './JiraRemoteAvatarUrls'

--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -1,9 +1,296 @@
-import AtlassianManager from 'parabol-client/utils/AtlassianManager'
+import AtlassianManager, {
+  AtlassianError,
+  RateLimitError
+} from 'parabol-client/utils/AtlassianManager'
+import JiraIssueId from 'parabol-client/shared/gqlIds/JiraIssueId'
+import composeJQL from 'parabol-client/utils/composeJQL'
+import JiraProjectKeyId from 'parabol-client/shared/gqlIds/JiraProjectKeyId'
+import {SprintPokerDefaults} from 'parabol-client/types/constEnums'
 import {authorizeOAuth2} from '../integrations/helpers/authorizeOAuth2'
 import {
   OAuth2AuthorizationParams,
   OAuth2RefreshAuthorizationParams
 } from '../integrations/OAuth2Manager'
+
+import tracer from 'dd-trace'
+import formats from 'dd-trace/ext/formats'
+import util from 'util'
+
+type LogLevel = 'error' | 'warn' | 'info' | 'debug'
+function trace(level: LogLevel, message: any, ...optionalParameters: any[]) {
+  const span = tracer.scope().active()
+  const time = new Date().toISOString()
+  const record = {time, level, message: util.format(message, optionalParameters)}
+
+  if (span) {
+    tracer.inject(span.context(), formats.LOG, record)
+  }
+
+  console.log(JSON.stringify(record))
+}
+
+const log = trace.bind(null, 'info')
+
+export interface JiraUser {
+  self: string
+  key: string
+  accountId: string
+  name: string
+  emailAddress: string
+  avatarUrls: {[key: string]: string}
+  displayName: string
+  active: boolean
+  timeZone: string
+}
+
+export interface AccessibleResource {
+  id: string
+  name: string
+  scopes: string[]
+  avatarUrl: string
+  url: string
+}
+
+interface AvatarURLs {
+  '48x48': string
+  '24x24': string
+  '16x16': string
+  '32x32': string
+}
+export interface JiraProject {
+  self: string
+  id: string
+  key: string
+  name: string
+  avatarUrls: AvatarURLs
+  projectCategory: {
+    self: string
+    id: string
+    name: string
+    description: string
+  }
+  simplified: boolean
+  style: string
+}
+
+export interface JiraProjectResponse {
+  self: string
+  nextPage: string
+  maxResults: number
+  startAt: number
+  total: number
+  isLast: boolean
+  values: JiraProject[]
+}
+
+export interface JiraIssueType {
+  self: string
+  id: string
+  description: string
+  iconUrl: string
+  name: string
+  subtask: boolean
+  fields?: {
+    issuetype: {
+      required: boolean
+      name: string
+      key: string
+      hasDefaultValue: false
+      operations: string[]
+    }
+  }
+}
+
+interface GetProjectsResult {
+  cloudId: string
+  newProjects: JiraProject[]
+}
+
+interface Reporter {
+  id: string
+}
+
+interface Assignee {
+  id: string
+}
+
+interface CreateIssueFields {
+  assignee: Assignee
+  summary: string
+  description?: Record<any, any>
+  reporter?: Reporter // probably can't use, it throws a lot of errors
+  project?: Partial<JiraProject>
+  issuetype?: Partial<JiraIssueType>
+}
+
+interface IssueCreateMetadata {
+  projects: (Pick<JiraProject, 'self' | 'id' | 'key' | 'name' | 'avatarUrls'> & {
+    issuetypes: [JiraIssueType, ...JiraIssueType[]]
+  })[]
+}
+
+export interface JiraCreateIssueResponse {
+  id: string
+  key: string
+  self: string
+}
+
+type GetProjectsCallback = (
+  error: AtlassianError | Error | null,
+  result: GetProjectsResult | null
+) => void
+
+type JiraIssueProperties = any
+type JiraIssueNames = any
+type JiraIssueSchema = any
+type JiraIssueTransition = any
+type JiraOperations = any
+type JiraIssueUpdateMetadata = any
+type JiraPageOfChangelogs = any
+type JiraVersionedRepresentations = any
+type JiraIncludedFields = any
+
+interface JiraIssueBean<F = {description: any; summary: string; created: string}, R = unknown> {
+  expand: string
+  id: string
+  self: string
+  key: string
+  renderedFields: R
+  properties: JiraIssueProperties
+  names: JiraIssueNames
+  schema: JiraIssueSchema
+  transitions: JiraIssueTransition[]
+  operations: JiraOperations
+  editmeta: JiraIssueUpdateMetadata
+  changelog: JiraPageOfChangelogs
+  versionedRepresentations: JiraVersionedRepresentations
+  fieldsToInclude: JiraIncludedFields
+  fields: F
+}
+
+export type JiraIssueRaw = JiraIssueBean<
+  {description: string; summary: string; issuetype: {id: string; iconUrl: string}; created: string},
+  {description: string}
+>
+
+interface JiraAuthor {
+  self: string
+  emailAddress: string
+  avatarUrls: AvatarURLs
+  displayName: string
+  active: boolean
+  timeZone: string
+  accountType: 'atlassian'
+}
+
+interface JiraAddCommentResponse {
+  self: string
+  id: string
+  author: JiraAuthor
+  body: {
+    version: 1
+    type: 'doc'
+    content: any[]
+  }
+  updateAuthor: JiraAuthor
+  created: string
+  updated: string
+  jsdPublic: true
+}
+
+export type JiraGetIssueRes = JiraIssueBean<JiraGQLFields>
+
+export interface JiraGQLFields {
+  issuetype: {
+    id: string
+    iconUrl: string
+  }
+  project?: {
+    simplified: boolean
+  }
+  cloudId: string
+  description: any
+  descriptionHTML: string
+  issueKey: string
+  summary: string
+  lastUpdated: string
+}
+interface JiraSearchResponse<
+  T = {
+    summary: string
+    description: string
+    issuetype: {id: string; iconUrl: string}
+    created: string
+  }
+> {
+  expand: string
+  startAt: number
+  maxResults: number
+  total: number
+  issues: {
+    expand: string
+    id: string
+    self: string
+    key: string
+    fields: T
+    renderedFields: {
+      description: string
+    }
+    changelog: {
+      histories: {
+        created: string
+      }[]
+    }
+  }[]
+}
+
+/*
+interface JiraField {
+  issuetype: {
+    id: string
+  }
+  clauseNames: string[]
+  custom: boolean
+  id: string
+  key: string
+  name: string
+  navigable: boolean
+  orderable: boolean
+  schema: {
+    custom: string
+    customId: number
+    type: string
+  }
+  searchable: boolean
+  untranslatedName: string
+}
+*/
+
+export interface JiraScreen {
+  id: string
+  name: string
+  description: string
+}
+
+export interface JiraScreenTab {
+  id: string
+  name: string
+}
+
+export interface JiraAddScreenFieldResponse {
+  id: string
+  name: string
+}
+
+interface JiraPageBean<T> {
+  startAt: number
+  maxResults: number
+  total: number
+  isLast: boolean
+  values: T[]
+}
+
+export type JiraScreensResponse = JiraPageBean<JiraScreen>
 
 class AtlassianServerManager extends AtlassianManager {
   fetch = fetch as any
@@ -37,6 +324,340 @@ class AtlassianServerManager extends AtlassianManager {
 
   constructor(accessToken: string) {
     super(accessToken)
+  }
+
+  async getAccessibleResources() {
+    return this.get<AccessibleResource[]>(
+      'https://api.atlassian.com/oauth/token/accessible-resources'
+    )
+  }
+
+  async getMyself(cloudId: string) {
+    return this.get<JiraUser>(`https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/myself`)
+  }
+
+  async getPaginatedProjects(cloudId: string, url: string, callback: GetProjectsCallback) {
+    const res = await this.get<JiraProjectResponse>(url)
+    if (res instanceof Error || res instanceof RateLimitError) {
+      callback(res, null)
+    } else {
+      callback(null, {cloudId, newProjects: res.values})
+      if (res.nextPage) {
+        await this.getPaginatedProjects(cloudId, res.nextPage, callback).catch(console.error)
+      }
+    }
+  }
+
+  async getProjects(cloudIds: string[], callback: GetProjectsCallback) {
+    return Promise.all(
+      cloudIds.map(async (cloudId) => {
+        return this.getPaginatedProjects(
+          cloudId,
+          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`,
+          callback
+        ).catch(console.error)
+      })
+    )
+  }
+
+  async getImage(imageUrl: string) {
+    const imageRes = await this.fetchWithTimeout(imageUrl, {
+      headers: {Authorization: this.headers.Authorization}
+    })
+
+    if (!imageRes || imageRes instanceof Error) return null
+    const arrayBuffer = await imageRes.arrayBuffer()
+    return {
+      imageBuffer: Buffer.from(arrayBuffer),
+      contentType: imageRes.headers.get('content-type')
+    }
+  }
+
+  async getAllProjects(cloudIds: string[]) {
+    const projects = [] as (JiraProject & {cloudId: string})[]
+    let error: Error | undefined
+    const getProjectPage = async (cloudId: string, url: string): Promise<void> => {
+      const res = await this.get<JiraProjectResponse>(url)
+      if (res instanceof Error || res instanceof RateLimitError) {
+        error = res
+      } else {
+        const pagedProjects = res.values.map((project) => ({
+          ...project,
+          cloudId
+        }))
+        projects.push(...pagedProjects)
+        if (res.nextPage) {
+          return getProjectPage(cloudId, res.nextPage)
+        }
+      }
+    }
+    await Promise.all(
+      cloudIds.map((cloudId) =>
+        getProjectPage(
+          cloudId,
+          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`
+        )
+      )
+    )
+
+    if (error) {
+      log('getAllProjects ERROR:', error)
+    }
+    return projects
+  }
+
+  async getProject(cloudId: string, projectKey: string) {
+    const project = await this.get<JiraProject>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/${projectKey}`
+    )
+
+    return project
+  }
+
+  async getCreateMeta(cloudId: string, projectKeys?: string[]) {
+    let args = ''
+    if (projectKeys) {
+      args += `projectKeys=${projectKeys.join(',')}`
+    }
+    if (args.length) {
+      args = '?' + args
+    }
+    return this.get<IssueCreateMetadata>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/createmeta${args}`
+    )
+  }
+
+  async getEditMeta(cloudId: string, issueKey: string) {
+    return this.get<IssueCreateMetadata>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}/editmeta`
+    )
+  }
+
+  async createIssue(cloudId: string, projectKey: string, issueFields: CreateIssueFields) {
+    const payload = {
+      fields: {
+        project: {
+          key: projectKey
+        },
+        ...issueFields
+      } as CreateIssueFields
+    }
+    return this.post<JiraCreateIssueResponse>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue`,
+      payload
+    )
+  }
+
+  async getCloudNameLookup() {
+    const sites = await this.getAccessibleResources()
+    const cloudNameLookup = {} as {[cloudId: string]: string}
+    if (sites instanceof Error || sites instanceof RateLimitError) {
+      return sites
+    }
+    sites.forEach((site) => {
+      cloudNameLookup[site.id] = site.name
+    })
+    return cloudNameLookup
+  }
+
+  async getIssue(
+    cloudId: string,
+    issueKey: string,
+    extraFieldIds: string[] = [],
+    extraExpand: string[] = []
+  ) {
+    const reqFields = extraFieldIds.includes('*all')
+      ? '*all'
+      : ['summary', 'description', 'issuetype', 'created', ...extraFieldIds].join(',')
+    const expand = ['renderedFields', 'changelog', 'editmeta', 'names', ...extraExpand].join(',')
+    const issueRes = await this.get<JiraIssueRaw>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}?fields=${reqFields}&expand=${expand}`
+    )
+    if (issueRes instanceof Error || issueRes instanceof RateLimitError) return issueRes
+    return {
+      ...issueRes,
+      fields: {
+        ...issueRes.fields,
+        descriptionHTML: issueRes.renderedFields.description,
+        cloudId,
+        issueKey,
+        id: JiraIssueId.join(cloudId, issueKey),
+        lastUpdated: issueRes.changelog.histories[0]?.created ?? issueRes.fields.created
+      }
+    }
+  }
+
+  async getIssues(
+    queryString: string | null,
+    isJQL: boolean,
+    projectFiltersByCloudId: {[cloudId: string]: string[]},
+    maxResults: number,
+    startAt?: number
+  ) {
+    const allIssues = [] as JiraGQLFields[]
+    let firstError: Error | undefined
+    const reqs = Object.entries(projectFiltersByCloudId).map(async ([cloudId, projectKeys]) => {
+      const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/search`
+      const jql = composeJQL(queryString, isJQL, projectKeys)
+      const payload = {
+        jql,
+        maxResults,
+        startAt,
+        fields: ['summary', 'description', 'issuetype', 'created'],
+        expand: ['renderedFields,changelog']
+      }
+
+      const res = await this.post<JiraSearchResponse>(url, payload)
+      if (res instanceof Error) {
+        if (!firstError) {
+          firstError = res
+          if (firstError.message.includes('not installed on this instance')) {
+            firstError.message = 'Jira access revoked. Please reintegrate with Jira.'
+          }
+        }
+        return
+      }
+      const issues = res.issues.map((issue) => {
+        const {key: issueKey, fields, renderedFields, changelog} = issue
+        const {description, summary, issuetype, created} = fields
+        const {description: descriptionHTML} = renderedFields
+        return {
+          issuetype,
+          summary,
+          description,
+          descriptionHTML,
+          cloudId,
+          issueKey,
+          lastUpdated: changelog.histories[0]?.created ?? created
+        }
+      })
+      allIssues.push(...issues)
+    })
+    await Promise.all(reqs)
+    return {error: firstError, issues: allIssues}
+  }
+
+  async getComments(cloudId: string, issueKey: string) {
+    return this.get(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}/comment`
+    ) as any
+  }
+
+  async getFieldScreens(cloudId: string, fieldId: string) {
+    return this.get(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/field/${fieldId}/screens`
+    ) as any
+  }
+
+  async addComment(cloudId: string, issueKey: string, body: any) {
+    const payload = {
+      body
+    }
+    return this.post<JiraAddCommentResponse>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}/comment`,
+      payload
+    )
+  }
+
+  async updateStoryPoints(
+    cloudId: string,
+    issueKey: string,
+    storyPoints: string | number,
+    fieldId: string
+  ) {
+    // according to Jira docs fields related to the time tracking have to be set in a different way than other fields
+    // https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put
+    // more context: https://github.com/ParabolInc/parabol/issues/5705#issuecomment-1007501068
+    let payload: Record<string, any>
+    const timeTrackingFieldId = 'timetracking'
+    const timeTrackingFieldLookup = {
+      timeoriginalestimate: 'originalEstimate',
+      timeestimate: 'remainingEstimate'
+    } as const
+    const timeTrackingFieldName =
+      timeTrackingFieldLookup[fieldId as keyof typeof timeTrackingFieldLookup]
+    if (!!timeTrackingFieldName) {
+      payload = {
+        update: {
+          [timeTrackingFieldId]: [
+            {
+              set: {
+                // time tracking fields have to be set in time format, we're setting them in (h)ours
+                [timeTrackingFieldName]: `${storyPoints}h`
+              }
+            }
+          ]
+        }
+      }
+    } else {
+      payload = {
+        fields: {
+          [fieldId]: storyPoints
+        }
+      }
+    }
+    const res = await this.put(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/${issueKey}`,
+      payload
+    )
+    if (res === null) return
+    if (res.message.includes('The app is not installed on this instance')) {
+      throw new Error(
+        'The user who added this issue was removed from Jira. Please remove & re-add the issue'
+      )
+    }
+    if (
+      res.message.startsWith(timeTrackingFieldName ? timeTrackingFieldId : fieldId) &&
+      res.message.includes('is not on the appropriate screen')
+    ) {
+      const projectKey = JiraProjectKeyId.join(issueKey)
+      const project = await this.getProject(cloudId, projectKey)
+
+      if (project instanceof RateLimitError || project instanceof Error) {
+        throw project
+      }
+
+      if (project.simplified) {
+        if (timeTrackingFieldName) {
+          throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR_ESTIMATION_TIMETRACKING)
+        }
+        throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR_ESTIMATION)
+      }
+
+      throw new Error(SprintPokerDefaults.JIRA_FIELD_UPDATE_ERROR)
+    }
+    throw res
+  }
+
+  async getScreens(cloudId: string, maxResults: number, startAt = 0) {
+    return this.get<JiraScreensResponse>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens?maxResults=${maxResults}&startAt=${startAt}`
+    )
+  }
+
+  async getScreenTabs(cloudId: string, screenId: string) {
+    // a screen has at least 1 tab
+    return this.get<[JiraScreenTab, ...JiraScreenTab[]]>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens/${screenId}/tabs`
+    )
+  }
+
+  async addFieldToScreenTab(cloudId: string, screenId: string, tabId: string, fieldId: string) {
+    return this.post<JiraAddScreenFieldResponse>(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/`,
+      {fieldId}
+    )
+  }
+
+  async removeFieldFromScreenTab(
+    cloudId: string,
+    screenId: string,
+    tabId: string,
+    fieldId: string
+  ) {
+    return this.delete(
+      `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/screens/${screenId}/tabs/${tabId}/fields/${fieldId}`
+    )
   }
 }
 

--- a/packages/server/utils/atlassian/jiraImages.ts
+++ b/packages/server/utils/atlassian/jiraImages.ts
@@ -2,7 +2,7 @@ import base64url from 'base64url'
 import cheerio from 'cheerio'
 import crypto from 'crypto'
 import ms from 'ms'
-import AtlassianManager from 'parabol-client/utils/AtlassianManager'
+import AtlassianServerManager from '../AtlassianServerManager'
 import getRedis from '../getRedis'
 
 export const NO_IMAGE_BUFFER = Buffer.from('X')
@@ -42,7 +42,7 @@ export const updateJiraImageUrls = (cloudId: string, descriptionHTML: string) =>
 }
 
 export const downloadAndCacheImages = async (
-  manager: AtlassianManager,
+  manager: AtlassianServerManager,
   imageUrlToHash: Record<string, string>
 ) => {
   return Promise.all(
@@ -53,7 +53,7 @@ export const downloadAndCacheImages = async (
 }
 
 export const downloadAndCacheImage = async (
-  manager: AtlassianManager,
+  manager: AtlassianServerManager,
   imageUrlHash: string,
   imageUrl: string
 ) => {

--- a/packages/server/utils/atlassian/jiraIssues.ts
+++ b/packages/server/utils/atlassian/jiraIssues.ts
@@ -1,11 +1,9 @@
 import stringify from 'fast-json-stable-stringify'
 import ms from 'ms'
 import {Unpromise} from 'parabol-client/types/generics'
-import AtlassianManager, {
-  JiraGetIssueRes,
-  RateLimitError
-} from 'parabol-client/utils/AtlassianManager'
+import {RateLimitError} from 'parabol-client/utils/AtlassianManager'
 import sleep from 'parabol-client/utils/sleep'
+import AtlassianServerManager, {JiraGetIssueRes} from '../AtlassianServerManager'
 import getRedis from '../getRedis'
 
 const ISSUE_TTL_MS = ms('2d')
@@ -29,7 +27,7 @@ type CacheError = RequestsInit
 
 /* helper fn to only do jira request side effects and return nothing */
 const getIssueFromJira = async (
-  manager: AtlassianManager,
+  manager: AtlassianServerManager,
   cloudId: string,
   issueKey: string,
   pushUpdateToClient: (
@@ -91,7 +89,7 @@ const getIssueFromJira = async (
 }
 
 export const getIssue = async (
-  manager: AtlassianManager,
+  manager: AtlassianServerManager,
   cloudId: string,
   issueKey: string,
   pushUpdateToClient: (

--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -15,7 +15,8 @@ module.exports = {
       },
       watch: ['dev/gqlExecutor.js'],
       // if the watched file doeesn't exist, wait for it instead of restarting
-      autorestart: false
+      autorestart: false,
+      log_file: 'logs/gqlExecutor.log'
     },
     {
       name: 'Socket Server',

--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -16,7 +16,8 @@ module.exports = {
       watch: ['dev/gqlExecutor.js'],
       // if the watched file doeesn't exist, wait for it instead of restarting
       autorestart: false,
-      log_file: 'logs/gqlExecutor.log'
+      log_file: 'dev/logs/gqlExecutor.log',
+      combine_logs: true
     },
     {
       name: 'Socket Server',
@@ -29,7 +30,9 @@ module.exports = {
       },
       watch: ['dev/web.js'],
       // if the watched file doeesn't exist, wait for it instead of restarting
-      autorestart: false
+      autorestart: false,
+      log_file: 'dev/logs/web.log',
+      combine_logs: true
     },
     {
       name: 'Dev Server',


### PR DESCRIPTION
Mainly associate the logs with the traces so it's possible to check which GraphQL request caused a certain debug output.
I needed to shuffle some stuff from `AtlassianManager` to `AtlassianServerManager` because `AtlassianManager` lives in `parabol-client` and we don't have the tracing stuff there. That's a cleaner solution anyways because we cannot call the API from the client because we wouldn't expose the secrets there.

## Demo

https://www.loom.com/share/0625c83f3d1845159d89db0253ba7da1?sid=fbbbd4ed-3719-470c-8fd5-f60ad2aeb9c9 🔒 

## Testing scenarios

- see demo
- check you have the correct datadog variables set (there is a [PR](https://github.com/ParabolInc/action-devops/pull/186/files#diff-8a86bc8dcf3eb7b34043c2b8509fec32fff3680a9c9067de3135e48216d974fe) 🔒) for these
- additionally add
  ```
  DD_LOGS_ENABLED='true'
  DD_LOGS_INJECTION='true'
  ```
- restart local datadog agent
  ```
  yarn db:stop ; yarn db:start
  ```
- run the dev build
  ```
  yarn dev
  ```
- check the agent status and the logs in DD
  ```
  docker exec -it docker-datadog-1 agent status
  ```
- add debug output to JiraServerManager::getAllProjects https://github.com/ParabolInc/parabol/blob/630d525434aa6863f92f508b4ec03d72655ea0da/packages/server/utils/AtlassianServerManager.ts#L402
  ```
  log('GEORG was here')
  ```
  make sure to only use `log` not `console.log`
- trigger the function call by integrating with atlassian, opening the task footer menu and searching for some non-existent project
- see the log message and trace connected in datadog

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
