### PR TITLE
fix: Make hasGCalError optional

### DIFF
--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -7863,7 +7863,7 @@ type StartSprintPokerSuccess {
   meeting: PokerMeeting!
   team: Team!
   teamId: ID!
-  hasGcalError: Boolean!
+  hasGcalError: Boolean
 }
 
 """

--- a/packages/server/graphql/public/typeDefs/startCheckIn.graphql
+++ b/packages/server/graphql/public/typeDefs/startCheckIn.graphql
@@ -7,7 +7,7 @@ type StartCheckInSuccess {
   meeting: ActionMeeting!
   meetingId: ID!
   team: Team!
-  hasGcalError: Boolean!
+  hasGcalError: Boolean
 }
 
 extend type Mutation {

--- a/packages/server/graphql/public/typeDefs/startRetrospective.graphql
+++ b/packages/server/graphql/public/typeDefs/startRetrospective.graphql
@@ -27,7 +27,7 @@ type StartRetrospectiveSuccess {
   meeting: RetrospectiveMeeting!
   meetingId: ID!
   team: Team!
-  hasGcalError: Boolean!
+  hasGcalError: Boolean
 }
 
 input CreateGcalEventInput {

--- a/packages/server/graphql/public/typeDefs/startTeamPrompt.graphql
+++ b/packages/server/graphql/public/typeDefs/startTeamPrompt.graphql
@@ -35,7 +35,7 @@ type StartTeamPromptSuccess {
   """
   True if there was an error creating the Google Calendar event. False if there was no error or no gcalInput was provided.
   """
-  hasGcalError: Boolean!
+  hasGcalError: Boolean
 }
 
 input CreateGcalEventInput {

--- a/packages/server/graphql/public/types/StartRetrospectiveSuccess.ts
+++ b/packages/server/graphql/public/types/StartRetrospectiveSuccess.ts
@@ -13,8 +13,7 @@ const StartRetrospectiveSuccess: StartRetrospectiveSuccessResolvers = {
   },
   team: ({teamId}, _args: unknown, {dataLoader}) => {
     return dataLoader.get('teams').loadNonNull(teamId)
-  },
-  hasGcalError: ({hasGcalError}) => !!hasGcalError
+  }
 }
 
 export default StartRetrospectiveSuccess


### PR DESCRIPTION
Fixes: #8976

During testing I ran into "Cannot return null for non-nullable field hasGCalError" issues. This is not necessary because it's not a criitical field. Avoid these kind of mistakes by just making it optional.

## Testing scenarios

- restart a team prompt via processRecurrence

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
