### PR TITLE
feat: speed up ai search

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai'
+import JSON5 from 'json5'
 import sendToSentry from './sendToSentry'
 import Reflection from '../database/types/Reflection'
 import {ModifyType} from '../graphql/public/resolverTypes'
@@ -206,8 +207,7 @@ class OpenAIServerManager {
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4-1106-preview',
-        response_format: {type: 'json_object'},
+        model: 'gpt-3.5-turbo-0125',
         messages: [
           {
             role: 'user',
@@ -221,9 +221,11 @@ class OpenAIServerManager {
       })
 
       const templateResponse = (response.choices[0]?.message?.content?.trim() as string) ?? null
-      return JSON.parse(templateResponse) as AITemplateSuggestion
+      const parsedResponse = JSON5.parse(templateResponse)
+      return parsedResponse as AITemplateSuggestion
     } catch (e) {
-      const error = e instanceof Error ? e : new Error('OpenAI failed to generate themes')
+      const error =
+        e instanceof Error ? e : new Error('OpenAI failed to generate the suggested template')
       console.error(error.message)
       sendToSentry(error)
       return null


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9340

GPT-3.5 turbo now has a large enough context window that it can accept the list of available templates.

I get similar results to GPT-4, and the response time is dramatically faster, so I think we should go with 3.5-turbo.

### To test

- [ ] Add the `aiTemplate` org feature flag
- [ ] Ask the AI Search input questions like "what's a template that helps us celebrate small wins"
- [ ] See that the results are similar to the results we get with the original search and that we no longer get timeouts