### PR TITLE
fix: Add teamId index to SuggestedAction

### DIFF
--- a/packages/server/database/rethinkDriver.ts
+++ b/packages/server/database/rethinkDriver.ts
@@ -166,7 +166,7 @@ export type RethinkSchema = {
     // tryRetroMeeting = 'tryRetroMeeting',
     // tryActionMeeting = 'tryActionMeeting'
     type: SuggestedActionCreateNewTeam | SuggestedActionInviteYourTeam | SuggestedActionTryTheDemo
-    index: 'userId'
+    index: 'userId' | 'teamId'
   }
   Task: {
     type: Task

--- a/packages/server/postgres/migrations/1717685812675_addSuggestedActionTeamIdIndex.ts
+++ b/packages/server/postgres/migrations/1717685812675_addSuggestedActionTeamIdIndex.ts
@@ -1,0 +1,21 @@
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+export async function up() {
+  await connectRethinkDB()
+  try {
+    await r.table('SuggestedAction').indexCreate('teamId').run()
+    await r.table('SuggestedAction').indexWait().run()
+  } catch {
+    // index already exists
+  }
+}
+
+export async function down() {
+  await connectRethinkDB()
+  try {
+    await r.table('SuggestedAction').indexDrop('teamId').run()
+  } catch {
+    // index already dropped
+  }
+}

--- a/packages/server/safeMutations/safeArchiveTeam.ts
+++ b/packages/server/safeMutations/safeArchiveTeam.ts
@@ -26,7 +26,7 @@ const safeArchiveTeam = async (teamId: string, dataLoader: DataLoaderWorker) => 
         })) as unknown as null,
       removedSuggestedActionIds: r
         .table('SuggestedAction')
-        .filter({teamId})
+        .getAll(teamId, {index: 'teamId'})
         .update(
           {
             removedAt: now


### PR DESCRIPTION
Removing a team would filter through all SuggestedActions which results in read spikes and is very slow.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
