### PR TITLE
chore(ci): release-to jobs for both staging and production will notify Slack whenever they fail

### DIFF
--- a/.github/workflows/release-to-prod.yml
+++ b/.github/workflows/release-to-prod.yml
@@ -44,3 +44,12 @@ jobs:
           expect-response-regex: '"status":"success"'
           timeout: 120000
           interval: 3000
+
+      - name: Report Status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GH_ACTIONS_NOTIFICATIONS }}

--- a/.github/workflows/release-to-staging.yml
+++ b/.github/workflows/release-to-staging.yml
@@ -120,3 +120,12 @@ jobs:
           expect-response-regex: '"status":"success"'
           timeout: 120000
           interval: 3000
+
+      - name: Report Status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GH_ACTIONS_NOTIFICATIONS }}


### PR DESCRIPTION
# Description

Adds notifications for Slack whenever release-to-[staging|production] workflow fail.
