### PR TITLE
feat: add menu to dashboard nav

### DIFF
--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -1,16 +1,17 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {useState} from 'react'
+import React from 'react'
 import {useFragment} from 'react-relay'
 import {PALETTE} from '~/styles/paletteV3'
 import {DashNavList_organization$key} from '../../__generated__/DashNavList_organization.graphql'
 import {TierEnum} from '../../__generated__/DowngradeToStarterMutation.graphql'
-import {Menu} from '../../ui/Menu/Menu'
-import {MenuItem} from '../../ui/Menu/MenuItem'
+import useBreakpoint from '../../hooks/useBreakpoint'
+import {Breakpoint} from '../../types/constEnums'
 import {upperFirst} from '../../utils/upperFirst'
 import LeftDashNavItem from '../Dashboard/LeftDashNavItem'
 import BaseTag from '../Tag/BaseTag'
 import DashNavListTeams from './DashNavListTeams'
+import DashNavMenu from './DashNavMenu'
 
 const EmptyTeams = styled('div')({
   fontSize: 16,
@@ -34,14 +35,12 @@ const Tag = styled(BaseTag)<{tier: TierEnum | null}>(({tier}) => ({
 }))
 
 interface Props {
-  className?: string
   organizationsRef: DashNavList_organization$key | null
   onClick?: () => void
 }
 
 const DashNavList = (props: Props) => {
-  const {className, onClick, organizationsRef} = props
-  const [showMenu, setShowMenu] = useState(false)
+  const {onClick, organizationsRef} = props
   const organizations = useFragment(
     graphql`
       fragment DashNavList_organization on Organization @relay(plural: true) {
@@ -56,15 +55,11 @@ const DashNavList = (props: Props) => {
     `,
     organizationsRef
   )
+  const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const teams = organizations?.flatMap((org) => org.viewerTeams)
 
   if (teams?.length === 0) {
     return <EmptyTeams>It appears you are not a member of any team!</EmptyTeams>
-  }
-
-  const handleClick = () => {
-    console.log('cklickkkckckck')
-    setShowMenu(true)
   }
 
   return (
@@ -86,26 +81,19 @@ const DashNavList = (props: Props) => {
               </div>
             </div>
 
-            <Menu
-              side='right'
-              sideOffset={20}
-              trigger={
-                <div>
-                  <StyledLeftDashNavItem
-                    className={className}
-                    onClick={handleClick}
-                    icon={'manageAccounts'}
-                    isViewerOnTeam
-                    // href={`/me/organizations/${org.id}/billing`}
-                    label={'Settings & Members'}
-                  />
-                </div>
-              }
-            >
-              <MenuItem className='h-80 w-full' onClick={() => {}}>
-                Change template
-              </MenuItem>
-            </Menu>
+            {isDesktop ? (
+              <DashNavMenu />
+            ) : (
+              <StyledLeftDashNavItem
+                className={'bg-transparent'}
+                icon={'manageAccounts'}
+                isViewerOnTeam
+                onClick={onClick}
+                href={`/me/organizations/${org.id}/billing`}
+                label={'Settings & Members'}
+              />
+            )}
+
             <div className='border-t border-solid border-slate-300' />
             <DashNavListTeams onClick={onClick} organizationRef={org} />
           </div>

--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -44,10 +44,11 @@ const DashNavList = (props: Props) => {
   const organizations = useFragment(
     graphql`
       fragment DashNavList_organization on Organization @relay(plural: true) {
+        ...DashNavListTeams_organization
+        ...DashNavMenu_organization
         id
         name
         tier
-        ...DashNavListTeams_organization
         viewerTeams {
           id
         }
@@ -82,7 +83,7 @@ const DashNavList = (props: Props) => {
             </div>
 
             {isDesktop ? (
-              <DashNavMenu orgId={org.id} />
+              <DashNavMenu organizationRef={org} />
             ) : (
               <StyledLeftDashNavItem
                 className={'bg-transparent'}

--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -82,7 +82,7 @@ const DashNavList = (props: Props) => {
             </div>
 
             {isDesktop ? (
-              <DashNavMenu />
+              <DashNavMenu orgId={org.id} />
             ) : (
               <StyledLeftDashNavItem
                 className={'bg-transparent'}
@@ -93,7 +93,6 @@ const DashNavList = (props: Props) => {
                 label={'Settings & Members'}
               />
             )}
-
             <div className='border-t border-solid border-slate-300' />
             <DashNavListTeams onClick={onClick} organizationRef={org} />
           </div>

--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React from 'react'
+import React, {useState} from 'react'
 import {useFragment} from 'react-relay'
 import {PALETTE} from '~/styles/paletteV3'
 import {DashNavList_organization$key} from '../../__generated__/DashNavList_organization.graphql'
 import {TierEnum} from '../../__generated__/DowngradeToStarterMutation.graphql'
+import {Menu} from '../../ui/Menu/Menu'
+import {MenuItem} from '../../ui/Menu/MenuItem'
 import {upperFirst} from '../../utils/upperFirst'
 import LeftDashNavItem from '../Dashboard/LeftDashNavItem'
 import BaseTag from '../Tag/BaseTag'
@@ -39,6 +41,7 @@ interface Props {
 
 const DashNavList = (props: Props) => {
   const {className, onClick, organizationsRef} = props
+  const [showMenu, setShowMenu] = useState(false)
   const organizations = useFragment(
     graphql`
       fragment DashNavList_organization on Organization @relay(plural: true) {
@@ -59,6 +62,11 @@ const DashNavList = (props: Props) => {
     return <EmptyTeams>It appears you are not a member of any team!</EmptyTeams>
   }
 
+  const handleClick = () => {
+    console.log('cklickkkckckck')
+    setShowMenu(true)
+  }
+
   return (
     <div className='w-full pr-2 lg:p-2'>
       {organizations?.map((org) => {
@@ -77,14 +85,27 @@ const DashNavList = (props: Props) => {
                 </div>
               </div>
             </div>
-            <StyledLeftDashNavItem
-              className={className}
-              onClick={onClick}
-              icon={'manageAccounts'}
-              isViewerOnTeam
-              href={`/me/organizations/${org.id}/billing`}
-              label={'Settings & Members'}
-            />
+
+            <Menu
+              side='right'
+              sideOffset={20}
+              trigger={
+                <div>
+                  <StyledLeftDashNavItem
+                    className={className}
+                    onClick={handleClick}
+                    icon={'manageAccounts'}
+                    isViewerOnTeam
+                    // href={`/me/organizations/${org.id}/billing`}
+                    label={'Settings & Members'}
+                  />
+                </div>
+              }
+            >
+              <MenuItem className='h-80 w-full' onClick={() => {}}>
+                Change template
+              </MenuItem>
+            </Menu>
             <div className='border-t border-solid border-slate-300' />
             <DashNavListTeams onClick={onClick} organizationRef={org} />
           </div>

--- a/packages/client/components/DashNavList/DashNavMenu.tsx
+++ b/packages/client/components/DashNavList/DashNavMenu.tsx
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
+import {useFragment} from 'react-relay'
 import {useHistory} from 'react-router'
+import {DashNavMenu_organization$key} from '../../__generated__/DashNavMenu_organization.graphql'
 import {PALETTE} from '../../styles/paletteV3'
 import {Menu} from '../../ui/Menu/Menu'
 import {MenuContent} from '../../ui/Menu/MenuContent'
@@ -16,17 +19,32 @@ const StyledLeftDashNavItem = styled(LeftDashNavItem)<{isViewerOnTeam: boolean}>
 )
 
 type Props = {
-  orgId: string
+  organizationRef: DashNavMenu_organization$key
 }
 
 const DashNavMenu = (props: Props) => {
-  const {orgId} = props
+  const {organizationRef} = props
   const history = useHistory()
+  const org = useFragment(
+    graphql`
+      fragment DashNavMenu_organization on Organization {
+        id
+        tier
+      }
+    `,
+    organizationRef
+  )
+  const {id: orgId, tier} = org
   const menuItems = [
     {
       label: (
         <>
-          Plans & Billing •&nbsp;<span className='text-sky-500'>Upgrade</span>
+          Plans & Billing{' '}
+          {tier === 'starter' && (
+            <>
+              •&nbsp;<span className='text-sky-500'>Upgrade</span>
+            </>
+          )}
         </>
       ),
       href: `/me/organizations/${orgId}/billing`

--- a/packages/client/components/DashNavList/DashNavMenu.tsx
+++ b/packages/client/components/DashNavList/DashNavMenu.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import {useHistory} from 'react-router'
 import {PALETTE} from '../../styles/paletteV3'
 import {Menu} from '../../ui/Menu/Menu'
 import {MenuItem} from '../../ui/Menu/MenuItem'
@@ -13,8 +14,44 @@ const StyledLeftDashNavItem = styled(LeftDashNavItem)<{isViewerOnTeam: boolean}>
   })
 )
 
-const DashNavMenu = () => {
-  const handleMenuItemClick = () => {}
+type Props = {
+  orgId: string
+}
+
+const DashNavMenu = (props: Props) => {
+  const {orgId} = props
+  const history = useHistory()
+  const menuItems = [
+    {
+      label: (
+        <>
+          Plans & Billing •&nbsp;<span className='text-sky-500'>Upgrade</span>
+        </>
+      ),
+      href: `/me/organizations/${orgId}/billing`
+    },
+    {
+      label: 'Teams',
+      href: `/me/organizations/${orgId}/teams`
+    },
+    {
+      label: 'Members',
+      href: `/me/organizations/${orgId}/members`
+    },
+    {
+      label: 'Organization Settings',
+      href: `/me/organizations/${orgId}/settings`
+    },
+    {
+      label: 'Authentication',
+      href: `/me/organizations/${orgId}/authentication`
+    }
+  ]
+
+  const handleMenuItemClick = (href: string) => {
+    history.push(href)
+  }
+
   return (
     <Menu
       side='right'
@@ -24,22 +61,18 @@ const DashNavMenu = () => {
         <div>
           <StyledLeftDashNavItem
             className={'bg-transparent'}
-            // onClick={handleClick}
             icon={'manageAccounts'}
             isViewerOnTeam
-            // href={`/me/organizations/${org.id}/billing`}
             label={'Settings & Members'}
           />
         </div>
       }
     >
-      <MenuItem onClick={handleMenuItemClick}>
-        Plans & Billing •&nbsp;<span className='text-sky-500'>Upgrade</span>
-      </MenuItem>
-      <MenuItem onClick={handleMenuItemClick}>Teams</MenuItem>
-      <MenuItem onClick={handleMenuItemClick}>Members</MenuItem>
-      <MenuItem onClick={handleMenuItemClick}>Organization Settings</MenuItem>
-      <MenuItem onClick={handleMenuItemClick}>Authentication</MenuItem>
+      {menuItems.map((item) => (
+        <MenuItem key={item.href} onClick={() => handleMenuItemClick(item.href)}>
+          {item.label}
+        </MenuItem>
+      ))}
     </Menu>
   )
 }

--- a/packages/client/components/DashNavList/DashNavMenu.tsx
+++ b/packages/client/components/DashNavList/DashNavMenu.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {useHistory} from 'react-router'
 import {PALETTE} from '../../styles/paletteV3'
 import {Menu} from '../../ui/Menu/Menu'
+import {MenuContent} from '../../ui/Menu/MenuContent'
 import {MenuItem} from '../../ui/Menu/MenuItem'
 import LeftDashNavItem from '../Dashboard/LeftDashNavItem'
 
@@ -54,9 +55,6 @@ const DashNavMenu = (props: Props) => {
 
   return (
     <Menu
-      side='right'
-      align='center'
-      sideOffset={20}
       trigger={
         <div>
           <StyledLeftDashNavItem
@@ -68,11 +66,13 @@ const DashNavMenu = (props: Props) => {
         </div>
       }
     >
-      {menuItems.map((item) => (
-        <MenuItem key={item.href} onClick={() => handleMenuItemClick(item.href)}>
-          {item.label}
-        </MenuItem>
-      ))}
+      <MenuContent side='right' align='center' sideOffset={20}>
+        {menuItems.map((item) => (
+          <MenuItem key={item.href} onClick={() => handleMenuItemClick(item.href)}>
+            {item.label}
+          </MenuItem>
+        ))}
+      </MenuContent>
     </Menu>
   )
 }

--- a/packages/client/components/DashNavList/DashNavMenu.tsx
+++ b/packages/client/components/DashNavList/DashNavMenu.tsx
@@ -1,0 +1,47 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {PALETTE} from '../../styles/paletteV3'
+import {Menu} from '../../ui/Menu/Menu'
+import {MenuItem} from '../../ui/Menu/MenuItem'
+import LeftDashNavItem from '../Dashboard/LeftDashNavItem'
+
+const StyledLeftDashNavItem = styled(LeftDashNavItem)<{isViewerOnTeam: boolean}>(
+  ({isViewerOnTeam}) => ({
+    color: isViewerOnTeam ? PALETTE.SLATE_700 : PALETTE.SLATE_600,
+    borderRadius: 44,
+    paddingLeft: 15
+  })
+)
+
+const DashNavMenu = () => {
+  const handleMenuItemClick = () => {}
+  return (
+    <Menu
+      side='right'
+      align='center'
+      sideOffset={20}
+      trigger={
+        <div>
+          <StyledLeftDashNavItem
+            className={'bg-transparent'}
+            // onClick={handleClick}
+            icon={'manageAccounts'}
+            isViewerOnTeam
+            // href={`/me/organizations/${org.id}/billing`}
+            label={'Settings & Members'}
+          />
+        </div>
+      }
+    >
+      <MenuItem onClick={handleMenuItemClick}>
+        Plans & Billing •&nbsp;<span className='text-sky-500'>Upgrade</span>
+      </MenuItem>
+      <MenuItem onClick={handleMenuItemClick}>Teams</MenuItem>
+      <MenuItem onClick={handleMenuItemClick}>Members</MenuItem>
+      <MenuItem onClick={handleMenuItemClick}>Organization Settings</MenuItem>
+      <MenuItem onClick={handleMenuItemClick}>Authentication</MenuItem>
+    </Menu>
+  )
+}
+
+export default DashNavMenu

--- a/packages/client/components/MeetingOptions.tsx
+++ b/packages/client/components/MeetingOptions.tsx
@@ -4,6 +4,7 @@ import React, {useEffect, useState} from 'react'
 import {useLazyLoadQuery} from 'react-relay'
 import {MeetingOptionsQuery} from '../__generated__/MeetingOptionsQuery.graphql'
 import {Menu} from '../ui/Menu/Menu'
+import {MenuContent} from '../ui/Menu/MenuContent'
 import {MenuItem} from '../ui/Menu/MenuItem'
 import {Tooltip} from '../ui/Tooltip/Tooltip'
 import {TooltipContent} from '../ui/Tooltip/TooltipContent'
@@ -92,17 +93,19 @@ const MeetingOptions = (props: Props) => {
         </OptionsButton>
       }
     >
-      <Tooltip open={openTooltip}>
-        <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-          <TooltipTrigger asChild>
-            <MenuItem onClick={handleClick} isDisabled={isDisabled}>
-              <div className='mr-3 flex text-slate-700'>{<SwapHorizIcon />}</div>
-              Change template
-            </MenuItem>
-          </TooltipTrigger>
-        </div>
-        <TooltipContent>{tooltipCopy}</TooltipContent>
-      </Tooltip>
+      <MenuContent sideOffset={10}>
+        <Tooltip open={openTooltip}>
+          <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+            <TooltipTrigger asChild>
+              <MenuItem onClick={handleClick} isDisabled={isDisabled}>
+                <div className='mr-3 flex text-slate-700'>{<SwapHorizIcon />}</div>
+                Change template
+              </MenuItem>
+            </TooltipTrigger>
+          </div>
+          <TooltipContent>{tooltipCopy}</TooltipContent>
+        </Tooltip>
+      </MenuContent>
     </Menu>
   )
 }

--- a/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
+++ b/packages/client/components/NewMeetingActionsCurrentMeetings.tsx
@@ -8,6 +8,7 @@ import useSnacksForNewMeetings from '~/hooks/useSnacksForNewMeetings'
 import {PALETTE} from '~/styles/paletteV3'
 import plural from '~/utils/plural'
 import {Menu} from '../ui/Menu/Menu'
+import {MenuContent} from '../ui/Menu/MenuContent'
 import FlatButton from './FlatButton'
 import SelectMeetingDropdown from './SelectMeetingDropdown'
 
@@ -56,7 +57,9 @@ const NewMeetingActionsCurrentMeetings = (props: Props) => {
         </CurrentButton>
       }
     >
-      <SelectMeetingDropdown meetings={activeMeetings!} />
+      <MenuContent className='w-[300px]' sideOffset={10}>
+        <SelectMeetingDropdown meetings={activeMeetings!} />
+      </MenuContent>
     </Menu>
   )
 }

--- a/packages/client/ui/Menu/Menu.tsx
+++ b/packages/client/ui/Menu/Menu.tsx
@@ -1,35 +1,16 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import React from 'react'
-import {twMerge} from 'tailwind-merge'
 
 interface MenuProps extends DropdownMenu.DropdownMenuProps {
   className?: string
   trigger: React.ReactNode
-  sideOffset?: number
-  side?: 'left' | 'right'
-  align?: 'start' | 'center' | 'end'
 }
 
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
-  ({align = 'end', trigger, className, children, sideOffset = 10, side, ...props}, ref) => {
-    return (
-      <DropdownMenu.Root {...props}>
-        <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
-        <DropdownMenu.Portal>
-          <DropdownMenu.Content
-            align={align}
-            className={twMerge(
-              'border-rad w-auto min-w-[200px] max-w-[400px] rounded-md bg-white shadow-lg outline-none',
-              className
-            )}
-            side={side}
-            sideOffset={sideOffset}
-            ref={ref}
-          >
-            {children}
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
-      </DropdownMenu.Root>
-    )
-  }
-)
+export const Menu: React.FC<MenuProps> = ({trigger, className, children, ...props}) => {
+  return (
+    <DropdownMenu.Root {...props}>
+      <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
+      <DropdownMenu.Portal>{children}</DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}

--- a/packages/client/ui/Menu/Menu.tsx
+++ b/packages/client/ui/Menu/Menu.tsx
@@ -7,16 +7,17 @@ interface MenuProps extends DropdownMenu.DropdownMenuProps {
   trigger: React.ReactNode
   sideOffset?: number
   side?: 'left' | 'right'
+  align?: 'start' | 'center' | 'end'
 }
 
 export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
-  ({trigger, className, children, sideOffset = 10, side, ...props}, ref) => {
+  ({align = 'end', trigger, className, children, sideOffset = 10, side, ...props}, ref) => {
     return (
       <DropdownMenu.Root {...props}>
         <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
         <DropdownMenu.Portal>
           <DropdownMenu.Content
-            align='end'
+            align={align}
             className={twMerge(
               'border-rad w-auto min-w-[200px] max-w-[400px] rounded-md bg-white shadow-lg outline-none',
               className

--- a/packages/client/ui/Menu/Menu.tsx
+++ b/packages/client/ui/Menu/Menu.tsx
@@ -5,10 +5,12 @@ import {twMerge} from 'tailwind-merge'
 interface MenuProps extends DropdownMenu.DropdownMenuProps {
   className?: string
   trigger: React.ReactNode
+  sideOffset?: number
+  side?: 'left' | 'right'
 }
 
 export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
-  ({trigger, className, children, ...props}, ref) => {
+  ({trigger, className, children, sideOffset = 10, side, ...props}, ref) => {
     return (
       <DropdownMenu.Root {...props}>
         <DropdownMenu.Trigger asChild>{trigger}</DropdownMenu.Trigger>
@@ -19,7 +21,8 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
               'border-rad w-auto min-w-[200px] max-w-[400px] rounded-md bg-white shadow-lg outline-none',
               className
             )}
-            sideOffset={10}
+            side={side}
+            sideOffset={sideOffset}
             ref={ref}
           >
             {children}

--- a/packages/client/ui/Menu/MenuContent.tsx
+++ b/packages/client/ui/Menu/MenuContent.tsx
@@ -1,0 +1,25 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import React from 'react'
+import {twMerge} from 'tailwind-merge'
+
+interface MenuContentProps extends DropdownMenu.MenuContentProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export const MenuContent = React.forwardRef<HTMLDivElement, MenuContentProps>(
+  ({className, children, ...props}, ref) => {
+    return (
+      <DropdownMenu.Content
+        className={twMerge(
+          'border-rad w-auto min-w-[200px] max-w-[400px] rounded-md bg-white shadow-lg outline-none',
+          className
+        )}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </DropdownMenu.Content>
+    )
+  }
+)


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9830

Loom demo: https://www.loom.com/share/ba5521f4b6464fd8bb5f6331ec5eab2e

![Screenshot 2024-06-12 at 19 01 51](https://github.com/ParabolInc/parabol/assets/39854876/68856802-4eed-4a5a-81f2-3e3e284e341f)

### To test

- [x] Click on "Settings & Members" and see the menu pops open, looking like the designs
- [x] On mobile, the menu doesn't open. It just takes you to the organization settings page