### PR TITLE
fix: fallback for missing avatar images

### DIFF
--- a/packages/client/components/Avatar/Avatar.tsx
+++ b/packages/client/components/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React, {forwardRef} from 'react'
+import React, {forwardRef, useState} from 'react'
 import defaultUserAvatar from '../../styles/theme/images/avatar-user.svg'
 import AvatarBadge from '../AvatarBadge/AvatarBadge'
 
@@ -7,7 +7,7 @@ type ImageBlockProps = Pick<Props, 'sansRadius' | 'sansShadow' | 'picture' | 'si
 
 const ImageBlock = styled('div')<ImageBlockProps>(
   ({sansRadius, sansShadow, picture, size, onClick}) => ({
-    backgroundImage: `url(${picture ?? defaultUserAvatar})`,
+    backgroundImage: `url(${picture})`,
     backgroundPosition: 'center center',
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
@@ -62,7 +62,10 @@ const Avatar = forwardRef((props: Props, ref: any) => {
     sansShadow,
     size
   } = props
-
+  const [imageUrl, setImageUrl] = useState(picture || defaultUserAvatar)
+  const onError = () => {
+    setImageUrl(defaultUserAvatar)
+  }
   return (
     <ImageBlock
       onTransitionEnd={onTransitionEnd}
@@ -72,9 +75,10 @@ const Avatar = forwardRef((props: Props, ref: any) => {
       onMouseEnter={onMouseEnter}
       sansRadius={sansRadius}
       sansShadow={sansShadow}
-      picture={picture}
+      picture={imageUrl}
       size={size}
     >
+      <img src={imageUrl} className='hidden' onError={onError} />
       {hasBadge && (
         <BadgeBlock>
           <BadgeBlockInner>


### PR DESCRIPTION
# Description

touches on #9555, but doesn't fix it properly.
this adds a fallback image in case their profile pic fails to load, but it only does this on the Avatar component (think user dash).  there may be other places that their avatar fails to load!

not eager to dump 1300 images into our github repo, but not sure what the better alternative is...

