### PR TITLE
fix: Only read the first ip of the x-forwarded-for header

### DIFF
--- a/packages/server/utils/uwsGetIP.ts
+++ b/packages/server/utils/uwsGetIP.ts
@@ -1,7 +1,7 @@
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
 
 const uwsGetIP = (res: HttpResponse, req: HttpRequest) => {
-  const clientIp = req.getHeader('x-forwarded-for')
+  const clientIp = req.getHeader('x-forwarded-for')?.split(',')[0]
   if (clientIp) return clientIp
   // returns ipv6 e.g. '0000:0000:0000:0000:0000:ffff:ac11:0001'
   return Buffer.from(res.getRemoteAddressAsText()).toString()


### PR DESCRIPTION
Server does not accept requests if there are more ips listed.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
