### PR TITLE
fix: remove top level graphql-relay dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "graphql": "15.7.2",
-    "graphql-relay": "^0.10.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",
     "jscodeshift": "^0.14.0",

--- a/packages/client/shared/gqlIds/DomainJoinRequestId.ts
+++ b/packages/client/shared/gqlIds/DomainJoinRequestId.ts
@@ -1,4 +1,25 @@
-import {toGlobalId, fromGlobalId} from 'graphql-relay'
+import {GraphQLID} from 'graphql'
+
+/**
+ * Takes a type name and an ID specific to that type name, and returns a
+ * "global ID" that is unique among all types.
+ */
+const toGlobalId = (type: string, id: string | number) => {
+  return btoa([type, GraphQLID.serialize(id)].join(':'))
+}
+
+/**
+ * Takes the "global ID" created by toGlobalID, and returns the type name and ID
+ * used to create it.
+ */
+const fromGlobalId = (globalId: string) => {
+  const unbasedGlobalId = atob(globalId)
+  const delimiterPos = unbasedGlobalId.indexOf(':')
+  return {
+    type: unbasedGlobalId.substring(0, delimiterPos),
+    id: unbasedGlobalId.substring(delimiterPos + 1)
+  }
+}
 
 const DomainJoinRequestId = {
   join: (id: number): string => toGlobalId('DomainJoinRequest', id),


### PR DESCRIPTION
This messed up the require order in the --no-deps build. I had previously added it because the DomainJoinRequestId depended on 2 functions from it while living in the client package. Instead I copied these very small helpers.

## Testing scenarios

```
 yarn && yarn pg:build && yarn build --no-deps && yarn predeploy && yarn start
```

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
