### PR TITLE
chore: Roll out AIGeneratedDiscussion to all users

### DIFF
--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -303,7 +303,6 @@ const initDemoOrg = () => {
       suggestGroups: false,
       teamsLimit: false,
       noPromptToJoinOrg: false,
-      AIGeneratedDiscussionPrompt: false,
       publicTeams: false
     },
     showConversionModal: false

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopic.tsx
@@ -90,7 +90,7 @@ const RetroTopic = (props: Props) => {
           reflections {
             ...EmailReflectionCard_reflection
           }
-          topicSummary: summary
+          discussionPromptQuestion
         }
         discussion {
           commentCount
@@ -121,7 +121,7 @@ const RetroTopic = (props: Props) => {
 
   const {reflectionGroup, discussion, id: stageId} = stage
   const {commentCount, discussionSummary} = discussion
-  const {reflections, title, voteCount, topicSummary} = reflectionGroup!
+  const {reflections, title, voteCount, discussionPromptQuestion} = reflectionGroup!
   const imageSource = isEmail ? 'static' : 'local'
   const icon = imageSource === 'local' ? 'thumb_up_18.svg' : 'thumb_up_18@3x.png'
   const src = `${ExternalLinks.EMAIL_CDN}${icon}`
@@ -143,16 +143,16 @@ const RetroTopic = (props: Props) => {
           </AnchorIfEmail>
         </td>
       </tr>
-      {(topicSummary || discussionSummary) && (
+      {(discussionPromptQuestion || discussionSummary) && (
         <tr>
           <td align='left' style={{lineHeight: '22px', fontSize: 14}}>
-            {topicSummary && (
+            {discussionPromptQuestion && (
               <>
                 <tr>
-                  <td style={topicTitleStyle}>{'🤖 Topic Summary'}</td>
+                  <td style={topicTitleStyle}>{'🤖 Discussion Question'}</td>
                 </tr>
                 <tr>
-                  <td style={textStyle}>{topicSummary}</td>
+                  <td style={textStyle}>{discussionPromptQuestion}</td>
                 </tr>
               </>
             )}

--- a/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroupSummaries.ts
@@ -15,7 +15,6 @@ const generateGroupSummaries = async (
     dataLoader.get('users').loadNonNull(facilitatorUserId),
     dataLoader.get('teams').loadNonNull(teamId)
   ])
-  const organization = await dataLoader.get('organizations').load(team.orgId)
   const isAISummaryAccessible = await canAccessAISummary(
     team,
     facilitator.featureFlags,
@@ -35,9 +34,6 @@ const generateGroupSummaries = async (
     sendToSentry(error, {userId: facilitator.id, tags: {meetingId}})
     return
   }
-  const aiGeneratedDiscussionPromptEnabled = organization.featureFlags?.includes(
-    'AIGeneratedDiscussionPrompt'
-  )
   await Promise.all(
     reflectionGroups.map(async (group) => {
       const reflectionsByGroupId = reflections.filter(
@@ -49,9 +45,7 @@ const generateGroupSummaries = async (
       )
       const [fullSummary, fullQuestion] = await Promise.all([
         manager.getSummary(reflectionTextByGroupId),
-        aiGeneratedDiscussionPromptEnabled
-          ? manager.getDiscussionPromptQuestion(group.title ?? 'Unknown', reflectionsByGroupId)
-          : undefined
+        manager.getDiscussionPromptQuestion(group.title ?? 'Unknown', reflectionsByGroupId)
       ])
       if (!fullSummary && !fullQuestion) return
       const summary = fullSummary?.slice(0, 2000)

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -3,7 +3,6 @@ A flag to give an individual organization super powers
 """
 enum OrganizationFeatureFlagsEnum {
   noAISummary
-  AIGeneratedDiscussionPrompt
   standupAISummary
   noPromptToJoinOrg
   suggestGroups

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -183,7 +183,6 @@ The types of flags that give an individual organization super powers
 """
 type OrganizationFeatureFlags {
   noAISummary: Boolean!
-  AIGeneratedDiscussionPrompt: Boolean!
   standupAISummary: Boolean!
   noPromptToJoinOrg: Boolean!
   suggestGroups: Boolean!

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -4,7 +4,6 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   noAISummary: ({noAISummary}) => !!noAISummary,
   standupAISummary: ({standupAISummary}) => !!standupAISummary,
   noPromptToJoinOrg: ({noPromptToJoinOrg}) => !!noPromptToJoinOrg,
-  AIGeneratedDiscussionPrompt: ({AIGeneratedDiscussionPrompt}) => !!AIGeneratedDiscussionPrompt,
   zoomTranscription: ({zoomTranscription}) => !!zoomTranscription,
   shareSummary: ({shareSummary}) => !!shareSummary,
   suggestGroups: ({suggestGroups}) => !!suggestGroups,


### PR DESCRIPTION
# Description

Fixes #8730 

## Testing scenarios

- [ ] Paid Team
  - Select a paid team
  - Run a retro meeting
  - See the AI generated discussion prompt in the discussion phase
  - In the meeting summary page, see discussion question for each topics instead of topic summary

- [ ] Free Trials
  - Create a new org/team
  - Run a retro meeting
  - See the AI generated discussion prompt in the discussion phase, with the free trial message
  - In the meeting summary page, see discussion question for each topics instead of topic summary

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
