### PR TITLE
feat(stripe): handle Stripe subscription events

### DIFF
--- a/packages/server/billing/stripeWebhookHandler.ts
+++ b/packages/server/billing/stripeWebhookHandler.ts
@@ -80,6 +80,41 @@ const eventLookup = {
         }
       `
       }
+    },
+    subscription: {
+      updated: {
+        getVars: ({customer, id}: {customer: string; id: string}) => ({
+          customerId: customer,
+          subscriptionId: id
+        }),
+        query: `
+        mutation StripeUpdateSubscription($customerId: ID!, $subscriptionId: ID!) {
+          stripeUpdateSubscription(customerId: $customerId, subscriptionId: $subscriptionId)
+        }
+      `
+      },
+      created: {
+        getVars: ({customer, id}: {customer: string; id: string}) => ({
+          customerId: customer,
+          subscriptionId: id
+        }),
+        query: `
+        mutation StripeCreateSubscription($customerId: ID!, $subscriptionId: ID!) {
+          stripeUpdateSubscription(customerId: $customerId, subscriptionId: $subscriptionId)
+        }
+      `
+      },
+      deleted: {
+        getVars: ({customer, id}: {customer: string; id: string}) => ({
+          customerId: customer,
+          subscriptionId: id
+        }),
+        query: `
+        mutation StripeDeleteSubscription($customerId: ID!, $subscriptionId: ID!) {
+          stripeDeleteSubscription(customerId: $customerId, subscriptionId: $subscriptionId)
+        }
+      `
+      }
     }
   }
 } as const

--- a/packages/server/graphql/private/mutations/stripeDeleteSubscription.ts
+++ b/packages/server/graphql/private/mutations/stripeDeleteSubscription.ts
@@ -4,7 +4,7 @@ import {isSuperUser} from '../../../utils/authorization'
 import {getStripeManager} from '../../../utils/stripe'
 import {MutationResolvers} from '../resolverTypes'
 
-const stripeUpdateSubscription: MutationResolvers['stripeUpdateSubscription'] = async (
+const stripeDeleteSubscription: MutationResolvers['stripeDeleteSubscription'] = async (
   _source,
   {customerId, subscriptionId},
   {authToken, dataLoader}
@@ -46,4 +46,4 @@ const stripeUpdateSubscription: MutationResolvers['stripeUpdateSubscription'] = 
   return true
 }
 
-export default stripeUpdateSubscription
+export default stripeDeleteSubscription

--- a/packages/server/graphql/private/mutations/stripeDeleteSubscription.ts
+++ b/packages/server/graphql/private/mutations/stripeDeleteSubscription.ts
@@ -28,17 +28,13 @@ const stripeUpdateSubscription: MutationResolvers['stripeUpdateSubscription'] = 
   if (!orgId) {
     throw new Error(`orgId not found on metadata for customer ${customerId}`)
   }
-  const [org, subscription]: [Organization, any] = await Promise.all([
-    await dataLoader.get('organizations').load(orgId),
-    await manager.getSubscriptionItem(subscriptionId)
-  ])
+  const org: Organization = await dataLoader.get('organizations').load(orgId)
 
   const {stripeSubscriptionId} = org
   if (stripeSubscriptionId !== subscriptionId) {
     throw new Error('Subscription ID does not match')
   }
 
-  console.log(subscription)
   await r
     .table('Organization')
     .get(orgId)

--- a/packages/server/graphql/private/mutations/stripeUpdateSubscription.ts
+++ b/packages/server/graphql/private/mutations/stripeUpdateSubscription.ts
@@ -1,0 +1,42 @@
+import getRethink from '../../../database/rethinkDriver'
+import {isSuperUser} from '../../../utils/authorization'
+import {getStripeManager} from '../../../utils/stripe'
+import {MutationResolvers} from '../resolverTypes'
+
+const stripeUpdateSubscription: MutationResolvers['stripeUpdateSubscription'] = async (
+  _source,
+  {customerId, subscriptionId},
+  {authToken}
+) => {
+  const r = await getRethink()
+  // AUTH
+  if (!isSuperUser(authToken)) {
+    throw new Error('Don’t be rude.')
+  }
+
+  // RESOLUTION
+  const manager = getStripeManager()
+  const stripeCustomer = await manager.retrieveCustomer(customerId)
+  if (stripeCustomer.deleted) {
+    throw new Error('Customer was deleted')
+  }
+
+  const {
+    metadata: {orgId}
+  } = stripeCustomer
+  if (!orgId) {
+    throw new Error(`orgId not found on metadata for customer ${customerId}`)
+  }
+
+  await r
+    .table('Organization')
+    .get(orgId)
+    .update({
+      stripeSubscriptionId: subscriptionId
+    })
+    .run()
+
+  return true
+}
+
+export default stripeUpdateSubscription

--- a/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
+++ b/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
@@ -70,8 +70,12 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
     return standardError(new Error('Organization does not have a subscription'), {userId: viewerId})
   }
 
-  if (tier !== 'starter') {
-    return standardError(new Error('Organization is not on the starter tier'), {
+  if (tier === 'enterprise') {
+    return standardError(new Error("Can not change an org's plan from enterprise to team"), {
+      userId: viewerId
+    })
+  } else if (tier === 'team') {
+    return standardError(new Error('Org is already on team tier'), {
       userId: viewerId
     })
   }

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -448,6 +448,35 @@ type Mutation {
   ): Boolean
 
   """
+  When stripe tells us a subscription was updated, update the details in our own DB
+  """
+  stripeUpdateSubscription(
+    """
+    The stripe customer ID, or stripeId
+    """
+    customerId: ID!
+    """
+    The stripe subscription ID
+    """
+    subscriptionId: ID!
+  ): Boolean
+
+  """
+  When stripe tells us a subscription was deleted, update the details in our own DB
+  """
+  stripeDeleteSubscription(
+    """
+    The stripe customer ID, or stripeId
+    """
+    customerId: ID!
+    """
+    The stripe subscription ID
+    """
+    subscriptionId: ID!
+  ): Boolean
+
+
+  """
   When a new invoiceitem is sent from stripe, tag it with metadata
   """
   stripeUpdateInvoiceItem(


### PR DESCRIPTION
# Description
When we increase the team subscription price from $6 to $8, it would be a new pricing ([parabol-pro-800](https://dashboard.stripe.com/prices/parabol-pro-800) vs. [parabol-pro-600](https://dashboard.stripe.com/prices/parabol-pro-600)) and that means we need to migrate all customers from the old subscriptions to new ones. I plan to do the migration with a separate script that interacts with Stripe directly. The change we need from Parabol app side is to listen for the subscription changes and then update the `stripeSubscriptionId` field for the org accordingly.

## Testing scenarios
1. Start a local listener `stripe listen --forward-to localhost:3000/stripe`
2. Upgrade an org to `team` tier and verify the `stripeId` and `stripeSubscriptionId` in `Organization` table match with the `customerId` and `subscriptionId` in Stripe
3. Go to the customer page in Stripe, cancel that subscription. Verify the `stripeSubscriptionId` in `Organization` table is removed.
4. Go back to the customer page in Stripe and manually create a new subscription. Verify the `stripeSubscriptionId` in the `Organization` table is updated with the `subscriptionId` from the new subscription.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
