### PR TITLE
chore: remove ai summary from discussion thread

### DIFF
--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -112,7 +112,7 @@ const handleCompletedRetrospectiveStage = async (
     }))
     await Promise.all([
       insertDiscussions(discussions),
-      addAIGeneratedContentToThreads(discussPhaseStages, meetingId, teamId, dataLoader),
+      addAIGeneratedContentToThreads(discussPhaseStages, meetingId, dataLoader),
       publishToEmbedder({jobType: 'relatedDiscussions:start', data: {meetingId}, priority: 0})
     ])
     if (videoMeetingURL) {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/8858

This PR doesn't remove the discussion summary from the meeting summary. This will be handled in a separate issue: https://github.com/ParabolInc/parabol/issues/9710

### To test

- [ ] Create a retro and have a group with two or more reflections
- [ ] See the AI discussion suggestion in the discussion thread, but not the AI Summary