### PR TITLE
fix: use radix-ui for avatars

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -13,5 +13,6 @@
         "singleQuote": false
       }
     }
-  ]
+  ],
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,30 +1,7 @@
 {
   "git.ignoreLimitWarning": true,
-  "eslint.packageManager": "yarn",
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.tabSize": 2,
-  "eslint.workingDirectories": [
-    {
-      "directory": "./packages/server",
-      "changeProcessCWD": true
-    },
-    {
-      "directory": "./packages/client",
-      "changeProcessCWD": true
-    }
-  ],
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    {
-      "language": "typescript",
-      "autoFix": true
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": true
-    }
-  ],
   "npm.packageManager": "yarn",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
@@ -53,5 +30,6 @@
     "**/graphql/private/schema.graphql": true,
     "**/graphql/public/schema.graphql": true,
     "**/resolverTypes.ts": true
-  }
+  },
+  "tailwindCSS.experimental.classRegex": [["clsx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"]]
 }

--- a/packages/client/components/ActionMeetingAgendaItems.tsx
+++ b/packages/client/components/ActionMeetingAgendaItems.tsx
@@ -93,7 +93,7 @@ const ActionMeetingAgendaItems = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <AgendaVerbatim>
-            <Avatar picture={picture} size={64} />
+            <Avatar picture={picture} className={'h-16 w-16'} />
             <StyledHeading>{content}</StyledHeading>
           </AgendaVerbatim>
           <StyledCopy>{`${preferredName}, what do you need?`}</StyledCopy>

--- a/packages/client/components/ActionMeetingUpdatesPrompt.tsx
+++ b/packages/client/components/ActionMeetingUpdatesPrompt.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
-import ActionMeetingUpdatesPromptTeamHelpText from '../modules/meeting/components/ActionMeetingUpdatesPromptTeamHelpText'
-import defaultUserAvatar from '../styles/theme/images/avatar-user.svg'
 import {ActionMeetingUpdatesPrompt_meeting$key} from '../__generated__/ActionMeetingUpdatesPrompt_meeting.graphql'
+import ActionMeetingUpdatesPromptTeamHelpText from '../modules/meeting/components/ActionMeetingUpdatesPromptTeamHelpText'
 import Avatar from './Avatar/Avatar'
 import PhaseHeaderDescription from './PhaseHeaderDescription'
 import PhaseHeaderTitle from './PhaseHeaderTitle'
