### PR TITLE
fix: support PG reconnects

### DIFF
--- a/packages/server/postgres/getKysely.ts
+++ b/packages/server/postgres/getKysely.ts
@@ -3,21 +3,26 @@ import getPg from './getPg'
 import {DB} from './pg.d'
 
 let kysely: Kysely<DB> | undefined
+
+const makeKysely = () => {
+  const nextPg = getPg()
+  nextPg.on('poolChange' as any, makeKysely)
+  return new Kysely<DB>({
+    dialect: new PostgresDialect({
+      pool: nextPg
+    })
+    // ,log(event) {
+    //   if (event.level === 'query') {
+    //     console.log(event.query.sql)
+    //     console.log(event.query.parameters)
+    //   }
+    // }
+  })
+}
+
 const getKysely = () => {
   if (!kysely) {
-    const pg = getPg()
-    kysely = new Kysely<DB>({
-      dialect: new PostgresDialect({
-        pool: pg
-      })
-      // query logging, if you'd like it:
-      // log(event) {
-      //   if (event.level === 'query') {
-      //     console.log(event.query.sql)
-      //     console.log(event.query.parameters)
-      //   }
-      // }
-    })
+    kysely = makeKysely()
   }
   return kysely
 }

--- a/packages/server/postgres/getPg.ts
+++ b/packages/server/postgres/getPg.ts
@@ -1,12 +1,31 @@
 import {Pool} from 'pg'
+import sleep from '../../client/utils/sleep'
 import getPgConfig from './getPgConfig'
 
 const config = getPgConfig()
+
+const graceFullyReconnect = async () => {
+  for (let i = 0; i < 1e6; i++) {
+    const nextPool = new Pool(getPgConfig())
+    try {
+      const testClient = await nextPool.connect()
+      testClient.release()
+      nextPool.on('error', graceFullyReconnect)
+      const oldPool = pool
+      pool = nextPool
+      oldPool?.emit('changePool')
+      return
+    } catch (e) {
+      await sleep(1000)
+    }
+  }
+}
 
 let pool: Pool | undefined
 const getPg = () => {
   if (!pool) {
     pool = new Pool(config)
+    pool.on('error', graceFullyReconnect)
   }
   return pool
 }


### PR DESCRIPTION
# Description

fixes #9643 

When the DB disconnects, it's nice to reconnect it.
This is a ridiculously hard problem as it turns out:
https://github.com/brianc/node-postgres/issues/1324
https://github.com/brianc/node-postgres/issues/2112

Depending on when & how the disconnect happens, the client may not be aware of it. 

For example:
- If PG sends `terminating connection due to administrator command` then the PG client reports the error `Connection terminated unexpectedly` and the app gets killed. I think it gets killed because it's a `ProcessInterrupts` routine coming from `postgres.c` and the severity is `FATAL`. 
- If PG sends `the database system is shutting down` then it reconnects just as expected. This is what we've seen coming from Google CloudSQL.
-  The driver also does not throw an error if a first connection hasn't happened, this is because the error event comes from a single connection, so if no connection is made, it can't emit that event, we just get `econnrefused`. I'm ignoring this case in this PR.

## Demo

start up the embedder & then kill the PG container in docker. sometimes you get case 1, sometimes case 2.
