### PR TITLE
chore: Remove deprecated userId from Atmosphere

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -110,8 +110,6 @@ export default class Atmosphere extends Environment {
   upgradeTransportPromise: Promise<void> | null = null
   // it's only null before login, so it's just a little white lie
   viewerId: string = null!
-  /** @deprecated */
-  userId: string | null = null
   tabCheckChannel?: BroadcastChannel
   constructor() {
     super({
@@ -414,8 +412,6 @@ export default class Atmosphere extends Environment {
     } else {
       this.viewerId = viewerId!
       window.localStorage.setItem(LocalStorageKey.APP_TOKEN_KEY, authToken)
-      // deprecated! will be removed soon
-      this.userId = viewerId
     }
   }
 
@@ -519,6 +515,5 @@ export default class Atmosphere extends Environment {
     this.querySubscriptions = []
     this.subscriptions = {}
     this.viewerId = null!
-    this.userId = null // DEPRECATED
   }
 }


### PR DESCRIPTION
# Description

The property has a deprecation notice for a couple of years now, time to retire it.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
