### PR TITLE
feat: update promote team copy

### DIFF
--- a/packages/client/modules/teamDashboard/components/PromoteTeamMemberModal/PromoteTeamMemberModal.tsx
+++ b/packages/client/modules/teamDashboard/components/PromoteTeamMemberModal/PromoteTeamMemberModal.tsx
@@ -9,8 +9,9 @@ import DialogContent from '../../../../components/DialogContent'
 import DialogTitle from '../../../../components/DialogTitle'
 import IconLabel from '../../../../components/IconLabel'
 import PrimaryButton from '../../../../components/PrimaryButton'
+import useMutationProps from '../../../../hooks/useMutationProps'
 import PromoteToTeamLeadMutation from '../../../../mutations/PromoteToTeamLeadMutation'
-import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
+import {upperFirst} from '../../../../utils/upperFirst'
 
 const StyledDialogContainer = styled(DialogContainer)({
   width: 420
@@ -20,41 +21,55 @@ const StyledButton = styled(PrimaryButton)({
   margin: '1.5rem auto 0'
 })
 
-interface Props extends WithMutationProps {
+interface Props {
   closePortal: () => void
   teamMember: PromoteTeamMemberModal_teamMember$key
 }
+
 const PromoteTeamMemberModal = (props: Props) => {
   const atmosphere = useAtmosphere()
-  const {
-    closePortal,
-    submitMutation,
-    submitting,
-    onError,
-    onCompleted,
-    teamMember: teamMemberRef
-  } = props
+  const {submitMutation, submitting, onError, onCompleted} = useMutationProps()
+  const {closePortal, teamMember: teamMemberRef} = props
   const teamMember = useFragment(
     graphql`
       fragment PromoteTeamMemberModal_teamMember on TeamMember {
         userId
         teamId
         preferredName
+        isSelf
+        team {
+          isOrgAdmin
+          teamLead {
+            isSelf
+            preferredName
+          }
+        }
       }
     `,
     teamMemberRef
   )
-  const {preferredName, teamId, userId} = teamMember
+  const {preferredName, teamId, userId, team, isSelf} = teamMember
+  const {isOrgAdmin, teamLead} = team ?? {}
+  const oldLeadName = teamLead?.preferredName
+  const isOldLeadSelf = teamLead?.isSelf
   const handleClick = () => {
     submitMutation()
     PromoteToTeamLeadMutation(atmosphere, {teamId, userId}, {onError, onCompleted})
     closePortal()
   }
+
+  const copyStart = `Are you sure? ${isOldLeadSelf ? 'You' : oldLeadName} will be removed as the team leader and ${isSelf ? 'You' : preferredName} will be promoted.`
+  const copyEnd =
+    isOldLeadSelf && isOrgAdmin
+      ? ''
+      : `${isSelf ? 'You' : upperFirst(preferredName)} will no longer be able to change team membership.`
+  const copy = `${copyStart} ${copyEnd}`
+
   return (
     <StyledDialogContainer>
       <DialogTitle>{'Are you sure?'}</DialogTitle>
       <DialogContent>
-        {`You will be removed as the team leader and promote ${preferredName}. You will no longer be able to change team membership. This cannot be undone!`}
+        {copy}
         <StyledButton size='medium' onClick={handleClick} waiting={submitting}>
           <IconLabel icon='arrow_forward' iconAfter label={`Yes, promote ${preferredName}`} />
         </StyledButton>
@@ -63,4 +78,4 @@ const PromoteTeamMemberModal = (props: Props) => {
   )
 }
 
-export default withMutationProps(PromoteTeamMemberModal)
+export default PromoteTeamMemberModal

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -27,6 +27,7 @@ const OrgTeams = (props: Props) => {
     `,
     organizationRef
   )
+
   const {
     open: openAddTeamDialog,
     close: closeAddTeamDialog,

--- a/packages/server/graphql/public/typeDefs/Team.graphql
+++ b/packages/server/graphql/public/typeDefs/Team.graphql
@@ -189,4 +189,9 @@ type Team {
   Emoji that will be used for giving kudos
   """
   kudosEmoji: String!
+
+  """
+  The team member that is the team lead
+  """
+  teamLead: TeamMember!
 }

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -761,11 +761,6 @@ type TeamMember {
   isOrgAdmin: Boolean!
 
   """
-  Is the viewer the org admin?
-  """
-  isViewerOrgAdmin: Boolean!
-
-  """
   true if the user prefers to not vote during a poker meeting
   """
   isSpectatingPoker: Boolean!

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -761,6 +761,11 @@ type TeamMember {
   isOrgAdmin: Boolean!
 
   """
+  Is the viewer the org admin?
+  """
+  isViewerOrgAdmin: Boolean!
+
+  """
   true if the user prefers to not vote during a poker meeting
   """
   isSpectatingPoker: Boolean!

--- a/packages/server/graphql/public/types/Team.ts
+++ b/packages/server/graphql/public/types/Team.ts
@@ -47,6 +47,10 @@ const Team: TeamResolvers = {
       .get('organizationUsersByUserIdOrgId')
       .load({userId: viewerId, orgId})
     return organizationUser?.role === 'ORG_ADMIN'
+  },
+  teamLead: async ({id: teamId}, _args, {dataLoader}) => {
+    const teamMembers = await dataLoader.get('teamMembersByTeamId').load(teamId)
+    return teamMembers.find((teamMember) => teamMember.isLead)!
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9732

<img width="1245" alt="Screenshot 2024-05-22 at 14 46 41" src="https://github.com/ParabolInc/parabol/assets/39854876/dbdc0b5a-4764-4657-af7d-d3bc116122bf">

### To test

- [ ] Go to Teams, and promote a user to the team lead
- [ ] See that the copy takes the following format: `Are you sure? User X will be removed as the team leader and User Y will be promoted. User X will no longer be able to change team membership.`
- [ ] But it doesn't show the final sentence if the org admin is removing themself as team lead
- [ ] And it says "you" if User X or Y is the viewer