### PR TITLE
fix: close websocket with reason on invalid token

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -68,7 +68,7 @@
     "@emotion/styled": "^10.0.27",
     "@mattkrick/graphql-trebuchet-client": "^2.2.1",
     "@mattkrick/sanitize-svg": "0.4.0",
-    "@mattkrick/trebuchet-client": "^3.0.2",
+    "@mattkrick/trebuchet-client": "3.0.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.2",
     "@mui/x-date-pickers": "^6.3.1",

--- a/packages/server/socketHandlers/handleOpen.ts
+++ b/packages/server/socketHandlers/handleOpen.ts
@@ -1,9 +1,13 @@
 import {WebSocketBehavior} from 'uWebSockets.js'
+import {TrebuchetCloseReason} from '../../client/types/constEnums'
 import activeClients from '../activeClients'
 import AuthToken from '../database/types/AuthToken'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 import keepAlive from '../socketHelpers/keepAlive'
 import {sendEncodedMessage} from '../socketHelpers/sendEncodedMessage'
+import {isAuthenticated} from '../utils/authorization'
+import checkBlacklistJWT from '../utils/checkBlacklistJWT'
+import sendToSentry from '../utils/sendToSentry'
 import handleConnect from './handleConnect'
 
 const APP_VERSION = process.env.npm_package_version
