### PR TITLE
feat: roll out ai icebreakers

### DIFF
--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
@@ -228,7 +228,6 @@ const NewCheckInQuestion = (props: Props) => {
     })
   }
   const hideAiIcebreaker = featureFlags?.noAISummary && !isFacilitating
-  console.log('🚀 ~ hideAiIcebreaker:', hideAiIcebreaker)
 
   return (
     <>
@@ -299,7 +298,7 @@ const NewCheckInQuestion = (props: Props) => {
               disabled={isModifyingCheckInQuestion}
               onClick={() => modifyCheckInQuestion('FUNNY')}
             >
-              More funny
+              Funnier
             </Button>
             <Button
               variant='outline'

--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
@@ -227,7 +227,7 @@ const NewCheckInQuestion = (props: Props) => {
       }
     })
   }
-  const hideAiIcebreaker = featureFlags?.noAISummary && !isFacilitating
+  const hideAiIcebreaker = featureFlags.noAISummary || !isFacilitating
 
   return (
     <>

--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
@@ -87,7 +87,7 @@ const NewCheckInQuestion = (props: Props) => {
         team {
           organization {
             featureFlags {
-              aiIcebreakers
+              noAISummary
             }
           }
         }
@@ -227,7 +227,8 @@ const NewCheckInQuestion = (props: Props) => {
       }
     })
   }
-  const shouldShowAiIcebreakers = featureFlags?.aiIcebreakers && isFacilitating
+  const hideAiIcebreaker = featureFlags?.noAISummary && !isFacilitating
+  console.log('🚀 ~ hideAiIcebreaker:', hideAiIcebreaker)
 
   return (
     <>
@@ -269,8 +270,8 @@ const NewCheckInQuestion = (props: Props) => {
           </div>
         )}
       </QuestionBlock>
-      {shouldShowAiIcebreakers && (
-        <div className='flex flex-col gap-4 rounded-lg bg-slate-100 p-3'>
+      {!hideAiIcebreaker && (
+        <div className='flex flex-col gap-4 rounded-lg bg-slate-100 p-6'>
           <div className='flex flex-col items-center justify-center gap-2'>
             <div className='inline-flex gap-2'>
               <div className='font-semibold'>Modify current icebreaker with AI</div>

--- a/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
+++ b/packages/server/graphql/private/typeDefs/updateOrgFeatureFlag.graphql
@@ -13,7 +13,6 @@ enum OrganizationFeatureFlagsEnum {
   singleColumnStandups
   publicTeams
   kudos
-  aiIcebreakers
   aiTemplate
   relatedDiscussions
 }

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -188,7 +188,6 @@ type OrganizationFeatureFlags {
   singleColumnStandups: Boolean!
   publicTeams: Boolean!
   kudos: Boolean!
-  aiIcebreakers: Boolean!
   aiTemplate: Boolean!
   relatedDiscussions: Boolean!
 }

--- a/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
+++ b/packages/server/graphql/public/types/OrganizationFeatureFlags.ts
@@ -12,7 +12,6 @@ const OrganizationFeatureFlags: OrganizationFeatureFlagsResolvers = {
   publicTeams: ({publicTeams}) => !!publicTeams,
   singleColumnStandups: ({singleColumnStandups}) => !!singleColumnStandups,
   kudos: ({kudos}) => !!kudos,
-  aiIcebreakers: ({aiIcebreakers}) => !!aiIcebreakers,
   aiTemplate: ({aiTemplate}) => !!aiTemplate,
   relatedDiscussions: ({relatedDiscussions}) => !!relatedDiscussions
 }


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9541

I find the AI suggestions OK, but I'd probably prefer a feature where the AI creates a brand-new icebreaker question based on a prompt. It _could_ suggest something that's not safe for work, but the facilitator would still need to approve it, so I think that's a tolerable risk. Just an idea for a future enhancement, anyway.


![Screenshot 2024-04-19 at 19 03 53](https://github.com/ParabolInc/parabol/assets/39854876/353d280b-03f9-4fa6-b73c-3df45d9a2efe)


### To test

- [ ] All users that are the facilitator and don't have the `noAISummary` flag now see the AI Icebreaker in the Icebreaker phase
- [ ] There are quick action buttons that let the user change the icebreaker
- [ ] The suggested icebreaker questions are safe for work