### PR TITLE
chore(gh-actions): reporting status to Slack if test or build GH Actions fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,3 +137,12 @@ jobs:
             --service=parabol-saas-production \
             --release-version=${{env.ACTION_VERSION}} \
             --minified-path-prefix=${{env.CDN_BUILD_URL}}
+
+      - name: Report Status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GH_ACTIONS_NOTIFICATIONS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
           retention-days: 7
 
       - name: Report Status
-        if: failure()
+        if: ${{ failure() && github.ref_name == 'master' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,3 +133,12 @@ jobs:
           name: test-results
           path: packages/integration-tests/test-results/
           retention-days: 7
+
+      - name: Report Status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GH_ACTIONS_NOTIFICATIONS }}


### PR DESCRIPTION
# Description

Notifies the team, on the Slack channel engineering, if build or test GH Action fails to avoid unexpected problems during releases.

Using [this available and super simple action](https://github.com/marketplace/actions/notify-slack-action) with the default and simplest step in the workflow.