### PR TITLE
fix: remove premium badges from activity library cards

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityGrid.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityGrid.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {Link} from 'react-router-dom'
-import {ActivityBadge} from './ActivityBadge'
 import {ActivityCard, ActivityCardImage} from './ActivityCard'
 import {Template} from './ActivityLibrary'
 import {ActivityLibraryCardDescription} from './ActivityLibraryCardDescription'
@@ -31,11 +30,6 @@ const ActivityGrid = ({templates, selectedCategory}: ActivityGridProps) => {
               title={template.name}
               type={template.type}
               templateRef={template}
-              badge={
-                !template.isFree ? (
-                  <ActivityBadge className='m-2 bg-gold-300 text-grape-700'>Premium</ActivityBadge>
-                ) : null
-              }
             >
               <ActivityCardImage
                 className='group-hover/card:hidden'

--- a/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
+++ b/packages/client/components/ActivityLibrary/CreateActivityCard.tsx
@@ -2,7 +2,7 @@ import {Add as AddIcon} from '@mui/icons-material'
 import clsx from 'clsx'
 import React from 'react'
 import {Link} from 'react-router-dom'
-import {ActivityBadge} from './ActivityBadge'
+
 import {ActivityCard} from './ActivityCard'
 import {AllCategoryID, CATEGORY_ID_TO_NAME, CATEGORY_THEMES} from './Categories'
 
@@ -22,7 +22,6 @@ const CreateActivityCard = (props: Props) => {
       <ActivityCard
         className={'flex-1 cursor-pointer'}
         theme={CATEGORY_THEMES[category]}
-        badge={<ActivityBadge className='m-2 bg-gold-300 text-grape-700'>Premium</ActivityBadge>}
       >
         <div className='flex h-full w-full flex-col items-center justify-center pb-2 font-semibold'>
           <div className='h-12 w-12'>

--- a/packages/client/components/RetroDrawerTemplateCard.tsx
+++ b/packages/client/components/RetroDrawerTemplateCard.tsx
@@ -6,7 +6,6 @@ import useAtmosphere from '../hooks/useAtmosphere'
 import useMutationProps from '../hooks/useMutationProps'
 import UpdateMeetingTemplateMutation from '../mutations/UpdateMeetingTemplateMutation'
 import {CATEGORY_THEMES, CategoryID} from '././ActivityLibrary/Categories'
-import {ActivityBadge} from './ActivityLibrary/ActivityBadge'
 import {ActivityCard, ActivityCardImage} from './ActivityLibrary/ActivityCard'
 import {ActivityLibraryCardDescription} from './ActivityLibrary/ActivityLibraryCardDescription'
 
@@ -54,11 +53,6 @@ const RetroDrawerTemplateCard = (props: Props) => {
           theme={CATEGORY_THEMES[template.category as CategoryID]}
           title={template.name}
           type='retrospective'
-          badge={
-            !template.isFree ? (
-              <ActivityBadge className='m-2 bg-gold-300 text-grape-700'>Premium</ActivityBadge>
-            ) : null
-          }
         >
           <ActivityCardImage
             className='group-hover/card:hidden'


### PR DESCRIPTION
# Description

Long time no see! This PR removes `Premium` badges from Activity Library as they're misleading

## Demo

No demo

## Testing scenarios

- [ ] Check the empty state in activity library
- [ ] Check if the newly created template doesn't have the `Premium badge`
- [ ] Check if `Premoim

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
