### PR TITLE
fix: limit invites from spammers

### DIFF
--- a/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
+++ b/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
@@ -48,7 +48,7 @@ const inviteToTeamHelper = async (
   ])
   const accepted = total - pending
   // if no one has accepted one of their 100+ invites, don't trust them
-  if (accepted === 0 && total + pending >= 100) {
+  if (accepted === 0 && total + invitees.length >= 100) {
     return standardError(new Error('Exceeded unaccepted invitation limit'), {userId: viewerId})
   }
 

--- a/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
+++ b/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
@@ -37,6 +37,21 @@ const inviteToTeamHelper = async (
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
 
+  const [total, pending] = await Promise.all([
+    r.table('TeamInvitation').getAll(teamId, {index: 'teamId'}).count().run(),
+    r
+      .table('TeamInvitation')
+      .getAll(teamId, {index: 'teamId'})
+      .filter({acceptedAt: null})
+      .count()
+      .run()
+  ])
+  const accepted = total - pending
+  // if no one has accepted one of their 100+ invites, don't trust them
+  if (accepted === 0 && total >= 100) {
+    return standardError(new Error('Exceeded unaccepted invitation limit'), {userId: viewerId})
+  }
+
   const untrustedDomains = ['tempmail.cn', 'qq.com']
   const filteredInvitees = invitees.filter(
     (invitee) => !untrustedDomains.includes(getDomainFromEmail(invitee).toLowerCase())
@@ -57,21 +72,6 @@ const inviteToTeamHelper = async (
 
   if (!validInvitees.length) {
     return standardError(new Error('No valid emails'), {userId: viewerId})
-  }
-
-  const [total, pending] = await Promise.all([
-    r.table('TeamInvitation').getAll(teamId, {index: 'teamId'}).count().run(),
-    r
-      .table('TeamInvitation')
-      .getAll(teamId, {index: 'teamId'})
-      .filter({acceptedAt: null})
-      .count()
-      .run()
-  ])
-  const accepted = total - pending
-  // if no one has accepted one of their 100+ invites, don't trust them
-  if (accepted === 0 && total >= 100) {
-    return standardError(new Error('Exceeded unaccepted invitation limit'), {userId: viewerId})
   }
 
   const [users, team, inviter] = await Promise.all([

--- a/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
+++ b/packages/server/graphql/mutations/helpers/inviteToTeamHelper.ts
@@ -48,7 +48,7 @@ const inviteToTeamHelper = async (
   ])
   const accepted = total - pending
   // if no one has accepted one of their 100+ invites, don't trust them
-  if (accepted === 0 && total >= 100) {
+  if (accepted === 0 && total + pending >= 100) {
     return standardError(new Error('Exceeded unaccepted invitation limit'), {userId: viewerId})
   }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9374

If the user has sent 100 or more invites and none have been accepted, prevent them from sending more invites. 

We could be stricter and set a lower limit or prevent them from sending invites even if they have more than one accepted invite if there are many unaccepted invites, but I'm more concerned about preventing real users from sending invites. 

### To test

- [ ] If there are 100 unaccepted invites, no more invites are sent