### PR TITLE
fix: Fetch CORS resources from network

### DIFF
--- a/packages/client/serviceWorker/sw.ts
+++ b/packages/client/serviceWorker/sw.ts
@@ -79,8 +79,10 @@ const onFetch = async (event: FetchEvent) => {
       // request.mode could be 'no-cors'
       // By fetching the URL without specifying the mode the response will not be opaque
       const isParabolHosted = url.startsWith(PUBLIC_PATH) || url.startsWith(self.origin)
-      const req = isParabolHosted ? request.url : request
-      const networkRes = await fetch(req)
+      // if one of our assets is not in the service worker cache, then it's either fetched via network or served from the broswer cache.
+      // The browser cache most likely has incorrect CORS headers set, so we better always fetch from the network.
+      const req = isParabolHosted ? fetch(request.url, {cache: 'no-store'}) : fetch(request)
+      const networkRes = await req
       const cache = await caches.open(DYNAMIC_CACHE)
       // cloning here because I'm not sure if we must clone before reading the body
       cache.put(request.url, networkRes.clone()).catch(console.error)


### PR DESCRIPTION
If we fetch our own assets we want a CORS response to properly cache it in the service worker. If the response is served from the browser cache however, then there is a high chance that the required response headers are missing and the browser responds with a CORS error instead of refetching the resource. This happens because the Vary header does not include headers not present in the original request. To avoid this error, always fetch from the network for requests we intend to cache in the SW.

## Demo

https://www.loom.com/share/280ee174d1484814a06e4d2a1c9c2674?sid=374d929f-89ef-4ae5-ad9b-b108e5391737

## Testing scenarios

- setup ngrok to get a public URL with https (`ngrok http 3000`) and configure it in `.env` afterwards
- locally run in production mode (`yarn predeploy && yarn start`)
- open the site from the public URL
- clear service worker cache
- close tab and reopen the site
- on master you'll now see broken login images, on PR this is fixed

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
