### PR TITLE
fix: Increase the number of projects fetched per request from Atlassian

### DIFF
--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -387,6 +387,7 @@ class AtlassianServerManager extends AtlassianManager {
         }))
         projects.push(...pagedProjects)
         if (res.nextPage) {
+          log('AtlassianServerManager.getAllProjects fetching more results', res.total)
           return getProjectPage(cloudId, res.nextPage)
         }
       }
@@ -395,7 +396,7 @@ class AtlassianServerManager extends AtlassianManager {
       cloudIds.map((cloudId) =>
         getProjectPage(
           cloudId,
-          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`
+          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name&maxResults=500`
         )
       )
     )


### PR DESCRIPTION
We ran into timeouts in `getAllProjects`, presumably because we're doing too many roundtrips. As a quick fix, increse the number of projects fetched per request from 50 to 500.

## Testing scenarios

- [ ] integrate with atlassian
- [ ] create a Sprint Poker meeting
- [ ] see the projects being fetched
- [ ] optionally decrease the max results fetched to 1 and see log output

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
