### PR TITLE
fix: team lead can view teams in org settings

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -87,6 +87,7 @@ const DashSidebar = (props: Props) => {
           id
           name
           isBillingLeader
+          isTeamLead
         }
       }
     `,
@@ -99,7 +100,7 @@ const DashSidebar = (props: Props) => {
   if (match) {
     const {orgId: orgIdFromParams} = match.params
     const currentOrg = organizations.find((org) => org.id === orgIdFromParams)
-    const {id: orgId, name, isBillingLeader} = currentOrg ?? {}
+    const {id: orgId, name, isBillingLeader, isTeamLead} = currentOrg ?? {}
     return (
       <Wrapper>
         <SideBarStartMeetingButton isOpen={isOpen} />
@@ -118,7 +119,7 @@ const DashSidebar = (props: Props) => {
                 href={`/me/organizations/${orgId}/${BILLING_PAGE}`}
                 label={'Plans & Billing'}
               />
-              {isBillingLeader && (
+              {(isBillingLeader || isTeamLead) && (
                 <NavItem
                   icon={'groups'}
                   href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}

--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -86,8 +86,6 @@ const DashSidebar = (props: Props) => {
           ...DashNavList_organization
           id
           name
-          isBillingLeader
-          isTeamLead
         }
       }
     `,
@@ -100,7 +98,7 @@ const DashSidebar = (props: Props) => {
   if (match) {
     const {orgId: orgIdFromParams} = match.params
     const currentOrg = organizations.find((org) => org.id === orgIdFromParams)
-    const {id: orgId, name, isBillingLeader, isTeamLead} = currentOrg ?? {}
+    const {id: orgId, name} = currentOrg ?? {}
     return (
       <Wrapper>
         <SideBarStartMeetingButton isOpen={isOpen} />
@@ -119,13 +117,11 @@ const DashSidebar = (props: Props) => {
                 href={`/me/organizations/${orgId}/${BILLING_PAGE}`}
                 label={'Plans & Billing'}
               />
-              {(isBillingLeader || isTeamLead) && (
-                <NavItem
-                  icon={'groups'}
-                  href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}
-                  label={'Teams'}
-                />
-              )}
+              <NavItem
+                icon={'groups'}
+                href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}
+                label={'Teams'}
+              />
               <NavItem
                 icon={'group'}
                 href={`/me/organizations/${orgId}/${MEMBERS_PAGE}`}

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -98,7 +98,6 @@ const MobileDashSidebar = (props: Props) => {
           ...DashNavList_organization
           id
           name
-          isBillingLeader
         }
       }
     `,
@@ -110,7 +109,7 @@ const MobileDashSidebar = (props: Props) => {
   if (match) {
     const {orgId: orgIdFromParams} = match.params
     const currentOrg = organizations.find((org) => org.id === orgIdFromParams)
-    const {id: orgId, name, isBillingLeader} = currentOrg ?? {}
+    const {id: orgId, name} = currentOrg ?? {}
     return (
       <DashSidebarStyles>
         <StandardHub handleMenuClick={handleMenuClick} viewer={viewer} />
@@ -131,14 +130,12 @@ const MobileDashSidebar = (props: Props) => {
                 href={`/me/organizations/${orgId}/${BILLING_PAGE}`}
                 label={'Plans & Billing'}
               />
-              {isBillingLeader && (
-                <LeftDashNavItem
-                  onClick={handleMenuClick}
-                  icon={'groups'}
-                  href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}
-                  label={'Teams'}
-                />
-              )}
+              <LeftDashNavItem
+                onClick={handleMenuClick}
+                icon={'groups'}
+                href={`/me/organizations/${orgId}/${TEAMS_PAGE}`}
+                label={'Teams'}
+              />
               <LeftDashNavItem
                 onClick={handleMenuClick}
                 icon={'group'}

--- a/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
@@ -91,16 +91,12 @@ const Organization = (props: Props) => {
           path={`${match.url}/${AUTHENTICATION_PAGE}`}
           render={(p) => <Authentication {...p} orgId={orgId} />}
         />
-        {(isBillingLeader || isTeamLead) && (
-          <>
-            <Route
-              exact
-              path={`${match.url}/${TEAMS_PAGE}`}
-              render={() => <OrgTeams organizationRef={organization} />}
-            />
-            <Route exact path={`${match.url}/${TEAMS_PAGE}/:teamId`} component={OrgTeamMembers} />
-          </>
-        )}
+        <Route
+          exact
+          path={`${match.url}/${TEAMS_PAGE}`}
+          render={() => <OrgTeams organizationRef={organization} />}
+        />
+        <Route exact path={`${match.url}/${TEAMS_PAGE}/:teamId`} component={OrgTeamMembers} />
       </Switch>
     </section>
   )

--- a/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
@@ -47,6 +47,7 @@ const query = graphql`
         ...OrgDetails_organization
         ...OrgTeams_organization
         isBillingLeader
+        isTeamLead
       }
     }
   }
