### PR TITLE
feat: update plan upgrade CTA label

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
@@ -89,7 +89,7 @@ const TeamSettings = (props: Props) => {
                   : 'This team is currently on a starter plan.'}
               </div>
               <PrimaryButton onClick={() => history.push(`/me/organizations/${orgId}`)}>
-                {`Upgrade Team to ${TierLabel.TEAM}`}
+                {`Upgrade to ${TierLabel.TEAM} Plan`}
               </PrimaryButton>
             </StyledRow>
           </Panel>


### PR DESCRIPTION
# Description

I was running through the app on an un-upgraded team and noticed the CTA to upgrade under TeamSettings was "Upgrade Team to Team" which read a bit oddly to me. It wasn't clear that "Team" was a plan you could buy. Without reading the description text near the CTA, I would have thought, "wait, isn't my team already a team?"

This trivial change changes the CTA to read "Upgrade to Team Plan"

Adding @nickoferrall to the PR review just in case there was some intention behind this CTA I missed

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
