### PR TITLE
fix: speed up team upgrade

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingForm.tsx
@@ -8,6 +8,7 @@ import {
 } from '@stripe/react-stripe-js'
 import {StripeElementChangeEvent} from '@stripe/stripe-js'
 import React, {useState} from 'react'
+import {commitLocalUpdate} from 'relay-runtime'
 import {CreateStripeSubscriptionMutation$data} from '../../../../__generated__/CreateStripeSubscriptionMutation.graphql'
 import Ellipsis from '../../../../components/Ellipsis/Ellipsis'
 import PrimaryButton from '../../../../components/PrimaryButton'
@@ -15,8 +16,10 @@ import StyledError from '../../../../components/StyledError'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
 import CreateStripeSubscriptionMutation from '../../../../mutations/CreateStripeSubscriptionMutation'
+import upgradeToTeamTierSuccessUpdater from '../../../../mutations/handlers/upgradeToTeamTierSuccessUpdater'
 import {PALETTE} from '../../../../styles/paletteV3'
 import SendClientSideEvent from '../../../../utils/SendClientSideEvent'
+import createProxyRecord from '../../../../utils/relay/createProxyRecord'
 
 const ButtonBlock = styled('div')({
   display: 'flex',
@@ -131,6 +134,11 @@ const BillingForm = (props: Props) => {
         setIsLoading(false)
         return
       }
+      commitLocalUpdate(atmosphere, (store) => {
+        const payload = createProxyRecord(store, 'payload', {})
+        payload.setLinkedRecord(store.get(orgId)!, 'organization')
+        upgradeToTeamTierSuccessUpdater(payload)
+      })
       onCompleted()
     }
 

--- a/packages/client/mutations/fragments/UpgradeToTeamTierFrag.ts
+++ b/packages/client/mutations/fragments/UpgradeToTeamTierFrag.ts
@@ -16,18 +16,13 @@ graphql`
       periodStart
       updatedAt
       lockedAt
+      teams {
+        isPaid
+        tier
+      }
     }
     meetings {
       showConversionModal
-    }
-  }
-`
-
-graphql`
-  fragment UpgradeToTeamTierFrag_team on UpgradeToTeamTierSuccess {
-    teams {
-      isPaid
-      tier
     }
   }
 `

--- a/packages/client/subscriptions/TeamSubscription.ts
+++ b/packages/client/subscriptions/TeamSubscription.ts
@@ -181,9 +181,6 @@ const subscription = graphql`
       OldUpgradeToTeamTierPayload {
         ...OldUpgradeToTeamTierMutation_team @relay(mask: false)
       }
-      UpgradeToTeamTierSuccess {
-        ...UpgradeToTeamTierFrag_team @relay(mask: false)
-      }
       UpdateIntegrationProviderSuccess {
         ...UpdateIntegrationProviderMutation_team @relay(mask: false)
       }

--- a/packages/server/graphql/mutations/helpers/oldUpgradeToTeamTier.ts
+++ b/packages/server/graphql/mutations/helpers/oldUpgradeToTeamTier.ts
@@ -32,7 +32,7 @@ const oldUpgradeToTeamTier = async (
   const manager = getStripeManager()
   const customer = stripeId
     ? await manager.updatePayment(stripeId, source)
-    : await manager.createCustomer(orgId, email, source)
+    : await manager.createCustomer(orgId, email, undefined, source)
 
   let subscriptionFields = {}
   if (!stripeSubscriptionId) {

--- a/packages/server/graphql/private/mutations/stripeDeleteSubscription.ts
+++ b/packages/server/graphql/private/mutations/stripeDeleteSubscription.ts
@@ -31,8 +31,10 @@ const stripeDeleteSubscription: MutationResolvers['stripeDeleteSubscription'] = 
   const org: Organization = await dataLoader.get('organizations').load(orgId)
 
   const {stripeSubscriptionId} = org
+  if (!stripeSubscriptionId) return false
+
   if (stripeSubscriptionId !== subscriptionId) {
-    throw new Error('Subscription ID does not match')
+    throw new Error(`Subscription ID does not match: ${stripeSubscriptionId} vs ${subscriptionId}`)
   }
 
   await r

--- a/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
+++ b/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
@@ -134,10 +134,6 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
   const data = {orgId, teamIds, meetingIds}
   publish(SubscriptionChannel.ORGANIZATION, orgId, 'UpgradeToTeamTierSuccess', data, subOptions)
 
-  teamIds.forEach((teamId) => {
-    const teamData = {orgId, teamIds: [teamId]}
-    publish(SubscriptionChannel.TEAM, teamId, 'UpgradeToTeamTierSuccess', teamData, subOptions)
-  })
   return data
 }
 

--- a/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
+++ b/packages/server/graphql/private/mutations/upgradeToTeamTier.ts
@@ -28,8 +28,10 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
   const userId = getUserId(authToken)
   const manager = getStripeManager()
   const invoice = await manager.retrieveInvoice(invoiceId)
-  const customerId = invoice.customer as string
-  const customer = await manager.retrieveCustomer(customerId)
+  const stripeId = invoice.customer as string
+  const stripeSubscriptionId = invoice.subscription as string
+  const customer = await manager.retrieveCustomer(stripeId)
+
   if (customer.deleted) {
     return standardError(new Error('Customer has been deleted'), {userId})
   }
@@ -51,24 +53,7 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
     dataLoader.get('users').loadNonNull(viewerId)
   ])
 
-  const {
-    stripeId,
-    tier,
-    activeDomain,
-    name: orgName,
-    stripeSubscriptionId,
-    trialStartDate
-  } = organization
-
-  if (!stripeId) {
-    return standardError(new Error('Organization does not have a stripe id'), {
-      userId: viewerId
-    })
-  }
-
-  if (!stripeSubscriptionId) {
-    return standardError(new Error('Organization does not have a subscription'), {userId: viewerId})
-  }
+  const {tier, activeDomain, name: orgName, trialStartDate} = organization
 
   if (tier === 'enterprise') {
     return standardError(new Error("Can not change an org's plan from enterprise to team"), {
@@ -93,7 +78,9 @@ const upgradeToTeamTier: MutationResolvers['upgradeToTeamTier'] = async (
           scheduledLockAt: null,
           lockedAt: null,
           updatedAt: now,
-          trialStartDate: null
+          trialStartDate: null,
+          stripeId,
+          stripeSubscriptionId
         })
     }).run(),
     pg

--- a/packages/server/graphql/public/mutations/createStripeSubscription.ts
+++ b/packages/server/graphql/public/mutations/createStripeSubscription.ts
@@ -1,7 +1,6 @@
 import Stripe from 'stripe'
 import getRethink from '../../../database/rethinkDriver'
 import {getUserId} from '../../../utils/authorization'
-import {fromEpochSeconds} from '../../../utils/epochTime'
 import standardError from '../../../utils/standardError'
 import {getStripeManager} from '../../../utils/stripe'
 import {MutationResolvers} from '../resolverTypes'
@@ -12,7 +11,6 @@ const createStripeSubscription: MutationResolvers['createStripeSubscription'] = 
   {authToken, dataLoader}
 ) => {
   const viewerId = getUserId(authToken)
-  const now = new Date()
   const r = await getRethink()
 
   const [viewer, organization, orgUsersCount, organizationUser] = await Promise.all([
@@ -44,7 +42,7 @@ const createStripeSubscription: MutationResolvers['createStripeSubscription'] = 
     const {id: customerId} = customer
     const res = await manager.attachPaymentToCustomer(customerId, paymentMethodId)
     if (res instanceof Error) return standardError(res, {userId: viewerId})
-    // wait until the payment is attached to the customer before updating the default payment method
+    // cannot updateDefaultPaymentMethod until it is attached to the customer
     await manager.updateDefaultPaymentMethod(customerId, paymentMethodId)
   } else {
     customer = await manager.createCustomer(orgId, email, paymentMethodId)
@@ -55,23 +53,6 @@ const createStripeSubscription: MutationResolvers['createStripeSubscription'] = 
   const latestInvoice = subscription.latest_invoice as Stripe.Invoice
   const paymentIntent = latestInvoice.payment_intent as Stripe.PaymentIntent
   const clientSecret = paymentIntent.client_secret
-
-  const subscriptionFields = {
-    periodEnd: fromEpochSeconds(subscription.current_period_end),
-    periodStart: fromEpochSeconds(subscription.current_period_start),
-    stripeSubscriptionId: subscription.id
-  }
-
-  await r({
-    updatedOrg: r
-      .table('Organization')
-      .get(orgId)
-      .update({
-        ...subscriptionFields,
-        stripeId: customer.id,
-        updatedAt: now
-      })
-  }).run()
 
   const data = {stripeSubscriptionClientSecret: clientSecret}
   return data

--- a/packages/server/utils/defaultTier.ts
+++ b/packages/server/utils/defaultTier.ts
@@ -1,1 +1,1 @@
-export const defaultTier = process.env.IS_ENTERPRISE ? 'enterprise' : 'starter'
+export const defaultTier = process.env.IS_ENTERPRISE === 'true' ? 'enterprise' : 'starter'

--- a/packages/server/utils/stripe/StripeManager.ts
+++ b/packages/server/utils/stripe/StripeManager.ts
@@ -90,10 +90,21 @@ export default class StripeManager {
     }
   }
 
-  async createCustomer(orgId: string, email: string, source?: string) {
+  async createCustomer(
+    orgId: string,
+    email: string,
+    paymentMethodId?: string | undefined,
+    source?: string
+  ) {
     return this.stripe.customers.create({
       email,
       source,
+      payment_method: paymentMethodId,
+      invoice_settings: paymentMethodId
+        ? {
+            default_payment_method: paymentMethodId
+          }
+        : undefined,
       metadata: {
         orgId
       }


### PR DESCRIPTION
# Description

Upgrading via stripe takes too long!
It's still too long, but this shaves off about 2 seconds (in the video it was 6!) & now you don't need to listen to webhooks to test locally.

## Demo

https://www.loom.com/share/a2482e91d4b940e19dd31f66fb7fa119?sid=67a06848-bc0e-490d-85ac-3d230073d975
