### PR TITLE
fix: remove oneOnOne column in Team table

### DIFF
--- a/packages/server/postgres/migrations/1714579256634_removeOneOnOneTeam.ts
+++ b/packages/server/postgres/migrations/1714579256634_removeOneOnOneTeam.ts
@@ -1,0 +1,22 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    ALTER TABLE "Team"
+    DROP COLUMN IF EXISTS "isOneOnOneTeam";
+  `)
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+    ALTER TABLE "Team"
+    ADD COLUMN IF NOT EXISTS "isOneOnOneTeam" BOOLEAN NOT NULL DEFAULT FALSE;
+  `)
+  await client.end()
+}


### PR DESCRIPTION
# Description

`Team.isOneOnOne` is not used anywhere, so let's remove it from the schema