### PR TITLE
chore: add more granular process recurrence tracing

### DIFF
--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -158,64 +158,67 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (_source
   )
   await tracer.trace('processRecurrence.startActiveMeetingSeries', async () =>
     Promise.allSettled(
-      activeMeetingSeries.map(async (meetingSeries) => {
-        const seriesTeam = await dataLoader.get('teams').loadNonNull(meetingSeries.teamId)
-        if (seriesTeam.isArchived || !seriesTeam.isPaid) {
-          return
-        }
+      activeMeetingSeries.map(async (meetingSeries) =>
+        tracer.trace('processRecurrence.startActiveMeetingSeries.meeting', async (span) => {
+          span?.setTag('meetingSeriesId', meetingSeries.id)
+          const seriesTeam = await dataLoader.get('teams').loadNonNull(meetingSeries.teamId)
+          if (seriesTeam.isArchived || !seriesTeam.isPaid) {
+            return
+          }
 
-        const [seriesOrg, lastMeeting] = await Promise.all([
-          dataLoader.get('organizations').load(seriesTeam.orgId),
-          dataLoader.get('lastMeetingByMeetingSeriesId').load(meetingSeries.id)
-        ])
+          const [seriesOrg, lastMeeting] = await Promise.all([
+            dataLoader.get('organizations').load(seriesTeam.orgId),
+            dataLoader.get('lastMeetingByMeetingSeriesId').load(meetingSeries.id)
+          ])
 
-        // remove this check after 2024-05-05
-        if (
-          lastMeeting?.meetingSeriesId !== meetingSeries.id ||
-          lastMeeting.teamId !== meetingSeries.teamId
-        ) {
-          const error = new Error(
-            'lastMeetingByMeetingSeriesId returned a meeting that does not match the series'
-          )
-          sendToSentry(error)
-          throw error
-        }
-
-        if (seriesOrg.lockedAt) {
-          return
-        }
-
-        // For meetings that should still be active, start the meeting and set its end time.
-        // Any subscriptions are handled by the shared meeting start code
-        const rrule = RRule.fromString(meetingSeries.recurrenceRule)
-        // technically, RRULE should never return NaN here but there's a bug in the library
-        // https://github.com/jakubroztocil/rrule/issues/321
-        if (isNaN(rrule.options.interval)) {
-          return
-        }
-
-        // Only get meetings that should currently be active, i.e. meetings that should have started
-        // within the last 24 hours, started after the last meeting in the series, and started before
-        // 'now'.
-        const fromDate = lastMeeting
-          ? new Date(
-              Math.max(lastMeeting.createdAt.getTime() + ms('10m'), now.getTime() - ms('24h'))
+          // remove this check after 2024-05-05
+          if (
+            lastMeeting?.meetingSeriesId !== meetingSeries.id ||
+            lastMeeting.teamId !== meetingSeries.teamId
+          ) {
+            const error = new Error(
+              'lastMeetingByMeetingSeriesId returned a meeting that does not match the series'
             )
-          : new Date(0)
-        const newMeetingsStartTimes = rrule.between(
-          getRRuleDateFromJSDate(fromDate),
-          getRRuleDateFromJSDate(now)
-        )
-        for (const startTime of newMeetingsStartTimes) {
-          const err = await startRecurringMeeting(
-            meetingSeries,
-            getJSDateFromRRuleDate(startTime),
-            dataLoader,
-            subOptions
+            sendToSentry(error)
+            throw error
+          }
+
+          if (seriesOrg.lockedAt) {
+            return
+          }
+
+          // For meetings that should still be active, start the meeting and set its end time.
+          // Any subscriptions are handled by the shared meeting start code
+          const rrule = RRule.fromString(meetingSeries.recurrenceRule)
+          // technically, RRULE should never return NaN here but there's a bug in the library
+          // https://github.com/jakubroztocil/rrule/issues/321
+          if (isNaN(rrule.options.interval)) {
+            return
+          }
+
+          // Only get meetings that should currently be active, i.e. meetings that should have started
+          // within the last 24 hours, started after the last meeting in the series, and started before
+          // 'now'.
+          const fromDate = lastMeeting
+            ? new Date(
+                Math.max(lastMeeting.createdAt.getTime() + ms('10m'), now.getTime() - ms('24h'))
+              )
+            : new Date(0)
+          const newMeetingsStartTimes = rrule.between(
+            getRRuleDateFromJSDate(fromDate),
+            getRRuleDateFromJSDate(now)
           )
-          if (!err) meetingsStarted++
-        }
-      })
+          for (const startTime of newMeetingsStartTimes) {
+            const err = await startRecurringMeeting(
+              meetingSeries,
+              getJSDateFromRRuleDate(startTime),
+              dataLoader,
+              subOptions
+            )
+            if (!err) meetingsStarted++
+          }
+        })
+      )
     )
   )
 


### PR DESCRIPTION
# Description

Relates to #9722 
We know the slowness stems from starting new meetings, let's see if it's all of them or just some outliers.

## Demo

<img width="1573" alt="image" src="https://github.com/ParabolInc/parabol/assets/7331043/3017f35c-b54e-4199-8f93-6d47c7de3fd5">

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
