### PR TITLE
feat(orgAdmin): org admin can promote others to org admin

### DIFF
--- a/packages/server/graphql/public/mutations/setOrgUserRole.ts
+++ b/packages/server/graphql/public/mutations/setOrgUserRole.ts
@@ -67,7 +67,7 @@ const setOrgUserRole: MutationResolvers['setOrgUserRole'] = async (
     roleToSet === 'ORG_ADMIN' || // promoting someone to ORG_ADMIN
     organizationUser.role === 'ORG_ADMIN' // the user is already an ORG_ADMIN so the mutation is intended to change their role
   ) {
-    if (!isSuperUser(authToken) && (!viewerOrgUser || viewerOrgUser.role !== 'ORG_ADMIN')) {
+    if (!isSuperUser(authToken) && viewerOrgUser?.role !== 'ORG_ADMIN') {
       return standardError(new Error('Only super user or org admin can perform this action'), {
         userId: viewerId
       })


### PR DESCRIPTION
# Description

Fixes #9642 

## Demo

![2024-04-17 11 24 17](https://github.com/ParabolInc/parabol/assets/1879975/13981f86-68df-4d61-bbd9-c301c3f39e40)


## Testing scenarios

- [ ] Org admin can promote/demote others to org admin
  - As a super user, run the GraphQL mutation ` setOrgUserRole(orgId: "xxx", userId: "yyy", role: ORG_ADMIN)` to promote user A to org admin
  - Login as user A
  - Verify user A can then promote user B to org admin through the UI
  - Verify user A can demote user B from org admin role through the UI

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
