### PR TITLE
fix: presign MeetingTemplate.illustrationUrl

### DIFF
--- a/packages/server/graphql/public/types/MeetingTemplate.ts
+++ b/packages/server/graphql/public/types/MeetingTemplate.ts
@@ -12,6 +12,9 @@ const MeetingTemplate: MeetingTemplateResolvers = {
   team: async ({teamId}, _args, {dataLoader}) => {
     return dataLoader.get('teams').loadNonNull(teamId)
   },
+  illustrationUrl: async ({illustrationUrl}, _args, {dataLoader}) => {
+    return dataLoader.get('fileStoreAsset').load(illustrationUrl)
+  },
   viewerLowestScope: async ({teamId}, _args, {authToken, dataLoader}) => {
     if (teamId === 'aGhostTeam') return 'PUBLIC'
     const viewerId = getUserId(authToken)


### PR DESCRIPTION
# Description

forgot about illustrationUrls! they need to be presigned, too, since they are UGC kept in the /store.