@@ -89,7 +88,7 @@ const ActionMeetingUpdatesPrompt = (props: Props) => {
   const taskCount = tasks.edges.length
   return (
     <StyledPrompt>
-      <Avatar picture={picture || defaultUserAvatar} size={64} />
+      <Avatar picture={picture} className={'h-16 w-16'} />
       <PromptText>
         <StyledHeader className='max-w-full'>
           {prefix}

--- a/packages/client/components/Avatar/Avatar.tsx
+++ b/packages/client/components/Avatar/Avatar.tsx
@@ -1,92 +1,33 @@
-import styled from '@emotion/styled'
-import React, {forwardRef, useState} from 'react'
+import clsx from 'clsx'
+import React, {forwardRef} from 'react'
 import defaultUserAvatar from '../../styles/theme/images/avatar-user.svg'
-import AvatarBadge from '../AvatarBadge/AvatarBadge'
-
-type ImageBlockProps = Pick<Props, 'sansRadius' | 'sansShadow' | 'picture' | 'size' | 'onClick'>
-
-const ImageBlock = styled('div')<ImageBlockProps>(
-  ({sansRadius, sansShadow, picture, size, onClick}) => ({
-    backgroundImage: `url(${picture})`,
-    backgroundPosition: 'center center',
-    backgroundRepeat: 'no-repeat',
-    backgroundSize: 'cover',
-    borderRadius: sansRadius ? 0 : '100%',
-    boxShadow: sansShadow ? 'none' : undefined,
-    cursor: onClick ? 'pointer' : 'default',
-    display: 'block',
-    flexShrink: 0,
-    width: size,
-    height: size
-  })
-)
-
-const BadgeBlock = styled('div')({
-  alignItems: 'center',
-  display: 'flex',
-  height: '25%',
-  justifyContent: 'center',
-  position: 'absolute',
-  right: 0,
-  top: 0,
-  width: '25%'
-})
-
-const BadgeBlockInner = styled('div')({
-  flexShrink: 0
-})
+import {Avatar as AvatarRoot} from '../../ui/Avatar/Avatar'
+import {AvatarFallback} from '../../ui/Avatar/AvatarFallback'
+import {AvatarImage} from '../../ui/Avatar/AvatarImage'
 
 interface Props {
   className?: string
-  hasBadge?: boolean
-  isConnected?: boolean
   onClick?: (e?: React.MouseEvent) => void
   onMouseEnter?: () => void
   onTransitionEnd?: () => void
-  picture: string
-  sansRadius?: boolean
-  sansShadow?: boolean
-  size: number
+  picture?: string | null
 }
 
-const Avatar = forwardRef((props: Props, ref: any) => {
-  const {
-    className,
-    hasBadge,
-    isConnected,
-    onClick,
-    onMouseEnter,
-    onTransitionEnd,
-    picture,
-    sansRadius,
-    sansShadow,
-    size
-  } = props
-  const [imageUrl, setImageUrl] = useState(picture || defaultUserAvatar)
-  const onError = () => {
-    setImageUrl(defaultUserAvatar)
-  }
+const Avatar = forwardRef<HTMLDivElement, Props>((props, ref) => {
+  const {className, onClick, onTransitionEnd, onMouseEnter, picture} = props
   return (
-    <ImageBlock
-      onTransitionEnd={onTransitionEnd}
-      className={className}
-      ref={ref}
+    <AvatarRoot
       onClick={onClick}
+      onTransitionEnd={onTransitionEnd}
       onMouseEnter={onMouseEnter}
-      sansRadius={sansRadius}
-      sansShadow={sansShadow}
-      picture={imageUrl}
-      size={size}
+      ref={ref}
+      className={clsx(`${onClick && 'cursor-pointer'}`, className)}
     >
-      <img src={imageUrl} className='hidden' onError={onError} />
-      {hasBadge && (
-        <BadgeBlock>
-          <BadgeBlockInner>
-            <AvatarBadge isConnected={isConnected || false} />
-          </BadgeBlockInner>
-        </BadgeBlock>
-      )}
-    </ImageBlock>
+      <AvatarImage src={picture || defaultUserAvatar} alt={'Avatar'} />
+      <AvatarFallback>
+        <img src={defaultUserAvatar} alt={'Avatar not found'} />
+      </AvatarFallback>
+    </AvatarRoot>
   )
 })
 

--- a/packages/client/components/Avatar/Avatar.tsx
+++ b/packages/client/components/Avatar/Avatar.tsx
@@ -6,6 +6,7 @@ import {AvatarFallback} from '../../ui/Avatar/AvatarFallback'
 import {AvatarImage} from '../../ui/Avatar/AvatarImage'
 
 interface Props {
+  alt?: string
   className?: string
   onClick?: (e?: React.MouseEvent) => void
   onMouseEnter?: () => void
@@ -14,7 +15,7 @@ interface Props {
 }
 
 const Avatar = forwardRef<HTMLDivElement, Props>((props, ref) => {
-  const {className, onClick, onTransitionEnd, onMouseEnter, picture} = props
+  const {alt, className, onClick, onTransitionEnd, onMouseEnter, picture} = props
   return (
     <AvatarRoot
       onClick={onClick}
@@ -23,9 +24,9 @@ const Avatar = forwardRef<HTMLDivElement, Props>((props, ref) => {
       ref={ref}
       className={clsx(`${onClick && 'cursor-pointer'}`, className)}
     >
-      <AvatarImage src={picture || defaultUserAvatar} alt={'Avatar'} />
+      <AvatarImage src={picture || defaultUserAvatar} alt={alt || 'Avatar'} />
       <AvatarFallback>
-        <img src={defaultUserAvatar} alt={'Avatar not found'} />
+        <img src={defaultUserAvatar} alt={alt || 'Avatar not found'} />
       </AvatarFallback>
     </AvatarRoot>
   )

--- a/packages/client/components/AvatarList.tsx
+++ b/packages/client/components/AvatarList.tsx
@@ -117,7 +117,7 @@ const AvatarList = (props: Props) => {
             onTransitionEnd={onTransitionEnd}
             status={status}
             offset={offsetSize * displayIdx}
-            className={`h-[${size}px] w-[${size}px]`}
+            className={`${size === 28 ? 'h-7 w-7' : size === 46 ? 'h-[46px] w-[46px]' : ''}`}
             borderColor={borderColor}
           />
         )

--- a/packages/client/components/AvatarList.tsx
+++ b/packages/client/components/AvatarList.tsx
@@ -3,10 +3,10 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {ReactElement, useLayoutEffect, useRef, useState} from 'react'
 import {useFragment} from 'react-relay'
 import useResizeObserver from '~/hooks/useResizeObserver'
+import {AvatarList_users$key} from '../__generated__/AvatarList_users.graphql'
 import useOverflowAvatars from '../hooks/useOverflowAvatars'
 import {TransitionStatus} from '../hooks/useTransition'
 import {BezierCurve} from '../types/constEnums'
-import {AvatarList_users$key} from '../__generated__/AvatarList_users.graphql'
 import AvatarListUser from './AvatarListUser'
 import OverflowAvatar from './OverflowAvatar'
 
@@ -117,7 +117,7 @@ const AvatarList = (props: Props) => {
             onTransitionEnd={onTransitionEnd}
             status={status}
             offset={offsetSize * displayIdx}
-            width={size}
+            className={`h-[${size}px] w-[${size}px]`}
             borderColor={borderColor}
           />
         )

--- a/packages/client/components/AvatarListUser.tsx
+++ b/packages/client/components/AvatarListUser.tsx
@@ -1,37 +1,18 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
+import clsx from 'clsx'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {TransitionStatus} from '~/hooks/useTransition'
+import {AvatarListUser_user$key} from '../__generated__/AvatarListUser_user.graphql'
 import {MenuPosition} from '../hooks/useCoords'
 import useTooltip from '../hooks/useTooltip'
 import {BezierCurve} from '../types/constEnums'
-import {AvatarListUser_user$key} from '../__generated__/AvatarListUser_user.graphql'
 import Avatar from './Avatar/Avatar'
 
 const Wrapper = styled('div')<{offset: number; isColumn?: boolean}>(({offset, isColumn}) => ({
   position: 'absolute',
   transform: `translate${isColumn ? 'Y' : 'X'}(${offset}px)`,
-  transition: `all 300ms ${BezierCurve.DECELERATE}`
-}))
-
-const StyledAvatar = styled(Avatar)<{
-  status?: TransitionStatus
-  isAnimated: boolean
-  borderColor?: string
-  width: number
-}>(({status, isAnimated, borderColor = '#fff', width}) => ({
-  border: `${width >= 40 ? '3px' : '2px'} solid ${borderColor}`,
-  opacity: !isAnimated
-    ? undefined
-    : status === TransitionStatus.EXITING || status === TransitionStatus.MOUNTED
-      ? 0
-      : 1,
-  transform: !isAnimated
-    ? undefined
-    : status === TransitionStatus.EXITING || status === TransitionStatus.MOUNTED
-      ? 'scale(0)'
-      : 'scale(1)',
   transition: `all 300ms ${BezierCurve.DECELERATE}`
 }))
 
@@ -43,7 +24,6 @@ interface Props {
   onTransitionEnd?: () => void
   status?: TransitionStatus
   user: AvatarListUser_user$key
-  width: number
   onClick?: () => void
   borderColor?: string
 }
@@ -57,7 +37,6 @@ const AvatarListUser = (props: Props) => {
     status,
     offset,
     isAnimated,
-    width,
     onClick,
     borderColor
   } = props
@@ -74,6 +53,9 @@ const AvatarListUser = (props: Props) => {
   const {tooltipPortal, openTooltip, closeTooltip, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER
   )
+  const isAnimating =
+    isAnimated && (status === TransitionStatus.EXITING || status === TransitionStatus.MOUNTED)
+
   return (
     <Wrapper
       ref={originRef}
@@ -83,15 +65,13 @@ const AvatarListUser = (props: Props) => {
       onMouseOver={openTooltip}
       onMouseLeave={closeTooltip}
     >
-      <StyledAvatar
-        className={className}
-        status={status}
+      <Avatar
+        className={clsx(
+          `border-solid border-[${borderColor || '#fff'}] duration-300 ease-out ${isAnimating ? 'scale-0 opacity-0' : 'scale-100 opacity-100'}`,
+          className
+        )}
         onTransitionEnd={onTransitionEnd}
         picture={picture}
-        size={width}
-        isAnimated={isAnimated}
-        borderColor={borderColor}
-        width={width}
       />
       {tooltipPortal(preferredName)}
     </Wrapper>

--- a/packages/client/components/DashboardAvatars/DashboardAvatar.tsx
+++ b/packages/client/components/DashboardAvatars/DashboardAvatar.tsx
@@ -2,15 +2,13 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {commitLocalUpdate, useFragment} from 'react-relay'
+import {DashboardAvatar_teamMember$key} from '../../__generated__/DashboardAvatar_teamMember.graphql'
 import useAtmosphere from '../../hooks/useAtmosphere'
 import {MenuPosition} from '../../hooks/useCoords'
 import useMutationProps from '../../hooks/useMutationProps'
 import useTooltip from '../../hooks/useTooltip'
 import ToggleTeamDrawerMutation from '../../mutations/ToggleTeamDrawerMutation'
-import {PALETTE} from '../../styles/paletteV3'
-import defaultUserAvatar from '../../styles/theme/images/avatar-user.svg'
 import {ElementWidth} from '../../types/constEnums'
-import {DashboardAvatar_teamMember$key} from '../../__generated__/DashboardAvatar_teamMember.graphql'
 import Avatar from '../Avatar/Avatar'
 
 interface Props {
@@ -20,20 +18,6 @@ interface Props {
 const AvatarWrapper = styled('div')({
   width: ElementWidth.DASHBOARD_AVATAR_OVERLAPPED
 })
-
-const StyledAvatar = styled(Avatar)<{isConnected: boolean; picture: string}>(
-  ({isConnected, picture}) => ({
-    // opacity causes transparency making overlap look bad. use img instead
-    backgroundImage: `${
-      isConnected ? '' : 'linear-gradient(rgba(255,255,255,.65), rgba(255,255,255,.65)),'
-    } url(${picture}), url(${defaultUserAvatar})`,
-    border: `2px solid ${PALETTE.SLATE_200}`,
-    ':hover': {
-      backgroundImage: `linear-gradient(rgba(255,255,255,.5), rgba(255,255,255,.5)),
-    url(${picture}), url(${defaultUserAvatar})`
-    }
-  })
-)
 
 const DashboardAvatar = (props: Props) => {
   const {teamMember: teamMemberRef} = props
@@ -86,13 +70,11 @@ const DashboardAvatar = (props: Props) => {
 
   return (
     <AvatarWrapper onMouseEnter={openTooltip} onMouseLeave={closeTooltip}>
-      <StyledAvatar
-        {...teamMember}
-        isConnected={!!isConnected}
+      <Avatar
         onClick={handleClick}
-        picture={picture || defaultUserAvatar}
+        picture={picture}
         ref={originRef}
-        size={ElementWidth.DASHBOARD_AVATAR}
+        className={`h-7 w-7 border-2 border-solid border-slate-200 after:absolute after:h-full after:w-full after:content-[""] hover:after:bg-white/30 ${!isConnected && 'after:bg-white/60'}`}
       />
       {tooltipPortal(preferredName)}
     </AvatarWrapper>

--- a/packages/client/components/DeckActivityAvatars.tsx
+++ b/packages/client/components/DeckActivityAvatars.tsx
@@ -2,10 +2,10 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
 import {useFragment} from 'react-relay'
+import {DeckActivityAvatars_stage$key} from '../__generated__/DeckActivityAvatars_stage.graphql'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useTransition, {TransitionStatus} from '../hooks/useTransition'
 import {PokerCards} from '../types/constEnums'
-import {DeckActivityAvatars_stage$key} from '../__generated__/DeckActivityAvatars_stage.graphql'
 import AvatarListUser from './AvatarListUser'
 
 const DeckActivityPanel = styled('div')({
@@ -18,16 +18,6 @@ const DeckActivityPanel = styled('div')({
   width: 64,
   zIndex: 100 // show above dimension column
 })
-
-const PeekingAvatar = styled(AvatarListUser)<{status?: TransitionStatus}>(({status}) => ({
-  opacity: status === TransitionStatus.EXITING ? 0 : 1,
-  transform:
-    status === TransitionStatus.MOUNTED
-      ? `translate(64px)`
-      : status === TransitionStatus.EXITING
-        ? 'scale(0)'
-        : undefined
-}))
 
 interface Props {
   stage: DeckActivityAvatars_stage$key
@@ -77,8 +67,14 @@ const DeckActivityAvatars = (props: Props) => {
         const {id: userId} = child
         const visibleScoreIdx = peekingUsers.findIndex((user) => user.id === userId)
         const displayIdx = visibleScoreIdx === -1 ? idx : visibleScoreIdx
+        const classLookup = {
+          [TransitionStatus.EXITING]: 'opacity-0 scale(0)',
+          [TransitionStatus.MOUNTED]: 'translate(64px)'
+        }
+
+        const avatarStatus = classLookup[status as keyof typeof classLookup] || ''
         return (
-          <PeekingAvatar
+          <AvatarListUser
             key={userId}
             status={status}
             onTransitionEnd={onTransitionEnd}
@@ -86,7 +82,7 @@ const DeckActivityAvatars = (props: Props) => {
             offset={(PokerCards.AVATAR_WIDTH - 10) * displayIdx}
             isColumn
             isAnimated
-            width={PokerCards.AVATAR_WIDTH as number}
+            className={`h-11.5 w-11.5 border-[3px] opacity-100 ${avatarStatus}`}
           />
         )
       })}

--- a/packages/client/components/DeckActivityAvatars.tsx
+++ b/packages/client/components/DeckActivityAvatars.tsx
@@ -67,12 +67,6 @@ const DeckActivityAvatars = (props: Props) => {
         const {id: userId} = child
         const visibleScoreIdx = peekingUsers.findIndex((user) => user.id === userId)
         const displayIdx = visibleScoreIdx === -1 ? idx : visibleScoreIdx
-        const classLookup = {
-          [TransitionStatus.EXITING]: 'opacity-0 scale(0)',
-          [TransitionStatus.MOUNTED]: 'translate(64px)'
-        }
-
-        const avatarStatus = classLookup[status as keyof typeof classLookup] || ''
         return (
           <AvatarListUser
             key={userId}
@@ -82,7 +76,7 @@ const DeckActivityAvatars = (props: Props) => {
             offset={(PokerCards.AVATAR_WIDTH - 10) * displayIdx}
             isColumn
             isAnimated
-            className={`h-11.5 w-11.5 border-[3px] opacity-100 ${avatarStatus}`}
+            className={`h-[46px] w-[46px] border-[3px] opacity-100 ${status === TransitionStatus.EXITING ? 'scale-0 opacity-0' : status === TransitionStatus.MOUNTED ? 'translate-x-64' : ''}`}
           />
         )
       })}

--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -295,7 +295,7 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
   return (
     <Wrapper data-cy={`${dataCy}-wrapper`} ref={ref} isReply={isReply} isDisabled={isDisabled}>
       <CommentContainer>
-        <Avatar picture={avatar} onClick={toggleAnonymous} className='transition-all m-2 h-8 w-8' />
+        <Avatar picture={avatar} onClick={toggleAnonymous} className='m-2 h-8 w-8 transition-all' />
         <EditorWrap>
           <CommentEditor
             dataCy={`${dataCy}`}

--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -3,6 +3,8 @@ import graphql from 'babel-plugin-relay/macro'
 import {ContentState, convertToRaw, EditorState} from 'draft-js'
 import React, {forwardRef, RefObject, useEffect, useState} from 'react'
 import {commitLocalUpdate, useFragment} from 'react-relay'
+import {DiscussionThreadInput_discussion$key} from '~/__generated__/DiscussionThreadInput_discussion.graphql'
+import {DiscussionThreadInput_viewer$key} from '~/__generated__/DiscussionThreadInput_viewer.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import useReplyEditorState from '~/hooks/useReplyEditorState'
@@ -13,8 +15,6 @@ import {SORT_STEP} from '~/utils/constants'
 import dndNoise from '~/utils/dndNoise'
 import {convertStateToRaw} from '~/utils/draftjs/convertToTaskContent'
 import isAndroid from '~/utils/draftjs/isAndroid'
-import {DiscussionThreadInput_discussion$key} from '~/__generated__/DiscussionThreadInput_discussion.graphql'
-import {DiscussionThreadInput_viewer$key} from '~/__generated__/DiscussionThreadInput_viewer.graphql'
 import {useBeforeUnload} from '../hooks/useBeforeUnload'
 import useInitialLocalState from '../hooks/useInitialLocalState'
 import CreateTaskMutation from '../mutations/CreateTaskMutation'
@@ -47,11 +47,6 @@ const CommentContainer = styled('div')({
   display: 'flex',
   flex: 1,
   padding: 4
-})
-
-const CommentAvatar = styled(Avatar)({
-  margin: 8,
-  transition: 'all 150ms'
 })
 
 const EditorWrap = styled('div')({
@@ -300,7 +295,7 @@ const DiscussionThreadInput = forwardRef((props: Props, ref: any) => {
   return (
     <Wrapper data-cy={`${dataCy}-wrapper`} ref={ref} isReply={isReply} isDisabled={isDisabled}>
       <CommentContainer>
-        <CommentAvatar size={32} picture={avatar} onClick={toggleAnonymous} />
+        <Avatar picture={avatar} onClick={toggleAnonymous} className='transition-all m-2 h-8 w-8' />
         <EditorWrap>
           <CommentEditor
             dataCy={`${dataCy}`}

--- a/packages/client/components/EditableAvatar/EditableAvatar.tsx
+++ b/packages/client/components/EditableAvatar/EditableAvatar.tsx
@@ -1,91 +1,32 @@
-import styled from '@emotion/styled'
 import {Edit as EditIcon} from '@mui/icons-material'
+import clsx from 'clsx'
 import React from 'react'
-import {panelShadow} from '../../styles/elevation'
-import {PALETTE} from '../../styles/paletteV3'
 import Avatar from '../Avatar/Avatar'
 
-const borderRadius = '50%'
-const borderRadiusPanel = 4
-const panelPadding = 8
-const panelPaddingHorizontal = panelPadding * 2
-
-const EditableAvatarRoot = styled('button')<Pick<Props, 'hasPanel'>>(({hasPanel}) => ({
-  backgroundColor: hasPanel ? '#FFFFFF' : undefined,
-  boxShadow: hasPanel ? panelShadow : undefined,
-  borderRadius: hasPanel ? borderRadiusPanel : borderRadius,
-  display: 'block',
-  padding: hasPanel ? panelPadding : '0',
-  position: 'relative'
-}))
-
-const EditableAvatarEditOverlay = styled('div')<Pick<Props, 'hasPanel' | 'size'>>(({hasPanel}) => ({
-  alignItems: 'center',
-  backgroundColor: PALETTE.SLATE_400,
-  borderRadius: hasPanel ? borderRadiusPanel : borderRadius,
-  color: PALETTE.SLATE_800,
-  cursor: 'pointer',
-  display: 'flex',
-  flexDirection: 'column',
-  fontSize: 14,
-  fontWeight: 600,
-  height: '100%',
-  justifyContent: 'center',
-  left: 0,
-  opacity: 0,
-  padding: 4,
-  position: 'absolute',
-  top: 0,
-  transition: 'all .3s ease-in-out',
-  width: '100%',
-  zIndex: 2,
-
-  '&:hover': {
-    opacity: 0.75
-  }
-}))
-
-const EditableAvatarImgBlock = styled('div')<Pick<Props, 'hasPanel' | 'size'>>(
-  ({hasPanel, size}) => ({
-    height: hasPanel ? size - panelPaddingHorizontal : size,
-    position: 'relative',
-    width: hasPanel ? size - panelPaddingHorizontal : size,
-    zIndex: 1
-  })
-)
-
 interface Props {
-  hasPanel?: boolean
   onClick?: () => void
   picture: string
-  size: number
-  unstyled?: boolean
+  className?: string
 }
 
 const EditableAvatar = (props: Props) => {
-  const {hasPanel, onClick, picture, size, unstyled} = props
-  const avatarSize = hasPanel ? size - panelPaddingHorizontal : size
+  const {onClick, picture, className} = props
   return (
-    <EditableAvatarRoot
-      className='flex items-center justify-center rounded-full border-4 border-slate-200 outline-none duration-300 ease-in-out hover:cursor-pointer hover:border-slate-400 focus:border-sky-500'
-      hasPanel={hasPanel}
-      onClick={onClick}
-      aria-label='click to update photo'
-      tabIndex={0}
-    >
+    <div className='relative cursor-pointer' onClick={onClick} aria-label='click to update photo'>
+      <Avatar
+        picture={picture}
+        className={clsx(`h-16 w-16 border-4 border-solid border-slate-200`, className)}
+      />
+      <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center rounded-full bg-slate-400 text-sm font-semibold text-slate-800 opacity-0 transition-opacity  duration-300 hover:opacity-75'>
+        EDIT
+      </div>
       <div
         aria-hidden
         className='icon-wrapper absolute top-0 right-0 z-10 rounded-full bg-slate-200 px-1.5 hover:bg-slate-200'
       >
         <EditIcon className='mb-[-2px] w-3.5 pt-0.5' />
       </div>
-      <EditableAvatarEditOverlay hasPanel={hasPanel} onClick={onClick} size={size}>
-        <span>{'EDIT'}</span>
-      </EditableAvatarEditOverlay>
-      <EditableAvatarImgBlock hasPanel={hasPanel} size={size}>
-        <Avatar picture={picture} size={avatarSize} sansRadius={unstyled} sansShadow={unstyled} />
-      </EditableAvatarImgBlock>
-    </EditableAvatarRoot>
+    </div>
   )
 }
 

--- a/packages/client/components/MeetingSidebarTeamMemberStageItems.tsx
+++ b/packages/client/components/MeetingSidebarTeamMemberStageItems.tsx
@@ -3,12 +3,12 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {MeetingSidebarTeamMemberStageItems_meeting$key} from '~/__generated__/MeetingSidebarTeamMemberStageItems_meeting.graphql'
+import {NewMeetingPhaseTypeEnum} from '../__generated__/ActionMeeting_meeting.graphql'
 import Avatar from '../components/Avatar/Avatar'
 import MeetingSubnavItem from '../components/MeetingSubnavItem'
 import useAnimatedPhaseListChildren from '../hooks/useAnimatedPhaseListChildren'
 import useAtmosphere from '../hooks/useAtmosphere'
 import useGotoStageId from '../hooks/useGotoStageId'
-import {NewMeetingPhaseTypeEnum} from '../__generated__/ActionMeeting_meeting.graphql'
 import MeetingSidebarPhaseItemChild from './MeetingSidebarPhaseItemChild'
 
 const AvatarBlock = styled('div')({
@@ -94,7 +94,7 @@ const MeetingSidebarTeamMemberStageItems = (props: Props) => {
               key={stageId}
               metaContent={
                 <AvatarBlock>
-                  <Avatar hasBadge={false} picture={picture} size={24} />
+                  <Avatar picture={picture} className='h-6 w-6' />
                 </AvatarBlock>
               }
               isDisabled={isViewerFacilitator ? !isNavigableByFacilitator : !isNavigable}

--- a/packages/client/components/MentionUser/MentionUser.tsx
+++ b/packages/client/components/MentionUser/MentionUser.tsx
@@ -13,7 +13,7 @@ const MentionUser = (props: MentionUserProps) => {
   const {active, preferredName, picture} = props
   return (
     <DraftMentionRow active={active}>
-      <Avatar picture={picture} size={24} />
+      <Avatar picture={picture} className='h-6 w-6' />
       <DraftMentionDescription>{preferredName}</DraftMentionDescription>
     </DraftMentionRow>
   )

--- a/packages/client/components/NewMeetingTeamPickerAvatars.tsx
+++ b/packages/client/components/NewMeetingTeamPickerAvatars.tsx
@@ -2,10 +2,8 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
 import {useFragment} from 'react-relay'
-import {PALETTE} from '../styles/paletteV3'
-import defaultUserAvatar from '../styles/theme/images/avatar-user.svg'
-import getShuffledArr from '../utils/getShuffledArr'
 import {NewMeetingTeamPickerAvatars_team$key} from '../__generated__/NewMeetingTeamPickerAvatars_team.graphql'
+import getShuffledArr from '../utils/getShuffledArr'
 import Avatar from './Avatar/Avatar'
 import ErrorBoundary from './ErrorBoundary'
 
@@ -22,10 +20,6 @@ const AvatarWrapper = styled('div')<{count: number}>(({count}) => ({
   width: count > 1 ? 20 : 'auto',
   height: count > 2 ? 20 : 'auto'
 }))
-
-const StyledAvatar = styled(Avatar)({
-  border: `2px solid ${PALETTE.SLATE_200}`
-})
 
 interface Props {
   teamRef: NewMeetingTeamPickerAvatars_team$key
@@ -73,7 +67,10 @@ const NewMeetingTeamPickerAvatars = (props: Props) => {
         return (
           <ErrorBoundary key={`pickerAvatar${teamMember.id}`}>
             <AvatarWrapper count={randomAvatars.length}>
-              <StyledAvatar {...teamMember} picture={picture || defaultUserAvatar} size={28} />
+              <Avatar
+                picture={picture}
+                className={`border-2 border-solid border-slate-200 h-7 w-7`}
+              />
             </AvatarWrapper>
           </ErrorBoundary>
         )

--- a/packages/client/components/NewMeetingTeamPickerAvatars.tsx
+++ b/packages/client/components/NewMeetingTeamPickerAvatars.tsx
@@ -69,7 +69,7 @@ const NewMeetingTeamPickerAvatars = (props: Props) => {
             <AvatarWrapper count={randomAvatars.length}>
               <Avatar
                 picture={picture}
-                className={`border-2 border-solid border-slate-200 h-7 w-7`}
+                className={`h-7 w-7 border-2 border-solid border-slate-200`}
               />
             </AvatarWrapper>
           </ErrorBoundary>

--- a/packages/client/components/OrgAvatarInput.tsx
+++ b/packages/client/components/OrgAvatarInput.tsx
@@ -34,10 +34,6 @@ const StyledDialogTitle = styled(DialogTitle)({
   textAlign: 'center'
 })
 
-const AvatarWithShadow = styled(Avatar)({
-  boxShadow: `0px 4px 5px 0px #DADADA`
-})
-
 interface Props {
   picture: string
   orgId: string
@@ -76,7 +72,10 @@ const OrgAvatarInput = (props: Props) => {
     <ModalBoundary>
       <StyledDialogTitle>{'Upload a New Photo'}</StyledDialogTitle>
       <AvatarBlock>
-        <AvatarWithShadow picture={picture} size={96} />
+        <Avatar
+          picture={picture}
+          className='h-24 w-24 shadow-[0_4px_5px_0px_rgba(218,218,218,1)]'
+        />
       </AvatarBlock>
       <AvatarInput error={error?.message} onSubmit={onSubmit} />
     </ModalBoundary>

--- a/packages/client/components/StandardHub/StandardHub.tsx
+++ b/packages/client/components/StandardHub/StandardHub.tsx
@@ -7,9 +7,9 @@ import WaveWhiteSVG from 'static/images/waveWhite.svg'
 import PlainButton from '~/components/PlainButton/PlainButton'
 import TierTag from '~/components/Tag/TierTag'
 import useRouter from '~/hooks/useRouter'
+import {StandardHub_viewer$key, TierEnum} from '../../__generated__/StandardHub_viewer.graphql'
 import {PALETTE} from '../../styles/paletteV3'
 import defaultUserAvatar from '../../styles/theme/images/avatar-user.svg'
-import {StandardHub_viewer$key, TierEnum} from '../../__generated__/StandardHub_viewer.graphql'
 import Avatar from '../Avatar/Avatar'
 
 const StandardHubRoot = styled('div')({
@@ -30,10 +30,6 @@ const User = styled('div')({
   cursor: 'pointer',
   flex: 1,
   position: 'relative'
-})
-
-const StyledAvatar = styled(Avatar)({
-  cursor: 'pointer'
 })
 
 const NameAndEmail = styled('div')({
@@ -120,7 +116,7 @@ const StandardHub = (props: Props) => {
   return (
     <StandardHubRoot>
       <User onClick={gotoUserSettings}>
-        <StyledAvatar hasBadge={false} picture={userAvatar} size={48} />
+        <Avatar picture={userAvatar} className='h-12 w-12' />
         <NameAndEmail>
           <PreferredName>{preferredName}</PreferredName>
           <Email>{email}</Email>

--- a/packages/client/components/TeamHealthVotingRow.tsx
+++ b/packages/client/components/TeamHealthVotingRow.tsx
@@ -1,11 +1,11 @@
+import {Check as CheckIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {TeamHealthVotingRow_stage$key} from '../__generated__/TeamHealthVotingRow_stage.graphql'
 import {PALETTE} from '../styles/paletteV3'
 import {PokerCards} from '../types/constEnums'
-import {TeamHealthVotingRow_stage$key} from '../__generated__/TeamHealthVotingRow_stage.graphql'
 import AvatarList from './AvatarList'
-import {Check as CheckIcon} from '@mui/icons-material'
 import MiniPokerCard from './MiniPokerCard'
 import PokerVotingNoVotes from './PokerVotingNoVotes'
 

--- a/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptDiscussionDrawer.tsx
@@ -4,18 +4,18 @@ import {JSONContent} from '@tiptap/react'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {TeamPromptDiscussionDrawer_meeting$key} from '~/__generated__/TeamPromptDiscussionDrawer_meeting.graphql'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useMutationProps from '~/hooks/useMutationProps'
 import AddReactjiToReactableMutation from '~/mutations/AddReactjiToReactableMutation'
 import ReactjiId from '~/shared/gqlIds/ReactjiId'
 import findStageById from '~/utils/meetings/findStageById'
-import {TeamPromptDiscussionDrawer_meeting$key} from '~/__generated__/TeamPromptDiscussionDrawer_meeting.graphql'
 import {PALETTE} from '../../styles/paletteV3'
 import Avatar from '../Avatar/Avatar'
 import DiscussionThreadRoot from '../DiscussionThreadRoot'
 import PlainButton from '../PlainButton/PlainButton'
-import PromptResponseEditor from '../promptResponse/PromptResponseEditor'
 import ReactjiSection from '../ReflectionCard/ReactjiSection'
+import PromptResponseEditor from '../promptResponse/PromptResponseEditor'
 import TeamPromptLastUpdatedTime from './TeamPromptLastUpdatedTime'
 
 const ThreadColumn = styled('div')({
@@ -157,7 +157,7 @@ const TeamPromptDiscussionDrawer = ({meetingRef, onToggleDrawer}: Props) => {
       <DiscussionResponseCard>
         <Header>
           <div className='flex items-center'>
-            <Avatar picture={teamMember.picture} size={48} />
+            <Avatar picture={teamMember.picture} className={'h-12 w-12'} />
             <TeamMemberName>
               {teamMember.preferredName}
               {response && (

--- a/packages/client/components/TeamPrompt/TeamPromptRepliesAvatarList.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptRepliesAvatarList.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {TeamPromptRepliesAvatarList_edges$key} from '~/__generated__/TeamPromptRepliesAvatarList_edges.graphql'
 import useOverflowAvatars from '~/hooks/useOverflowAvatars'
 import {TransitionStatus} from '~/hooks/useTransition'
-import {TeamPromptRepliesAvatarList_edges$key} from '~/__generated__/TeamPromptRepliesAvatarList_edges.graphql'
 import AvatarListUser from '../AvatarListUser'
 import TeamPromptOverflowAvatar from './TeamPromptOverflowAvatar'
 
@@ -70,7 +70,7 @@ const TeamPromptRepliesAvatarList = (props: Props) => {
                 onTransitionEnd={onTransitionEnd}
                 status={status}
                 offset={offsetSize * displayIdx}
-                width={AVATAR_SIZE}
+                className='h-6 w-6'
               />
               <TeamPromptOverflowAvatar
                 key={`${userId}:overflowCount`}
@@ -92,7 +92,7 @@ const TeamPromptRepliesAvatarList = (props: Props) => {
             onTransitionEnd={onTransitionEnd}
             status={status}
             offset={offsetSize * displayIdx}
-            width={AVATAR_SIZE}
+            className='h-6 w-6'
           />
         )
       })}

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled'
+import {Link} from '@mui/icons-material'
 import {Editor as EditorState} from '@tiptap/core'
 import {JSONContent} from '@tiptap/react'
 import graphql from 'babel-plugin-relay/macro'
 import React, {useMemo} from 'react'
-import {commitLocalUpdate, useFragment} from 'react-relay'
 import CopyToClipboard from 'react-copy-to-clipboard'
+import {commitLocalUpdate, useFragment} from 'react-relay'
+import {TeamPromptResponseCard_stage$key} from '~/__generated__/TeamPromptResponseCard_stage.graphql'
 import useAnimatedCard from '~/hooks/useAnimatedCard'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import useEventCallback from '~/hooks/useEventCallback'
@@ -13,9 +15,13 @@ import {Elevation} from '~/styles/elevation'
 import {PALETTE} from '~/styles/paletteV3'
 import {BezierCurve, Card} from '~/types/constEnums'
 import plural from '~/utils/plural'
-import {TeamPromptResponseCard_stage$key} from '~/__generated__/TeamPromptResponseCard_stage.graphql'
+import {MenuPosition} from '../../hooks/useCoords'
 import useMutationProps from '../../hooks/useMutationProps'
+import useTooltip from '../../hooks/useTooltip'
 import UpsertTeamPromptResponseMutation from '../../mutations/UpsertTeamPromptResponseMutation'
+import SendClientSideEvent from '../../utils/SendClientSideEvent'
+import makeAppURL from '../../utils/makeAppURL'
+import {mergeRefs} from '../../utils/react/mergeRefs'
 import Avatar from '../Avatar/Avatar'
 import PlainButton from '../PlainButton/PlainButton'
 import PromptResponseEditor from '../promptResponse/PromptResponseEditor'
@@ -23,12 +29,6 @@ import {ResponseCardDimensions, ResponsesGridBreakpoints} from './TeamPromptGrid
 import TeamPromptLastUpdatedTime from './TeamPromptLastUpdatedTime'
 import TeamPromptRepliesAvatarList from './TeamPromptRepliesAvatarList'
 import {TeamPromptResponseEmojis} from './TeamPromptResponseEmojis'
-import makeAppURL from '../../utils/makeAppURL'
-import SendClientSideEvent from '../../utils/SendClientSideEvent'
-import {mergeRefs} from '../../utils/react/mergeRefs'
-import useTooltip from '../../hooks/useTooltip'
-import {MenuPosition} from '../../hooks/useCoords'
-import {Link} from '@mui/icons-material'
 
 const twoColumnResponseMediaQuery = `@media screen and (min-width: ${ResponsesGridBreakpoints.TWO_RESPONSE_COLUMN}px)`
 const threeColumnResponseMediaQuery = `@media screen and (min-width: ${ResponsesGridBreakpoints.THREE_RESPONSE_COLUMNS}px)`
@@ -254,7 +254,7 @@ const TeamPromptResponseCard = (props: Props) => {
       isSingleColumn={isSingleColumn}
     >
       <ResponseHeader>
-        <Avatar picture={picture} size={48} />
+        <Avatar picture={picture} className='h-12 w-12' />
         <TeamMemberName>
           {preferredName}
           {response && (

--- a/packages/client/components/ThreadedAvatarColumn.tsx
+++ b/packages/client/components/ThreadedAvatarColumn.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import defaultUserAvatar from '../styles/theme/images/avatar-user.svg'
 import Avatar from './Avatar/Avatar'
 
 const AvatarCol = styled('div')<{isReply: boolean | undefined}>(({isReply}) => ({
@@ -8,8 +7,6 @@ const AvatarCol = styled('div')<{isReply: boolean | undefined}>(({isReply}) => (
   paddingRight: 8,
   paddingLeft: isReply ? undefined : 8
 }))
-
-const ColumnAvatar = styled(Avatar)({})
 
 interface Props {
   isReply: boolean | undefined
@@ -20,7 +17,7 @@ const ThreadedAvatarColumn = (props: Props) => {
   const {picture, isReply} = props
   return (
     <AvatarCol isReply={isReply}>
-      <ColumnAvatar size={32} picture={picture || defaultUserAvatar} />
+      <Avatar picture={picture} className='h-8 w-8' />
     </AvatarCol>
   )
 }

--- a/packages/client/components/TopBarAvatar.tsx
+++ b/packages/client/components/TopBarAvatar.tsx
@@ -2,10 +2,10 @@ import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
+import {TopBarAvatar_viewer$key} from '~/__generated__/TopBarAvatar_viewer.graphql'
 import {MenuPosition} from '~/hooks/useCoords'
 import useMenu from '~/hooks/useMenu'
 import lazyPreload from '~/utils/lazyPreload'
-import {TopBarAvatar_viewer$key} from '~/__generated__/TopBarAvatar_viewer.graphql'
 import {PALETTE} from '../styles/paletteV3'
 import defaultUserAvatar from '../styles/theme/images/avatar-user.svg'
 import Avatar from './Avatar/Avatar'
@@ -16,7 +16,7 @@ const AvatarWrapper = styled('button')({
   borderRadius: 100,
   marginLeft: 8,
   padding: 4,
-  ':focus': {
+  ':focus-visible': {
     boxShadow: `0 0 0 2px ${PALETTE.SKY_400}`,
     cursor: 'pointer',
     outline: 'none'
@@ -55,9 +55,8 @@ const TopBarAvatar = (props: Props) => {
         <Avatar
           onMouseEnter={StandardHubUserMenu.preload}
           ref={originRef}
-          hasBadge={false}
           picture={userAvatar}
-          size={40}
+          className='h-10 w-10 cursor-pointer'
         />
         {viewer && menuPortal(<StandardHubUserMenu menuProps={menuProps} viewerRef={viewer} />)}
       </AvatarWrapper>

--- a/packages/client/components/UserAvatarInput.tsx
+++ b/packages/client/components/UserAvatarInput.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import sanitizeSVG from '@mattkrick/sanitize-svg'
+import {Close} from '@mui/icons-material'
 import React from 'react'
 import jpgWithoutEXIF from '~/utils/jpgWithoutEXIF'
 import useAtmosphere from '../hooks/useAtmosphere'
@@ -9,7 +10,6 @@ import svgToPng from '../utils/svgToPng'
 import Avatar from './Avatar/Avatar'
 import AvatarInput from './AvatarInput'
 import DialogTitle from './DialogTitle'
-import {Close} from '@mui/icons-material'
 import FlatButton from './FlatButton'
 
 const AvatarBlock = styled('div')({
@@ -75,7 +75,7 @@ const UserAvatarInput = (props: Props) => {
       <div>
         {/* upload */}
         <AvatarBlock>
-          <Avatar picture={picture} size={96} />
+          <Avatar picture={picture} className='w-24 h-24' />
         </AvatarBlock>
         <AvatarInput error={error?.message} onSubmit={onSubmit} />
       </div>

--- a/packages/client/components/UserAvatarInput.tsx
+++ b/packages/client/components/UserAvatarInput.tsx
@@ -75,7 +75,7 @@ const UserAvatarInput = (props: Props) => {
       <div>
         {/* upload */}
         <AvatarBlock>
-          <Avatar picture={picture} className='w-24 h-24' />
+          <Avatar picture={picture} className='h-24 w-24' />
         </AvatarBlock>
         <AvatarInput error={error?.message} onSubmit={onSubmit} />
       </div>

--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewMeetingCheckInPrompt.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewMeetingCheckInPrompt.tsx
@@ -3,11 +3,8 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {NewMeetingCheckInPrompt_meeting$key} from '~/__generated__/NewMeetingCheckInPrompt_meeting.graphql'
-import Avatar from '../../../../components/Avatar/Avatar'
-import useBreakpoint from '../../../../hooks/useBreakpoint'
-import defaultUserAvatar from '../../../../styles/theme/images/avatar-user.svg'
-import {Breakpoint} from '../../../../types/constEnums'
 import {NewMeetingCheckInPrompt_teamMember$key} from '../../../../__generated__/NewMeetingCheckInPrompt_teamMember.graphql'
+import Avatar from '../../../../components/Avatar/Avatar'
 import NewMeetingCheckInGreeting from '../NewMeetingCheckInGreeting'
 import NewCheckInQuestion from './NewCheckInQuestion'
 
@@ -73,15 +70,13 @@ const NewMeetingCheckinPrompt = (props: Props) => {
     `,
     teamMemberRef
   )
-  const isLargeViewport = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const {picture} = teamMember
   const {localPhase} = meeting
   const {checkInGreeting} = localPhase
-  const size = isLargeViewport ? 160 : 128
   return (
     <PromptBlock>
       <AvatarBlock>
-        <Avatar picture={picture || defaultUserAvatar} size={size} />
+        <Avatar picture={picture} className={`h-32 w-32 sidebar-left:h-40 sidebar-left:w-40`} />
       </AvatarBlock>
       <CheckInBlock>
         <NewMeetingCheckInGreeting checkInGreeting={checkInGreeting!} teamMember={teamMember} />

--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -3,9 +3,10 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {useEffect, useRef, useState} from 'react'
 import {useFragment} from 'react-relay'
 import {
-  AgendaItem_meeting$key,
-  AgendaItem_meeting$data
+  AgendaItem_meeting$data,
+  AgendaItem_meeting$key
 } from '~/__generated__/AgendaItem_meeting.graphql'
+import {AgendaItem_agendaItem$key} from '../../../../__generated__/AgendaItem_agendaItem.graphql'
 import Avatar from '../../../../components/Avatar/Avatar'
 import IconButton from '../../../../components/IconButton'
 import MeetingSubnavItem from '../../../../components/MeetingSubnavItem'
@@ -20,7 +21,6 @@ import pinIcon from '../../../../styles/theme/images/icons/pin.svg'
 import unpinIcon from '../../../../styles/theme/images/icons/unpin.svg'
 import {ICON_SIZE} from '../../../../styles/typographyV2'
 import findStageAfterId from '../../../../utils/meetings/findStageAfterId'
-import {AgendaItem_agendaItem$key} from '../../../../__generated__/AgendaItem_agendaItem.graphql'
 
 const AgendaItemStyles = styled('div')({
   position: 'relative',
@@ -199,7 +199,7 @@ const AgendaItem = (props: Props) => {
 
   const getIcon = () => {
     if (pinned && isHovering) return <SvgIcon alt='unpinIcon' src={unpinIcon} />
-    else if (!pinned && !isHovering) return <Avatar hasBadge={false} picture={picture} size={24} />
+    else if (!pinned && !isHovering) return <Avatar picture={picture} className='h-6 w-6' />
     else return <SvgIcon alt='pinnedIcon' src={pinIcon} />
   }
 

--- a/packages/client/modules/teamDashboard/components/ManageTeam/ManageTeamMember.tsx
+++ b/packages/client/modules/teamDashboard/components/ManageTeam/ManageTeamMember.tsx
@@ -134,7 +134,7 @@ const ManageTeamMember = (props: Props) => {
 
   return (
     <StyledRow ref={ref}>
-      <Avatar size={24} picture={picture} />
+      <Avatar className='h-6 w-6' picture={picture} />
       <Content>
         <Name>{preferredName}</Name>
         <TeamLeadLabel isLead={isLead || isOrgAdmin}>

--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
@@ -1,27 +1,26 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import Avatar from '../../../../components/Avatar/Avatar'
 import React from 'react'
+import {useFragment} from 'react-relay'
 import {BillingLeader_orgUser$key} from '../../../../__generated__/BillingLeader_orgUser.graphql'
 import {BillingLeader_organization$key} from '../../../../__generated__/BillingLeader_organization.graphql'
-import Row from '../../../../components/Row/Row'
-import {ElementWidth} from '../../../../types/constEnums'
-import RowInfoHeading from '../../../../components/Row/RowInfoHeading'
-import RowInfoHeader from '../../../../components/Row/RowInfoHeader'
-import RowActions from '../../../../components/Row/RowActions'
-import FlatButton from '../../../../components/FlatButton'
-import RowInfo from '../../../../components/Row/RowInfo'
-import {useFragment} from 'react-relay'
-import IconLabel from '../../../../components/IconLabel'
-import lazyPreload from '../../../../utils/lazyPreload'
-import useMenu from '../../../../hooks/useMenu'
+import Avatar from '../../../../components/Avatar/Avatar'
 import BillingLeaderMenu from '../../../../components/BillingLeaderMenu'
-import {MenuPosition} from '../../../../hooks/useCoords'
-import useTooltip from '../../../../hooks/useTooltip'
-import LeaveOrgModal from '../LeaveOrgModal/LeaveOrgModal'
-import useModal from '../../../../hooks/useModal'
-import RemoveFromOrgModal from '../RemoveFromOrgModal/RemoveFromOrgModal'
+import FlatButton from '../../../../components/FlatButton'
+import IconLabel from '../../../../components/IconLabel'
+import Row from '../../../../components/Row/Row'
+import RowActions from '../../../../components/Row/RowActions'
+import RowInfo from '../../../../components/Row/RowInfo'
+import RowInfoHeader from '../../../../components/Row/RowInfoHeader'
+import RowInfoHeading from '../../../../components/Row/RowInfoHeading'
 import BaseTag from '../../../../components/Tag/BaseTag'
+import {MenuPosition} from '../../../../hooks/useCoords'
+import useMenu from '../../../../hooks/useMenu'
+import useModal from '../../../../hooks/useModal'
+import useTooltip from '../../../../hooks/useTooltip'
+import lazyPreload from '../../../../utils/lazyPreload'
+import LeaveOrgModal from '../LeaveOrgModal/LeaveOrgModal'
+import RemoveFromOrgModal from '../RemoveFromOrgModal/RemoveFromOrgModal'
 
 const StyledRow = styled(Row)<{isFirstRow: boolean}>(({isFirstRow}) => ({
   padding: '12px 16px',
@@ -112,7 +111,7 @@ const BillingLeader = (props: Props) => {
 
   return (
     <StyledRow isFirstRow={isFirstRow}>
-      <Avatar hasBadge={false} picture={picture} size={ElementWidth.BILLING_AVATAR} />
+      <Avatar picture={picture} className='h-11 w-11' />
       <RowInfo>
         <RowInfoHeader>
           <RowInfoHeading>{preferredName}</RowInfoHeading>

--- a/packages/client/modules/userDashboard/components/OrgBilling/NewBillingLeaderMenu.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/NewBillingLeaderMenu.tsx
@@ -1,21 +1,21 @@
-import React, {forwardRef, useMemo} from 'react'
-import Menu from '../../../../components/Menu'
-import MenuItem from '../../../../components/MenuItem'
-import MenuItemLabel from '../../../../components/MenuItemLabel'
-import {MenuProps} from '../../../../hooks/useMenu'
-import {useFragment} from 'react-relay'
 import graphql from 'babel-plugin-relay/macro'
+import React, {forwardRef, useMemo} from 'react'
+import {useFragment} from 'react-relay'
 import {
   NewBillingLeaderMenu_organization$data,
   NewBillingLeaderMenu_organization$key
 } from '~/__generated__/NewBillingLeaderMenu_organization.graphql'
 import Avatar from '../../../../components/Avatar/Avatar'
-import TypeAheadLabel from '../../../../components/TypeAheadLabel'
-import useFilteredItems from '../../../../hooks/useFilteredItems'
 import {EmptyDropdownMenuItemLabel} from '../../../../components/EmptyDropdownMenuItemLabel'
-import SetOrgUserRoleMutation from '../../../../mutations/SetOrgUserRoleMutation'
+import Menu from '../../../../components/Menu'
+import MenuItem from '../../../../components/MenuItem'
+import MenuItemLabel from '../../../../components/MenuItemLabel'
+import TypeAheadLabel from '../../../../components/TypeAheadLabel'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useFilteredItems from '../../../../hooks/useFilteredItems'
+import {MenuProps} from '../../../../hooks/useMenu'
 import useMutationProps from '../../../../hooks/useMutationProps'
+import SetOrgUserRoleMutation from '../../../../mutations/SetOrgUserRoleMutation'
 
 interface Props {
   menuProps: MenuProps
@@ -96,7 +96,7 @@ const NewBillingLeaderMenu = forwardRef((props: Props, ref: any) => {
             label={
               <MenuItemLabel>
                 <div className='pr-8'>
-                  <Avatar picture={picture} size={32} />
+                  <Avatar picture={picture} className='h-8 w-8' />
                 </div>
                 <TypeAheadLabel query={newLeaderSearchQuery} label={preferredName} />
               </MenuItemLabel>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgDetails.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgDetails.tsx
@@ -1,15 +1,15 @@
 import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
 import {useFragment} from 'react-relay'
-import OrgAvatarInput from '../../../../components/OrgAvatarInput'
-import useModal from '../../../../hooks/useModal'
 import {OrgDetails_organization$key} from '../../../../__generated__/OrgDetails_organization.graphql'
-import OrgBillingDangerZone from './OrgBillingDangerZone'
-import defaultOrgAvatar from '../../../../styles/theme/images/avatar-organization.svg'
-import EditableOrgName from '../../../../components/EditableOrgName'
-import OrganizationDetails from '../Organization/OrganizationDetails'
 import Avatar from '../../../../components/Avatar/Avatar'
 import EditableAvatar from '../../../../components/EditableAvatar/EditableAvatar'
+import EditableOrgName from '../../../../components/EditableOrgName'
+import OrgAvatarInput from '../../../../components/OrgAvatarInput'
+import useModal from '../../../../hooks/useModal'
+import defaultOrgAvatar from '../../../../styles/theme/images/avatar-organization.svg'
+import OrganizationDetails from '../Organization/OrganizationDetails'
+import OrgBillingDangerZone from './OrgBillingDangerZone'
 
 type Props = {
   organizationRef: OrgDetails_organization$key
@@ -51,12 +51,14 @@ const OrgDetails = (props: Props) => {
       <div className='mb-4 flex w-full items-center'>
         {modalPortal(<OrgAvatarInput picture={pictureOrDefault} orgId={orgId} />)}
         {isBillingLeader ? (
-          <div onClick={togglePortal} className='mr-2'>
-            <EditableAvatar hasPanel picture={pictureOrDefault} size={64} unstyled />
-          </div>
+          <EditableAvatar
+            onClick={togglePortal}
+            picture={pictureOrDefault}
+            className='mr-4 h-16 w-16'
+          />
         ) : (
           <div className='mr-4 w-16'>
-            <Avatar picture={pictureOrDefault} size={64} sansRadius sansShadow />
+            <Avatar picture={pictureOrDefault} />
           </div>
         )}
         <div className='text-gray-600 ml-2 flex flex-grow flex-col items-start'>

--- a/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembersRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembersRow.tsx
@@ -1,19 +1,17 @@
-import React from 'react'
+import {MoreVert} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
 import {useFragment} from 'react-relay'
 import {OrgTeamMembersRow_teamMember$key} from '../../../../__generated__/OrgTeamMembersRow_teamMember.graphql'
-import {Avatar} from '../../../../ui/Avatar/Avatar'
-import {AvatarFallback} from '../../../../ui/Avatar/AvatarFallback'
-import {AvatarImage} from '../../../../ui/Avatar/AvatarImage'
-import {Button} from '../../../../ui/Button/Button'
-import {MoreVert} from '@mui/icons-material'
-import {OrgTeamMemberMenu} from './OrgTeamMemberMenu'
+import Avatar from '../../../../components/Avatar/Avatar'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
 import {MenuPosition} from '../../../../hooks/useCoords'
 import useMenu from '../../../../hooks/useMenu'
+import useModal from '../../../../hooks/useModal'
+import {Button} from '../../../../ui/Button/Button'
 import PromoteTeamMemberModal from '../../../teamDashboard/components/PromoteTeamMemberModal/PromoteTeamMemberModal'
 import RemoveTeamMemberModal from '../../../teamDashboard/components/RemoveTeamMemberModal/RemoveTeamMemberModal'
-import useModal from '../../../../hooks/useModal'
-import useAtmosphere from '../../../../hooks/useAtmosphere'
+import {OrgTeamMemberMenu} from './OrgTeamMemberMenu'
 
 type Props = {
   teamMemberRef: OrgTeamMembersRow_teamMember$key
@@ -65,10 +63,7 @@ export const OrgTeamMembersRow = (props: Props) => {
   return (
     <div className='flex w-full items-center justify-center gap-4 p-4'>
       <div>
-        <Avatar className='h-8 w-8'>
-          <AvatarImage src={teamMember.picture} alt={teamMember.preferredName} />
-          <AvatarFallback>{teamMember.preferredName.substring(0, 2)}</AvatarFallback>
-        </Avatar>
+        <Avatar className='h-8 w-8' picture={teamMember.picture} alt={teamMember.preferredName} />
       </div>
       <div className='flex w-full flex-col gap-y-1 py-1'>
         <div className='text-gray-700 inline-flex items-center gap-x-2 text-lg font-bold'>

--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -3,6 +3,14 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {forwardRef, Ref} from 'react'
 import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
+import {
+  OrgMemberRow_organization$data,
+  OrgMemberRow_organization$key
+} from '../../../../__generated__/OrgMemberRow_organization.graphql'
+import {
+  OrgMemberRow_organizationUser$data,
+  OrgMemberRow_organizationUser$key
+} from '../../../../__generated__/OrgMemberRow_organizationUser.graphql'
 import Avatar from '../../../../components/Avatar/Avatar'
 import FlatButton, {FlatButtonProps} from '../../../../components/FlatButton'
 import IconLabel from '../../../../components/IconLabel'
@@ -12,6 +20,7 @@ import RowInfo from '../../../../components/Row/RowInfo'
 import RowInfoHeader from '../../../../components/Row/RowInfoHeader'
 import RowInfoHeading from '../../../../components/Row/RowInfoHeading'
 import RowInfoLink from '../../../../components/Row/RowInfoLink'
+import BaseTag from '../../../../components/Tag/BaseTag'
 import EmphasisTag from '../../../../components/Tag/EmphasisTag'
 import InactiveTag from '../../../../components/Tag/InactiveTag'
 import RoleTag from '../../../../components/Tag/RoleTag'
@@ -22,15 +31,6 @@ import defaultUserAvatar from '../../../../styles/theme/images/avatar-user.svg'
 import {Breakpoint} from '../../../../types/constEnums'
 import lazyPreload from '../../../../utils/lazyPreload'
 import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
-import {
-  OrgMemberRow_organization$key,
-  OrgMemberRow_organization$data
-} from '../../../../__generated__/OrgMemberRow_organization.graphql'
-import {
-  OrgMemberRow_organizationUser$key,
-  OrgMemberRow_organizationUser$data
-} from '../../../../__generated__/OrgMemberRow_organizationUser.graphql'
-import BaseTag from '../../../../components/Tag/BaseTag'
 
 const AvatarBlock = styled('div')({
   display: 'none',
@@ -113,7 +113,7 @@ interface UserAvatarProps {
 const UserAvatar: React.FC<UserAvatarProps> = ({picture}) => (
   <AvatarBlock>
     {picture ? (
-      <Avatar hasBadge={false} picture={picture} size={44} />
+      <Avatar picture={picture} className='h-11 w-11' />
     ) : (
       <img alt='default avatar' src={defaultUserAvatar} />
     )}

--- a/packages/client/modules/userDashboard/components/OrganizationRow/OrganizationRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrganizationRow/OrganizationRow.tsx
@@ -127,7 +127,7 @@ const OrganizationRow = (props: Props) => {
   return (
     <Row>
       <OrgAvatar onClick={onRowClick}>
-        <Avatar size={44} picture={orgAvatar} />
+        <Avatar className='h-11 w-11' picture={orgAvatar} />
       </OrgAvatar>
       <RowInner>
         <StyledRowInfo>

--- a/packages/client/modules/userDashboard/components/UserSettingsForm/UserSettingsForm.tsx
+++ b/packages/client/modules/userDashboard/components/UserSettingsForm/UserSettingsForm.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import React, {lazy} from 'react'
+import {UserProfileQuery} from '../../../../__generated__/UserProfileQuery.graphql'
 import EditableAvatar from '../../../../components/EditableAvatar/EditableAvatar'
 import FieldLabel from '../../../../components/FieldLabel/FieldLabel'
 import BasicInput from '../../../../components/InputField/BasicInput'
@@ -13,7 +14,6 @@ import defaultUserAvatar from '../../../../styles/theme/images/avatar-user.svg'
 import {Breakpoint, Layout} from '../../../../types/constEnums'
 import withForm, {WithFormProps} from '../../../../utils/relay/withForm'
 import Legitity from '../../../../validation/Legitity'
-import {UserProfileQuery} from '../../../../__generated__/UserProfileQuery.graphql'
 import NotificationErrorMessage from '../../../notifications/components/NotificationErrorMessage'
 
 const SettingsForm = styled('form')({
@@ -84,7 +84,7 @@ function UserSettings(props: UserSettingsProps) {
   return (
     <SettingsForm onSubmit={onSubmit}>
       <div onClick={togglePortal}>
-        <EditableAvatar picture={pictureOrDefault} size={96} />
+        <EditableAvatar picture={pictureOrDefault} className='h-24 w-24' />
       </div>
       {modalPortal(<UserAvatarInput closeModal={togglePortal} picture={pictureOrDefault} />)}
       <InfoBlock>

--- a/packages/client/ui/Avatar/Avatar.tsx
+++ b/packages/client/ui/Avatar/Avatar.tsx
@@ -1,11 +1,9 @@
-import React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 import clsx from 'clsx'
+import React from 'react'
+import {forwardRadix} from '../forwardRadix'
 
-export const Avatar = React.forwardRef<
-  HTMLSpanElement,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({className, ...props}, ref) => (
+export const Avatar = forwardRadix<typeof AvatarPrimitive.Root>(({className, ...props}, ref) => (
   <AvatarPrimitive.Root
     ref={ref}
     className={clsx('relative flex shrink-0 overflow-hidden rounded-full', className)}


### PR DESCRIPTION
# Description

fixes #9632 

I broke the avatars trying to do a cheap fix. The right way to load fallbacks is using radix-ui, which has that functionality built into it + a ton of accessibility things, so this PR refactors all avatars to use radix-ui + tailwinds.

This also fixes some really ugly avatar related stuff like below

<img width="185" alt="Screenshot 2024-04-11 at 11 34 45 AM" src="https://github.com/ParabolInc/parabol/assets/5514175/19efb52a-c3a7-4752-b33a-58d3f0122722">
<img width="118" alt="Screenshot 2024-04-11 at 11 34 18 AM" src="https://github.com/ParabolInc/parabol/assets/5514175/10b6be3c-38c1-4e91-bf3c-38306cff5998">

