### PR TITLE
chore: Gracefully shutdown the embedder

### DIFF
--- a/packages/embedder/EmbeddingsJobQueueStream.ts
+++ b/packages/embedder/EmbeddingsJobQueueStream.ts
@@ -13,10 +13,16 @@ export class EmbeddingsJobQueueStream implements AsyncIterableIterator<DBJob> {
   }
 
   orchestrator: WorkflowOrchestrator
+  done: boolean
+
   constructor(orchestrator: WorkflowOrchestrator) {
     this.orchestrator = orchestrator
+    this.done = false
   }
   async next(): Promise<IteratorResult<DBJob>> {
+    if (this.done) {
+      return {done: true as const, value: undefined}
+    }
     const pg = getKysely()
     const getJob = (isFailed: boolean) => {
       return pg
@@ -57,9 +63,11 @@ export class EmbeddingsJobQueueStream implements AsyncIterableIterator<DBJob> {
     }
   }
   return() {
+    this.done = true
     return Promise.resolve({done: true as const, value: undefined})
   }
   throw(error: any) {
+    this.done = true
     return Promise.resolve({done: true as const, value: error})
   }
 }

--- a/packages/embedder/embedder.ts
+++ b/packages/embedder/embedder.ts
@@ -48,7 +48,9 @@ const run = async () => {
   const streams = mergeAsyncIterators(jobQueueStreams)
 
   const kill: NodeJS.SignalsListener = (signal) => {
-    Logger.log(`Server ID: ${SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown.`)
+    Logger.log(
+      `Server ID: ${SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown.`
+    )
     primaryLock?.release().catch(() => {})
     // close streams manually, streams.return only works if any of the stream retruns a datum, if these are idle, it will wait forever
     jobQueueStreams.forEach((s) => s.return())
@@ -72,4 +74,3 @@ const run = async () => {
 }
 
 run()
-

--- a/packages/embedder/embedder.ts
+++ b/packages/embedder/embedder.ts
@@ -52,8 +52,6 @@ const run = async () => {
       `Server ID: ${SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown.`
     )
     primaryLock?.release().catch(() => {})
-    // close streams manually, streams.return only works if any of the stream retruns a datum, if these are idle, it will wait forever
-    jobQueueStreams.forEach((s) => s.return())
     streams.return?.()
   }
   process.on('SIGTERM', kill)

--- a/packages/embedder/lint-staged.config.js
+++ b/packages/embedder/lint-staged.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  '*.{ts,tsx}': ['eslint --fix', 'prettier --config ../../.prettierrc --ignore-path ./.eslintignore --write'],
+  '*.graphql': ['prettier --config ../../.prettierrc --ignore-path ./.eslintignore --write'],
+  '**/*.{ts,tsx}': () => 'tsc --noEmit -p tsconfig.json'
+}

--- a/packages/embedder/logMemoryUse.ts
+++ b/packages/embedder/logMemoryUse.ts
@@ -6,5 +6,5 @@ export const logMemoryUse = () => {
     const {rss} = memoryUsage
     const usedMB = Math.floor(rss / MB)
     console.log('Memory use:', usedMB, 'MB')
-  }, 10000)
+  }, 10000).unref()
 }

--- a/packages/embedder/logPerformance.ts
+++ b/packages/embedder/logPerformance.ts
@@ -14,6 +14,6 @@ export const logPerformance = (logEvery: number, resetEvery: number) => {
       logs = 0
       start = performance.now()
     }
-  }, logEvery * 1000)
+  }, logEvery * 1000).unref()
   return counter
 }

--- a/packages/embedder/mergeAsyncIterators.ts
+++ b/packages/embedder/mergeAsyncIterators.ts
@@ -89,8 +89,7 @@ export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
       // Unwind remaining iterators on failure
       await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
       throw err
-    }
-    finally {
+    } finally {
       // Unwind remaining iterators on success
       await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
     }

--- a/packages/embedder/mergeAsyncIterators.ts
+++ b/packages/embedder/mergeAsyncIterators.ts
@@ -12,9 +12,7 @@ type Result<T extends AsyncIterator<any>> = UnYield<Awaited<ReturnType<T['next']
 
 // Promise.race has a memory leak
 // To avoid: https://github.com/tc39/proposal-async-iterator-helpers/issues/15#issuecomment-1937011820