@@ -11,11 +15,32 @@ export type SocketUserData = {
   connectionContext: ConnectionContext
   authToken: AuthToken
   ip: string
+  protocol: string
   done?: true
 }
 
 const handleOpen: WebSocketBehavior<SocketUserData>['open'] = async (socket) => {
-  const {authToken, ip} = socket.getUserData()
+  const {authToken, ip, protocol} = socket.getUserData()
+  if (protocol !== 'trebuchet-ws') {
+    sendToSentry(new Error(`WebSocket error: invalid protocol: ${protocol}`))
+    // WS Error 1002 is roughly HTTP 412 Precondition Failed because we can't support the req header
+    socket.end(412, 'Invalid protocol')
+    return
+  }
+
+  if (!isAuthenticated(authToken)) {
+    socket.end(401, TrebuchetCloseReason.EXPIRED_SESSION)
+    return
+  }
+
+  // ALL async calls must come after the message listener, or we'll skip out on messages (e.g. resub after server restart)
+  const {sub: userId, iat} = authToken
+  const isBlacklistedJWT = await checkBlacklistJWT(userId, iat)
+  if (isBlacklistedJWT) {
+    socket.end(401, TrebuchetCloseReason.EXPIRED_SESSION)
+    return
+  }
+
   const connectionContext = (socket.getUserData().connectionContext = new ConnectionContext(
     socket,
     authToken,

--- a/packages/server/socketHandlers/handleUpgrade.ts
+++ b/packages/server/socketHandlers/handleUpgrade.ts
@@ -1,38 +1,14 @@
 import {WebSocketBehavior} from 'uWebSockets.js'
-import {TrebuchetCloseReason} from '../../client/types/constEnums'
-import safetyPatchRes from '../safetyPatchRes'
-import {isAuthenticated} from '../utils/authorization'
-import checkBlacklistJWT from '../utils/checkBlacklistJWT'
 import getQueryToken from '../utils/getQueryToken'
-import sendToSentry from '../utils/sendToSentry'
 import uwsGetIP from '../utils/uwsGetIP'
 
-const handleUpgrade: WebSocketBehavior<void>['upgrade'] = async (res, req, context) => {
-  safetyPatchRes(res)
-  const protocol = req.getHeader('sec-websocket-protocol')
-  if (protocol !== 'trebuchet-ws') {
-    sendToSentry(new Error(`WebSocket error: invalid protocol: ${protocol}`))
-    // WS Error 1002 is roughly HTTP 412 Precondition Failed because we can't support the req header
-    res.writeStatus('412').end()
-    return
-  }
-  const authToken = getQueryToken(req)
-  if (!isAuthenticated(authToken)) {
-    res.writeStatus('401').end()
-    return
-  }
-
+const handleUpgrade: WebSocketBehavior<void>['upgrade'] = (res, req, context) => {
   const key = req.getHeader('sec-websocket-key')
+  const protocol = req.getHeader('sec-websocket-protocol')
   const extensions = req.getHeader('sec-websocket-extensions')
   const ip = uwsGetIP(res, req)
-  const {sub: userId, iat} = authToken
-  // ALL async calls must come after the message listener, or we'll skip out on messages (e.g. resub after server restart)
-  const isBlacklistedJWT = await checkBlacklistJWT(userId, iat)
-  if (isBlacklistedJWT) {
-    res.writeStatus('401').end(TrebuchetCloseReason.EXPIRED_SESSION)
-    return
-  }
-  res.upgrade({ip, authToken}, key, protocol, extensions, context)
+  const authToken = getQueryToken(req)
+  res.upgrade({ip, authToken, protocol}, key, protocol, extensions, context)
 }
 
 export default handleUpgrade

--- a/yarn.lock
+++ b/yarn.lock
@@ -4980,10 +4980,10 @@
   resolved "https://registry.yarnpkg.com/@mattkrick/sanitize-svg/-/sanitize-svg-0.4.0.tgz#388c29614cf72aa0dd9803c77c9c9d070bd3cd2d"
   integrity sha512-TnPI97WVAxo8SQcPy8aV3OF9/2WjXB5/+pRNVudIWR7Bhi5ZjtR/ur162So08GkvsvB914AXCW2sxFh1x6KhHA==
 
-"@mattkrick/trebuchet-client@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@mattkrick/trebuchet-client/-/trebuchet-client-3.0.2.tgz#336d687256fb9ac7bb407f656bf2f69f35f817e1"
-  integrity sha512-JLOx8gd+cGkDeHhdnns0oor2UNv5uRZ8A/Jfw3NhQcVqQe6R+x9xIHW29M2T78TDHUWqItTgntX+cdDLqVjVvg==
+"@mattkrick/trebuchet-client@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@mattkrick/trebuchet-client/-/trebuchet-client-3.0.1.tgz#3fc49f7858652a55dca92cb0c14c0313df931619"
+  integrity sha512-5uHCldCqmVntoyujTzRfmGtjld8k4JuBdFN0SvhvRFf83FPaNeoit6Mh8VgrcxxxKujKeYCQDMQH6LWwpsshgQ==
   dependencies:
     "@mattkrick/fast-rtc-peer" "^0.4.1"
     eventemitter3 "^4.0.7"
@@ -20311,7 +20311,7 @@ string-similarity@^3.0.0:
   resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-3.0.0.tgz#07b0bc69fae200ad88ceef4983878d03793847c7"
   integrity sha512-7kS7LyTp56OqOI2BDWQNVnLX/rCxIQn+/5M0op1WV6P8Xx6TZNdajpuqQdiJ7Xx+p1C5CsWMvdiBp9ApMhxzEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20328,15 +20328,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.0:
   version "5.1.0"
@@ -20414,7 +20405,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20427,13 +20418,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -22287,7 +22271,7 @@ workbox-window@6.5.4:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.5.4"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22300,15 +22284,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Description

fix #8370 

The server wasn't closing websockets with a `reason` when the session was invalidated.
This is important because if a `reason` is included, the client nukes the authToken.
Either I missed an API change in uws.js, or it hasn't been working for awhile.
This also rolls back to trebuchet-client 3.0.1 because once `canConnect` is true, it should not turn to false when it encounters an error. It should just try again.

The downside to this pattern is that the server has to upgrade the HTTP1.1 request to a websocket before it can close the websocket. This means the server tells the client that the websocket is open (fires `WebSocket.onopen`), the client sends pending messages (e.g. subscription requests) and then the server immediately closes it. It's extra work on the client & server, but sending a 401 during a websocket upgrade does not make it to the client. Per the spec: https://websockets.spec.whatwg.org/#eventdef-websocket-error 

```
User agents must not convey any failure information to scripts in a way that would allow a script to distinguish the following situations:

A server whose host name could not be resolved.

A server to which packets could not successfully be routed.

A server that refused the connection on the specified port.

A server that failed to correctly perform a TLS handshake (e.g., the server certificate can’t be verified).

A server that did not complete the opening handshake (e.g. because it was not a WebSocket server).

A WebSocket server that sent a correct opening handshake, but that specified options that caused the client to drop the connection (e.g. the server specified a subprotocol that the client did not offer).

A WebSocket server that abruptly closed the connection after successfully completing the opening handshake.

In all of these cases, [the WebSocket connection close code](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5) would be 1006, as required by WebSocket Protocol. [[WSP]](https://websockets.spec.whatwg.org/#biblio-wsp)

Allowing a script to distinguish these cases would allow a script to probe the user’s local network in preparation for an attack.
```


### TEST

- [ ] be logged in, change the SERVER_SECRET and restart the server. Upon reconnect, the client logs out automatically with a snack that says the session has expired. 