### PR TITLE
fix: Only list available categories in edit template

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetailsCategoryBadge.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityDetails/ActivityDetailsCategoryBadge.tsx
@@ -7,7 +7,7 @@ import {useFragment} from 'react-relay'
 import {ActivityDetailsCategoryBadge_template$key} from '~/__generated__/ActivityDetailsCategoryBadge_template.graphql'
 import PlainButton from '../../PlainButton/PlainButton'
 import ActivityDetailsBadge from './ActivityDetailsBadge'
-import {CATEGORY_ID_TO_NAME, CATEGORY_THEMES, CategoryID} from '../Categories'
+import {CATEGORY_ID_TO_NAME, CATEGORY_THEMES, CategoryID, MAIN_CATEGORIES} from '../Categories'
 import useTemplateCategoryMutation from '../../../mutations/UpdateTemplateCategoryMutation'
 
 interface Props {
@@ -49,7 +49,7 @@ const ActivityDetailsCategoryBadge = (props: Props) => {
       <DropdownMenu.Portal>
         <DropdownMenu.Content className='border-rad rounded bg-white shadow-lg' sideOffset={5}>
           <DropdownMenu.RadioGroup value={category} onValueChange={updateTemplateCategory}>
-            {Object.keys(CATEGORY_THEMES).map((c) => {
+            {MAIN_CATEGORIES.map((c) => {
               const categoryId = c as CategoryID
               return (
                 <DropdownMenu.RadioItem


### PR DESCRIPTION
# Description

Don't list custom and quick start as categories as these cannot be assigned.

## Demo

<img width="625" alt="image" src="https://github.com/ParabolInc/parabol/assets/7331043/a45ff3ac-1606-4f84-977c-f42c6f2a3da8">

## Testing scenarios

- [ ] open the category selection dropdown in the edit template dialog

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
