### PR TITLE
chore: remove summary from retro reflection group

### DIFF
--- a/packages/server/database/types/ReflectionGroup.ts
+++ b/packages/server/database/types/ReflectionGroup.ts
@@ -10,7 +10,6 @@ export interface ReflectionGroupInput {
   voterIds?: string[]
   title?: string
   smartTitle?: string
-  summary?: string
   discussionPromptQuestion?: string
 }
 
@@ -25,7 +24,6 @@ export default class ReflectionGroup {
   // userIds of the voters
   voterIds: string[]
   smartTitle: string | null
-  summary: string | null
   title: string | null
   discussionPromptQuestion: string | null
   constructor(input: ReflectionGroupInput) {
@@ -38,7 +36,6 @@ export default class ReflectionGroup {
       updatedAt,
       voterIds,
       smartTitle,
-      summary,
       title,
       discussionPromptQuestion
     } = input
@@ -52,7 +49,6 @@ export default class ReflectionGroup {
     this.updatedAt = updatedAt || now
     this.voterIds = voterIds || []
     this.smartTitle = smartTitle || null
-    this.summary = summary || null
     this.title = title || null
     this.discussionPromptQuestion = discussionPromptQuestion || null
   }

--- a/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
+++ b/packages/server/graphql/mutations/helpers/notifications/SlackNotifier.ts
@@ -658,10 +658,6 @@ export const SlackNotifier = {
       makeSection(`*Topic:*\n<${discussionUrl}|${topic}>`)
     ]
 
-    if (reflectionGroup.summary) {
-      slackBlocks.push(makeSection(`*Summary:*\n${reflectionGroup.summary}`))
-    }
-
     slackBlocks.push(makeSection(`*Reflections:* \n${reflectionsText}`))
 
     const notificationChannel = {

--- a/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
+++ b/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
@@ -112,7 +112,7 @@ const resetRetroMeetingToGroupStage = {
       r.table('Task').getAll(r.args(discussionIdsToDelete), {index: 'discussionId'}).delete().run(),
       pg
         .updateTable('RetroReflectionGroup')
-        .set({voterIds: [], summary: null, discussionPromptQuestion: null})
+        .set({voterIds: [], discussionPromptQuestion: null})
         .where('id', 'in', reflectionGroupIds)
         .execute(),
       r.table('NewMeeting').get(meetingId).update({phases: newPhases}).run(),

--- a/packages/server/postgres/migrations/1718641323037_removeSummaryFromRetroGroup.ts
+++ b/packages/server/postgres/migrations/1718641323037_removeSummaryFromRetroGroup.ts
@@ -1,0 +1,46 @@
+import {Kysely, PostgresDialect} from 'kysely'
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+import getPg from '../getPg'
+
+export async function up() {
+  try {
+    await connectRethinkDB()
+
+    await r
+      .table('RetroReflectionGroup')
+      .replace((row) => row.without('summary'))
+      .run()
+
+    const pg = new Kysely<any>({
+      dialect: new PostgresDialect({
+        pool: getPg()
+      })
+    })
+
+    await pg.schema.alterTable('RetroReflectionGroup').dropColumn('summary').execute()
+  } catch (e) {
+    console.error('Error during migration:', e)
+  }
+}
+
+export async function down() {
+  try {
+    await connectRethinkDB()
+
+    await r.table('RetroReflectionGroup').update({summary: null}).run()
+
+    const pg = new Kysely<any>({
+      dialect: new PostgresDialect({
+        pool: getPg()
+      })
+    })
+
+    await pg.schema
+      .alterTable('RetroReflectionGroup')
+      .addColumn('summary', 'varchar(2000)')
+      .execute()
+  } catch (e) {
+    console.error('Error during rollback:', e)
+  }
+}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9712

### To test

- [ ] Run the migration and see that `summary` is successfully removed from the Retro Reflection Group table