### PR TITLE
fix: Don't reset failed embedding jobs

### DIFF
--- a/packages/embedder/resetStalledJobs.ts
+++ b/packages/embedder/resetStalledJobs.ts
@@ -13,6 +13,7 @@ export const resetStalledJobs = () => {
         stateMessage: 'stalled'
       }))
       .where('startAt', '<', new Date(Date.now() - ms('5m')))
+      .where('state', '=', 'running')
       .execute()
   }, ms('5m')).unref()
 }


### PR DESCRIPTION
# Description

Fixes #9842 
When resetting stalled jobs we did not check whether it was still running or it had failed. This would reset the jobs to queued so the embedder would retry failed job indefinetely.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] have some permanently failing jobs in the job queue (for example with `null` embeddingsMetadataId)
- [ ] optionally decrease the reset stalled job timeout form 5m to something shorter (2 places)
- [ ] see the retry count not going up after 5

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
