### PR TITLE
fix: Fetch Jira projects in parallel

### DIFF
--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -358,7 +358,38 @@ class AtlassianServerManager extends AtlassianManager {
   async getAllProjects(cloudIds: string[]) {
     const projects = [] as (JiraProject & {cloudId: string})[]
     let error: Error | undefined
-    const getProjectPage = async (cloudId: string, url: string): Promise<void> => {
+    const getProjectsPage = async (
+      cloudId: string,
+      startAt: number,
+      maxResults: number
+    ): Promise<void> => {
+      const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name&startAt=${startAt}`
+      const res = await this.get<JiraProjectResponse>(url)
+      if (res instanceof Error || res instanceof RateLimitError) {
+        error = res
+      } else {
+        const pagedProjects = res.values.map((project) => ({
+          ...project,
+          cloudId
+        }))
+        projects.push(...pagedProjects)
+
+        if (pagedProjects.length < maxResults && res.nextPage) {
+          Logger.log(
+            'Underfetched in getAllProjects, requested',
+            maxResults,
+            'got',
+            pagedProjects.length
+          )
+          const nextStart = res.startAt + pagedProjects.length
+          const nextMaxResults = maxResults - pagedProjects.length
+          return getProjectsPage(cloudId, nextStart, nextMaxResults)
+        }
+      }
+    }
+
+    const getProjects = async (cloudId: string) => {
+      const url = `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name`
       const res = await this.get<JiraProjectResponse>(url)
       if (res instanceof Error || res instanceof RateLimitError) {
         error = res
@@ -369,19 +400,20 @@ class AtlassianServerManager extends AtlassianManager {
         }))
         projects.push(...pagedProjects)
         if (res.nextPage) {
-          Logger.log('AtlassianServerManager.getAllProjects fetching more results', res.total)
-          return getProjectPage(cloudId, res.nextPage)
+          const {total} = res
+          const nextStart = res.startAt + pagedProjects.length
+          const fetches = [] as Array<Promise<void>>
+          // 50 is the default maxResults for Jira, Jira does not respond with more than that
+          const maxResults = 50
+          for (let i = nextStart; i < total; i += maxResults) {
+            fetches.push(getProjectsPage(cloudId, i, maxResults))
+          }
+          await Promise.all(fetches)
         }
       }
     }
-    await Promise.all(
-      cloudIds.map((cloudId) =>
-        getProjectPage(
-          cloudId,
-          `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/project/search?orderBy=name&maxResults=500`
-        )
-      )
-    )
+
+    await Promise.all(cloudIds.map((cloudId) => getProjects(cloudId)))
 
     if (error) {
       Logger.log('getAllProjects ERROR:', error)


### PR DESCRIPTION
Previously we tried to fetch more projects per page, but Jira only ever returns 50 max. Instead once we know how many projects there are after fetching the first page, we fetch all remaining pages in parallel.

I observed we are fetching the projects multiple times, also when we do seemingly unrelated things like selecting all issues or checking/unchecking "use JQL". This is not addressed here.

## Demo

https://www.loom.com/share/16d9346aa4f4428198b539f46786a209?sid=be0817a7-4799-4846-895c-c89425daaf58

## Testing scenarios

- integrate with a Jira account with lots of projects (I can invite you)
- try sprint poker

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
