### PR TITLE
feat: write equality checker to file store

### DIFF
--- a/packages/server/fileStorage/FileStoreManager.ts
+++ b/packages/server/fileStorage/FileStoreManager.ts
@@ -39,4 +39,9 @@ export default abstract class FileStoreManager {
     const partialPath = `Organization/${orgId}/template/${filename}.${dotfreeExt}`
     return this.putUserFile(file, partialPath)
   }
+
+  async putDebugFile(file: ArrayBufferLike, nameWithExt: string) {
+    const partialPath = `__debug__/${nameWithExt}`
+    return this.putUserFile(file, partialPath)
+  }
 }

--- a/packages/server/graphql/private/mutations/checkRethinkPgEquality.ts
+++ b/packages/server/graphql/private/mutations/checkRethinkPgEquality.ts
@@ -1,6 +1,5 @@
-import fs from 'fs'
-import path from 'path'
 import getRethink from '../../../database/rethinkDriver'
+import getFileStoreManager from '../../../fileStorage/getFileStoreManager'
 import getKysely from '../../../postgres/getKysely'
 import {checkRowCount, checkTableEq} from '../../../postgres/utils/checkEqBase'
 import {
@@ -20,12 +19,10 @@ const handleResult = async (
   const resultStr = JSON.stringify(result)
   if (!writeToFile) return resultStr
 
-  const fileName = `${tableName}-${new Date()}`
-  const fileDir = path.join(process.cwd(), '__rethinkEquality__')
-  const fileLocation = path.join(fileDir, fileName)
-  await fs.promises.mkdir(fileDir, {recursive: true})
-  await fs.promises.writeFile(fileLocation, resultStr)
-  return `Result written to ${fileLocation}`
+  const fileName = `rethinkdbEquality_${tableName}_${new Date().toISOString()}.json`
+  const manager = getFileStoreManager()
+  const buffer = Buffer.from(resultStr, 'utf-8')
+  return manager.putDebugFile(buffer, fileName)
 }
 
 const checkRethinkPgEquality: MutationResolvers['checkRethinkPgEquality'] = async (


### PR DESCRIPTION
# Description

Writes errors to S3 instead of to the local filesystem.
Now we don't have to go on a scavenger hunt across our pods trying to find the file 🎉 
e.g. https://action-files.parabol.co/local-development/store/__debug__/rethinkdbEquality_RetroReflectionGroup_2024-05-28T21:50:43.936Z.json