### PR TITLE
chore: Allow global Jira Server integration provider

### DIFF
--- a/packages/server/graphql/mutations/addIntegrationProvider.ts
+++ b/packages/server/graphql/mutations/addIntegrationProvider.ts
@@ -30,12 +30,19 @@ const addIntegrationProvider = {
     context: GQLContext
   ) => {
     const {authToken, dataLoader, socketId: mutatorId} = context
-    const {teamId} = input
+    const {teamId, scope} = input
     const operationId = dataLoader.share()
     const subOptions = {mutatorId, operationId}
 
     // AUTH
-    if (!isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
+    if (scope === 'global') {
+      if (!isSuperUser(authToken)) {
+        return {error: {message: 'Global scope requires su'}}
+      }
+      if (teamId !== 'aGhostTeam') {
+        return {error: {message: 'Global scope requires teamId to be aGhostTeam'}}
+      }
+    } else if (!isTeamMember(authToken, teamId) && !isSuperUser(authToken)) {
       return {error: {message: 'Must be on the team for which the provider is created'}}
     }
 

--- a/packages/server/graphql/public/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/public/typeDefs/_legacy.graphql
@@ -8631,6 +8631,7 @@ The scope this provider was created on by a user (excluding global scope)
 enum IntegrationProviderEditableScopeEnum {
   org
   team
+  global
 }
 
 """

--- a/packages/server/graphql/types/IntegrationProviderEditableScopeEnum.ts
+++ b/packages/server/graphql/types/IntegrationProviderEditableScopeEnum.ts
@@ -1,13 +1,14 @@
 import {GraphQLEnumType} from 'graphql'
 
-export type TIntegrationProviderEditableScopeEnum = 'org' | 'team'
+export type TIntegrationProviderEditableScopeEnum = 'org' | 'team' | 'global'
 
 const IntegrationProviderEditableScopeEnum = new GraphQLEnumType({
   name: 'IntegrationProviderEditableScopeEnum',
   description: 'The scope this provider was created on by a user (excluding global scope)',
   values: {
     org: {},
-    team: {}
+    team: {},
+    global: {}
   }
 })
 

--- a/packages/server/graphql/types/JiraServerIntegration.ts
+++ b/packages/server/graphql/types/JiraServerIntegration.ts
@@ -77,7 +77,11 @@ const JiraServerIntegration = new GraphQLObjectType<{teamId: string; userId: str
 
         const providers = await dataLoader
           .get('sharedIntegrationProviders')
-          .load({service: 'jiraServer', orgTeamIds, teamIds: [teamId]})
+          .load({
+            service: 'jiraServer',
+            orgTeamIds: [...orgTeamIds, 'aGhostTeam'],
+            teamIds: [teamId]
+          })
         return providers
       }
     },

--- a/packages/server/postgres/migrations/1716995191300_allowGlobalOAuth1Provider.ts
+++ b/packages/server/postgres/migrations/1716995191300_allowGlobalOAuth1Provider.ts
@@ -1,0 +1,19 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+  DO $$
+  BEGIN
+    ALTER TABLE "IntegrationProvider"
+      DROP CONSTRAINT global_provider_must_be_oauth2;
+  END $$;
+  `)
+  await client.end()
+}
+
+export async function down() {
+  //noop, the constraint was a leftover and served no purpose
+}


### PR DESCRIPTION
# Description

Allow super users to add global integration providers, including Jira Server. Jira Server global integration is still treated as a shared integration, as there is no cloud instance.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
