### PR TITLE
fix: remove AI UI if user doesn't have access to AI

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -40,19 +40,25 @@ const WholeMeetingSummary = (props: Props) => {
     `,
     meetingRef
   )
+  const hasAI = window.__ACTION__.hasOpenAI
   if (meeting.__typename === 'RetrospectiveMeeting') {
     const {summary: wholeMeetingSummary, reflectionGroups, organization} = meeting
     const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
     const hasMoreThanOneReflection = reflections?.length && reflections.length > 1
-    if (!hasMoreThanOneReflection || organization.featureFlags.noAISummary) return null
+    if (!hasMoreThanOneReflection || organization.featureFlags.noAISummary || !hasAI) return null
     if (!wholeMeetingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   } else if (meeting.__typename === 'TeamPromptMeeting') {
     const {summary: wholeMeetingSummary, responses, organization} = meeting
-    if (!organization.featureFlags.standupAISummary || organization.featureFlags.noAISummary) {
+    if (
+      !organization.featureFlags.standupAISummary ||
+      organization.featureFlags.noAISummary ||
+      !hasAI ||
+      !responses ||
+      responses.length === 0
+    ) {
       return null
     }
-    if (!responses || responses.length === 0) return null
     if (!wholeMeetingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   }

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -9,6 +9,11 @@ interface Props {
   meetingRef: WholeMeetingSummary_meeting$key
 }
 
+const isServer = typeof window === 'undefined'
+const hasAI = isServer
+  ? !!process.env.OPEN_AI_API_KEY
+  : !!window.__ACTION__ && !!window.__ACTION__.hasOpenAI
+
 const WholeMeetingSummary = (props: Props) => {
   const {meetingRef} = props
   const meeting = useFragment(
@@ -40,7 +45,6 @@ const WholeMeetingSummary = (props: Props) => {
     `,
     meetingRef
   )
-  const hasAI = window.__ACTION__.hasOpenAI
   if (meeting.__typename === 'RetrospectiveMeeting') {
     const {summary: wholeMeetingSummary, reflectionGroups, organization} = meeting
     const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9822

Demo: https://www.loom.com/share/9cc4e5ff56134197ae0e7295359c9dbf

### To test

- [ ] Run the app normally and see the AI Icebreaker, discussion question, and AI meeting summary
- [ ] Comment out the `OPEN_AI_API_KEY` env var in your `.env`
- [ ] Run `yarn predeploy`
- [ ] Create a retro meeting and see that the AI icebreaker, discussion question, and AI meeting summary do not show up 