### PR TITLE
fix: fix the issue where a successful upgrade won't refresh the billing page

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -8,7 +8,6 @@ import {
 } from '@stripe/react-stripe-js'
 import {StripeElementChangeEvent} from '@stripe/stripe-js'
 import React, {useState} from 'react'
-import {commitLocalUpdate} from 'react-relay'
 import {CreateStripeSubscriptionMutation$data} from '../../../../__generated__/CreateStripeSubscriptionMutation.graphql'
 import Ellipsis from '../../../../components/Ellipsis/Ellipsis'
 import PrimaryButton from '../../../../components/PrimaryButton'
@@ -126,19 +125,11 @@ const BillingForm = (props: Props) => {
         setErrorMsg(newErrMsg)
         return
       }
-      const {error, paymentIntent} = await stripe.confirmCardPayment(stripeSubscriptionClientSecret)
+      const {error} = await stripe.confirmCardPayment(stripeSubscriptionClientSecret)
       if (error) {
         setErrorMsg(error.message)
         setIsLoading(false)
         return
-      }
-      if (paymentIntent.status === 'succeeded') {
-        commitLocalUpdate(atmosphere, (store) => {
-          const organization = store.get(orgId)
-          if (!organization) return
-          organization.setValue('team', 'billingTier')
-          organization.setValue('team', 'tier')
-        })
       }
       onCompleted()
     }

--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '@stripe/react-stripe-js'
 import {StripeElementChangeEvent} from '@stripe/stripe-js'
 import React, {useState} from 'react'
+import {commitLocalUpdate} from 'react-relay'
 import {CreateStripeSubscriptionMutation$data} from '../../../../__generated__/CreateStripeSubscriptionMutation.graphql'
 import Ellipsis from '../../../../components/Ellipsis/Ellipsis'
 import PrimaryButton from '../../../../components/PrimaryButton'
@@ -125,11 +126,19 @@ const BillingForm = (props: Props) => {
         setErrorMsg(newErrMsg)
         return
       }
-      const {error} = await stripe.confirmCardPayment(stripeSubscriptionClientSecret)
+      const {error, paymentIntent} = await stripe.confirmCardPayment(stripeSubscriptionClientSecret)
       if (error) {
         setErrorMsg(error.message)
         setIsLoading(false)
         return
+      }
+      if (paymentIntent.status === 'succeeded') {
+        commitLocalUpdate(atmosphere, (store) => {
+          const organization = store.get(orgId)
+          if (!organization) return
+          organization.setValue('team', 'billingTier')
+          organization.setValue('team', 'tier')
+        })
       }
       onCompleted()
     }

--- a/packages/client/mutations/handlers/upgradeToTeamTierSuccessUpdater.ts
+++ b/packages/client/mutations/handlers/upgradeToTeamTierSuccessUpdater.ts
@@ -5,6 +5,8 @@ const upgradeToTeamTierSuccessUpdater = (payload: RecordProxy) => {
   if (organization) {
     organization.setValue(true, 'showConfetti')
     organization.setValue(true, 'showDrawer')
+    organization.setValue('team', 'billingTier')
+    organization.setValue('team', 'tier')
   }
 }
 export default upgradeToTeamTierSuccessUpdater


### PR DESCRIPTION
# Description

Fixes #9737 

## Demo
Stripe webhooks are slow locally. Please be patient while viewing this GIF😂:

![2024-05-08 14 57 05](https://github.com/ParabolInc/parabol/assets/1879975/b2e5523b-bcf9-4d46-bb7b-a56bf7a0d49b)


## Testing scenarios

- [ ] Upgrade to `team`
  - Upgrade an org to `team` tier
  - ~Brew a cup of coffee and wait~
  - Observe the billing page refreshes itself and the confetti shows up eventually

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
