### PR TITLE
fix: only query templates when a user clicks the options menu

### DIFF
--- a/packages/client/components/MeetingTopBar.tsx
+++ b/packages/client/components/MeetingTopBar.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import {Comment} from '@mui/icons-material'
-import React, {ReactElement, ReactNode, useState} from 'react'
+import React, {ReactElement, ReactNode} from 'react'
 import {PALETTE} from '~/styles/paletteV3'
 import {meetingAvatarMediaQueries} from '../styles/meeting'
 import hasToken from '../utils/hasToken'
@@ -165,7 +165,6 @@ const MeetingTopBar = (props: Props) => {
   } = props
   const showButton = isDemoRoute() && !hasToken()
   const showDiscussionButton = toggleDrawer && !isRightDrawerOpen
-  const [showDrawer, setShowDrawer] = useState(false)
   const isOptionsVisible = !!meetingId && !isDemoRoute()
 
   return (
@@ -183,13 +182,7 @@ const MeetingTopBar = (props: Props) => {
           </PrimaryActionBlock>
         )}
         {avatarGroup}
-        {isOptionsVisible && (
-          <RetroDrawerRoot
-            meetingId={meetingId}
-            setShowDrawer={setShowDrawer}
-            showDrawer={showDrawer}
-          />
-        )}
+        {isOptionsVisible && <RetroDrawerRoot meetingId={meetingId} />}
         {showDiscussionButton && toggleDrawer && (
           <ButtonContainer>
             <Badge>

--- a/packages/client/components/RetroDrawer.tsx
+++ b/packages/client/components/RetroDrawer.tsx
@@ -20,13 +20,19 @@ const RetroDrawer = (props: Props) => {
 
   const {viewer} = usePreloadedQuery<RetroDrawerQuery>(
     graphql`
-      query RetroDrawerQuery($first: Int!, $type: MeetingTypeEnum!, $meetingId: ID!) {
+      query RetroDrawerQuery(
+        $first: Int!
+        $type: MeetingTypeEnum!
+        $meetingId: ID!
+        $isMenuOpen: Boolean!
+      ) {
         viewer {
           meeting(meetingId: $meetingId) {
             id
           }
           availableTemplates(first: $first, type: $type)
-            @connection(key: "RetroDrawer_availableTemplates") {
+            @connection(key: "RetroDrawer_availableTemplates")
+            @include(if: $isMenuOpen) {
             edges {
               node {
                 ...RetroDrawerTemplateCard_template
@@ -40,7 +46,7 @@ const RetroDrawer = (props: Props) => {
     queryRef
   )
 
-  const templates = viewer.availableTemplates.edges
+  const templates = viewer.availableTemplates?.edges
   const meeting = viewer.meeting
   const isMobile = !useBreakpoint(Breakpoint.FUZZY_TABLET)
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
@@ -77,7 +83,7 @@ const RetroDrawer = (props: Props) => {
                 <Close />
               </div>
             </div>
-            {templates.map((template) => (
+            {templates?.map((template) => (
               <RetroDrawerTemplateCard
                 key={template.node.id}
                 meetingId={meeting!.id}

--- a/packages/client/components/RetroDrawer.tsx
+++ b/packages/client/components/RetroDrawer.tsx
@@ -40,7 +40,7 @@ const RetroDrawer = (props: Props) => {
     queryRef
   )
 
-  const templates = viewer?.availableTemplates?.edges ?? []
+  const templates = viewer.availableTemplates.edges
   const meeting = viewer.meeting
   const isMobile = !useBreakpoint(Breakpoint.FUZZY_TABLET)
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)

--- a/packages/client/components/RetroDrawerRoot.tsx
+++ b/packages/client/components/RetroDrawerRoot.tsx
@@ -1,27 +1,41 @@
-import React, {Suspense} from 'react'
+import React, {Suspense, useState} from 'react'
 import retroDrawerQuery, {RetroDrawerQuery} from '../__generated__/RetroDrawerQuery.graphql'
 import useQueryLoaderNow from '../hooks/useQueryLoaderNow'
+import MeetingOptions from './MeetingOptions'
 import RetroDrawer from './RetroDrawer'
 
 type Props = {
-  showDrawer: boolean
-  setShowDrawer: (showDrawer: boolean) => void
   meetingId: string
 }
 
 const RetroDrawerRoot = (props: Props) => {
-  const {showDrawer, setShowDrawer, meetingId} = props
+  const {meetingId} = props
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [showDrawer, setShowDrawer] = useState(false)
+
+  const handleOpenMenu = () => {
+    setIsMenuOpen(true)
+  }
+
   const queryRef = useQueryLoaderNow<RetroDrawerQuery>(retroDrawerQuery, {
     first: 2000,
     type: 'retrospective',
     meetingId
   })
   return (
-    <Suspense fallback={''}>
-      {queryRef && (
-        <RetroDrawer showDrawer={showDrawer} setShowDrawer={setShowDrawer} queryRef={queryRef} />
-      )}
-    </Suspense>
+    <>
+      <MeetingOptions
+        showDrawer={showDrawer}
+        setShowDrawer={setShowDrawer}
+        handleOpenMenu={handleOpenMenu}
+        meetingId={meetingId}
+      />
+      <Suspense fallback={''}>
+        {queryRef && isMenuOpen && (
+          <RetroDrawer queryRef={queryRef} showDrawer={showDrawer} setShowDrawer={setShowDrawer} />
+        )}
+      </Suspense>
+    </>
   )
 }
 

--- a/packages/client/components/RetroDrawerRoot.tsx
+++ b/packages/client/components/RetroDrawerRoot.tsx
@@ -20,7 +20,8 @@ const RetroDrawerRoot = (props: Props) => {
   const queryRef = useQueryLoaderNow<RetroDrawerQuery>(retroDrawerQuery, {
     first: 2000,
     type: 'retrospective',
-    meetingId
+    meetingId,
+    isMenuOpen
   })
   return (
     <>
@@ -31,7 +32,7 @@ const RetroDrawerRoot = (props: Props) => {
         meetingId={meetingId}
       />
       <Suspense fallback={''}>
-        {queryRef && isMenuOpen && (
+        {queryRef && (
           <RetroDrawer queryRef={queryRef} showDrawer={showDrawer} setShowDrawer={setShowDrawer} />
         )}
       </Suspense>

--- a/packages/client/ui/Menu/Menu.tsx
+++ b/packages/client/ui/Menu/Menu.tsx
@@ -2,16 +2,15 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import React from 'react'
 import {twMerge} from 'tailwind-merge'
 
-interface MenuProps {
-  trigger: React.ReactNode
+interface MenuProps extends DropdownMenu.DropdownMenuProps {
   className?: string
-  children: React.ReactNode
+  trigger: React.ReactNode
 }
 
 export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
-  ({trigger, className, children}, ref) => {
+  ({trigger, className, children, ...props}, ref) => {
     return (
-      <DropdownMenu.Root>
+      <DropdownMenu.Root {...props}>
         <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
         <DropdownMenu.Portal>
           <DropdownMenu.Content


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9620

### To test

- [ ] Load a retro meeting and see that the templates are not queried by default
- [ ] Click on the options menu in the Reflect stage and see that the templates are now queried 