### PR TITLE
chore(ci): add capability to manually generate Docker Images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - "release-please--**"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
# Description

Adds workflow_dispatch to allow building docker images manually on-demand. It simply requires to go to the Github Action - Build, click on  `Run workflow` and select the branch or tag. The build action will start on that branch/tag and produce and image, pushing it to the development repository. The tag of that Docker image is the sha of the last commit on the branch or tag.

This only works once merged to master.