### PR TITLE
chore: Associate logs with traces

### DIFF
--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -14,6 +14,7 @@ import handleEnterpriseOrgQuantityChanges from './handleEnterpriseOrgQuantityCha
 import handleTeamOrgQuantityChanges from './handleTeamOrgQuantityChanges'
 import {getUserById} from '../../postgres/queries/getUsersByIds'
 import {DataLoaderWorker} from '../../graphql/graphql'
+import {Logger} from '../../utils/Logger'
 
 const maybeUpdateOrganizationActiveDomain = async (
   orgId: string,
@@ -170,5 +171,5 @@ export default async function adjustUserCount(
     .run()
 
   handleEnterpriseOrgQuantityChanges(paidOrgs, dataLoader).catch()
-  handleTeamOrgQuantityChanges(paidOrgs).catch(console.error)
+  handleTeamOrgQuantityChanges(paidOrgs).catch(Logger.error)
 }

--- a/packages/server/billing/helpers/terminateSubscription.ts
+++ b/packages/server/billing/helpers/terminateSubscription.ts
@@ -1,5 +1,6 @@
 import getRethink from '../../database/rethinkDriver'
 import Organization from '../../database/types/Organization'
+import {Logger} from '../../utils/Logger'
 import {getStripeManager} from '../../utils/stripe'
 
 const terminateSubscription = async (orgId: string) => {
@@ -30,7 +31,7 @@ const terminateSubscription = async (orgId: string) => {
     try {
       await manager.deleteSubscription(stripeSubscriptionId)
     } catch (e) {
-      console.error(`cannot delete subscription ${stripeSubscriptionId}`, e)
+      Logger.error(`cannot delete subscription ${stripeSubscriptionId}`, e)
     }
   }
   return stripeSubscriptionId

--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -13,6 +13,7 @@ import AzureDevOpsServerManager, {
   TeamProjectReference,
   WorkItem
 } from '../utils/AzureDevOpsServerManager'
+import {Logger} from '../utils/Logger'
 import sendToSentry from '../utils/sendToSentry'
 import RootDataLoader from './RootDataLoader'
 
@@ -215,7 +216,7 @@ export const azureDevOpsAllWorkItems = (
 
           const {error, workItems} = restResult
           if (error !== undefined || workItems === undefined) {
-            console.log(error)
+            Logger.log(error)
             return [] as AzureDevOpsWorkItem[]
           }
 
@@ -264,7 +265,7 @@ export const azureDevUserInfo = (
           const restResult = await manager.getMe()
           const {error, azureDevOpsUser} = restResult
           if (error !== undefined || azureDevOpsUser === undefined) {
-            console.log(error)
+            Logger.log(error)
             return undefined
           }
           return {
@@ -303,7 +304,7 @@ export const allAzureDevOpsAccessibleOrgs = (
           const results = await manager.getAccessibleOrgs(id)
           const {error, accessibleOrgs} = results
           // handle error if defined
-          console.log(error)
+          Logger.log(error)
           return accessibleOrgs.map((resource) => ({
             ...resource
           }))
@@ -340,7 +341,7 @@ export const allAzureDevOpsProjects = (
           )
           const {error, projects} = await manager.getAllUserProjects()
           if (error !== undefined) {
-            console.log(error)
+            Logger.log(error)
             return []
           }
           if (projects !== null) resultReferences.push(...projects)
@@ -383,7 +384,7 @@ export const azureDevOpsProject = (
           )
           const projectRes = await manager.getProject(instanceId, projectId)
           if (projectRes instanceof Error) {
-            console.log(projectRes)
+            Logger.log(projectRes)
             return null
           }
           return {
@@ -475,7 +476,7 @@ export const azureDevOpsUserStory = (
           const restResult = await manager.getWorkItemData(instanceId, workItemIds)
           const {error, workItems} = restResult
           if (error !== undefined || workItems.length !== 1 || !workItems[0]) {
-            console.log(error)
+            Logger.log(error)
             return null
           } else {
             const returnedWorkItem: WorkItem = workItems[0]
@@ -637,7 +638,7 @@ export const azureDevOpsWorkItems = (
           const workItemData = await manager.getWorkItemData(instanceId, workItemIds)
           const {error: workItemDataError, workItems: returnedWorkItems} = workItemData
           if (workItemDataError !== undefined) {
-            console.log(error)
+            Logger.log(error)
             return []
           }
 

--- a/packages/server/fileStorage/GCSManager.ts
+++ b/packages/server/fileStorage/GCSManager.ts
@@ -1,6 +1,7 @@
 import {sign} from 'jsonwebtoken'
 import mime from 'mime-types'
 import path from 'path'
+import {Logger} from '../utils/Logger'
 import FileStoreManager from './FileStoreManager'
 
 interface CloudKey {
@@ -132,7 +133,7 @@ export default class GCSManager extends FileStoreManager {
       // https://github.com/nodejs/undici/issues/583#issuecomment-1577475664
       // GCS will cause undici to error randomly with `SocketError: other side closed` `code: 'UND_ERR_SOCKET'`
       if ((e as any).cause?.code === 'UND_ERR_SOCKET') {
-        console.log('   Retrying GCS Post:', fullPath)
+        Logger.log('   Retrying GCS Post:', fullPath)
         await this.putFile(file, fullPath)
       }
     }

--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -16,6 +16,7 @@ import removeSuggestedAction from '../../safeMutations/removeSuggestedAction'
 import {analytics} from '../../utils/analytics/analytics'
 import {getUserId, isTeamMember} from '../../utils/authorization'
 import getPhase from '../../utils/getPhase'
+import {Logger} from '../../utils/Logger'
 import publish from '../../utils/publish'
 import standardError from '../../utils/standardError'
 import {DataLoaderWorker, GQLContext} from '../graphql'
@@ -230,7 +231,7 @@ export default {
     const updatedTaskIds = (result && result.updatedTaskIds) || []
 
     analytics.checkInEnd(completedCheckIn, meetingMembers, team, dataLoader)
-    sendNewMeetingSummary(completedCheckIn, context).catch(console.log)
+    sendNewMeetingSummary(completedCheckIn, context).catch(Logger.log)
     checkTeamsLimit(team.orgId, dataLoader)
 
     const events = teamMembers.map(

--- a/packages/server/graphql/mutations/endSprintPoker.ts
+++ b/packages/server/graphql/mutations/endSprintPoker.ts
@@ -20,6 +20,7 @@ import sendNewMeetingSummary from './helpers/endMeeting/sendNewMeetingSummary'
 import {IntegrationNotifier} from './helpers/notifications/IntegrationNotifier'
 import removeEmptyTasks from './helpers/removeEmptyTasks'
 import updateTeamInsights from './helpers/updateTeamInsights'
+import {Logger} from '../../utils/Logger'
 
 export default {
   type: new GraphQLNonNull(EndSprintPokerPayload),
@@ -114,7 +115,7 @@ export default {
     analytics.sprintPokerEnd(completedMeeting, meetingMembers, template, dataLoader)
     const isKill = !!(phase && phase.phaseType !== 'ESTIMATE')
     if (!isKill) {
-      sendNewMeetingSummary(completedMeeting, context).catch(console.log)
+      sendNewMeetingSummary(completedMeeting, context).catch(Logger.log)
       checkTeamsLimit(team.orgId, dataLoader)
     }
     const events = teamMembers.map(

--- a/packages/server/graphql/mutations/helpers/activatePrevSlackAuth.ts
+++ b/packages/server/graphql/mutations/helpers/activatePrevSlackAuth.ts
@@ -2,6 +2,7 @@ import ms from 'ms'
 import getRethink from '../../../database/rethinkDriver'
 import SlackServerManager from '../../../utils/SlackServerManager'
 import {upsertNotifications} from '../addSlackAuth'
+import {Logger} from '../../../utils/Logger'
 
 const activatePrevSlackAuth = async (userId: string, teamId: string) => {
   const r = await getRethink()
@@ -29,7 +30,7 @@ const activatePrevSlackAuth = async (userId: string, teamId: string) => {
     const manager = new SlackServerManager(botAccessToken)
     const authRes = await manager.isValidAuthToken(botAccessToken)
     if (!authRes.ok) {
-      console.error(authRes.error)
+      Logger.error(authRes.error)
       return
     }
 

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -6,6 +6,7 @@ import {AutogroupReflectionGroupType} from '../../../database/types/MeetingRetro
 import {SubscriptionChannel} from '../../../../client/types/constEnums'
 import publish from '../../../utils/publish'
 import {analytics} from '../../../utils/analytics/analytics'
+import {Logger} from '../../../utils/Logger'
 
 const generateGroups = async (
   reflections: Reflection[],
@@ -24,13 +25,13 @@ const generateGroups = async (
 
   const themes = await manager.generateThemes(groupReflectionsInput)
   if (!themes) {
-    console.warn('ChatGPT was unable to generate themes')
+    Logger.warn('ChatGPT was unable to generate themes')
     return
   }
   const groupedReflections = await manager.groupReflections(groupReflectionsInput, themes)
 
   if (!groupedReflections) {
-    console.warn('ChatGPT was unable to group the reflections')
+    Logger.warn('ChatGPT was unable to group the reflections')
     return
   }
   const autogroupReflectionGroups: AutogroupReflectionGroupType[] = []

--- a/packages/server/graphql/mutations/helpers/getCCFromCustomer.ts
+++ b/packages/server/graphql/mutations/helpers/getCCFromCustomer.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe'
 import {getStripeManager} from '../../../utils/stripe'
 import {stripeCardToDBCard} from './stripeCardToDBCard'
+import {Logger} from '../../../utils/Logger'
 
 export default async function getCCFromCustomer(
   customer: Stripe.Customer | Stripe.DeletedCustomer
@@ -16,7 +17,7 @@ export default async function getCCFromCustomer(
     // customers that used Stripe Elements have default_payment_method: https://stripe.com/docs/payments/payment-methods/transitioning?locale=en-GB
     const cardRes = await manager.retrieveDefaultCardDetails(customer.id)
     if (cardRes instanceof Error) {
-      console.error(cardRes)
+      Logger.error(cardRes)
       return undefined
     }
     return stripeCardToDBCard(cardRes)

--- a/packages/server/graphql/mutations/helpers/removeFromOrg.ts
+++ b/packages/server/graphql/mutations/helpers/removeFromOrg.ts
@@ -8,6 +8,7 @@ import {DataLoaderWorker} from '../../graphql'
 import removeTeamMember from './removeTeamMember'
 import resolveDowngradeToStarter from './resolveDowngradeToStarter'
 import {RDatum} from '../../../database/stricterR'
+import {Logger} from '../../../utils/Logger'
 
 const removeFromOrg = async (
   userId: string,
@@ -93,7 +94,7 @@ const removeFromOrg = async (
   try {
     await adjustUserCount(userId, orgId, InvoiceItemType.REMOVE_USER, dataLoader)
   } catch (e) {
-    console.log(e)
+    Logger.log(e)
   }
   await setUserTierForUserIds([userId])
   return {

--- a/packages/server/graphql/mutations/helpers/resolveDowngradeToStarter.ts
+++ b/packages/server/graphql/mutations/helpers/resolveDowngradeToStarter.ts
@@ -3,6 +3,7 @@ import Organization from '../../../database/types/Organization'
 import getKysely from '../../../postgres/getKysely'
 import updateTeamByOrgId from '../../../postgres/queries/updateTeamByOrgId'
 import {analytics} from '../../../utils/analytics/analytics'
+import {Logger} from '../../../utils/Logger'
 import setTierForOrgUsers from '../../../utils/setTierForOrgUsers'
 import setUserTierForOrgId from '../../../utils/setUserTierForOrgId'
 import {getStripeManager} from '../../../utils/stripe'
@@ -22,7 +23,7 @@ const resolveDowngradeToStarter = async (
   try {
     await manager.deleteSubscription(stripeSubscriptionId)
   } catch (e) {
-    console.log(e)
+    Logger.log(e)
   }
 
   const [org] = await Promise.all([

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -29,6 +29,7 @@ import removeEmptyTasks from './removeEmptyTasks'
 import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
 import gatherInsights from './gatherInsights'
 import NotificationMentioned from '../../../database/types/NotificationMentioned'
+import {Logger} from '../../../utils/Logger'
 
 const getTranscription = async (recallBotId?: string | null) => {
   if (!recallBotId) return
@@ -245,7 +246,7 @@ const summarizeRetroMeeting = async (meeting: MeetingRetrospective, context: Int
 
   dataLoader.get('newMeetings').clear(meetingId)
   // wait for whole meeting summary to be generated before sending summary email and updating qualAIMeetingCount
-  sendNewMeetingSummary(meeting, context).catch(console.log)
+  sendNewMeetingSummary(meeting, context).catch(Logger.log)
   updateQualAIMeetingsCount(meetingId, teamId, dataLoader)
   // wait for meeting stats to be generated before sending Slack notification
   IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -14,6 +14,7 @@ import updateTeamInsights from './updateTeamInsights'
 import generateStandupMeetingSummary from './generateStandupMeetingSummary'
 import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
 import gatherInsights from './gatherInsights'
+import {Logger} from '../../../utils/Logger'
 
 const summarizeTeamPrompt = async (meeting: MeetingTeamPrompt, context: InternalContext) => {
   const {dataLoader} = context
@@ -31,7 +32,7 @@ const summarizeTeamPrompt = async (meeting: MeetingTeamPrompt, context: Internal
 
   dataLoader.get('newMeetings').clear(meeting.id)
   // wait for whole meeting summary to be generated before sending summary email and updating qualAIMeetingCount
-  sendNewMeetingSummary(meeting, context).catch(console.log)
+  sendNewMeetingSummary(meeting, context).catch(Logger.log)
   updateQualAIMeetingsCount(meeting.id, meeting.teamId, dataLoader)
   // wait for meeting stats to be generated before sending Slack notification
   IntegrationNotifier.endMeeting(dataLoader, meeting.id, meeting.teamId)

--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -13,6 +13,7 @@ import standardError from '../../utils/standardError'
 import {DataLoaderWorker, GQLContext} from '../graphql'
 import isValid from '../isValid'
 import getKysely from '../../postgres/getKysely'
+import {Logger} from '../../utils/Logger'
 
 const MAX_NUM_TEAMS = 40
 
@@ -168,7 +169,7 @@ export default {
     const successes = results.filter((result) => typeof result === 'string')
     const failures = results.filter((result) => typeof result !== 'string')
     const successStr = successes.join('\n')
-    console.error('failures', failures)
+    Logger.error('failures', failures)
     return successStr
   }
 }

--- a/packages/server/graphql/mutations/navigateMeeting.ts
+++ b/packages/server/graphql/mutations/navigateMeeting.ts
@@ -11,6 +11,7 @@ import {GQLContext} from '../graphql'
 import NavigateMeetingPayload from '../types/NavigateMeetingPayload'
 import handleCompletedStage from './helpers/handleCompletedStage'
 import removeScheduledJobs from './helpers/removeScheduledJobs'
+import {Logger} from '../../utils/Logger'
 
 export default {
   type: new GraphQLNonNull(NavigateMeetingPayload),
@@ -84,7 +85,7 @@ export default {
         phaseCompleteData = await handleCompletedStage(stage, meeting, dataLoader)
         if (stage.scheduledEndTime) {
           // not critical, no await needed
-          removeScheduledJobs(stage.scheduledEndTime, {meetingId}).catch(console.error)
+          removeScheduledJobs(stage.scheduledEndTime, {meetingId}).catch(Logger.error)
           stage.scheduledEndTime = null
         }
       }

--- a/packages/server/graphql/mutations/selectTemplate.ts
+++ b/packages/server/graphql/mutations/selectTemplate.ts
@@ -8,6 +8,7 @@ import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import SelectTemplatePayload from '../types/SelectTemplatePayload'
 import {getFeatureTier} from '../types/helpers/getFeatureTier'
+import {Logger} from '../../utils/Logger'
 
 const selectTemplate = {
   description: 'Set the selected template for the upcoming retro meeting',
@@ -37,7 +38,7 @@ const selectTemplate = {
     ])
 
     if (!template || !template.isActive) {
-      console.log('no template', selectedTemplateId, template)
+      Logger.log('no template', selectedTemplateId, template)
       return standardError(new Error('Template not found'), {userId: viewerId})
     }
 

--- a/packages/server/graphql/mutations/updateAzureDevOpsDimensionField.ts
+++ b/packages/server/graphql/mutations/updateAzureDevOpsDimensionField.ts
@@ -5,6 +5,7 @@ import upsertAzureDevOpsDimensionFieldMap, {
   AzureDevOpsFieldMapProps
 } from '../../postgres/queries/upsertAzureDevOpsDimensionFieldMap'
 import {isTeamMember} from '../../utils/authorization'
+import {Logger} from '../../utils/Logger'
 import publish from '../../utils/publish'
 import {GQLContext} from '../graphql'
 import UpdateAzureDevOpsDimensionFieldPayload from '../types/UpdateAzureDevOpsDimensionFieldPayload'
@@ -57,7 +58,7 @@ const updateAzureDevOpsDimensionField = {
     },
     {authToken, dataLoader, socketId: mutatorId}: GQLContext
   ) => {
-    //console.log(`Inside updateAzureDevOpsDimensionField`)
+    //Logger.log(`Inside updateAzureDevOpsDimensionField`)
     const operationId = dataLoader.share()
     const subOptions = {mutatorId, operationId}
 
@@ -91,7 +92,7 @@ const updateAzureDevOpsDimensionField = {
       } as AzureDevOpsFieldMapProps
       await upsertAzureDevOpsDimensionFieldMap(props)
     } catch (e) {
-      console.log(e)
+      Logger.log(e)
     }
 
     const data = {teamId, meetingId}

--- a/packages/server/graphql/mutations/updateGitHubDimensionField.ts
+++ b/packages/server/graphql/mutations/updateGitHubDimensionField.ts
@@ -3,6 +3,7 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import MeetingPoker from '../../database/types/MeetingPoker'
 import upsertGitHubDimensionFieldMap from '../../postgres/queries/upsertGitHubDimensionFieldMap'
 import {isTeamMember} from '../../utils/authorization'
+import {Logger} from '../../utils/Logger'
 import publish from '../../utils/publish'
 import {GQLContext} from '../graphql'
 import UpdateGitHubDimensionFieldPayload from '../types/UpdateGitHubDimensionFieldPayload'
@@ -66,7 +67,7 @@ const updateGitHubDimensionField = {
     try {
       await upsertGitHubDimensionFieldMap(teamId, dimensionName, nameWithOwner, labelTemplate)
     } catch (e) {
-      console.log(e)
+      Logger.log(e)
     }
 
     const data = {meetingId, teamId}

--- a/packages/server/graphql/private/mutations/autopauseUsers.ts
+++ b/packages/server/graphql/private/mutations/autopauseUsers.ts
@@ -3,6 +3,7 @@ import adjustUserCount from '../../../billing/helpers/adjustUserCount'
 import getRethink from '../../../database/rethinkDriver'
 import getUserIdsToPause from '../../../postgres/queries/getUserIdsToPause'
 import {MutationResolvers} from '../resolverTypes'
+import {Logger} from '../../../utils/Logger'
 
 const autopauseUsers: MutationResolvers['autopauseUsers'] = async (
   _source,
@@ -32,7 +33,7 @@ const autopauseUsers: MutationResolvers['autopauseUsers'] = async (
         try {
           return await adjustUserCount(userId, orgIds, InvoiceItemType.AUTO_PAUSE_USER, dataLoader)
         } catch (e) {
-          console.warn(`Error adjusting user count`)
+          Logger.warn(`Error adjusting user count`)
         }
         return undefined
       })

--- a/packages/server/graphql/private/mutations/connectSocket.ts
+++ b/packages/server/graphql/private/mutations/connectSocket.ts
@@ -6,6 +6,7 @@ import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
 import getListeningUserIds, {RedisCommand} from '../../../utils/getListeningUserIds'
 import getRedis from '../../../utils/getRedis'
+import {Logger} from '../../../utils/Logger'
 import publish from '../../../utils/publish'
 import {MutationResolvers} from '../resolverTypes'
 
@@ -44,7 +45,7 @@ const connectSocket: MutationResolvers['connectSocket'] = async (
       .getAll(userId, {index: 'userId'})
       .filter({removedAt: null, inactive: true})('orgId')
       .run()
-    adjustUserCount(userId, orgIds, InvoiceItemType.UNPAUSE_USER, dataLoader).catch(console.log)
+    adjustUserCount(userId, orgIds, InvoiceItemType.UNPAUSE_USER, dataLoader).catch(Logger.log)
     // TODO: re-identify
   }
   const datesAreOnSameDay = now.toDateString() === lastSeenAt.toDateString()

--- a/packages/server/graphql/private/mutations/runScheduledJobs.ts
+++ b/packages/server/graphql/private/mutations/runScheduledJobs.ts
@@ -8,6 +8,7 @@ import publish from '../../../utils/publish'
 import {DataLoaderWorker} from '../../graphql'
 import {IntegrationNotifier} from '../../mutations/helpers/notifications/IntegrationNotifier'
 import {MutationResolvers} from '../resolverTypes'
+import {Logger} from '../../../utils/Logger'
 
 const processMeetingStageTimeLimits = async (
   job: ScheduledJobMeetingStageTimeLimit,
@@ -48,9 +49,9 @@ const processJob = async (job: ScheduledJobUnion, dataLoader: DataLoaderWorker) 
     return processMeetingStageTimeLimits(
       job as ScheduledJobMeetingStageTimeLimit,
       dataLoader
-    ).catch(console.error)
+    ).catch(Logger.error)
   } else if (job.type === 'LOCK_ORGANIZATION' || job.type === 'WARN_ORGANIZATION') {
-    return processTeamsLimitsJob(job as ScheduledTeamLimitsJob, dataLoader).catch(console.error)
+    return processTeamsLimitsJob(job as ScheduledTeamLimitsJob, dataLoader).catch(Logger.error)
   }
 }
 
@@ -73,7 +74,7 @@ const runScheduledJobs: MutationResolvers['runScheduledJobs'] = async (
     const {runAt} = job
     const timeout = Math.max(0, runAt.getTime() - now.getTime())
     setTimeout(() => {
-      processJob(job, dataLoader).catch(console.error)
+      processJob(job, dataLoader).catch(Logger.error)
     }, timeout)
   })
 

--- a/packages/server/graphql/public/mutations/acceptRequestToJoinDomain.ts
+++ b/packages/server/graphql/public/mutations/acceptRequestToJoinDomain.ts
@@ -14,6 +14,7 @@ import publish from '../../../utils/publish'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import DomainJoinRequestId from 'parabol-client/shared/gqlIds/DomainJoinRequestId'
 import {getUserById} from '../../../postgres/queries/getUsersByIds'
+import {Logger} from '../../../utils/Logger'
 
 // TODO (EXPERIMENT: prompt-to-join-org): some parts are borrowed from acceptTeamInvitation, create generic functions
 const acceptRequestToJoinDomain: MutationResolvers['acceptRequestToJoinDomain'] = async (
@@ -106,7 +107,7 @@ const acceptRequestToJoinDomain: MutationResolvers['acceptRequestToJoinDomain'] 
       try {
         await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
       } catch (e) {
-        console.log(e)
+        Logger.log(e)
       }
       await setUserTierForUserIds([userId])
     }

--- a/packages/server/graphql/public/mutations/updateGitLabDimensionField.ts
+++ b/packages/server/graphql/public/mutations/updateGitLabDimensionField.ts
@@ -2,6 +2,7 @@ import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import MeetingPoker from '../../../database/types/MeetingPoker'
 import upsertGitLabDimensionFieldMap from '../../../postgres/queries/upsertGitLabDimensionFieldMap'
 import {isTeamMember} from '../../../utils/authorization'
+import {Logger} from '../../../utils/Logger'
 import publish from '../../../utils/publish'
 import {MutationResolvers} from '../resolverTypes'
 import {getUserId} from './../../../utils/authorization'
@@ -40,7 +41,7 @@ const updateGitLabDimensionField: MutationResolvers['updateGitLabDimensionField'
     const {providerId} = gitlabAuth
     await upsertGitLabDimensionFieldMap(teamId, dimensionName, projectId, providerId, labelTemplate)
   } catch (e) {
-    console.log(e)
+    Logger.log(e)
   }
 
   const data = {meetingId, teamId}

--- a/packages/server/graphql/public/types/TeamHealthStage.ts
+++ b/packages/server/graphql/public/types/TeamHealthStage.ts
@@ -2,6 +2,7 @@ import {TeamHealthStageResolvers} from '../resolverTypes'
 import {getUserId} from '../../../utils/authorization'
 import TeamHealthStageDB from '../../../database/types/TeamHealthStage'
 import isValid from '../../isValid'
+import {Logger} from '../../../utils/Logger'
 
 export type TeamHealthStageSource = TeamHealthStageDB & {
   meetingId: string
@@ -21,7 +22,7 @@ const TeamHealthStage: TeamHealthStageResolvers = {
   },
   readyCount: async ({meetingId, readyToAdvance}, _args, {dataLoader}, ref) => {
     if (!readyToAdvance) return 0
-    if (!meetingId) console.log('no meetingid', ref)
+    if (!meetingId) Logger.log('no meetingid', ref)
     const meeting = await dataLoader.get('newMeetings').load(meetingId)
     const {facilitatorUserId} = meeting
     return readyToAdvance.filter((userId) => userId !== facilitatorUserId).length

--- a/packages/server/graphql/queries/helpers/fetchGitHubRepos.ts
+++ b/packages/server/graphql/queries/helpers/fetchGitHubRepos.ts
@@ -4,6 +4,7 @@ import getGitHubRequest from '../../../utils/getGitHubRequest'
 import getRepositories from '../../../utils/githubQueries/getRepositories.graphql'
 import {DataLoaderWorker} from '../../graphql'
 import {GQLContext} from './../../graphql'
+import {Logger} from '../../../utils/Logger'
 
 export interface GitHubRepo {
   id: string
@@ -25,7 +26,7 @@ const fetchGitHubRepos = async (
   const githubRequest = getGitHubRequest(info, context, {accessToken})
   const [data, error] = await githubRequest<GetRepositoriesQuery>(getRepositories)
   if (error) {
-    console.error(error.message)
+    Logger.error(error.message)
     return []
   }
   const {viewer} = data

--- a/packages/server/graphql/queries/helpers/fetchGitLabProjects.ts
+++ b/packages/server/graphql/queries/helpers/fetchGitLabProjects.ts
@@ -2,6 +2,7 @@ import {GraphQLResolveInfo} from 'graphql'
 import {isNotNull} from 'parabol-client/utils/predicates'
 import GitLabServerManager from '../../../integrations/gitlab/GitLabServerManager'
 import {GQLContext} from '../../graphql'
+import {Logger} from '../../../utils/Logger'
 
 const fetchGitLabProjects = async (
   teamId: string,
@@ -18,7 +19,7 @@ const fetchGitLabProjects = async (
   const manager = new GitLabServerManager(auth, context, info, provider.serverBaseUrl)
   const [data, error] = await manager.getProjects({})
   if (error) {
-    console.error(error.message)
+    Logger.error(error.message)
     return []
   }
   return (

--- a/packages/server/graphql/types/NewMeetingStage.ts
+++ b/packages/server/graphql/types/NewMeetingStage.ts
@@ -11,6 +11,7 @@ import GenericMeetingPhase, {
   NewMeetingPhaseTypeEnum as NewMeetingPhaseTypeEnumType
 } from '../../database/types/GenericMeetingPhase'
 import {getUserId} from '../../utils/authorization'
+import {Logger} from '../../utils/Logger'
 import {GQLContext} from '../graphql'
 import GraphQLISO8601Type from './GraphQLISO8601Type'
 import NewMeeting from './NewMeeting'
@@ -112,7 +113,7 @@ export const newMeetingStageFields = () => ({
       ref: any
     ) => {
       if (!readyToAdvance) return 0
-      if (!meetingId) console.log('no meetingid', ref)
+      if (!meetingId) Logger.log('no meetingid', ref)
       const meeting = await dataLoader.get('newMeetings').load(meetingId)
       const {facilitatorUserId} = meeting
       return readyToAdvance.filter((userId: string) => userId !== facilitatorUserId).length

--- a/packages/server/graphql/types/PokerMeeting.ts
+++ b/packages/server/graphql/types/PokerMeeting.ts
@@ -1,6 +1,7 @@
 import {GraphQLID, GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLObjectType} from 'graphql'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import {getUserId} from '../../utils/authorization'
+import {Logger} from '../../utils/Logger'
 import {GQLContext} from '../graphql'
 import NewMeeting from './NewMeeting'
 import PokerMeetingMember from './PokerMeetingMember'
@@ -39,7 +40,7 @@ const PokerMeeting = new GraphQLObjectType<any, GQLContext>({
       resolve: async ({id: meetingId}, {storyId: taskId}, {dataLoader}) => {
         const task = await dataLoader.get('tasks').load(taskId)
         if (task.meetingId !== meetingId) {
-          console.log('naughty storyId supplied to PokerMeeting')
+          Logger.log('naughty storyId supplied to PokerMeeting')
           return null
         }
         return task

--- a/packages/server/postgres/queries/upsertAzureDevOpsDimensionFieldMap.ts
+++ b/packages/server/postgres/queries/upsertAzureDevOpsDimensionFieldMap.ts
@@ -1,3 +1,4 @@
+import {Logger} from '../../utils/Logger'
 import getPg from '../getPg'
 import {upsertAzureDevOpsDimensionFieldMapQuery} from './generated/upsertAzureDevOpsDimensionFieldMapQuery'
 
@@ -22,7 +23,7 @@ const upsertAzureDevOpsDimensionFieldMap = async (props: AzureDevOpsFieldMapProp
     projectKey,
     workItemType
   } = props
-  console.log(`Inside upsertAzureDevOpsDimensionFieldMap - props:${JSON.stringify(props)}`)
+  Logger.log(`Inside upsertAzureDevOpsDimensionFieldMap - props:${JSON.stringify(props)}`)
   return upsertAzureDevOpsDimensionFieldMapQuery.run(
     {
       fieldMap: {

--- a/packages/server/safeMutations/acceptTeamInvitation.ts
+++ b/packages/server/safeMutations/acceptTeamInvitation.ts
@@ -6,6 +6,7 @@ import generateUID from '../generateUID'
 import {DataLoaderWorker} from '../graphql/graphql'
 import {Team} from '../postgres/queries/getTeamsByIds'
 import getNewTeamLeadUserId from '../safeQueries/getNewTeamLeadUserId'
+import {Logger} from '../utils/Logger'
 import setUserTierForUserIds from '../utils/setUserTierForUserIds'
 import addTeamIdToTMS from './addTeamIdToTMS'
 import insertNewTeamMember from './insertNewTeamMember'
@@ -92,7 +93,7 @@ const acceptTeamInvitation = async (team: Team, userId: string, dataLoader: Data
     try {
       await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
     } catch (e) {
-      console.log(e)
+      Logger.log(e)
     }
     await setUserTierForUserIds([userId])
   }

--- a/packages/server/safetyPatchRes.ts
+++ b/packages/server/safetyPatchRes.ts
@@ -1,4 +1,5 @@
 import {HttpResponse, RecognizedString} from 'uWebSockets.js'
+import {Logger} from './utils/Logger'
 
 type Header = [key: RecognizedString, value: RecognizedString]
 
@@ -36,7 +37,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._end = res.end
   res.end = (body?: RecognizedString) => {
     if (res.done) {
-      console.warn(`uWS: Called end after done`)
+      Logger.warn(`uWS: Called end after done`)
     }
     if (res.done || res.aborted) return res
     res.done = true
@@ -46,7 +47,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._close = res.close
   res.close = () => {
     if (res.done) {
-      console.warn(`uWS: Called close after done`)
+      Logger.warn(`uWS: Called close after done`)
     }
     if (res.done || res.aborted) return res
     res.done = true
@@ -61,7 +62,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._tryEnd = res.tryEnd
   res.tryEnd = (fullBodyOrChunk: RecognizedString, totalSize: number) => {
     if (res.done) {
-      console.warn(`uWS: Called tryEnd after done`)
+      Logger.warn(`uWS: Called tryEnd after done`)
     }
     if (res.done || res.aborted) return [true, true]
     return flush(() => res._tryEnd(fullBodyOrChunk, totalSize))
@@ -70,7 +71,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._write = res.write
   res.write = (chunk: RecognizedString) => {
     if (res.done) {
-      console.warn(`uWS: Called write after done`)
+      Logger.warn(`uWS: Called write after done`)
     }
     if (res.done || res.aborted) return res
     return res._write(chunk)
@@ -79,7 +80,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._writeHeader = res.writeHeader
   res.writeHeader = (key: RecognizedString, value: RecognizedString) => {
     if (res.done) {
-      console.warn(`uWS: Called writeHeader after done`)
+      Logger.warn(`uWS: Called writeHeader after done`)
     }
     res.headers.push([key, value])
     return res
@@ -88,7 +89,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._writeStatus = res.writeStatus
   res.writeStatus = (status: RecognizedString) => {
     if (res.done) {
-      console.error(`uWS: Called writeStatus after done ${status}`)
+      Logger.error(`uWS: Called writeStatus after done ${status}`)
     }
     res.status = status
     return res
@@ -97,7 +98,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._upgrade = res.upgrade
   res.upgrade = (...args) => {
     if (res.done) {
-      console.error(`uWS: Called upgrade after done`)
+      Logger.error(`uWS: Called upgrade after done`)
     }
     if (res.done || res.aborted) return
     return res._cork(() => {
@@ -108,7 +109,7 @@ const safetyPatchRes = (res: HttpResponse) => {
   res._getRemoteAddressAsText = res.getRemoteAddressAsText
   res.getRemoteAddressAsText = () => {
     if (res.done) {
-      console.error(`uWS: Called getRemoteAddressAsText after done`)
+      Logger.error(`uWS: Called getRemoteAddressAsText after done`)
     }
     if (res.done || res.aborted) return Buffer.from('')
     return res._getRemoteAddressAsText()

--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -11,25 +11,7 @@ import {
   OAuth2AuthorizationParams,
   OAuth2RefreshAuthorizationParams
 } from '../integrations/OAuth2Manager'
-
-import tracer from 'dd-trace'
-import formats from 'dd-trace/ext/formats'
-import util from 'util'
-
-type LogLevel = 'error' | 'warn' | 'info' | 'debug'
-function trace(level: LogLevel, message: any, ...optionalParameters: any[]) {
-  const span = tracer.scope().active()
-  const time = new Date().toISOString()
-  const record = {time, level, message: util.format(message, optionalParameters)}
-
-  if (span) {
-    tracer.inject(span.context(), formats.LOG, record)
-  }
-
-  console.log(JSON.stringify(record))
-}
-
-const log = trace.bind(null, 'info')
+import {Logger} from './Logger'
 
 export interface JiraUser {
   self: string
@@ -343,7 +325,7 @@ class AtlassianServerManager extends AtlassianManager {
     } else {
       callback(null, {cloudId, newProjects: res.values})
       if (res.nextPage) {
-        await this.getPaginatedProjects(cloudId, res.nextPage, callback).catch(console.error)
+        await this.getPaginatedProjects(cloudId, res.nextPage, callback).catch(Logger.error)
       }
     }
   }
@@ -355,7 +337,7 @@ class AtlassianServerManager extends AtlassianManager {
           cloudId,
           `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`,
           callback
-        ).catch(console.error)
+        ).catch(Logger.error)
       })
     )
   }
@@ -387,7 +369,7 @@ class AtlassianServerManager extends AtlassianManager {
         }))
         projects.push(...pagedProjects)
         if (res.nextPage) {
-          log('AtlassianServerManager.getAllProjects fetching more results', res.total)
+          Logger.log('AtlassianServerManager.getAllProjects fetching more results', res.total)
           return getProjectPage(cloudId, res.nextPage)
         }
       }
@@ -402,7 +384,7 @@ class AtlassianServerManager extends AtlassianManager {
     )
 
     if (error) {
-      log('getAllProjects ERROR:', error)
+      Logger.log('getAllProjects ERROR:', error)
     }
     return projects
   }

--- a/packages/server/utils/Logger.ts
+++ b/packages/server/utils/Logger.ts
@@ -11,7 +11,7 @@ const LogFun = {
 } satisfies Record<LogLevel, Console[keyof Console]>
 
 function trace(level: LogLevel, message: any, ...optionalParameters: any[]) {
-  if (!process.env.DD_LOGS_INJECTION) {
+  if (process.env.DD_LOGS_INJECTION !== 'true') {
     return LogFun[level](message, ...optionalParameters)
   }
 

--- a/packages/server/utils/Logger.ts
+++ b/packages/server/utils/Logger.ts
@@ -1,0 +1,35 @@
+import tracer from 'dd-trace'
+import formats from 'dd-trace/ext/formats'
+import util from 'util'
+
+type LogLevel = 'error' | 'warn' | 'info' | 'debug'
+const LogFun = {
+  error: console.error,
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug
+} satisfies Record<LogLevel, Console[keyof Console]>
+
+function trace(level: LogLevel, message: any, ...optionalParameters: any[]) {
+  if (!process.env.DD_LOGS_INJECTION) {
+    return LogFun[level](message, ...optionalParameters)
+  }
+
+  const span = tracer.scope().active()
+  const time = new Date().toISOString()
+  const record = {time, level, message: util.format(message, optionalParameters)}
+
+  if (span) {
+    tracer.inject(span.context(), formats.LOG, record)
+  }
+
+  LogFun[level](JSON.stringify(record))
+}
+
+export const Logger = {
+  log: trace.bind(null, 'info'),
+  error: trace.bind(null, 'error'),
+  warn: trace.bind(null, 'warn'),
+  info: trace.bind(null, 'info'),
+  debug: trace.bind(null, 'debug')
+}

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -3,6 +3,7 @@ import JSON5 from 'json5'
 import sendToSentry from './sendToSentry'
 import Reflection from '../database/types/Reflection'
 import {ModifyType} from '../graphql/public/resolverTypes'
+import {Logger} from './Logger'
 
 type Prompt = {
   question: string
@@ -188,7 +189,7 @@ class OpenAIServerManager {
       return themes.split(', ')
     } catch (e) {
       const error = e instanceof Error ? e : new Error('OpenAI failed to generate themes')
-      console.error(error.message)
+      Logger.error(error.message)
       sendToSentry(error)
       return null
     }
@@ -226,7 +227,7 @@ class OpenAIServerManager {
     } catch (e) {
       const error =
         e instanceof Error ? e : new Error('OpenAI failed to generate the suggested template')
-      console.error(error.message)
+      Logger.error(error.message)
       sendToSentry(error)
       return null
     }

--- a/packages/server/utils/RecallAIServerManager.ts
+++ b/packages/server/utils/RecallAIServerManager.ts
@@ -4,6 +4,7 @@ import {ExternalLinks} from '../../client/types/constEnums'
 import appOrigin from '../appOrigin'
 import {TranscriptBlock} from '../database/types/MeetingRetrospective'
 import sendToSentry from './sendToSentry'
+import {Logger} from './Logger'
 
 const sdk = api('@recallai/v1.6#536jnqlf7d6blh')
 
@@ -19,7 +20,7 @@ const getBase64Image = async () => {
     const base64Image = buffer.toString('base64')
     return base64Image
   } catch (error) {
-    console.error(error)
+    Logger.error(error)
     return null
   }
 }

--- a/packages/server/utils/StaticServer.ts
+++ b/packages/server/utils/StaticServer.ts
@@ -3,6 +3,7 @@ import mime from 'mime-types'
 import path from 'path'
 import {brotliCompressSync} from 'zlib'
 import isCompressible from './isCompressible'
+import {Logger} from './Logger'
 class StaticFileMeta {
   mtime: string
   size: number
@@ -63,7 +64,7 @@ export default class StaticServer {
         }
         makePathnames(dirname, this.pathnames, '')
       } catch (e) {
-        console.log(e)
+        Logger.log(e)
       }
     })
   }

--- a/packages/server/utils/publish.ts
+++ b/packages/server/utils/publish.ts
@@ -1,4 +1,5 @@
 import getPubSub from './getPubSub'
+import {Logger} from './Logger'
 
 export interface SubOptions {
   mutatorId?: string // passing the socket id of the mutator will omit sending a message to that user
@@ -18,7 +19,7 @@ const publish = <T>(
   const rootValue = {[subName]: {fieldName: type, [type]: payload}}
   getPubSub()
     .publish(`${topic}.${channel}`, {rootValue, executorServerId: SERVER_ID!, ...subOptions})
-    .catch(console.error)
+    .catch(Logger.error)
 }
 
 export default publish

--- a/packages/server/utils/stripe/StripeManager.ts
+++ b/packages/server/utils/stripe/StripeManager.ts
@@ -1,5 +1,6 @@
 import {InvoiceItemType} from 'parabol-client/types/constEnums'
 import Stripe from 'stripe'
+import {Logger} from '../Logger'
 import sendToSentry from '../sendToSentry'
 
 export default class StripeManager {
@@ -15,7 +16,7 @@ export default class StripeManager {
     try {
       return this.stripe.webhooks.constructEvent(rawBody, signature, StripeManager.WEBHOOK_SECRET)
     } catch (e) {
-      console.log('StripeWebhookError:', e)
+      Logger.log('StripeWebhookError:', e)
       return null
     }
   }


### PR DESCRIPTION
Add trace information to log output for server side log statements. This does not include logging from code exclusively used for debugging, deploying or development.
The environment variable [`DD_LOGS_INJECTION`](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/nodejs/) is used to enable or disable this behaviour.

## Testing scenarios

- run the app and trigger a log output (for example throw in MailManagerDebug and send a summary)

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
