### PR TITLE
fix: remove ai from summary url if no ai env var

### DIFF
--- a/packages/client/mutations/EndRetrospectiveMutation.ts
+++ b/packages/client/mutations/EndRetrospectiveMutation.ts
@@ -128,7 +128,10 @@ export const endRetrospectiveTeamOnNext: OnNextHandler<
     } else {
       const reflections = reflectionGroups.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
       const hasMoreThanOneReflection = reflections.length > 1
-      const hasOpenAISummary = hasMoreThanOneReflection && !organization.featureFlags.noAISummary
+      const hasOpenAISummary =
+        hasMoreThanOneReflection &&
+        !organization.featureFlags.noAISummary &&
+        window.__ACTION__.hasOpenAI
       const hasTeamHealth = phases.some((phase) => phase.phaseType === 'TEAM_HEALTH')
       const pathname = `/new-summary/${meetingId}`
       const search = new URLSearchParams()


### PR DESCRIPTION
Discovered by @Dschoordsch [here](https://parabol.slack.com/archives/C608QL4RH/p1719502480380049)

### To test

- [ ] Remove `OpenAI` env var
- [ ] End a retro meeting
- [ ] See that the summary does not have `ai=true` in the URL