### PR TITLE
feat: Add search template mutation

### DIFF
--- a/packages/client/components/ActivityLibrary/ActivityLibraryEmptyState.tsx
+++ b/packages/client/components/ActivityLibrary/ActivityLibraryEmptyState.tsx
@@ -14,7 +14,7 @@ const ActivityLibraryEmptyState = (props: Props) => {
   const {categoryId, searchQuery} = props
   const showResultsNotFound = categoryId !== 'custom' || searchQuery !== ''
 
-  if (categoryId === 'favorite') {
+  if (!searchQuery && categoryId === 'favorite') {
     return (
       <div className='relative mx-auto flex justify-center p-2 align-middle text-slate-700'>
         <div className='p-4 md:p-0 '>

--- a/packages/client/hooks/useDebouncedSearch.ts
+++ b/packages/client/hooks/useDebouncedSearch.ts
@@ -1,0 +1,37 @@
+import {useEffect, useRef, useState} from 'react'
+
+/**
+ * Debounces a search string. It will wait for the user to stop typing or finishing a word before returning the debounced search string.
+ */
+export const useDebouncedSearch = (search: string) => {
+  const wordEndChars = /[\s,.\!?:;\-\(\)\[\]\{\}<>"'\\|&*+=#%@$]/
+  const timer = useRef<NodeJS.Timeout>()
+  const [debouncedSearch, setDebouncedSearch] = useState('')
+
+  useEffect(() => {
+    if (!search) {
+      setDebouncedSearch(search)
+      return
+    }
+    // if they finished a word, send it now
+    if (wordEndChars.test(search.at(-1)!)) {
+      setDebouncedSearch(search)
+      return
+    }
+    // assuming 40 wpm with 5 characters per word we get 300ms between characters
+    // give some wiggle room for slow typers
+    timer.current = setTimeout(() => {
+      setDebouncedSearch(search)
+      timer.current = undefined
+    }, 500)
+    return () => {
+      clearTimeout(timer.current)
+      timer.current = undefined
+    }
+  }, [search])
+
+  return {
+    debouncedSearch,
+    dirty: !!timer.current
+  }
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -144,7 +144,6 @@
     "tayden-clusterfck": "^0.7.0",
     "tlds": "^1.192.0",
     "tslib": "^2.4.0",
-    "unicode-substring": "^1.0.0",
-    "use-debounce": "^10.0.0"
+    "unicode-substring": "^1.0.0"
   }
 }

--- a/packages/embedder/ai_models/TextEmbeddingsInference.ts
+++ b/packages/embedder/ai_models/TextEmbeddingsInference.ts
@@ -77,7 +77,7 @@ export class TextEmbeddingsInference extends AbstractEmbeddingsModel {
       body: {inputs: content}
     })
     if (error) {
-      if (response.status !== 429 || retries < 1) return new Error(error.error)
+      if (response?.status !== 429 || retries < 1) return new Error(error.error)
       await sleep(2000)
       return this.getEmbedding(content, retries - 1)
     }

--- a/packages/embedder/importHistoricalRetrospectiveDiscussionTopic.ts
+++ b/packages/embedder/importHistoricalRetrospectiveDiscussionTopic.ts
@@ -27,7 +27,7 @@ export const importHistoricalRetrospectiveDiscussionTopic = async () => {
   const earliestImportedDiscussion = await pg
     .selectFrom('EmbeddingsMetadata')
     .select(['id', 'refUpdatedAt', 'refId'])
-    .where('objectType', '=', 'retrospectiveDiscussionTopic')
+    .where('objectType', '=', 'meetingTemplate')
     .orderBy('refUpdatedAt')
     .limit(1)
     .executeTakeFirst()

--- a/packages/server/__tests__/user.test.ts
+++ b/packages/server/__tests__/user.test.ts
@@ -1,5 +1,5 @@
 import faker from 'faker'
-import {sendIntranet, signUp, signUpWithEmail} from './common'
+import {sendIntranet, sendPublic, signUp, signUpWithEmail} from './common'
 
 test('Get user by id', async () => {
   const {email, userId} = await signUp()
@@ -119,6 +119,67 @@ test('First user is patientZero', async () => {
       user: {
         id: user2Id,
         isPatient0: false
+      }
+    }
+  })
+})
+
+test.each([
+  ['card game', ['moscowPrioritizationTemplate', 'estimatedEffortTemplate', 'wsjfTemplate']],
+  ['winning loosing', ['winningStreakTemplate']],
+  [
+    'project failure',
+    [
+      'whyDidTheProjectFailPremortemTemplate',
+      'successAndFailurePremortemTemplate',
+      'postmortemAnalysisTemplate',
+      'blamelessPostmortemTemplate',
+      'simplePostmortemTemplate',
+      'softwareProjectPostmortemTemplate',
+      'movieDirectorPostmortemTemplate',
+      'fortuneTellerPremortemTemplate',
+      'timelinePremortemTemplate',
+      'howLikelyToFailPremortemTemplate',
+      'engineeringPostmortemTemplate',
+      'resourceAllocationPremortemTemplate',
+      'processImprovementPostmortemTemplate',
+      'incidentImpactPostmortemTemplate',
+      'bestworstCaseScenarioPremortemTemplate',
+      'gameShowPostmortemTemplate',
+      'timeTravelPostmortemTemplate',
+      'teamEfficiencyPremortemTemplate',
+      'risksAndPrecautionsPremortemTemplate',
+      'obstacleCoursePremortemTemplate',
+      'stakeholderSatisfactionPostmortemTemplate'
+    ]
+  ],
+  ['christmas', ['aChristmasCarolRetrospectiveTemplate']],
+  ['risk management', ['riskManagementPostmortemTemplate', 'risksAndPrecautionsPremortemTemplate']],
+  ['animals', ['iguanaCrocodileKomodoDragonPremortemTemplate']],
+  ['plants', ['roseThornBudTemplate']]
+])('Template search - %s', async (search, templateIds) => {
+  const {authToken} = await signUp()
+
+  const user = await sendPublic({
+    query: `
+      query Template($search: String!) {
+        viewer {
+          templateSearch(search: $search) {
+            id
+          }
+        }
+      }
+    `,
+    variables: {
+      search
+    },
+    authToken
+  })
+
+  expect(user).toMatchObject({
+    data: {
+      viewer: {
+        templateSearch: expect.arrayContaining(templateIds.map((id) => ({id})))
       }
     }
   })

--- a/packages/server/__tests__/user.test.ts
+++ b/packages/server/__tests__/user.test.ts
@@ -124,7 +124,8 @@ test('First user is patientZero', async () => {
   })
 })
 
-test.each([
+// The tests only work after the embeddings were generated, which is not the case on CI
+test.skip.each([
   ['card game', ['moscowPrioritizationTemplate', 'estimatedEffortTemplate', 'wsjfTemplate']],
   ['winning loosing', ['winningStreakTemplate']],
   [

--- a/packages/server/graphql/public/typeDefs/User.graphql
+++ b/packages/server/graphql/public/typeDefs/User.graphql
@@ -445,6 +445,16 @@ type User {
   ): MeetingTemplateConnection!
 
   """
+  Activities available to the user matching the search
+  """
+  templateSearch(
+    """
+    Search query
+    """
+    search: String!
+  ): [MeetingTemplate!]!
+
+  """
   A prototype for a team experience. Includes meeting templates and meeting types that have no templates
   """
   activity(

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -211,7 +211,7 @@ const User: UserResolvers = {
     const data = await response.json()
 
     const MODEL = 'Embeddings_ember_1'
-    const SIMILARITY_THRESHOLD = 0.45
+    const SIMILARITY_THRESHOLD = 0.5
 
     const pg = getKysely()
     const similarEmbeddings = await pg

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -8,6 +8,7 @@ import generateInvoice from '../../../billing/helpers/generateInvoice'
 import generateUpcomingInvoice from '../../../billing/helpers/generateUpcomingInvoice'
 import getRethink from '../../../database/rethinkDriver'
 import MeetingTemplate from '../../../database/types/MeetingTemplate'
+import getKysely from '../../../postgres/getKysely'
 import {
   getUserId,
   isSuperUser,
@@ -183,6 +184,73 @@ const User: UserResolvers = {
       .sort((a, b) => (a.sortOrder > b.sortOrder ? -1 : 1))
 
     return connectionFromTemplateArray(allActivities, first, after)
+  },
+  templateSearch: async ({id: userId}, {search}, {authToken, dataLoader}) => {
+    if (!search) return []
+    const viewerId = getUserId(authToken)
+    const user = await dataLoader.get('users').loadNonNull(userId)
+    const teamIds =
+      viewerId === userId || isSuperUser(authToken)
+        ? user.tms
+        : user.tms.filter((teamId: string) => authToken.tms.includes(teamId))
+
+    const organizationUsers = await dataLoader.get('organizationUsersByUserId').load(viewerId)
+    const userOrgIds = organizationUsers.map(({orgId}) => orgId)
+
+    const allOrgTeams = (await dataLoader.get('teamsByOrgIds').loadMany(userOrgIds))
+      .filter(isValid)
+      .flat()
+    // all team ids which could have accessible templates
+    const allTeamIds = ['aGhostTeam', ...allOrgTeams.map(({id}) => id)]
+
+    const response = await fetch('http://localhost:3040/embed', {
+      method: 'POST',
+      body: JSON.stringify({inputs: search}),
+      headers: {'Content-Type': 'application/json'}
+    })
+    const data = await response.json()
+
+    const MODEL = 'Embeddings_ember_1'
+    const SIMILARITY_THRESHOLD = 0.45
+
+    const pg = getKysely()
+    const similarEmbeddings = await pg
+      .with('Model', (qc) =>
+        qc
+          .selectFrom(MODEL)
+          .innerJoin('EmbeddingsMetadata', 'EmbeddingsMetadata.id', `${MODEL}.embeddingsMetadataId`)
+          .select([`${MODEL}.id`, 'embeddingsMetadataId', 'embedding', 'refId'])
+          .where('objectType', '=', 'meetingTemplate')
+          .where('teamId', 'in', allTeamIds)
+      )
+      .with('CosineSimilarity', (pg) =>
+        pg
+          .selectFrom(['Model'])
+          .select(({eb, val, parens, ref}) => [
+            ref('Model.id').as('embeddingId'),
+            ref('Model.embeddingsMetadataId').as('embeddingsMetadataId'),
+            ref('Model.refId').as('refId'),
+            eb(
+              val(1),
+              '-',
+              parens('Model.embedding' as any, '<=>' as any, JSON.stringify(data[0]))
+            ).as('similarity')
+          ])
+      )
+      .selectFrom('CosineSimilarity')
+      .select(['embeddingId', 'similarity', 'embeddingsMetadataId', 'refId'])
+      .where('similarity', '>=', SIMILARITY_THRESHOLD)
+      .orderBy('similarity', 'desc')
+      .execute()
+
+    const aiActivityIds = similarEmbeddings.map(({refId}) => refId)
+
+    // TODO filter out seasonal templates
+    const activities = await dataLoader.get('meetingTemplates').loadMany(aiActivityIds)
+    const accessibleActivities = activities.filter(isValid).filter((activity) => {
+      return activity.scope !== 'TEAM' || teamIds.includes(activity.teamId)
+    })
+    return accessibleActivities
   },
   parseSAMLMetadata: async (_source, {metadataURL, domain}) => {
     const metadata = await getSSOMetadataFromURL(metadataURL)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -122,6 +122,7 @@
     "nodemailer": "^6.9.9",
     "oauth-1.0a": "^2.2.6",
     "openai": "^4.24.1",
+    "openapi-fetch": "^0.9.7",
     "oy-vey": "^0.12.1",
     "parabol-client": "7.36.0",
     "pg": "^8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21584,11 +21584,6 @@ use-composed-ref@^1.3.0:
   resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.3.0.tgz#3d8104db34b7b264030a9d916c5e94fbe280dbda"
   integrity sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==
 
-use-debounce@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-10.0.0.tgz#5091b18d6c16292605f588bae3c0d2cfae756ff2"
-  integrity sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==
-
 use-isomorphic-layout-effect@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9902,9 +9902,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001580, caniuse-lite@~1.0.0:
-  version "1.0.30001614"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001614.tgz#f894b4209376a0bf923d67d9c361d96b1dfebe39"
-  integrity sha512-jmZQ1VpmlRwHgdP1/uiKzgiAuGOfLEJsYFP4+GBou/QQ4U6IOJCB4NP1c+1p9RGLpwObcT94jA5/uO+F1vBbog==
+  version "1.0.30001623"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001623.tgz#e982099dcb229bb6ab35f5aebe2f8d79ccf6e8a8"
+  integrity sha512-X/XhAVKlpIxWPpgRTnlgZssJrF0m6YtRA0QDWgsBNT12uZM6LPRydR7ip405Y3t1LamD8cP2TZFEDZFBf5ApcA==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -17152,6 +17152,13 @@ openapi-fetch@^0.9.3:
   dependencies:
     openapi-typescript-helpers "^0.0.7"
 
+openapi-fetch@^0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/openapi-fetch/-/openapi-fetch-0.9.7.tgz#e224d1176e11ec68671caf0df6b736d649be97ed"
+  integrity sha512-NMp/GEmWSGO0b2d731IdGXcMP2PF85Rk1q+oy2Mx/DYMdP3pgTZTRamKxgZpkHhM4iOVsyD1iP5HKL9Fr6CH2Q==
+  dependencies:
+    openapi-typescript-helpers "^0.0.8"
+
 openapi-types@^12.1.0:
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.1.1.tgz#0aface4e05ba60efbf51153ed6af23988796617d"
@@ -17161,6 +17168,11 @@ openapi-typescript-helpers@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.7.tgz#1d0ead67c35864d189c2cb2d0556854ccbb16c38"
   integrity sha512-7nwlAtdA1fULipibFRBWE/rnF114q6ejRYzNvhdA/x+qTWAZhXGLc/368dlwMlyJDvCQMCnADjpzb5BS5ZmNSA==
+
+openapi-typescript-helpers@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.8.tgz#460f395362cc16e4a5de56264b7b1c5a03746e35"
+  integrity sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g==
 
 opener@^1.5.2:
   version "1.5.2"


### PR DESCRIPTION
# Description

Fixes #9774, #9775
Add a template search query to the User object.

## Demo

https://www.loom.com/share/114efbf0a1864ba09816c0bf87a28620?sid=86867080-17c0-405a-bf6a-828a591bdfad

## Testing scenarios

- [ ] search for templates in the activity library
- [ ] create custom templates, wait for the embedding (ca. 1min, you can check `EmbeddingsJobQueue` is empty) and search for it

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
