### PR TITLE
feat: OpenAIGeneration model for embedder

### DIFF
--- a/packages/embedder/ai_models/AbstractModel.ts
+++ b/packages/embedder/ai_models/AbstractModel.ts
@@ -11,7 +11,6 @@ export interface GenerationModelConfig extends ModelConfig {}
 
 export abstract class AbstractModel {
   public readonly url?: string
-  public modelInstance: any
 
   constructor(config: ModelConfig) {
     this.url = this.normalizeUrl(config.url)
@@ -57,7 +56,6 @@ export interface GenerationOptions {
   temperature?: number
   topK?: number
   topP?: number
-  truncate?: boolean
 }
 
 export abstract class AbstractGenerationModel extends AbstractModel {

--- a/packages/embedder/ai_models/ModelManager.ts
+++ b/packages/embedder/ai_models/ModelManager.ts
@@ -7,6 +7,7 @@ import {
   GenerationModelConfig,
   ModelConfig
 } from './AbstractModel'
+import OpenAIGeneration from './OpenAIGeneration'
 import TextEmbeddingsInference from './TextEmbeddingsInference'
 import TextGenerationInference from './TextGenerationInference'
 
@@ -16,7 +17,7 @@ interface ModelManagerConfig {
 }
 
 export type EmbeddingsModelType = 'text-embeddings-inference'
-export type GenerationModelType = 'text-generation-inference'
+export type GenerationModelType = 'openai' | 'text-generation-inference'
 
 export class ModelManager {
   embeddingModels: AbstractEmbeddingsModel[]
@@ -80,9 +81,11 @@ export class ModelManager {
       const [modelType, _] = modelConfig.model.split(':') as [GenerationModelType, string]
 
       switch (modelType) {
+        case 'openai': {
+          return new OpenAIGeneration(modelConfig)
+        }
         case 'text-generation-inference': {
-          const generator = new TextGenerationInference(modelConfig)
-          return generator
+          return new TextGenerationInference(modelConfig)
         }
         default:
           throw new Error(`unsupported summarization model '${modelType}'`)

--- a/packages/embedder/ai_models/OpenAIGeneration.ts
+++ b/packages/embedder/ai_models/OpenAIGeneration.ts
@@ -1,0 +1,94 @@
+import OpenAI from 'openai'
+import {
+  AbstractGenerationModel,
+  GenerationModelConfig,
+  GenerationModelParams,
+  GenerationOptions
+} from './AbstractModel'
+
+const MAX_REQUEST_TIME_S = 3 * 60
+
+export type ModelId = 'gpt-3.5-turbo-0125' | 'gpt-4-turbo-preview'
+
+type OpenAIGenerationOptions = Omit<GenerationOptions, 'topK'>
+
+const modelIdDefinitions: Record<ModelId, GenerationModelParams> = {
+  'gpt-3.5-turbo-0125': {
+    maxInputTokens: 4096
+  },
+  'gpt-4-turbo-preview': {
+    maxInputTokens: 128000
+  }
+}
+
+function isValidModelId(object: any): object is ModelId {
+  return Object.keys(modelIdDefinitions).includes(object)
+}
+
+export class OpenAIGeneration extends AbstractGenerationModel {
+  private openAIApi: OpenAI | null
+  private modelId: ModelId
+
+  constructor(config: GenerationModelConfig) {
+    super(config)
+    if (!process.env.OPEN_AI_API_KEY) {
+      this.openAIApi = null
+      return
+    }
+    this.openAIApi = new OpenAI({
+      apiKey: process.env.OPEN_AI_API_KEY,
+      organization: process.env.OPEN_AI_ORG_ID
+    })
+  }
+
+  async summarize(content: string, options: OpenAIGenerationOptions) {
+    if (!this.openAIApi) {
+      const eMsg = 'OpenAI is not configured'
+      console.log('OpenAIGenerationSummarizer.summarize(): ', eMsg)
+      throw new Error(eMsg)
+    }
+    const {maxNewTokens: max_tokens = 512, seed, stop, temperature = 0.8, topP: top_p} = options
+    const prompt = `Create a brief, one-paragraph summary of the following: ${content}`
+
+    try {
+      const response = await this.openAIApi.chat.completions.create({
+        frequency_penalty: 0,
+        max_tokens,
+        messages: [
+          {
+            role: 'user',
+            content: prompt
+          }
+        ],
+        model: this.modelId,
+        presence_penalty: 0,
+        temperature,
+        seed,
+        stop,
+        top_p
+      })
+      const maybeSummary = response.choices[0]?.message?.content?.trim()
+      if (!maybeSummary) throw new Error('OpenAI returned empty summary')
+      return maybeSummary
+    } catch (e) {
+      console.log('OpenAIGenerationSummarizer.summarize(): ', e)
+      throw e
+    }
+  }
+  protected constructModelParams(config: GenerationModelConfig): GenerationModelParams {
+    const modelConfigStringSplit = config.model.split(':')
+    if (modelConfigStringSplit.length != 2) {
+      throw new Error('OpenAIGeneration model string must be colon-delimited and len 2')
+    }
+
+    const maybeModelId = modelConfigStringSplit[1]
+    if (!isValidModelId(maybeModelId))
+      throw new Error(`OpenAIGeneration model id unknown: ${maybeModelId}`)
+
+    this.modelId = maybeModelId
+
+    return modelIdDefinitions[maybeModelId]
+  }
+}
+
+export default OpenAIGeneration

--- a/packages/embedder/ai_models/TextEmbeddingsInference.ts
+++ b/packages/embedder/ai_models/TextEmbeddingsInference.ts
@@ -63,7 +63,7 @@ export class TextEmbeddingsInference extends AbstractEmbeddingsModel {
     if (!this.url) throw new Error('TextGenerationInferenceSummarizer model requires url')
     const maybeModelId = modelConfigStringSplit[1]
     if (!isValidModelId(maybeModelId))
-      throw new Error(`TextGenerationInference model subtype unknown: ${maybeModelId}`)
+      throw new Error(`TextGenerationInference model id unknown: ${maybeModelId}`)
     return modelIdDefinitions[maybeModelId]
   }
 }

--- a/packages/embedder/ai_models/TextGenerationInference.ts
+++ b/packages/embedder/ai_models/TextGenerationInference.ts
@@ -25,16 +25,8 @@ export class TextGenerationInference extends AbstractGenerationModel {
     super(config)
   }
 
-  public async summarize(content: string, options: GenerationOptions) {
-    const {
-      maxNewTokens: max_new_tokens = 512,
-      seed,
-      stop,
-      temperature = 0.8,
-      topP,
-      topK,
-      truncate
-    } = options
+  async summarize(content: string, options: GenerationOptions) {
+    const {maxNewTokens: max_new_tokens = 512, seed, stop, temperature = 0.8, topP, topK} = options
     const parameters = {
       max_new_tokens,
       seed,
@@ -42,7 +34,7 @@ export class TextGenerationInference extends AbstractGenerationModel {
       temperature,
       topP,
       topK,
-      truncate
+      truncate: true
     }
     const prompt = `Create a brief, one-paragraph summary of the following: ${content}`
     const fetchOptions = {
@@ -59,27 +51,27 @@ export class TextGenerationInference extends AbstractGenerationModel {
     }
 
     try {
-      // console.log(`TextGenerationInterface.summarize(): summarizing from ${this.url}/generate`)
+      // console.log(`TextGenerationInference.summarize(): summarizing from ${this.url}/generate`)
       const res = await fetchWithRetry(`${this.url}/generate`, fetchOptions)
       const json = await res.json()
       if (!json || !json.generated_text)
-        throw new Error('TextGenerationInterface.summarize(): malformed response')
+        throw new Error('TextGenerationInference.summarize(): malformed response')
       return json.generated_text as string
     } catch (e) {
-      console.log('TextGenerationInterfaceSummarizer.summarize(): timeout')
+      console.log('TextGenerationInferenceSummarizer.summarize(): timeout')
       throw e
     }
   }
   protected constructModelParams(config: GenerationModelConfig): GenerationModelParams {
     const modelConfigStringSplit = config.model.split(':')
     if (modelConfigStringSplit.length != 2) {
-      throw new Error('TextGenerationInterface model string must be colon-delimited and len 2')
+      throw new Error('TextGenerationInference model string must be colon-delimited and len 2')
     }
 
-    if (!this.url) throw new Error('TextGenerationInterfaceSummarizer model requires url')
+    if (!this.url) throw new Error('TextGenerationInferenceSummarizer model requires url')
     const maybeModelId = modelConfigStringSplit[1]
     if (!isValidModelId(maybeModelId))
-      throw new Error(`TextGenerationInterface model subtype unknown: ${maybeModelId}`)
+      throw new Error(`TextGenerationInference model id unknown: ${maybeModelId}`)
     return modelIdDefinitions[maybeModelId]
   }
 }

--- a/packages/embedder/embedder.ts
+++ b/packages/embedder/embedder.ts
@@ -162,9 +162,8 @@ const dequeueAndEmbedUntilEmpty = async (modelManager: ModelManager) => {
       try {
         const generator = modelManager.generationModels[0] // use 1st generator
         if (!generator) throw new Error(`Generator unavailable`)
-        const summarizeOptions = {maxInputTokens, truncate: true}
         console.log(`embedder:     ...summarizing ${itemKey} for ${modelTable}`)
-        embedText = await generator.summarize(fullText, summarizeOptions)
+        embedText = await generator.summarize(fullText, {maxNewTokens: maxInputTokens})
       } catch (e) {
         await updateJobState(jobQueueId, 'failed', {
           stateMessage: `unable to summarize long embed text: ${e}`

--- a/packages/embedder/indexing/embeddingsTablesOps.ts
+++ b/packages/embedder/indexing/embeddingsTablesOps.ts
@@ -52,7 +52,7 @@ export async function selectMetaToQueue(
     .where(({eb, not, or, and, exists, selectFrom}) =>
       and([
         or([
-          not(eb('em.models', '<@', sql`ARRAY[${sql.ref('model')}]::varchar[]` as any) as any),
+          not(eb('em.models', '@>', sql`ARRAY[${sql.ref('model')}]::varchar[]` as any) as any),
           eb('em.models' as any, 'is', null)
         ]),
         not(


### PR DESCRIPTION
# Description

Implements #9436 

## Demo

```
...
embedder:     ...summarizing retrospectiveDiscussionTopic:nzyvX6Nbzy:nzyw41YGfa for Embeddings_ember_1
embedder: completed retrospectiveDiscussionTopic:nzyvX6Nbzy:nzyw41YGfa -> Embeddings_ember_1
...
```

Original `fullText` (names redacted):

```
A topic "Culture & Departures" was discussed during the meeting "Retro
#108" that followed the "Hero’s Journey 👑 + Kudos" template.

Participants were prompted with, "Cavern: What challenges lie ahead?".

- Anonymous wrote, "(long, sorry!) I hope the majority of the company
  does not think that X was treated unfairly. I also hope they not
  think that the Sales team is a bunch of "sharks" who aren't willing to
  accommodate people with different personality types. From my
  perspective X was given nothing but support and help. A LOT of
  help. Despite that, X was consistently the lowest performer on the
  team by a large margin.

I was very frustrated by X's going away message, which to me came across
as selfish, immature, and unnecessarily inflammatory. No company is
perfect, we can all improve. I like X a lot as a person. But I don't
think X was treated poorly during his time here and it bothers me
that X left how he did, making all those accusations. - Y "

- Anonymous wrote, "I feel that the recent departures somehow impact the
  trust of many members towards how things are handled, and we need now
  more than ever to regroup, be very transparent and reflect on how we
  can do better as a team "
- Anonymous wrote, "I didn't like X's insinuations that we are kinda
  sorta racist. I think he would have been the first person to tell you
  that Z (former sales member) was bad at their job.

We can be better at DE&I, but I also see that our company has a wide
variety of people from all kinds of backgrounds working together and
thriving. Let's not lose sight of that. "

- Anonymous wrote, "I feel like we have had some weird days, maybe even
  with a bit of tension. Watching P's new TT video made me reflect
  on some silent meetings we have sat on during the past weeks. I don't
  think this is a very big issue, but I wonder if we are keeping some
  tensions unsaid."
- Anonymous wrote, "X's message hit me hard, it made me wonder how
  much his perspective or general ... concern? is shared"

```

OpenAI GPT 3.5 Turbo:

```
During the meeting "Retro #108", the topic of "Culture & Departures" was discussed following the "Hero’s Journey 👑 + Kudos" template. Participants were prompted with the question, "Cavern: What challenges lie ahead?". Various anonymous comments were made regarding recent departures impacting trust within the team, reflections on diversity, tensions within the company, and differing perspectives on the departure of a former team member. The discussion highlighted the importance of transparency, reflection, and unity in moving forward as a team.
```

Compare with Zephyr:

```
 During the "Retro #108" meeting, using the "Hero’s Journey 👑 + Kudos" template, the topic of culture and departures was discussed. Participants were prompted to contemplate the challenges that lie ahead in the cavernous space. An anonymous individual expressed their hope that the majority of the company did not view X's departure as unfair or interpret the Sales team's actions as unaccommodating towards those with different personality types. The writer described X as receiving a significant amount of assistance and support, yet continuously being the lowest-performing member of the team by a substantial margin. They expressed frustration with X's dismissal message, which they felt came across as selfish, immature, and inflammatory. Another anonymous individual voiced concerns regarding the impact of recent departures on members' trust in the handling of issues. They suggested that the company should be transparent and reflect on how to improve as a team. A third anonymous writer disapproved of X insinuations about potential racism within the company, highlighting Z's poor job performance as evidence. The individual expressed concern regarding the company's efforts towards DE&I but acknowledged that it employs a diverse group of individuals who thrive together. Another anonymous writer reflected on some tense meetings and wondered if there were unsaid tensions present. A final anonymous writer was moved by X's farewell message and questioned how widely held perspectives or concerns might be.
```

## Testing scenarios

```sql
UPDATE "EmbeddingsMetadata" SET "models" = '{}'
WHERE id IN (
    SELECT em.id
    FROM "EmbeddingsMetadata" em
    JOIN "Embeddings_ember_1" e ON em.id = e."embeddingsMetadataId"
    WHERE NOT "embedText" IS NULL
)
```

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
