### PR TITLE
chore: remove discussion prompt from summary

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopic.tsx
@@ -90,7 +90,6 @@ const RetroTopic = (props: Props) => {
           reflections {
             ...EmailReflectionCard_reflection
           }
-          discussionPromptQuestion
         }
         discussion {
           commentCount
@@ -121,7 +120,7 @@ const RetroTopic = (props: Props) => {
 
   const {reflectionGroup, discussion, id: stageId} = stage
   const {commentCount, discussionSummary} = discussion
-  const {reflections, title, voteCount, discussionPromptQuestion} = reflectionGroup!
+  const {reflections, title, voteCount} = reflectionGroup!
   const imageSource = isEmail ? 'static' : 'local'
   const icon = imageSource === 'local' ? 'thumb_up_18.svg' : 'thumb_up_18@3x.png'
   const src = `${ExternalLinks.EMAIL_CDN}${icon}`
@@ -143,29 +142,15 @@ const RetroTopic = (props: Props) => {
           </AnchorIfEmail>
         </td>
       </tr>
-      {(discussionPromptQuestion || discussionSummary) && (
+      {discussionSummary && (
         <tr>
           <td align='left' style={{lineHeight: '22px', fontSize: 14}}>
-            {discussionPromptQuestion && (
-              <>
-                <tr>
-                  <td style={topicTitleStyle}>{'🤖 Discussion Question'}</td>
-                </tr>
-                <tr>
-                  <td style={textStyle}>{discussionPromptQuestion}</td>
-                </tr>
-              </>
-            )}
-            {discussionSummary && (
-              <>
-                <tr>
-                  <td style={topicTitleStyle}>{'🤖 Discussion Summary'}</td>
-                </tr>
-                <tr>
-                  <td style={textStyle}>{discussionSummary}</td>
-                </tr>
-              </>
-            )}
+            <tr>
+              <td style={topicTitleStyle}>{'🤖 Discussion Summary'}</td>
+            </tr>
+            <tr>
+              <td style={textStyle}>{discussionSummary}</td>
+            </tr>
           </td>
         </tr>
       )}

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -26,16 +26,8 @@ const WholeMeetingSummary = (props: Props) => {
         }
         ... on RetrospectiveMeeting {
           reflectionGroups(sortBy: voteCount) {
-            summary
-          }
-          phases {
-            phaseType
-            ... on DiscussPhase {
-              stages {
-                discussion {
-                  summary
-                }
-              }
+            reflections {
+              id
             }
           }
         }
@@ -49,14 +41,12 @@ const WholeMeetingSummary = (props: Props) => {
     meetingRef
   )
   if (meeting.__typename === 'RetrospectiveMeeting') {
-    const {summary: wholeMeetingSummary, reflectionGroups, phases} = meeting
-    const discussPhase = phases!.find((phase) => phase.phaseType === 'discuss')
-    const {stages} = discussPhase ?? {}
-    const hasTopicSummary = reflectionGroups!.some((group) => group.summary)
-    const hasDiscussionSummary = !!stages?.some((stage) => stage.discussion?.summary)
-    const hasOpenAISummary = hasTopicSummary || hasDiscussionSummary
-    if (!hasOpenAISummary) return null
-    if (hasOpenAISummary && !wholeMeetingSummary) return <WholeMeetingSummaryLoading />
+    const {summary: wholeMeetingSummary, reflectionGroups, organization} = meeting
+    const hasMoreThanOneReflection =
+      (reflectionGroups?.length && reflectionGroups.length > 1) ||
+      reflectionGroups?.some((group) => group.reflections.length > 1)
+    if (!hasMoreThanOneReflection || organization.featureFlags.noAISummary) return null
+    if (!wholeMeetingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   } else if (meeting.__typename === 'TeamPromptMeeting') {
     const {summary: wholeMeetingSummary, responses, organization} = meeting

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -42,9 +42,8 @@ const WholeMeetingSummary = (props: Props) => {
   )
   if (meeting.__typename === 'RetrospectiveMeeting') {
     const {summary: wholeMeetingSummary, reflectionGroups, organization} = meeting
-    const hasMoreThanOneReflection =
-      (reflectionGroups?.length && reflectionGroups.length > 1) ||
-      reflectionGroups?.some((group) => group.reflections.length > 1)
+    const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
+    const hasMoreThanOneReflection = reflections?.length && reflections.length > 1
     if (!hasMoreThanOneReflection || organization.featureFlags.noAISummary) return null
     if (!wholeMeetingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -31,8 +31,12 @@ graphql`
       autogroupReflectionGroups {
         groupTitle
       }
+      organization {
+        featureFlags {
+          noAISummary
+        }
+      }
       reflectionGroups(sortBy: voteCount) {
-        summary
         reflections {
           id
         }
@@ -43,13 +47,6 @@ graphql`
       }
       phases {
         phaseType
-        ... on DiscussPhase {
-          stages {
-            discussion {
-              summary
-            }
-          }
-        }
       }
     }
     team {
@@ -109,7 +106,14 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
   const {isKill, meeting} = payload
   const {atmosphere, history} = context
   if (!meeting) return
-  const {id: meetingId, teamId, reflectionGroups, phases, autogroupReflectionGroups} = meeting
+  const {
+    id: meetingId,
+    teamId,
+    reflectionGroups,
+    phases,
+    autogroupReflectionGroups,
+    organization
+  } = meeting
   if (meetingId === RetroDemo.MEETING_ID) {
     if (isKill) {
       window.localStorage.removeItem('retroDemo')
@@ -122,12 +126,9 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
       history.push(`/team/${teamId}`)
       popEndMeetingToast(atmosphere, meetingId)
     } else {
-      const discussPhase = phases.find((phase) => phase.phaseType === 'discuss')
-      const {stages} = discussPhase ?? {}
-      const hasTopicSummary = reflectionGroups.some((group) => group.summary)
       const reflections = reflectionGroups.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
-      const hasDiscussionSummary = !!stages?.some((stage) => stage.discussion?.summary)
-      const hasOpenAISummary = hasTopicSummary || hasDiscussionSummary
+      const hasMoreThanOneReflection = reflections.length > 1
+      const hasOpenAISummary = hasMoreThanOneReflection || !organization.featureFlags.noAISummary
       const hasTeamHealth = phases.some((phase) => phase.phaseType === 'TEAM_HEALTH')
       const pathname = `/new-summary/${meetingId}`
       const search = new URLSearchParams()

--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -128,7 +128,7 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
     } else {
       const reflections = reflectionGroups.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
       const hasMoreThanOneReflection = reflections.length > 1
-      const hasOpenAISummary = hasMoreThanOneReflection || !organization.featureFlags.noAISummary
+      const hasOpenAISummary = hasMoreThanOneReflection && !organization.featureFlags.noAISummary
       const hasTeamHealth = phases.some((phase) => phase.phaseType === 'TEAM_HEALTH')
       const pathname = `/new-summary/${meetingId}`
       const search = new URLSearchParams()

--- a/packages/server/graphql/mutations/helpers/generateDiscussionPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/generateDiscussionPrompt.ts
@@ -40,9 +40,10 @@ const generateDiscussionPrompt = async (
         ({reflectionGroupId}) => reflectionGroupId === group.id
       )
       if (reflectionsByGroupId.length <= 1) return
-      const [fullQuestion] = await Promise.all([
-        manager.getDiscussionPromptQuestion(group.title ?? 'Unknown', reflectionsByGroupId)
-      ])
+      const fullQuestion = await manager.getDiscussionPromptQuestion(
+        group.title ?? 'Unknown',
+        reflectionsByGroupId
+      )
       if (!fullQuestion) return
       const discussionPromptQuestion = fullQuestion?.slice(0, 2000)
       return Promise.all([

--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -13,8 +13,8 @@ import {DataLoaderWorker} from '../../graphql'
 import addAIGeneratedContentToThreads from './addAIGeneratedContentToThreads'
 import addDiscussionTopics from './addDiscussionTopics'
 import addRecallBot from './addRecallBot'
+import generateDiscussionPrompt from './generateDiscussionPrompt'
 import generateDiscussionSummary from './generateDiscussionSummary'
-import generateGroupSummaries from './generateGroupSummaries'
 import generateGroups from './generateGroups'
 import {publishToEmbedder} from './publishToEmbedder'
 import removeEmptyReflections from './removeEmptyReflections'
@@ -92,7 +92,7 @@ const handleCompletedRetrospectiveStage = async (
         .run()
       data.meeting = meeting
       // dont await for the OpenAI API response
-      generateGroupSummaries(meeting.id, teamId, dataLoader, facilitatorUserId)
+      generateDiscussionPrompt(meeting.id, teamId, dataLoader, facilitatorUserId)
     }
 
     return {[stage.phaseType]: data}

--- a/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
+++ b/packages/server/graphql/mutations/helpers/handleCompletedStage.ts
@@ -112,7 +112,7 @@ const handleCompletedRetrospectiveStage = async (
     }))
     await Promise.all([
       insertDiscussions(discussions),
-      addAIGeneratedContentToThreads(discussPhaseStages, meetingId, teamId, dataLoader),
+      addAIGeneratedContentToThreads(discussPhaseStages, meetingId, dataLoader),
       publishToEmbedder({jobType: 'relatedDiscussions:start', data: {meetingId}, priority: 0})
     ])
     if (videoMeetingURL) {

--- a/packages/server/graphql/types/Discussion.ts
+++ b/packages/server/graphql/types/Discussion.ts
@@ -155,7 +155,7 @@ const Discussion = new GraphQLObjectType<any, GQLContext>({
     },
     summary: {
       type: GraphQLString,
-      description: `The GPT-3 generated summary of the discussion. Undefined if the user doesnt have access to the feature or the stage isn't completed`
+      description: `The AI generated summary of the discussion. Undefined if the user doesnt have access to the feature or the stage isn't completed`
     }
   })
 })

--- a/packages/server/graphql/types/RetroReflectionGroup.ts
+++ b/packages/server/graphql/types/RetroReflectionGroup.ts
@@ -87,10 +87,6 @@ const RetroReflectionGroup: GraphQLObjectType = new GraphQLObjectType<any, GQLCo
       type: new GraphQLNonNull(GraphQLFloat),
       description: 'The sort order of the reflection group'
     },
-    summary: {
-      type: GraphQLString,
-      description: `The AI generated summary of this reflection group`
-    },
     discussionPromptQuestion: {
       type: GraphQLString,
       description: `The AI generated question to prompt and engage the discussion of this reflection group`


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9710

Demo: https://www.loom.com/share/728f893c2e054fbbad82f849e89ffeaa

The AI Summary for the reflection group is no longer being used but I don't want to remove it now as it looks like we're migrating that table from RethinkDB to PG. I've created an issue: https://github.com/ParabolInc/parabol/issues/9712

### To test

- [ ] Add comments to a discussion thread 
- [ ] Go to the meeting summary and see that there's an AI Summary of the discussion thread and no discussion prompt