### PR TITLE
fix: clicking scope link does not affect checkbox

### DIFF
--- a/packages/client/components/ScopingSearchResultItem.tsx
+++ b/packages/client/components/ScopingSearchResultItem.tsx
@@ -66,7 +66,11 @@ const ScopingSearchResultItem = (props: Props) => {
   const {onCompleted, onError, submitMutation} = useMutationProps()
   const disabled = !isSelected && usedServiceTaskIds.size >= Threshold.MAX_POKER_STORIES
   const isTemp = isTempId(serviceTaskId)
-  const onClick = () => {
+
+  const handleClick = (e: React.MouseEvent) => {
+    console.log('🚀 ~ clicked!:')
+    e.stopPropagation()
+
     if (disabled || isTemp) return
     submitMutation()
     const variables = {
@@ -85,12 +89,23 @@ const ScopingSearchResultItem = (props: Props) => {
       persistQuery?.()
     }
   }
+
+  const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    e.stopPropagation()
+  }
+
   return (
-    <Item onClick={onClick}>
+    <Item onClick={handleClick}>
       <Checkbox active={isSelected || isTemp} disabled={disabled} />
       <Issue>
         <Title>{summary}</Title>
-        <StyledLink href={url} rel='noopener noreferrer' target='_blank' title={linkTitle}>
+        <StyledLink
+          href={url}
+          rel='noopener noreferrer'
+          target='_blank'
+          title={linkTitle}
+          onClick={handleLinkClick}
+        >
           {linkText}
           {isTemp && <Ellipsis />}
         </StyledLink>

--- a/packages/client/components/ScopingSearchResultItem.tsx
+++ b/packages/client/components/ScopingSearchResultItem.tsx
@@ -67,9 +67,7 @@ const ScopingSearchResultItem = (props: Props) => {
   const disabled = !isSelected && usedServiceTaskIds.size >= Threshold.MAX_POKER_STORIES
   const isTemp = isTempId(serviceTaskId)
 
-  const handleClick = (e: React.MouseEvent) => {
-    e.stopPropagation()
-
+  const onClick = () => {
     if (disabled || isTemp) return
     submitMutation()
     const variables = {
@@ -95,7 +93,7 @@ const ScopingSearchResultItem = (props: Props) => {
   }
 
   return (
-    <Item onClick={handleClick}>
+    <Item onClick={onClick}>
       <Checkbox active={isSelected || isTemp} disabled={disabled} />
       <Issue>
         <Title>{summary}</Title>

--- a/packages/client/components/ScopingSearchResultItem.tsx
+++ b/packages/client/components/ScopingSearchResultItem.tsx
@@ -68,7 +68,6 @@ const ScopingSearchResultItem = (props: Props) => {
   const isTemp = isTempId(serviceTaskId)
 
   const handleClick = (e: React.MouseEvent) => {
-    console.log('🚀 ~ clicked!:')
     e.stopPropagation()
 
     if (disabled || isTemp) return

--- a/packages/client/components/ScopingSearchResultItem.tsx
+++ b/packages/client/components/ScopingSearchResultItem.tsx
@@ -90,6 +90,7 @@ const ScopingSearchResultItem = (props: Props) => {
   }
 
   const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    // don't propagate or the checkbox will be toggled
     e.stopPropagation()
   }
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9858

Loom demo: https://www.loom.com/share/d47bb7b4bdce4ad49cc43cbbd7e38714

### To test

- [ ] Click a link in the scope phase of Poker and see that it does not check/uncheck the checkbox