### PR TITLE
fix(dev-stack): update text-embeddings-inference to 1.2.2

### DIFF
--- a/docker/stacks/development/docker-compose.yml
+++ b/docker/stacks/development/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     networks:
       parabol-network:
   text-embeddings-inference:
-    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2.2
     command:
       - "--model-id=llmrails/ember-v1"
     platform: linux/x86_64


### PR DESCRIPTION
# Description
Text Embeddings 1.2 had a [bug](https://github.com/huggingface/text-embeddings-inference/issues/241) and it would not start without a variable HF_MODEL_ID.