### PR TITLE
fix: ensure pool is callable after custom template migration

### DIFF
--- a/packages/server/postgres/migrations/1709933510512_addFreeCustomTemplatesRemaining.ts
+++ b/packages/server/postgres/migrations/1709933510512_addFreeCustomTemplatesRemaining.ts
@@ -13,8 +13,6 @@ export async function up() {
     .addColumn('freeCustomRetroTemplatesRemaining', 'int2', (col) => col.defaultTo(2).notNull())
     .addColumn('freeCustomPokerTemplatesRemaining', 'int2', (col) => col.defaultTo(2).notNull())
     .execute()
-
-  await pg.destroy()
 }
 
 export async function down() {
@@ -29,6 +27,4 @@ export async function down() {
     .dropColumn('freeCustomRetroTemplatesRemaining')
     .dropColumn('freeCustomPokerTemplatesRemaining')
     .execute()
-
-  await pg.destroy()
 }


### PR DESCRIPTION
See Slack thread where the release initially failed: https://parabol.slack.com/archives/C836NA350/p1711538854886859

There was an error: `Error: Cannot use a pool after calling end on the pool`. 

`await pg.destroy()` closes all db connections: https://kysely.dev/docs/getting-started

It looks like we should remove this line to keep the connection open. 