### PR TITLE
fix: ensure dashboard sidebar animates smoothly

### DIFF
--- a/packages/client/components/DashNavList/DashNavList.tsx
+++ b/packages/client/components/DashNavList/DashNavList.tsx
@@ -67,7 +67,11 @@ const DashNavList = (props: Props) => {
     <div className='w-full p-2 lg:pt-4'>
       {organizations?.map((org) => (
         <div key={org.id} className='mb-3 w-full rounded-lg border border-solid border-slate-400'>
-          <div className='border-b border-solid border-slate-300 p-2'>
+          <div
+            className={
+              org.viewerTeams.length > 0 ? `border-b border-solid border-slate-300 p-2` : 'p-2'
+            }
+          >
             <div className='flex flex-wrap items-center pb-1'>
               <div className='flex min-w-0 flex-1 flex-wrap items-center justify-between'>
                 <span className='pl-2 text-base font-semibold leading-6 text-slate-700'>

--- a/packages/client/components/DashNavList/DashNavListTeams.tsx
+++ b/packages/client/components/DashNavList/DashNavListTeams.tsx
@@ -59,6 +59,7 @@ const DashNavListTeams = (props: Props) => {
   const getIcon = (lockedAt: string | null, isPaid: boolean | null) =>
     lockedAt || !isPaid ? 'warning' : 'group'
 
+  if (!viewerTeams.length) return null
   return (
     <div className='p-2'>
       {viewerTeams.map((team) => {

--- a/packages/client/components/SideBarStartMeetingButton.tsx
+++ b/packages/client/components/SideBarStartMeetingButton.tsx
@@ -9,7 +9,7 @@ const Button = styled(FlatPrimaryButton)<{isOpen: boolean}>(({isOpen}) => ({
   height: 40,
   overflow: 'hidden',
   padding: 0,
-  width: isOpen ? '100%' : 40,
+  width: isOpen ? 200 : 40,
   marginTop: 16,
   marginBottom: 14, // account for nav margin 2px
   transition: `all 300ms ${BezierCurve.DECELERATE}`,

--- a/packages/client/ui/Menu/MenuContent.tsx
+++ b/packages/client/ui/Menu/MenuContent.tsx
@@ -12,7 +12,7 @@ export const MenuContent = React.forwardRef<HTMLDivElement, MenuContentProps>(
     return (
       <DropdownMenu.Content
         className={twMerge(
-          'border-rad w-auto min-w-[200px] max-w-[400px] rounded-md bg-white shadow-lg outline-none',
+          'border-rad z-10 w-auto min-w-[200px] max-w-[400px] rounded-md bg-white shadow-lg outline-none',
           className
         )}
         ref={ref}


### PR DESCRIPTION
Fix issues @mattkrick shared [here](https://github.com/ParabolInc/parabol/pull/9863#issuecomment-2187305336)

Loom demo: https://www.loom.com/share/7ec1e767949b4c7fbee1fff3afe2ed09

This PR ensures that:

- Opening and closing the sidebar animates smoothly
- If an org has no teams, there's no divider
- The settings menu doesn't conflict with the text on the task cards

Things to note:
- I reduced the width of the Add Meeting button slightly. It's still wider than prod, but narrower than it was. 
- The three-line long team name is an edge case. A team name with the max characters allowed is usually 2 lines, but if the characters are particularly wide, e.g. `3` instead of `i`, it can take up three lines. I'm hesitant about changing the padding without a review from @ackernaut, so I'd prefer to merge this.
- I also like your point about removing the menu. I think Terry could see how it feels in production and decide whether to keep/remove it. 