### PR TITLE
feat: make all templates free

### DIFF
--- a/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
+++ b/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
@@ -15,31 +15,6 @@ export async function up() {
   await client.end()
 }
 
-const PREV_FREE_TEMPLATE_IDS = [
-  'herosJourneyTemplate',
-  'roseThornBudTemplate',
-  'winningStreakTemplate',
-  'starfishTemplate',
-  'hopesAndFearsTemplate',
-  'sixThinkingHatsTemplate',
-  'hotAirBalloonTemplate',
-  'heardSeenRespectedHSRTemplate',
-  'wRAPTemplate',
-  'speedCarTemplate',
-  'surprisedWorriedInspiredTemplate',
-  'marieKondoRetrospectiveTemplate',
-  'highlightsLowlightsTemplate',
-  'saMoLoTemplate',
-  'superheroRetrospectiveTemplate',
-  'questionsCommentsConcernsTemplate',
-  'dreamTeamRetrospectiveTemplate',
-  'handsOnDeckActivityTemplate',
-  'alwaysBeLearningRetrospectiveTemplate',
-  'scrumValuesRetrospectiveTemplate',
-  'estimatedEffortTemplate',
-  'wsjfTemplate'
-]
-
 export async function down() {
   // noop
 }

--- a/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
+++ b/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
@@ -41,22 +41,5 @@ const PREV_FREE_TEMPLATE_IDS = [
 ]
 
 export async function down() {
-  const client = new Client(getPgConfig())
-  await client.connect()
-  await client.query(
-    `
-    UPDATE "MeetingTemplate"
-      SET "isFree" = false
-      WHERE "orgId" = 'aGhostOrg'
-    `
-  )
-  await client.query(
-    `
-    UPDATE "MeetingTemplate"
-    SET "isFree" = true
-    WHERE id = ANY ($1)
-   `,
-    [PREV_FREE_TEMPLATE_IDS]
-  )
-  await client.end()
+  // noop
 }

--- a/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
+++ b/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
@@ -8,6 +8,7 @@ export async function up() {
     `
     UPDATE "MeetingTemplate"
       SET "isFree" = true
+      WHERE "orgId" = 'aGhostOrg'
    `
   )
 
