### PR TITLE
fix: Allow starting recurring meetings without GCal

### DIFF
--- a/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
+++ b/packages/client/components/ActivityLibrary/ScheduleMeetingButton.tsx
@@ -39,15 +39,10 @@ const ScheduleMeetingButton = (props: Props) => {
       fragment ScheduleMeetingButton_team on Team {
         id
         viewerTeamMember {
-          isSelf
           integrations {
             gcal {
-              auth {
-                id
-              }
               cloudProvider {
                 id
-                clientId
               }
             }
           }
@@ -73,7 +68,7 @@ const ScheduleMeetingButton = (props: Props) => {
     closeModal()
   }
 
-  if (!cloudProvider) return null
+  if (!cloudProvider && !withRecurrence) return null
   return (
     <>
       <SecondaryButton onClick={handleClick} waiting={submitting} className='h-14'>

--- a/packages/client/components/ScheduleDialog.tsx
+++ b/packages/client/components/ScheduleDialog.tsx
@@ -139,12 +139,11 @@ export const ScheduleDialog = (props: Props) => {
     }
   }
 
+  const subTitle = `Create a ${withRecurrence ? 'recurring meeting series' : 'meeting'}${gcal?.cloudProvider ? ' or add the meeting to your calendar.' : '.'}`
   return (
     <div className='space-y-4 overflow-auto p-4'>
       <div className='text-lg font-semibold leading-none'>Schedule Your Meeting</div>
-      <div className='text-sm text-slate-800'>
-        Create a recurring meeting series or add the meeting to your calendar.
-      </div>
+      <div className='text-sm text-slate-800'>{subTitle}</div>
       <div className='flex flex-col'>
         <input
           className='form-input rounded border border-solid border-slate-500 p-2 font-sans text-base hover:border-slate-600 focus:border-slate-600 focus:outline-none focus:ring-1 focus:ring-slate-600'


### PR DESCRIPTION
# Description

We were hiding the schedule button when no GCal integration was available on the instance. This is wrong in some cases when the dialog still allows to set up recurrence.
This PR also addresses a small title mismatch discovered by @garethaledavies which claimed recurring meetings when the option was not available.

Fixes #9913 #9777 

## Demo

https://www.loom.com/share/fda8dcea642949f698d37962fab216b6?sid=a2acbf99-6e62-4a0d-becb-f63a9da21b96

## Testing scenarios

- [ ] with GCal integration provider (after `yarn build && yarn predeploy`) test the schedule dialog in
  - [ ] poker and checkin show only the GCal options
  - [ ] retro and team prompt show GCal and recurrence options
- [ ] remove the global GCal integration provider and test the schedule button again
  - [ ] poker and checkin do not show one
  - [ ] team prompt and retro only show the recurrence options

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
