### PR TITLE
fix: node-loader that ignores public path

### DIFF
--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -36,8 +36,12 @@ module.exports = (config) => {
         path.join(SERVER_ROOT, 'server.ts')
       ],
       embedder: [DOTENV, path.join(EMBEDDER_ROOT, 'embedder.ts')],
-      gqlExecutor: [DOTENV, path.join(GQL_ROOT, 'gqlExecutor.ts')],
-      preDeploy: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/preDeploy.ts')],
+      gqlExecutor: [DOTENV, INIT_PUBLIC_PATH, path.join(GQL_ROOT, 'gqlExecutor.ts')],
+      preDeploy: [
+        DOTENV,
+        INIT_PUBLIC_PATH,
+        path.join(PROJECT_ROOT, 'scripts/toolboxSrc/preDeploy.ts')
+      ],
       pushToCDN: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/pushToCDN.ts')],
       migrate: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/standaloneMigrations.ts')],
       assignSURole: [DOTENV, path.join(PROJECT_ROOT, 'scripts/toolboxSrc/assignSURole.ts')]
@@ -120,7 +124,8 @@ module.exports = (config) => {
           test: /\.node$/,
           use: [
             {
-              loader: 'node-loader',
+              // use our fork of node-loader to exclude the public path from the script
+              loader: path.resolve(__dirname, './utils/node-loader-private/cjs.js'),
               options: {
                 // sharp's bindings.gyp is hardcoded to look for libvips 2 directories up
                 // rather than do a custom build, we just output it 2 directories down (/node/binaries)

--- a/scripts/webpack/utils/node-loader-private/cjs.js
+++ b/scripts/webpack/utils/node-loader-private/cjs.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const loader = require("./index");
+
+module.exports = loader.default;
+module.exports.raw = loader.raw;

--- a/scripts/webpack/utils/node-loader-private/index.js
+++ b/scripts/webpack/utils/node-loader-private/index.js
@@ -1,0 +1,36 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = loader;
+exports.raw = void 0;
+
+var _loaderUtils = require("loader-utils");
+
+var _options = _interopRequireDefault(require("./options.json"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/*
+  MIT License http://www.opensource.org/licenses/mit-license.php
+  Author Tobias Koppers @sokra
+*/
+function loader(content) {
+  const options = this.getOptions(_options.default);
+  const name = (0, _loaderUtils.interpolateName)(this, typeof options.name !== "undefined" ? options.name : "[contenthash].[ext]", {
+    context: this.rootContext,
+    content
+  });
+  this.emitFile(name, content);
+  return `
+try {
+  process.dlopen(module, __dirname + require("path").sep + ${JSON.stringify(name)}${typeof options.flags !== "undefined" ? `, ${JSON.stringify(options.flags)}` : ""});
+} catch (error) {
+  throw new Error('node-loader:\\n' + error);
+}
+`;
+}
+
+const raw = true;
+exports.raw = raw;

--- a/scripts/webpack/utils/node-loader-private/options.json
+++ b/scripts/webpack/utils/node-loader-private/options.json
@@ -1,0 +1,20 @@
+{
+  "title": "Node Loader options",
+  "type": "object",
+  "properties": {
+    "name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
+    },
+    "flags": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
# Description

#9278 broke master because the webpack public path is being used for loading node binaries.
this ignores the public path when loading custom binaries.