### PR TITLE
feat: support env-defined saml issuer for PPMIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ SOCKET_PORT='3001'
 # INVITATION_SHORTLINK='example.com'
 # If true, all new orgs will default to being enterprise tier. Use for PPMIs
 # IS_ENTERPRISE=false
+# PPMI single tenant use only. Will set the SAML issuer to this value.
+# SAML_ISSUER=''
 
 # AUTHENTICATION
 # AUTH_INTERNAL_DISABLED='false'

--- a/packages/server/graphql/public/mutations/helpers/SAMLHelpers/getURLWithSAMLRequestParam.ts
+++ b/packages/server/graphql/public/mutations/helpers/SAMLHelpers/getURLWithSAMLRequestParam.ts
@@ -2,13 +2,14 @@ import {v4 as uuid} from 'uuid'
 import zlib from 'zlib'
 
 const getURLWithSAMLRequestParam = (destination: string, slug: string) => {
+  const issuer = process.env.SAML_ISSUER || `https://${process.env.HOST}/saml-metadata/${slug}`
   const template = `
   <samlp:AuthnRequest
       xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
       xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_${uuid()}" Version="2.0" IssueInstant="${new Date().toISOString()}" Destination="${destination}" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" AssertionConsumerServiceURL="https://${
     process.env.HOST
   }/saml/${slug}">
-  <saml:Issuer>https://${process.env.HOST}/saml-metadata/${slug}</saml:Issuer>
+  <saml:Issuer>${issuer}</saml:Issuer>
       <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" AllowCreate="false"/>
   </samlp:AuthnRequest>
   `


### PR DESCRIPTION
# Description

fix #9454

Supports single tenant SAML:
- admins can set `env.SAML_ISSUER` & override what parabol calls itself to the IdP
- admins can use a single SAML record for the entire instance if SSO is the only way to log in to the app & a SAML record already exists. To set up SAML, they can temporarily enable email/password auth & then after it's set up successfully they can disable that. 
