### PR TITLE
fix(single-tenant): application upgrades do not need --profile databases

### DIFF
--- a/docker/stacks/single-tenant-host/README.md
+++ b/docker/stacks/single-tenant-host/README.md
@@ -18,7 +18,7 @@ To run Parabol in single tenant mode (e.g. simple docker-compose on a docker hos
 
 1. Edit the `docker-compose.yaml` and change the `#image:tag` changing the tag. Ex: from `v7.15.0` to `v7.15.2`.
 2. (optional) In a different terminal, run `docker compose logs -f` to follow the upgrade.
-3. Run `docker compose --profile databases --profile parabol up -d`. It will start the `pre-deploy` and, once it is done successfully, then it will stop and recreate the `web-server` and `gql-executor` with the new version of the image. **This step implies a downtime**.
+3. Run `docker compose --profile parabol up -d`. It will start the `pre-deploy` and, once it is done successfully, then it will stop and recreate the `web-server` and `gql-executor` with the new version of the image. **This step implies a downtime**.
 4. Verify the application is still up and running.
 
 ## Running Chronos


### PR DESCRIPTION
# Description
Fixes the readme of the single-tenant instances