### PR TITLE
fix: Optimize processRecurrence

### DIFF
--- a/packages/server/dataloader/customLoaderMakers.ts
+++ b/packages/server/dataloader/customLoaderMakers.ts
@@ -33,6 +33,7 @@ import getRedis from '../utils/getRedis'
 import isUserVerified from '../utils/isUserVerified'
 import NullableDataLoader from './NullableDataLoader'
 import RootDataLoader from './RootDataLoader'
+import normalizeArrayResults from './normalizeArrayResults'
 import normalizeResults from './normalizeResults'
 
 export interface MeetingSettingsKey {
@@ -611,17 +612,13 @@ export const activeMeetingsByMeetingSeriesId = (parent: RootDataLoader) => {
   return new DataLoader<number, AnyMeeting[], string>(
     async (keys) => {
       const r = await getRethink()
-      const res = await Promise.all(
-        keys.map((key) => {
-          return r
-            .table('NewMeeting')
-            .getAll(key, {index: 'meetingSeriesId'})
-            .filter({endedAt: null}, {default: true})
-            .orderBy(r.asc('createdAt'))
-            .run()
-        })
-      )
-      return res
+      const res = await r
+        .table('NewMeeting')
+        .getAll(r.args(keys), {index: 'meetingSeriesId'})
+        .filter({endedAt: null}, {default: true})
+        .orderBy(r.asc('createdAt'))
+        .run()
+      return normalizeArrayResults(keys, res, 'meetingSeriesId')
     },
     {
       ...parent.dataLoaderOptions
@@ -633,18 +630,18 @@ export const lastMeetingByMeetingSeriesId = (parent: RootDataLoader) => {
   return new DataLoader<number, AnyMeeting | null, string>(
     async (keys) => {
       const r = await getRethink()
-      const res = await Promise.all(
-        keys.map((key) => {
-          return r
-            .table('NewMeeting')
-            .getAll(key, {index: 'meetingSeriesId'})
-            .orderBy(r.desc('createdAt'))
-            .nth(0)
-            .default(null)
-            .run()
-        })
+      const res = await (
+        r
+          .table('NewMeeting')
+          .getAll(r.args(keys), {index: 'meetingSeriesId'})
+          .group('meetingSeriesId') as RDatum
       )
-      return res
+        .orderBy(r.desc('createdAt'))
+        .nth(0)
+        .default(null)
+        .ungroup()('reduction')
+        .run()
+      return normalizeResults(keys, res as AnyMeeting[], 'meetingSeriesId')
     },
     {
       ...parent.dataLoaderOptions

--- a/packages/server/dataloader/normalizeArrayResults.ts
+++ b/packages/server/dataloader/normalizeArrayResults.ts
@@ -1,0 +1,23 @@
+/**
+ * Normalize results with a one to many mapping for the keys, so the key is usually a foreign key
+ */
+export const normalizeArrayResults = <KeyT extends string | number, T extends {[key: string]: any}>(
+  keys: Readonly<KeyT[]>,
+  results: T[],
+  key: keyof T
+) => {
+  const map = {} as Record<KeyT, T[]>
+  results.forEach((result: T) => {
+    if (!map[result[key]]) {
+      map[result[key]] = [] as T[]
+    }
+    map[result[key]].push(result)
+  })
+  const mappedResults = [] as T[][]
+  keys.forEach((key) => {
+    mappedResults.push(map[key])
+  })
+  return mappedResults
+}
+
+export default normalizeArrayResults

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -127,7 +127,6 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
     .table('NewMeeting')
     .between([false, r.minval], [false, now], {index: 'hasEndedScheduledEndTime'})
     .run()
-  // 500ms
 
   const res = await Promise.all(
     meetingsToEnd.map((meeting) => {
@@ -149,7 +148,6 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
 
   // For each active meeting series, get the meeting start times (according to rrule) after the most
   // recent meeting start time and before now.
-  // 500ms
   const activeMeetingSeries = await getActiveMeetingSeries()
   await Promise.allSettled(
     activeMeetingSeries.map(async (meetingSeries) => {


### PR DESCRIPTION
Fixes #9664 

MeetingSeries related dataloaders were loading data one by one instead of batching resulting in more roundtrips.

## Testing scenarios

- create many meeting series for example by running
  ```
  for i in {1..100}; do yarn workspace parabol-server test process; done
  ```
  (Note that these fail in signup for lack of randomness in faker after many iterations.)
- Run `processRecurrence` and don't see any errors

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
