### PR TITLE
fix: download pdf shows multiple pages

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/ExportToCSV.tsx
@@ -351,21 +351,19 @@ const ExportToCSV = (props: Props) => {
 
   const {emailCSVUrl, referrer, corsOptions} = props
   return (
-    <>
-      <tr>
-        <td align='center' style={iconLinkLabel} width='100%'>
-          <AnchorIfEmail isEmail={referrer === 'email'} href={emailCSVUrl} title={label}>
-            <img
-              alt={label}
-              src={`${ExternalLinks.EMAIL_CDN}cloud_download.png`}
-              style={imageStyle}
-              {...corsOptions}
-            />
-            <span style={labelStyle}>{label}</span>
-          </AnchorIfEmail>
-        </td>
-      </tr>
-    </>
+    <tr className='print:hidden'>
+      <td align='center' style={iconLinkLabel} width='100%'>
+        <AnchorIfEmail isEmail={referrer === 'email'} href={emailCSVUrl} title={label}>
+          <img
+            alt={label}
+            src={`${ExternalLinks.EMAIL_CDN}cloud_download.png`}
+            style={imageStyle}
+            {...corsOptions}
+          />
+          <span style={labelStyle}>{label}</span>
+        </AnchorIfEmail>
+      </td>
+    </tr>
   )
 }
 

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailReflectionCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailReflectionCard.tsx
@@ -18,6 +18,7 @@ const contentStyle = {
   borderStyle: 'solid',
   borderWidth: '1px',
   boxSizing: 'content-box',
+  breakInside: 'avoid',
   color: PALETTE.SLATE_700,
   fontFamily: FONT_FAMILY.SANS_SERIF,
   fontSize: '14px',

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopic.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/RetroTopic.tsx
@@ -169,7 +169,7 @@ const RetroTopic = (props: Props) => {
           <td align='center'>
             <table>
               <tr>
-                <td>
+                <td className='text-center'>
                   <AnchorIfEmail href={to} isEmail={isEmail} style={commentLinkStyle}>
                     {commentLinkLabel}
                   </AnchorIfEmail>

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -149,6 +149,9 @@ const SummarySheet = (props: Props) => {
     printWindow.document.close()
     printWindow.focus()
     printWindow.print()
+    printWindow.onafterprint = () => {
+      printWindow.close()
+    }
   }
 
   return (

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummarySheet.tsx
@@ -5,7 +5,7 @@ import {SummarySheet_meeting$key} from 'parabol-client/__generated__/SummaryShee
 import CreateAccountSection from 'parabol-client/modules/demo/components/CreateAccountSection'
 import {sheetShadow} from 'parabol-client/styles/elevation'
 import {ACTION} from 'parabol-client/utils/constants'
-import React from 'react'
+import React, {useRef} from 'react'
 import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
 import useAtmosphere from '../../../../../hooks/useAtmosphere'
@@ -90,12 +90,65 @@ const SummarySheet = (props: Props) => {
     `,
     meetingRef
   )
-  const {id: meetingId, meetingType, taskCount} = meeting
+  const {id: meetingId, meetingType, taskCount, name} = meeting
   const isDemo = !!props.isDemo
+  const sheetRef = useRef<HTMLTableElement | null>(null)
 
   const downloadPDF = () => {
     SendClientSideEvent(atmosphere, 'Download PDF Clicked', {meetingId})
-    window.print()
+
+    const printStyles = `
+      <style>
+        @media print {
+          body {
+            margin: 0;
+            padding: 0;
+          }
+          table {
+            page-break-after: auto;
+            margin: 0 auto;
+            width: 100%;
+            max-width: 800px;
+          }
+          tr, td {
+            page-break-inside: avoid;
+            page-break-after: auto;
+          }
+          thead {
+            display: table-header-group;
+          }
+          tfoot {
+            display: table-footer-group;
+          }
+          .print\\:hidden {
+            display: none !important;
+          }
+          .print\\:w-[210mm] {
+            width: 100%;
+          }
+          .text-center {
+            text-align: center;
+          }
+        }
+      </style>
+    `
+
+    const printWindow = window.open('', '_blank')
+    if (!printWindow) return
+    printWindow.document.write(`
+      <html>
+        <head>
+          <title>Parabol: ${name} Summary</title>
+        </head>
+        <body>
+          ${printStyles}
+          ${sheetRef.current?.outerHTML}
+        </body>
+      </html>
+    `)
+    printWindow.document.close()
+    printWindow.focus()
+    printWindow.print()
   }
 
   return (
@@ -105,6 +158,7 @@ const SummarySheet = (props: Props) => {
       height='100%'
       align='center'
       bgcolor='#FFFFFF'
+      ref={sheetRef}
       style={sheetStyle}
     >
       <tbody>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9862

In production, download to pdf just downloads the first page, rather than all pages. This is because `window.print()` just shows the visible part of the web page in a SPA.

In this PR, I'm opening a new window and rending the HTML as a static snapshot so that all of the content is visible. 

The pdf shows "about:blank" at the bottom left of the page. I don't think this can be removed as the browser checks the URL. And there's some box shadow at the end of the summary in the PDF, but I think that's fine. 

### To test

- [ ] Create a retro with a lot of content
- [ ] In the meeting summary, click "Download to PDF"
- [ ] See that it downloads every page, not just the first