@@ -56,8 +57,8 @@ export async function down() {
   await client.query(
     `
     UPDATE "MeetingTemplate"
-      SET "isFree" = true
-      WHERE id = ANY ($1)
+    SET "isFree" = true
+    WHERE id = ANY ($1)
    `,
     [PREV_FREE_TEMPLATES]
   )

--- a/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
+++ b/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
@@ -15,34 +15,29 @@ export async function up() {
   await client.end()
 }
 
-const PREV_FREE_TEMPLATES = [
-  'aChristmasCarolRetrospectiveTemplate',
-  'diwaliRetrospectiveTemplate',
-  'dropAddKeepImproveDAKITemplate',
-  'easterRetrospectiveTemplate',
-  'energyLevelsTemplate',
-  'halloweenRetrospectiveTemplate',
-  'holiRetrospectiveTemplate',
-  'keepProblemTryTemplate',
-  'leanCoffeeTemplate',
-  'lunarNewYearRetrospectiveTemplate',
-  'midsummerRetrospectiveTemplate',
-  'mountainClimberTemplate',
-  'newYearRetrospectiveTemplate',
-  'sWOTAnalysisTemplate',
-  'teamCharterTemplate',
-  'teamRetreatPlanningTemplate',
-  'thanksgivingRetrospectiveTemplate',
-  'threeLittlePigsTemplate',
+const PREV_FREE_TEMPLATE_IDS = [
+  'herosJourneyTemplate',
+  'roseThornBudTemplate',
+  'winningStreakTemplate',
+  'starfishTemplate',
+  'hopesAndFearsTemplate',
+  'sixThinkingHatsTemplate',
+  'hotAirBalloonTemplate',
+  'heardSeenRespectedHSRTemplate',
+  'wRAPTemplate',
+  'speedCarTemplate',
+  'surprisedWorriedInspiredTemplate',
+  'marieKondoRetrospectiveTemplate',
+  'highlightsLowlightsTemplate',
+  'saMoLoTemplate',
+  'superheroRetrospectiveTemplate',
+  'questionsCommentsConcernsTemplate',
+  'dreamTeamRetrospectiveTemplate',
+  'handsOnDeckActivityTemplate',
+  'alwaysBeLearningRetrospectiveTemplate',
+  'scrumValuesRetrospectiveTemplate',
   'estimatedEffortTemplate',
-  'wsjfTemplate',
-  'startStopContinueTemplate',
-  'gladSadMadTemplate',
-  'whatWentWellTemplate',
-  'workingStuckTemplate',
-  'sailboatTemplate',
-  'original4Template',
-  'fourLsTemplate'
+  'wsjfTemplate'
 ]
 
 export async function down() {
@@ -52,6 +47,7 @@ export async function down() {
     `
     UPDATE "MeetingTemplate"
       SET "isFree" = false
+      WHERE "orgId" = 'aGhostOrg'
     `
   )
   await client.query(
@@ -60,7 +56,7 @@ export async function down() {
     SET "isFree" = true
     WHERE id = ANY ($1)
    `,
-    [PREV_FREE_TEMPLATES]
+    [PREV_FREE_TEMPLATE_IDS]
   )
   await client.end()
 }

--- a/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
+++ b/packages/server/postgres/migrations/1709551949071_makeAllTemplatesFree.ts
@@ -1,0 +1,65 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(
+    `
+    UPDATE "MeetingTemplate"
+      SET "isFree" = true
+   `
+  )
+
+  await client.end()
+}
+
+const PREV_FREE_TEMPLATES = [
+  'aChristmasCarolRetrospectiveTemplate',
+  'diwaliRetrospectiveTemplate',
+  'dropAddKeepImproveDAKITemplate',
+  'easterRetrospectiveTemplate',
+  'energyLevelsTemplate',
+  'halloweenRetrospectiveTemplate',
+  'holiRetrospectiveTemplate',
+  'keepProblemTryTemplate',
+  'leanCoffeeTemplate',
+  'lunarNewYearRetrospectiveTemplate',
+  'midsummerRetrospectiveTemplate',
+  'mountainClimberTemplate',
+  'newYearRetrospectiveTemplate',
+  'sWOTAnalysisTemplate',
+  'teamCharterTemplate',
+  'teamRetreatPlanningTemplate',
+  'thanksgivingRetrospectiveTemplate',
+  'threeLittlePigsTemplate',
+  'estimatedEffortTemplate',
+  'wsjfTemplate',
+  'startStopContinueTemplate',
+  'gladSadMadTemplate',
+  'whatWentWellTemplate',
+  'workingStuckTemplate',
+  'sailboatTemplate',
+  'original4Template',
+  'fourLsTemplate'
+]
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(
+    `
+    UPDATE "MeetingTemplate"
+      SET "isFree" = false
+    `
+  )
+  await client.query(
+    `
+    UPDATE "MeetingTemplate"
+      SET "isFree" = true
+      WHERE id = ANY ($1)
+   `,
+    [PREV_FREE_TEMPLATES]
+  )
+  await client.end()
+}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9472

I suggest that we don't remove all of the template limit logic as it's possible that we will want to implement template limits again in the near future. 

So, we should just set `isFree` to true for all meeting templates.

When I run `yarn pg:migrate up` I get the following error locally:

<details>

> - 1709551949071_makeAllTemplatesFree
> Rolling back attempted migration ...
RethinkDBError [ReqlOpFailedError]: Table `actionDevelopment.MeetingTemplate` does not exist in:
r.db("actionDevelopment").table("TemplateDimension").getAll(r.args(["estimatedEffortTemplate", "p5L84RD2og", "nLmvkxa43S", "wsjfTemplate"]), {
    index: "templateId"
}).merge((var_1) => {
    scale: r.db("actionDevelopment").table("TemplateScale").get(var_1("scaleId"))
}).orderBy("sortOrder").group("templateId").ungroup().merge((var_1) => {
    name: r.db("actionDevelopment").table("MeetingTemplate").get(var_1("group"))("name"),
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                             
    id: var_1("group"),
    dimensions: var_1("reduction")
})
    at Cursor.handleErrors (/Users/nickoferrall/parabol/node_modules/rethinkdb-ts/lib/response/cursor.js:274:23)
    at Cursor.resolve (/Users/nickoferrall/parabol/node_modules/rethinkdb-ts/lib/response/cursor.js:190:18)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Function.run (/Users/nickoferrall/parabol/node_modules/rethinkdb-ts/lib/query-builder/query-runner.js:28:29) {
  msg: 'Table `actionDevelopment.MeetingTemplate` does not exist.',
  type: 17,
  cause: undefined,
  term: [ 35, [ [Array], [Array] ] ]
}

</details>

This migration is almost identical to [this one](https://github.com/ParabolInc/parabol/blob/7d7c39c10ae016794b2e4c1c8f302467409fc5b9/packages/server/postgres/migrations/1698831891828_moreFreeRetroTemplates.ts), so I assume it's a problem with my local set-up. It's referring to Rethinkdb when the table is in PG. Please let me know if you recognise the error. If not, I'll keep digging into it.

### To test

- [ ] Run the migration and see that all templates are free for all users