### PR TITLE
chore: add GH Action, on Snyk PRs commit yarn.lock

### DIFF
--- a/.github/workflows/snyk-yarn-lock-commit.yml
+++ b/.github/workflows/snyk-yarn-lock-commit.yml
@@ -1,0 +1,29 @@
+name: Update Snyk PR to add yarn.lock
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  update-snyk-pr:
+    if: contains(github.event.pull_request.title.toLowerCase(), '[snyk]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, no need to create one
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Commit yarn.lock to the PR branch
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          git add yarn.lock
+          git commit -m "Update yarn.lock" || echo "No changes to commit"
+          git push
+


### PR DESCRIPTION
# Description

Had a couple of minutes for a little palette cleanser. Decided to create this action.

If the PR title include [snyk] (case-insensitive), check out the PR branch, run yarn install, and then commit the resulting lock file and push the branch.

## Testing scenarios

- [ ] Close a snyk PR and reopen it

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
