### PR TITLE
fix: clear kudos received notifications

### DIFF
--- a/packages/server/postgres/migrations/1717083323369_removeKudosNotifications.ts
+++ b/packages/server/postgres/migrations/1717083323369_removeKudosNotifications.ts
@@ -1,14 +1,14 @@
-import {Kysely, PostgresDialect} from 'kysely'
-import getPg from '../getPg'
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
 
 export async function up() {
-  const pg = new Kysely<any>({
-    dialect: new PostgresDialect({
-      pool: getPg()
-    })
-  })
-
-  await pg.deleteFrom('Notification').where('type', '=', 'KUDOS_RECEIVED').execute()
+  try {
+    await connectRethinkDB()
+    await r.table('Notification').filter(r.row('type').eq('KUDOS_RECEIVED')).delete().run()
+    await r.getPoolMaster()?.drain()
+  } catch (e) {
+    console.log(e)
+  }
 }
 
 export async function down() {

--- a/packages/server/postgres/migrations/1717083323369_removeKudosNotifications.ts
+++ b/packages/server/postgres/migrations/1717083323369_removeKudosNotifications.ts
@@ -1,0 +1,16 @@
+import {Kysely, PostgresDialect} from 'kysely'
+import getPg from '../getPg'
+
+export async function up() {
+  const pg = new Kysely<any>({
+    dialect: new PostgresDialect({
+      pool: getPg()
+    })
+  })
+
+  await pg.deleteFrom('Notification').where('type', '=', 'KUDOS_RECEIVED').execute()
+}
+
+export async function down() {
+  // noop
+}


### PR DESCRIPTION
Fix issue on staging where kudos notifications can't be resolved: https://app.datadoghq.com/logs?query=service%3Aparabol%20env%3Astaging&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAY_KGuJT0GOswAAAAAAAAAAYAAAAAEFZX0tHdWxDQUFCQ2xQY1BFQzd3dlFBQgAAACQAAAAAMDE4ZmNhMWItMjJmNy00ZWUyLWI1ZTItZThmMjBmNjhlMTkx&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1717079344464&to_ts=1717082944464&live=true