### PR TITLE
fix: can scroll public teams modal

### DIFF
--- a/packages/client/components/DashNavList/PublicTeamsModal.tsx
+++ b/packages/client/components/DashNavList/PublicTeamsModal.tsx
@@ -32,7 +32,7 @@ const PublicTeamsModal = (props: Props) => {
 
   return (
     <Dialog isOpen={isOpen} onClose={onClose}>
-      <DialogContent className='z-10'>
+      <DialogContent className='z-10 overflow-scroll'>
         <DialogTitle>{`${publicTeamsCount} ${plural(publicTeamsCount, 'Public Team', 'Public Teams')}`}</DialogTitle>
         <DialogDescription>
           Request to join as a Team Member on any public teams at{' '}


### PR DESCRIPTION
In production, if there are a bunch of public teams, you can't scroll down to see all of them. 

This PR lets users scroll down to see all of their teams. 