### PR TITLE
fix: fix kudos in standups in nested lists

### DIFF
--- a/packages/server/graphql/public/mutations/helpers/__tests__/getKudosUserIdsFromJson.test.ts
+++ b/packages/server/graphql/public/mutations/helpers/__tests__/getKudosUserIdsFromJson.test.ts
@@ -151,6 +151,67 @@ describe('findMentionsByEmoji', () => {
               text: ' both mentioned ❤️'
             }
           ]
+        },
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'List item with mention '
+                    },
+                    {
+                      type: 'mention',
+                      attrs: {
+                        id: 'user_id_list_1',
+                        label: 'userlistone'
+                      }
+                    },
+                    {
+                      type: 'text',
+                      text: ' ❤️ in a list'
+                    }
+                  ]
+                },
+                {
+                  type: 'listItem',
+                  content: [
+                    {
+                      type: 'bulletList',
+                      content: [
+                        {
+                          type: 'listItem',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [
+                                {
+                                  type: 'mention',
+                                  attrs: {
+                                    id: 'user_id_nested_list',
+                                    label: 'usernestedlist'
+                                  }
+                                },
+                                {
+                                  type: 'text',
+                                  text: ' Nested mention ❤️'
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }
@@ -179,5 +240,12 @@ describe('findMentionsByEmoji', () => {
     const result = getKudosUserIdsFromJson(doc, emoji)
     const uniqueResult = Array.from(new Set(result))
     expect(result).toEqual(uniqueResult)
+  })
+
+  it('handles nested list mentions correctly for emoji ❤️', () => {
+    const emoji = '❤️'
+    const result = getKudosUserIdsFromJson(doc, emoji)
+    expect(result).toContain('user_id_list_1')
+    expect(result).toContain('user_id_nested_list')
   })
 })

--- a/packages/server/graphql/public/mutations/helpers/__tests__/getKudosUserIdsFromJson.test.ts
+++ b/packages/server/graphql/public/mutations/helpers/__tests__/getKudosUserIdsFromJson.test.ts
@@ -220,7 +220,15 @@ describe('findMentionsByEmoji', () => {
   it('returns correct mention user IDs for emoji ❤️', () => {
     const emoji = '❤️'
     const result = getKudosUserIdsFromJson(doc, emoji)
-    expect(result).toEqual(['user_id_1', 'user_id_2', 'user_id_3', 'user_id_4', 'user_id_5'])
+    expect(result).toEqual([
+      'user_id_1',
+      'user_id_2',
+      'user_id_3',
+      'user_id_4',
+      'user_id_5',
+      'user_id_list_1',
+      'user_id_nested_list'
+    ])
   })
 
   it('returns correct mention user IDs for different emoji (🌮)', () => {
@@ -240,12 +248,5 @@ describe('findMentionsByEmoji', () => {
     const result = getKudosUserIdsFromJson(doc, emoji)
     const uniqueResult = Array.from(new Set(result))
     expect(result).toEqual(uniqueResult)
-  })
-
-  it('handles nested list mentions correctly for emoji ❤️', () => {
-    const emoji = '❤️'
-    const result = getKudosUserIdsFromJson(doc, emoji)
-    expect(result).toContain('user_id_list_1')
-    expect(result).toContain('user_id_nested_list')
   })
 })


### PR DESCRIPTION
We didn't handle kudos in nested structures. Made function recursive

How to test:

- Write some standup response with kudos in nested lists, example:

<img width="353" alt="image" src="https://github.com/ParabolInc/parabol/assets/466991/46169bc9-a543-447a-a851-c06365d0b212">

- See kudos sent correctly