### PR TITLE
fix: connectionContext always available

### DIFF
--- a/packages/server/socketHandlers/handleOpen.ts
+++ b/packages/server/socketHandlers/handleOpen.ts
@@ -32,6 +32,15 @@ const handleOpen: WebSocketBehavior<SocketUserData>['open'] = async (socket) => 
     return
   }
 
+  // add the connectionContext before an async call to make sure it's available in handleMessage
+  const connectionContext = (socket.getUserData().connectionContext = new ConnectionContext(
+    socket,
+    authToken,
+    ip
+  ))
+
+  activeClients.set(connectionContext)
+
   // ALL async calls must come after the message listener, or we'll skip out on messages (e.g. resub after server restart)
   const {sub: userId, iat} = authToken
   const isBlacklistedJWT = await checkBlacklistJWT(userId, iat)
@@ -40,12 +49,6 @@ const handleOpen: WebSocketBehavior<SocketUserData>['open'] = async (socket) => 
     return
   }
 
-  const connectionContext = (socket.getUserData().connectionContext = new ConnectionContext(
-    socket,
-    authToken,
-    ip
-  ))
-  activeClients.set(connectionContext)
   // messages will start coming in before handleConnect completes & sit in the readyQueue
   const nextAuthToken = await handleConnect(connectionContext)
   sendEncodedMessage(connectionContext, {version: APP_VERSION, authToken: nextAuthToken})


### PR DESCRIPTION
Developing locally, sometimes when the server would restart i'd get a `cannot read isReady of undefined` error.
I think that's because connectionContext wasn't created synchronously, so this fixes that.
In my testing, it fixes the problem, but there may be a 2nd culprit somewhere.  