@@ -58,7 +59,7 @@ const Organization = (props: Props) => {
   const match = useRouteMatch<{orgId: string}>('/me/organizations/:orgId')!
   const {organization} = viewer
   if (!organization) return null
-  const {id: orgId, isBillingLeader} = organization
+  const {id: orgId, isBillingLeader, isTeamLead} = organization
 
   return (
     <section className={'px-4 md:px-8'}>
@@ -90,7 +91,7 @@ const Organization = (props: Props) => {
           path={`${match.url}/${AUTHENTICATION_PAGE}`}
           render={(p) => <Authentication {...p} orgId={orgId} />}
         />
-        {isBillingLeader && (
+        {(isBillingLeader || isTeamLead) && (
           <>
             <Route
               exact

--- a/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
@@ -47,7 +47,6 @@ const query = graphql`
         ...OrgDetails_organization
         ...OrgTeams_organization
         isBillingLeader
-        isTeamLead
       }
     }
   }
@@ -59,7 +58,7 @@ const Organization = (props: Props) => {
   const match = useRouteMatch<{orgId: string}>('/me/organizations/:orgId')!
   const {organization} = viewer
   if (!organization) return null
-  const {id: orgId, isBillingLeader, isTeamLead} = organization
+  const {id: orgId} = organization
 
   return (
     <section className={'px-4 md:px-8'}>

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -18,8 +18,8 @@ const OrgTeams = (props: Props) => {
     graphql`
       fragment OrgTeams_organization on Organization {
         id
+        isOrgAdmin
         isBillingLeader
-        isTeamLead
         allTeams {
           id
           ...OrgTeamsRow_team
@@ -34,13 +34,16 @@ const OrgTeams = (props: Props) => {
     isOpen: isAddTeamDialogOpened
   } = useDialogState()
 
-  const {allTeams, isBillingLeader, isTeamLead} = organization
-  if (!isBillingLeader && !isTeamLead) return null
-
+  const {allTeams, isBillingLeader, isOrgAdmin} = organization
   return (
     <div className='max-w-4xl pb-4'>
       <div className='flex items-center justify-center py-1'>
-        <h1 className='flex-1 text-2xl font-semibold leading-7'>Teams</h1>
+        <div>
+          <h1 className='text-2xl font-semibold leading-7'>Teams</h1>
+          {!isBillingLeader && !isOrgAdmin && (
+            <p className='text-gray-600 mb-2'>Only showing teams you're a member of</p>
+          )}
+        </div>
         <div className='ml-auto'>
           <Button
             variant='secondary'

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -19,6 +19,7 @@ const OrgTeams = (props: Props) => {
       fragment OrgTeams_organization on Organization {
         id
         isBillingLeader
+        isTeamLead
         allTeams {
           id
           ...OrgTeamsRow_team
@@ -33,8 +34,8 @@ const OrgTeams = (props: Props) => {
     isOpen: isAddTeamDialogOpened
   } = useDialogState()
 
-  const {allTeams, isBillingLeader} = organization
-  if (!isBillingLeader) return null
+  const {allTeams, isBillingLeader, isTeamLead} = organization
+  if (!isBillingLeader && !isTeamLead) return null
 
   return (
     <div className='max-w-4xl pb-4'>

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -20,6 +20,9 @@ const OrgTeams = (props: Props) => {
         id
         isOrgAdmin
         isBillingLeader
+        featureFlags {
+          publicTeams
+        }
         allTeams {
           id
           ...OrgTeamsRow_team
@@ -34,13 +37,15 @@ const OrgTeams = (props: Props) => {
     isOpen: isAddTeamDialogOpened
   } = useDialogState()
 
-  const {allTeams, isBillingLeader, isOrgAdmin} = organization
+  const {allTeams, isBillingLeader, isOrgAdmin, featureFlags} = organization
+  const hasPublicTeamsFlag = featureFlags.publicTeams
+  const showAllTeams = isBillingLeader || isOrgAdmin || hasPublicTeamsFlag
   return (
     <div className='max-w-4xl pb-4'>
       <div className='flex items-center justify-center py-1'>
         <div>
           <h1 className='text-2xl font-semibold leading-7'>Teams</h1>
-          {!isBillingLeader && !isOrgAdmin && (
+          {!showAllTeams && (
             <p className='text-gray-600 mb-2'>Only showing teams you're a member of</p>
           )}
         </div>

--- a/packages/server/graphql/types/Organization.ts
+++ b/packages/server/graphql/types/Organization.ts
@@ -10,6 +10,7 @@ import {
 import {
   getUserId,
   isSuperUser,
+  isTeamLead,
   isUserBillingLeader,
   isUserOrgAdmin
 } from '../../utils/authorization'
@@ -104,6 +105,14 @@ const Organization: GraphQLObjectType<any, GQLContext> = new GraphQLObjectType<a
         return allTeamsOnOrg
           .filter((team) => authToken.tms.includes(team.id))
           .sort((a, b) => a.name.localeCompare(b.name))
+      }
+    },
+    isTeamLead: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: 'true if the viewer is a team lead for a team in the organization',
+      resolve: async (_, _args: unknown, {authToken, dataLoader}) => {
+        const viewerId = getUserId(authToken)
+        return authToken.tms.some((teamId) => isTeamLead(viewerId, teamId, dataLoader))
       }
     },
     periodEnd: {


### PR DESCRIPTION
Fix: https://github.com/ParabolInc/parabol/issues/9738

![image](https://github.com/ParabolInc/parabol/assets/39854876/14cc1a41-86c0-41b5-b600-a32768e68516)


### To test

- [ ] Team lead can view the teams page even if they're not the billing lead