-export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
-  iterators: T
-) {
+export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(iterators: T) {
   type ResultThunk = () => [number, Result<T[number]>]
   let count = iterators.length as number
   let capability: PromiseCapability<ResultThunk | null> | undefined

--- a/packages/embedder/mergeAsyncIterators.ts
+++ b/packages/embedder/mergeAsyncIterators.ts
@@ -14,7 +14,7 @@ type Result<T extends AsyncIterator<any>> = UnYield<Awaited<ReturnType<T['next']
 // To avoid: https://github.com/tc39/proposal-async-iterator-helpers/issues/15#issuecomment-1937011820
 export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
   iterators: T
-): AsyncIterableIterator<{[P in keyof T]: [ParseInt<`${P}`>, Result<T[P]>]}[number]> {
+) {
   type ResultThunk = () => [number, Result<T[number]>]
   let count = iterators.length as number
   let capability: PromiseCapability<ResultThunk | null> | undefined
@@ -51,7 +51,7 @@ export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
     void getNext(idx, iterable)
   }
 
-  const it = {
+  const it: AsyncIterableIterator<{[P in keyof T]: [ParseInt<`${P}`>, Result<T[P]>]}[number]> = {
     [Symbol.asyncIterator]: () => it,
     next: async () => {
       const nextQueuedResult = queuedResults.shift()
@@ -84,7 +84,7 @@ export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
       await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
       return {done: true as const, value: undefined}
     },
-    throw: async (error) => {
+    throw: async () => {
       await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
       return {done: true as const, value: undefined}
     }

--- a/packages/embedder/mergeAsyncIterators.ts
+++ b/packages/embedder/mergeAsyncIterators.ts
@@ -15,83 +15,79 @@ type Result<T extends AsyncIterator<any>> = UnYield<Awaited<ReturnType<T['next']
 export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
   iterators: T
 ): AsyncIterableIterator<{[P in keyof T]: [ParseInt<`${P}`>, Result<T[P]>]}[number]> {
-  return (async function* () {
-    type ResultThunk = () => [number, Result<T[number]>]
-    let count = iterators.length as number
-    let capability: PromiseCapability<ResultThunk | null> | undefined
-    const queuedResults: ResultThunk[] = []
-    const getNext = async (idx: number, iterator: T[number]) => {
-      try {
-        const next = await iterator.next()
-        if (next.done) {
-          if (--count === 0 && capability !== undefined) {
-            capability.resolve(null)
-          }
-        } else {
-          resolveResult(() => {
-            void getNext(idx, iterator)
-            return [idx, next.value]
-          })
+  type ResultThunk = () => [number, Result<T[number]>]
+  let count = iterators.length as number
+  let capability: PromiseCapability<ResultThunk | null> | undefined
+  const queuedResults: ResultThunk[] = []
+  const getNext = async (idx: number, iterator: T[number]) => {
+    try {
+      const next = await iterator.next()
+      if (next.done) {
+        if (--count === 0 && capability !== undefined) {
+          capability.resolve(null)
         }
-      } catch (error) {
+      } else {
         resolveResult(() => {
-          throw error
+          void getNext(idx, iterator)
+          return [idx, next.value]
         })
       }
+    } catch (error) {
+      resolveResult(() => {
+        throw error
+      })
     }
-    const resolveResult = (resultThunk: ResultThunk) => {
-      if (capability === undefined) {
-        queuedResults.push(resultThunk)
+  }
+  const resolveResult = (resultThunk: ResultThunk) => {
+    if (capability === undefined) {
+      queuedResults.push(resultThunk)
+    } else {
+      capability.resolve(resultThunk)
+    }
+  }
+
+  // Begin all iterators
+  for (const [idx, iterable] of iterators.entries()) {
+    void getNext(idx, iterable)
+  }
+
+  const it = {
+    [Symbol.asyncIterator]: () => it,
+    next: async () => {
+      const nextQueuedResult = queuedResults.shift()
+      if (nextQueuedResult !== undefined) {
+        return {done: false as const, value: nextQueuedResult()}
+      }
+      if (count === 0) {
+        return {done: true as const, value: undefined}
+      }
+
+      // Promise.withResolvers() is not yet implemented in node
+      capability = {
+        resolve: undefined as any,
+        reject: undefined as any,
+        promise: undefined as any
+      }
+      capability.promise = new Promise((res, rej) => {
+        capability!.resolve = res
+        capability!.reject = rej
+      })
+      const nextResult = await capability.promise
+      if (nextResult === null) {
+        return {done: true as const, value: undefined}
       } else {
-        capability.resolve(resultThunk)
+        capability = undefined
+        return {done: false as const, value: nextResult()}
       }
-    }
-
-    try {
-      // Begin all iterators
-      for (const [idx, iterable] of iterators.entries()) {
-        void getNext(idx, iterable)
-      }
-
-      // Delegate to iterables as results complete
-      while (true) {
-        while (true) {
-          const nextQueuedResult = queuedResults.shift()
-          if (nextQueuedResult === undefined) {
-            break
-          } else {
-            yield nextQueuedResult()
-          }
-        }
-        if (count === 0) {
-          break
-        } else {
-          // Promise.withResolvers() is not yet implemented in node
-          capability = {
-            resolve: undefined as any,
-            reject: undefined as any,
-            promise: undefined as any
-          }
-          capability.promise = new Promise((res, rej) => {
-            capability!.resolve = res
-            capability!.reject = rej
-          })
-          const nextResult = await capability.promise
-          if (nextResult === null) {
-            break
-          } else {
-            capability = undefined
-            yield nextResult()
-          }
-        }
-      }
-    } catch (err) {
-      // Unwind remaining iterators on failure
+    },
+    return: async () => {
       await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
-      throw err
-    } finally {
-      // Unwind remaining iterators on success
+      return {done: true as const, value: undefined}
+    },
+    throw: async (error) => {
       await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
+      return {done: true as const, value: undefined}
     }
-  })()
+  }
+  return it
 }

--- a/packages/embedder/mergeAsyncIterators.ts
+++ b/packages/embedder/mergeAsyncIterators.ts
@@ -87,10 +87,12 @@ export function mergeAsyncIterators<T extends AsyncIterator<any>[] | []>(
       }
     } catch (err) {
       // Unwind remaining iterators on failure
-      try {
-        await Promise.all(iterators.map((iterator) => iterator.return?.()))
-      } catch {}
+      await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
       throw err
+    }
+    finally {
+      // Unwind remaining iterators on success
+      await Promise.allSettled(iterators.map((iterator) => iterator.return?.()))
     }
   })()
 }

--- a/packages/embedder/package.json
+++ b/packages/embedder/package.json
@@ -10,6 +10,7 @@
     "url": "git+https://github.com/ParabolInc/parabol.git"
   },
   "scripts": {
+    "precommit": "lint-staged",
     "lint": "eslint --fix . --ext .ts,.tsx",
     "lint:check": "eslint . --ext .ts,.tsx",
     "prettier": "prettier --config ../../.prettierrc --write \"**/*.{ts,tsx}\"",

--- a/packages/embedder/resetStalledJobs.ts
+++ b/packages/embedder/resetStalledJobs.ts
@@ -14,5 +14,5 @@ export const resetStalledJobs = () => {
       }))
       .where('startAt', '<', new Date(Date.now() - ms('5m')))
       .execute()
-  }, ms('5m'))
+  }, ms('5m')).unref()
 }

--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -30,13 +30,15 @@ const run = async () => {
   const executorChannel = GQLExecutorChannelId.join(SERVER_ID!)
 
   // on shutdown, remove consumer from the group
-  process.on('SIGTERM', async () => {
+  process.on('SIGTERM', async (signal) => {
+    console.log(`Server ID: ${SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown.`)
     await publisher.xgroup(
       'DELCONSUMER',
       ServerChannel.GQL_EXECUTOR_STREAM,
       ServerChannel.GQL_EXECUTOR_CONSUMER_GROUP,
       executorChannel
     )
+    console.log(`Server ID: ${SERVER_ID}. Graceful shutdown complete, exiting.`)
     process.exit()
   })
 


### PR DESCRIPTION
# Description

Fixes #9693
End all streams on receiving a kill signal to properly shutdown the embedder. Ending just the merged stream does not work in the current situation as it will wait indefinitely if all the workers are idle.

## Demo

Nothing to see here.

## Testing scenarios
 
- run the embedder outside of pm2
  ```
  sh -c 'export SERVER_ID=7 && exec node dev/embedder.js'
  ```
- send `SIGINT` via Ctrl+C
- see the process ending gracefully

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
