### PR TITLE
chore: fix misleading `isLead` field name on `Team`

### DIFF
--- a/packages/server/graphql/types/Team.ts
+++ b/packages/server/graphql/types/Team.ts
@@ -142,7 +142,7 @@ const Team: GraphQLObjectType = new GraphQLObjectType<ITeam, GQLContext>({
         return dataLoader.get('teamInvitationsByTeamId').load(teamId)
       }
     },
-    isLead: {
+    isViewerLead: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'true if the viewer is the team lead, else false',
       resolve: async (


### PR DESCRIPTION
The field indicates whether the viewer is the lead, but when used in a query for a different user, the result could be read wrong.