### PR TITLE
fix: After parameter for meetingCount was ignored

### DIFF
--- a/packages/server/graphql/public/types/Company.ts
+++ b/packages/server/graphql/public/types/Company.ts
@@ -139,7 +139,7 @@ const Company: CompanyResolvers = {
     const teams = await getTeamsByOrgIds(orgIds, dataLoader, true)
     const teamIds = teams.map(({id}) => id)
     if (teamIds.length === 0) return 0
-    const filterFn = after ? () => true : (meeting: any) => meeting('createdAt').ge(after)
+    const filterFn = after ? (meeting: any) => meeting('createdAt').ge(after) : () => true
     return r
       .table('NewMeeting')
       .getAll(r.args(teamIds), {index: 'teamId'})


### PR DESCRIPTION
# Description

The check was the wrong way round

## Testing scenarios

run the following query with different `after` parameters and see the count change
```
query MeetingCount {
  company(domain: "parabol.co") {
    meetingCount(after: "2024-02-20T00:00:00.000Z")
  }
}
```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
