### PR TITLE
fix: not all jira projects are displayed in the list if there are a lot of them

### DIFF
--- a/packages/client/components/TaskFooterIntegrateMenuList.tsx
+++ b/packages/client/components/TaskFooterIntegrateMenuList.tsx
@@ -110,10 +110,12 @@ const TaskFooterIntegrateMenuList = (props: Props) => {
 
   useEffect(() => {
     // if searching for a repoIntegration that doesnt exist in the cache, it could be stale so use the network
+    // It is possible that user has a lot of repositories, if nothing was found in initial request, query everything
+    const veryBigNumberOfRepositories = 10000
     if (!networkOnly && filteredIntegrations.length === 0) {
       setNetworkOnly(true)
       setKeepParentFocus(false)
-      setFirst((first) => first + 50)
+      setFirst((first) => first + veryBigNumberOfRepositories)
     }
   }, [filteredIntegrations.length])
 


### PR DESCRIPTION
Problem:
- Some users have a lot of jira projects, more than 1000 it looks like
- They start searching their project and can't find it because we maximum fetch 100 on frontend

Quick solution:
- increase number of projects we fetch on frontend. It is only fetched when project is not found. We fetch all projects on backend anyway ATM

Hot to test:
- Play with jira projects dropdown, try to search various projects, see everything working
- Add few different integrations like github etc, see nothing is broken
- Ideally: use jira account with 100+ projects, search project at the end of the list, see it works. 