### PR TITLE
fix: add meeting block is now 70px

### DIFF
--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -18,8 +18,8 @@ import SideBarStartMeetingButton from '../SideBarStartMeetingButton'
 import LeftDashNavItem from './LeftDashNavItem'
 
 const Nav = styled('nav')<{isOpen: boolean}>(({isOpen}) => ({
-  // 78px is total height of 'Add meeting' block
-  height: 'calc(100% - 78px)',
+  // 70px is total height of 'Add meeting' block
+  height: 'calc(100% - 70px)',
   userSelect: 'none',
   transition: `all 300ms`,
   transform: isOpen ? undefined : `translateX(-${NavSidebar.WIDTH}px)`,


### PR DESCRIPTION
With the new nav styles, the add meeting primary button block is a little shorter, so update the nav layout