### PR TITLE
chore(docker): fonts are managed with the rest of app related stuff

### DIFF
--- a/docker/images/parabol-ubi/dockerfiles/basic.dockerfile
+++ b/docker/images/parabol-ubi/dockerfiles/basic.dockerfile
@@ -10,15 +10,16 @@ ENV HOME=/home/node \
     NPM_CONFIG_PREFIX=/home/node/.npm-global \
     PORT=3000
 
-# Create a directory to store fonts
-RUN mkdir -p /usr/share/fonts
-COPY --chown=node static/fonts /usr/share/fonts
 COPY --chown=node --chmod=755 docker/images/parabol-ubi/entrypoints/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chown=node docker/images/parabol-ubi/tools/ip-to-server_id ${HOME}/tools/ip-to-server_id
 
 # Required for pushToCDN to work with FILE_STORE_PROVIDER set to 'local'
 RUN mkdir -p ${HOME}/parabol/self-hosted && \
     chown node:node ${HOME}/parabol/self-hosted
+
+# Create a directory to store fonts
+RUN mkdir -p /usr/share/fonts
+COPY --chown=node static/fonts /usr/share/fonts
 
 COPY --chown=node .env.example ${HOME}/parabol/.env.example
 


### PR DESCRIPTION
# Description

Moves the folder creation and copy of fonts where the rest of the application related stuff are. That improves the docker pull commands when fonts change, as things that are above it are very unlikely to change.