### PR TITLE
fix: Avoid adding embedding jobs without metadata id

### DIFF
--- a/packages/embedder/insertDiscussionsIntoMetadataAndQueue.ts
+++ b/packages/embedder/insertDiscussionsIntoMetadataAndQueue.ts
@@ -35,9 +35,9 @@ export const insertDiscussionsIntoMetadataAndQueue = async (
       .with('Metadata', (qc) =>
         qc
           .selectFrom('Insert')
-          .fullJoin(
+          .innerJoin(
             sql<{model: string}>`UNNEST(ARRAY[${sql.join(tableNames)}])`.as('model'),
-            (join) => join.onTrue()
+            (join) => join.on('Insert.id', 'is not', null)
           )
           .select(['id', 'model'])
       )

--- a/packages/embedder/insertMeetingTemplatesIntoMetadataAndQueue.ts
+++ b/packages/embedder/insertMeetingTemplatesIntoMetadataAndQueue.ts
@@ -37,9 +37,9 @@ export const insertMeetingTemplatesIntoMetadataAndQueue = async (
     .with('Metadata', (qc) =>
       qc
         .selectFrom('Insert')
-        .fullJoin(
+        .innerJoin(
           sql<{model: string}>`UNNEST(ARRAY[${sql.join(tableNames)}])`.as('model'),
-          (join) => join.onTrue()
+          (join) => join.on('Insert.id', 'is not', null)
         )
         .select(['id', 'model'])
     )


### PR DESCRIPTION
# Description

When no new metadata was inserted, the resulting empty array would be fully outer joined with the models, resulting in [undefined, 'ember_1'] pairs.

## Testing scenarios

- [ ] start the server and see no jobs with `embed:start` and `embeddingsMetadataId === null` is added to the EmbeddingsJobQueue table

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
