### PR TITLE
fix: remove Organization.teams field from gql

### DIFF
--- a/packages/client/mutations/fragments/UpgradeToTeamTierFrag.ts
+++ b/packages/client/mutations/fragments/UpgradeToTeamTierFrag.ts
@@ -16,7 +16,7 @@ graphql`
       periodStart
       updatedAt
       lockedAt
-      teams {
+      viewerTeams {
         isPaid
         tier
       }

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -52,11 +52,6 @@ type Organization {
   """
   picture: URL
 
-  """
-  all the teams the viewer is on in the organization
-  """
-  teams: [Team!]!
-
   tier: TierEnum!
 
   billingTier: TierEnum!


### PR DESCRIPTION
we had an old field in the GQL schema that had no resolver. this fixes it