### PR TITLE
fix: fix the issue where timer doesn't work in TEAM_HEALTH phase

### DIFF
--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -57,7 +57,8 @@ const DEFAULT_TIME_LIMIT = {
   vote: 3,
   discuss: 5,
   ESTIMATE: 5,
-  SCOPE: 3
+  SCOPE: 3,
+  TEAM_HEALTH: 1
 } as Record<NewMeetingPhaseTypeEnum, number>
 
 interface Props {

--- a/packages/client/components/TeamHealth.tsx
+++ b/packages/client/components/TeamHealth.tsx
@@ -18,6 +18,7 @@ import * as RadioGroup from '@radix-ui/react-radio-group'
 import clsx from 'clsx'
 import RaisedButton from './RaisedButton'
 import getTeamHealthVoteColor from '../utils/getTeamHealthVoteColor'
+import StageTimerDisplay from './StageTimerDisplay'
 
 interface Props {
   avatarGroup: ReactElement
@@ -32,6 +33,8 @@ const TeamHealth = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment TeamHealth_meeting on NewMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
         id
         endedAt
         showSidebar
@@ -83,6 +86,7 @@ const TeamHealth = (props: Props) => {
           <PhaseHeaderTitle>{phaseLabelLookup.TEAM_HEALTH}</PhaseHeaderTitle>
         </MeetingTopBar>
         <PhaseWrapper>
+          <StageTimerDisplay meeting={meeting} />
           <div className='flex h-[300px] flex-col items-center'>
             <div className='text-center text-2xl'>{question}</div>
             {isRevealed && votes ? (


### PR DESCRIPTION
# Description

Fixes #9540 

## Demo

![2024-04-03 12 02 49](https://github.com/ParabolInc/parabol/assets/1879975/1c37b510-61f8-4772-8d01-162ca8749219)


## Testing scenarios
- [ ] Timer present in team health phase
  - Start a retro meeting with team health option selected
  - Go to the team health phase
  - Start a timer
  - See the timer & count down properly shown up


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
