### PR TITLE
fix: Don't reuse another team members integrated task

### DIFF
--- a/packages/client/utils/AtlassianManager.ts
+++ b/packages/client/utils/AtlassianManager.ts
@@ -58,7 +58,6 @@ export default abstract class AtlassianManager {
     'write:jira-work',
     'offline_access'
   ]
-  static MANAGE_SCOPE: JiraPermissionScope[] = [...AtlassianManager.SCOPE, 'manage:jira-project']
   accessToken: string
   protected headers = {
     Authorization: '',

--- a/packages/client/utils/JiraServerClientManager.ts
+++ b/packages/client/utils/JiraServerClientManager.ts
@@ -4,6 +4,7 @@ import {MenuMutationProps} from '../hooks/useMutationProps'
 import AddTeamMemberIntegrationAuthMutation from '../mutations/AddTeamMemberIntegrationAuthMutation'
 import CreateOAuth1AuthorizeUrlMutation from '../mutations/CreateOAuth1AuthorizeUrlMutation'
 import getOAuthPopupFeatures from './getOAuthPopupFeatures'
+
 class JiraServerClientManager {
   static SCOPES = 'read_api'
   static openOAuth(

--- a/packages/server/graphql/mutations/helpers/importTasksForPoker.ts
+++ b/packages/server/graphql/mutations/helpers/importTasksForPoker.ts
@@ -16,7 +16,7 @@ const importTasksForPoker = async (
   const existingTasks = await r
     .table('Task')
     .getAll(r.args(integrationHashes), {index: 'integrationHash'})
-    .filter({teamId})
+    .filter({teamId, userId})
     .run()
   const integrationHashToTaskId = {} as Record<string, string>
   additiveUpdates.map((update) => {


### PR DESCRIPTION
If we reuse another team members integrated task, then we can end up in a situation where they're not on the team anymore and mess up the integration access.

## Testing scenarios

- create a team with 2 users: Stan and Lili
- Lili starts Poker, adds Task ABC-1 from Jira and finishes the meeting
- Stan removes Lili from the team
- Stan starts a Poker meeting and also adds ABC-1
- check DB that the new task for ABC-1 has the userId of Stan
  - something along the lines of these queries
    ```
    r.db('actionDevelopment').table('NewMeeting').get('vQvshNiFz2')
    r.db('actionDevelopment').table('Task').getAll('vQvsROWc6I', 'vQsYJeTEVa')
    ```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
