### PR TITLE
feat: Make top team templates clickable

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashInsights/TopRetroTemplatesCard.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashInsights/TopRetroTemplatesCard.tsx
@@ -5,6 +5,7 @@ import {TopRetroTemplatesCard_insights$key} from '~/__generated__/TopRetroTempla
 import SimpleTooltip from '../../../../components/SimpleTooltip'
 import TeamInsightsCard from './TeamInsightsCard'
 import plural from '../../../../utils/plural'
+import {useHistory} from 'react-router'
 
 interface Props {
   teamInsightsRef: TopRetroTemplatesCard_insights$key
@@ -12,6 +13,7 @@ interface Props {
 
 const TopRetroTemplatesCard = (props: Props) => {
   const {teamInsightsRef} = props
+  const history = useHistory()
   const insights = useFragment(
     graphql`
       fragment TopRetroTemplatesCard_insights on TeamInsights {
@@ -35,6 +37,10 @@ const TopRetroTemplatesCard = (props: Props) => {
     return null
   }
 
+  const onClick = (templateId: string) => {
+    history.push(`/activity-library/details/${templateId}`)
+  }
+
   return (
     <TeamInsightsCard
       teamInsightsRef={insights}
@@ -42,18 +48,19 @@ const TopRetroTemplatesCard = (props: Props) => {
       tooltip='The most used retro templates on your team in the last 12 months'
     >
       <div className='flex w-full flex-col'>
-        {topRetroTemplates.map((template, index) => {
+        {topRetroTemplates.map((template) => {
           const {reflectTemplate, count} = template
-          const {name, illustrationUrl} = reflectTemplate
+          const {id, name, illustrationUrl} = reflectTemplate
           return (
-            <SimpleTooltip
-              text={`Used ${plural(count, 'once', `${count} times`)} in the last 12 months`}
-              className='my-2 flex items-center rounded border-2 border-grape-500 bg-fuscia-100 text-sm font-semibold text-slate-700'
-              key={index}
-            >
-              <img className='m-1 h-10 w-10' src={illustrationUrl} />
-              {name}
-            </SimpleTooltip>
+            <div key={id} onClick={() => onClick(id)}>
+              <SimpleTooltip
+                text={`Used ${plural(count, 'once', `${count} times`)} in the last 12 months`}
+                className='my-2 flex items-center rounded border-2 border-grape-500 bg-fuscia-100 text-sm font-semibold text-slate-700'
+              >
+                <img className='m-1 h-10 w-10' src={illustrationUrl} />
+                {name}
+              </SimpleTooltip>
+            </div>
           )
         })}
         {topRetroTemplates.length === 1 && (


### PR DESCRIPTION
Redirect directly to the activity libraray.

## Demo

https://github.com/ParabolInc/parabol/assets/7331043/88edc8e3-1417-426a-8b5c-6d61780964dc

## Testing scenarios

  - in top templates click on one
 
## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
