### PR TITLE
fix: Activity library illustrations in Firefox

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -36,11 +36,7 @@ export const ActivityCardImage = (props: PropsWithChildren<ActivityCardImageProp
         className
       )}
     >
-      <img
-        className='object-contain'
-        src={backgroundSrc}
-        alt=''
-      />
+      <img className='object-contain' src={backgroundSrc} alt='' />
       <img
         className='absolute top-0 left-0 z-10 h-full w-full object-contain p-10'
         src={src}

--- a/packages/client/components/ActivityLibrary/ActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityCard.tsx
@@ -35,8 +35,12 @@ export const ActivityCardImage = (props: PropsWithChildren<ActivityCardImageProp
         'relative flex h-full w-full items-center justify-center overflow-hidden',
         className
       )}
-      style={{backgroundImage: `url(${backgroundSrc})`, backgroundSize: 'cover'}}
     >
+      <img
+        className='object-contain'
+        src={backgroundSrc}
+        alt=''
+      />
       <img
         className='absolute top-0 left-0 z-10 h-full w-full object-contain p-10'
         src={src}


### PR DESCRIPTION
# Description

Add the background image as an img tag. This way it's used to auto size.

## Demo

<img width="1247" alt="image" src="https://github.com/ParabolInc/parabol/assets/7331043/31a543f2-7e86-4ce6-89af-43c4fb3f4484">

## Testing scenarios

- [ ] check activity library on
  - [ ] Firefox
  - [ ] Chrome
  - [ ] Safari

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
