### PR TITLE
fix: Configure trusted proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ SERVER_SECRET='key_SERVER_SECRET'
 # Cluster node number 0 - 1023. Must be unique per process.
 SERVER_ID='1'
 # Used to read the client IP from the X-Forwarded-For header, if not set, it will use the first IP in the list.
+# If configured, it must match the number of proxies in the stack, otherwise it might rate limit all traffic coming from the proxy.
 # TRUSTED_PROXY_COUNT='1'
 # Websocket port for the websocket server, only used in development (yarn dev)
 SOCKET_PORT='3001'

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ PROTO='http'
 SERVER_SECRET='key_SERVER_SECRET'
 # Cluster node number 0 - 1023. Must be unique per process.
 SERVER_ID='1'
+# Used to read the client IP from the X-Forwarded-For header, if not set, it will use the first IP in the list.
+# TRUSTED_PROXY_COUNT='1'
 # Websocket port for the websocket server, only used in development (yarn dev)
 SOCKET_PORT='3001'
 

--- a/packages/server/utils/uwsGetIP.ts
+++ b/packages/server/utils/uwsGetIP.ts
@@ -1,7 +1,11 @@
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
 
+const TRUSTED_PROXY_COUNT = Number(process.env.TRUSTED_PROXY_COUNT)
+// if TRUSTED_PROXY_COUNT is not configured correctly we fall back to reading the first IP to avoid rate limiting our proxy
+const CLIENT_IP_POS = isNaN(TRUSTED_PROXY_COUNT) ? 0 : -1 - TRUSTED_PROXY_COUNT
+
 const uwsGetIP = (res: HttpResponse, req: HttpRequest) => {
-  const clientIp = req.getHeader('x-forwarded-for')?.split(',')[0]
+  const clientIp = req.getHeader('x-forwarded-for')?.split(',').at(CLIENT_IP_POS)
   if (clientIp) return clientIp
   // returns ipv6 e.g. '0000:0000:0000:0000:0000:ffff:ac11:0001'
   return Buffer.from(res.getRemoteAddressAsText()).toString()


### PR DESCRIPTION
Our proxy will add the client ip to the x-forwarded-for header correctly and also itself as it does NAT. Configure the number of trusted proxies to read the correct entry from the header to avoid manipulation by clients.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
