### PR TITLE
fix: Allow to start recurrence for existing Standups

### DIFF
--- a/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
+++ b/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
@@ -139,16 +139,17 @@ const updateRecurrenceSettings: MutationResolvers['updateRecurrenceSettings'] = 
   if (!meeting) {
     return standardError(new Error('Meeting not found'), {userId: viewerId})
   }
-  const {teamId, meetingSeriesId} = meeting
-  if (!meetingSeriesId) {
-    return standardError(new Error('Meeting is not recurring'), {userId: viewerId})
-  }
+  const {teamId, meetingType, meetingSeriesId} = meeting
   if (!isTeamMember(authToken, teamId)) {
     return standardError(new Error('Team not found'), {userId: viewerId})
   }
 
-  if (meeting.meetingSeriesId) {
-    const meetingSeries = await dataLoader.get('meetingSeries').loadNonNull(meeting.meetingSeriesId)
+  if (meetingType !== 'teamPrompt' && meetingType !== 'retrospective') {
+    return standardError(new Error('Recurring meeting type is not implemented'), {userId: viewerId})
+  }
+
+  if (meetingSeriesId) {
+    const meetingSeries = await dataLoader.get('meetingSeries').loadNonNull(meetingSeriesId)
     const {gcalSeriesId, teamId, facilitatorId, recurrenceRule} = meetingSeries
 
     if (!recurrenceSettings.rrule) {


### PR DESCRIPTION
# Description

Fixes #9901
I had messed this up in #9370

## Demo

https://github.com/ParabolInc/parabol/assets/7331043/d8cabb2d-0b22-448f-9755-1d9012e8be32

## Testing scenarios

- [ ] Create a standup without recurrence
- [ ] In the meeting start the recurrence

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
