### PR TITLE
chore: disable change template ui if phase complete

### DIFF
--- a/packages/client/components/MeetingOptions.tsx
+++ b/packages/client/components/MeetingOptions.tsx
@@ -12,19 +12,24 @@ type Props = {
   setShowDrawer: (showDrawer: boolean) => void
   showDrawer: boolean
   hasReflections: boolean
+  isPhaseComplete: boolean
 }
 
 const MeetingOptions = (props: Props) => {
-  const {setShowDrawer, showDrawer, hasReflections} = props
+  const {setShowDrawer, showDrawer, hasReflections, isPhaseComplete} = props
   const [isOpen, setIsOpen] = useState(false)
+  const isDisabled = hasReflections || isPhaseComplete
+  const tooltipCopy = hasReflections
+    ? 'You can only change the template if no reflections have been added.'
+    : 'You can only change the template if the phase is not complete.'
 
   const handleClick = () => {
-    if (hasReflections) return
+    if (isDisabled) return
     setShowDrawer(!showDrawer)
   }
 
   const handleMouseEnter = () => {
-    if (hasReflections) {
+    if (isDisabled) {
       setIsOpen(true)
     }
   }
@@ -45,15 +50,13 @@ const MeetingOptions = (props: Props) => {
       <Tooltip open={isOpen}>
         <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
           <TooltipTrigger asChild>
-            <MenuItem onClick={handleClick} isDisabled={hasReflections}>
+            <MenuItem onClick={handleClick} isDisabled={isDisabled}>
               <div className='mr-3 flex text-slate-700'>{<SwapHorizIcon />}</div>
               Change template
             </MenuItem>
           </TooltipTrigger>
         </div>
-        <TooltipContent>
-          {'You can only change the template if no reflections have been added.'}
-        </TooltipContent>
+        <TooltipContent>{tooltipCopy}</TooltipContent>
       </Tooltip>
     </Menu>
   )

--- a/packages/client/components/RetroDrawer.tsx
+++ b/packages/client/components/RetroDrawer.tsx
@@ -31,6 +31,9 @@ const RetroDrawer = (props: Props) => {
               localPhase {
                 ... on ReflectPhase {
                   phaseType
+                  stages {
+                    isComplete
+                  }
                 }
               }
             }
@@ -56,6 +59,7 @@ const RetroDrawer = (props: Props) => {
   const phaseType = meeting?.localPhase?.phaseType
   const isMobile = !useBreakpoint(Breakpoint.FUZZY_TABLET)
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
+  const isPhaseComplete = meeting?.localPhase?.stages?.every((stage) => stage.isComplete) ?? false
 
   const toggleDrawer = () => {
     setShowDrawer(!showDrawer)
@@ -77,6 +81,7 @@ const RetroDrawer = (props: Props) => {
       <MeetingOptions
         hasReflections={hasReflections}
         showDrawer={showDrawer}
+        isPhaseComplete={isPhaseComplete}
         setShowDrawer={setShowDrawer}
       />
       <ResponsiveDashSidebar


### PR DESCRIPTION
Fix: https://github.com/ParabolInc/parabol/issues/9577

### To test

- [ ]  start retro, add reflection, go to next stage, go back to reflect & delete the 1 reflection, try to change template, and see disabled button with tooltip explanation 