### PR TITLE
fix: Increase process recurrence timeout

### DIFF
--- a/packages/chronos/chronos.ts
+++ b/packages/chronos/chronos.ts
@@ -102,16 +102,16 @@ const chronos = () => {
     processRecurrence: {
       onTick: () => {
         const query = `
-        mutation ProcessRecurrence{
-          processRecurrence{
-            ... on ProcessRecurrenceSuccess {
-              meetingsStarted
-              meetingsEnded
+          mutation ProcessRecurrence {
+            processRecurrence{
+              ... on ProcessRecurrenceSuccess {
+                meetingsStarted
+                meetingsEnded
+              }
             }
           }
-        }
-      `
-        publishWebhookGQL(query, {})
+        `
+        publishWebhookGQL(query, {}, {longRunning: true})
       },
       cronTime: CHRONOS_PROCESS_RECURRENCE
     }

--- a/packages/server/utils/PubSubPromise.ts
+++ b/packages/server/utils/PubSubPromise.ts
@@ -5,6 +5,7 @@ import numToBase64 from './numToBase64'
 import sendToSentry from './sendToSentry'
 
 const STANDARD_TIMEOUT = ms('10s')
+const LONG_TIMEOUT = ms('60s')
 const ADHOC_TIMEOUT = ms('10m')
 
 interface Job {
@@ -17,6 +18,7 @@ const {SERVER_ID} = process.env
 interface BaseRequest {
   executorServerId?: string
   isAdHoc?: boolean
+  longRunning?: boolean
 }
 
 export default class PubSubPromise<Request extends BaseRequest, Response> {
@@ -51,8 +53,8 @@ export default class PubSubPromise<Request extends BaseRequest, Response> {
     return new Promise<Response>((resolve, reject) => {
       const nextJob = numToBase64(this.jobCounter++)
       const jobId = `${SERVER_ID}:${nextJob}`
-      const {isAdHoc} = request
-      const timeout = isAdHoc ? ADHOC_TIMEOUT : STANDARD_TIMEOUT
+      const {isAdHoc, longRunning} = request
+      const timeout = isAdHoc ? ADHOC_TIMEOUT : longRunning ? LONG_TIMEOUT : STANDARD_TIMEOUT
       const timeoutId = setTimeout(() => {
         delete this.jobs[jobId]
         reject(new Error('TIMEOUT'))

--- a/packages/server/utils/publishWebhookGQL.ts
+++ b/packages/server/utils/publishWebhookGQL.ts
@@ -3,13 +3,18 @@ import ServerAuthToken from '../database/types/ServerAuthToken'
 import getGraphQLExecutor from './getGraphQLExecutor'
 import sendToSentry from './sendToSentry'
 
-const publishWebhookGQL = async (query: string, variables: Variables) => {
+interface PublishOptions {
+  longRunning?: boolean
+}
+
+const publishWebhookGQL = async (query: string, variables: Variables, options?: PublishOptions) => {
   try {
     return await getGraphQLExecutor().publish({
       authToken: new ServerAuthToken(),
       query,
       variables,
-      isPrivate: true
+      isPrivate: true,
+      ...options
     })
   } catch (e) {
     const error = e instanceof Error ? e : new Error('GQL executor failed to publish')


### PR DESCRIPTION
Fixes #9664

We know this might be long running, so adding a separate long running timeout. We're not reusing the adhoc timeout as this is excessive and might obfuscate issues in the query.

## Testing scenarios

- add debug output to https://github.com/ParabolInc/parabol/blob/4f49f950325e1092ac138b5d8cf401781a6dbda0/packages/server/utils/PubSubPromise.ts#L57
- add `CHRONOS_PROCESS_RECURRENCE='* * * * *'` to your `.env`
- run `yarn build && yarn start`
- check the output

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
