### PR TITLE
fix: Threaded reply input does not immediately close

### DIFF
--- a/packages/client/components/ThreadedReplyButton.tsx
+++ b/packages/client/components/ThreadedReplyButton.tsx
@@ -18,8 +18,14 @@ interface Props {
 
 const ThreadedReplyButton = (props: Props) => {
   const {onReply, dataCy} = props
+
+  const onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // stop propagating so the new reply is not immediately cancelled
+    e.stopPropagation()
+    onReply()
+  }
   return (
-    <Reply data-cy={`${dataCy}-reply-button`} onClick={onReply}>
+    <Reply data-cy={`${dataCy}-reply-button`} onClick={onClick}>
       Reply
     </Reply>
   )


### PR DESCRIPTION
# Description

Fixes #9650 

When replying a local update is commited to the store. This happened in the mouse event handler and is propagated to other components before the event handling of the click finished. This caused the `useClickAway` handler to fire for the same click event and revert the store update immediately. There are two ways to fix this, stop propagating the event or do 

## Demo

https://github.com/ParabolInc/parabol/assets/7331043/87aa505e-7b1e-4ee9-85de-60de27c657d6

## Testing scenarios

- start a discussion thread and play around with the reply button

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
