### PR TITLE
fix: Handle invitation links with invalid auth token

### DIFF
--- a/packages/client/mutations/AcceptTeamInvitationMutation.ts
+++ b/packages/client/mutations/AcceptTeamInvitationMutation.ts
@@ -215,7 +215,10 @@ const AcceptTeamInvitationMutation: StandardMutation<
       const serverError = getGraphQLError(data, errors)
       if (serverError) {
         const message = serverError.message
-        if (message === InvitationTokenError.ALREADY_ACCEPTED) {
+        if (message === InvitationTokenError.NOT_SIGNED_IN) {
+          // if the user follows an invitation link with an invalid auth token, invalidate it
+          atmosphere.setAuthToken(null)
+        } else if (message === InvitationTokenError.ALREADY_ACCEPTED) {
           handleAuthenticationRedirect(acceptTeamInvitation, {
             atmosphere,
             history,


### PR DESCRIPTION
When following an invitation link with an old auth token, we would just show an ugly error message and don't give the user an action to do. Sign them out if we get the 'notSignedIn' error.

## Demo

https://www.loom.com/share/76bd4fce2f7140fc929d82798d6310f6?sid=3b4d8953-ec62-4dd1-a0a1-639e4be6f945

## Testing scenarios

- [ ] Sign in
- [ ] Close the tab
- [ ] Restart the server with new secret
- [ ] Follow an invite link

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
