### PR TITLE
chore: update ironbank GH action to copy ip-to-server-id script

### DIFF
--- a/.github/workflows/ironbank.yml
+++ b/.github/workflows/ironbank.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           docker cp temp-container:/home/node/parabol/dist ./dist
           docker cp temp-container:/home/node/parabol/build ./build
+          docker cp temp-container:/home/node/tools/ip-to-server_id ./tools/ip-to-server_id
 
       - name: Zip the files
         run: zip -r ${{ github.event.inputs.version_number }}.zip dist build


### PR DESCRIPTION
# Description
The ironbank GH action does not copy the tools script to use the pod IP for server ID in the application image. This adds that script to the artifacts used for that process


## Final checklist

- [x ] I checked the [code review guidelines](../docs/codeReview.md)
- [x ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ x] PR title is human readable and could be used in changelog
