### PR TITLE
fix: handle failed 3DS payments

### DIFF
--- a/packages/server/billing/stripeWebhookHandler.ts
+++ b/packages/server/billing/stripeWebhookHandler.ts
@@ -82,17 +82,6 @@ const eventLookup = {
       }
     },
     subscription: {
-      updated: {
-        getVars: ({customer, id}: {customer: string; id: string}) => ({
-          customerId: customer,
-          subscriptionId: id
-        }),
-        query: `
-        mutation StripeUpdateSubscription($customerId: ID!, $subscriptionId: ID!) {
-          stripeUpdateSubscription(customerId: $customerId, subscriptionId: $subscriptionId)
-        }
-      `
-      },
       created: {
         getVars: ({customer, id}: {customer: string; id: string}) => ({
           customerId: customer,
@@ -100,7 +89,7 @@ const eventLookup = {
         }),
         query: `
         mutation StripeCreateSubscription($customerId: ID!, $subscriptionId: ID!) {
-          stripeUpdateSubscription(customerId: $customerId, subscriptionId: $subscriptionId)
+          stripeCreateSubscription(customerId: $customerId, subscriptionId: $subscriptionId)
         }
       `
       },

--- a/packages/server/graphql/mutations/helpers/oldUpgradeToTeamTier.ts
+++ b/packages/server/graphql/mutations/helpers/oldUpgradeToTeamTier.ts
@@ -33,7 +33,7 @@ const oldUpgradeToTeamTier = async (
   const customer = stripeId
     ? await manager.updatePayment(stripeId, source)
     : await manager.createCustomer(orgId, email, undefined, source)
-
+  if (customer instanceof Error) throw customer
   let subscriptionFields = {}
   if (!stripeSubscriptionId) {
     const subscription = await manager.createTeamSubscriptionOld(customer.id, orgId, quantity)

--- a/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
+++ b/packages/server/graphql/private/mutations/draftEnterpriseInvoice.ts
@@ -101,6 +101,7 @@ const draftEnterpriseInvoice: MutationResolvers['draftEnterpriseInvoice'] = asyn
   if (!stripeId) {
     // create the customer
     const customer = await manager.createCustomer(orgId, apEmail || user.email)
+    if (customer instanceof Error) throw customer
     await r.table('Organization').get(orgId).update({stripeId: customer.id}).run()
     customerId = customer.id
   } else {

--- a/packages/server/graphql/private/mutations/stripeCreateSubscription.ts
+++ b/packages/server/graphql/private/mutations/stripeCreateSubscription.ts
@@ -4,7 +4,7 @@ import {isSuperUser} from '../../../utils/authorization'
 import {getStripeManager} from '../../../utils/stripe'
 import {MutationResolvers} from '../resolverTypes'
 
-const stripeUpdateSubscription: MutationResolvers['stripeUpdateSubscription'] = async (
+const stripeCreateSubscription: MutationResolvers['stripeCreateSubscription'] = async (
   _source,
   {customerId, subscriptionId},
   {authToken}
@@ -49,4 +49,4 @@ const stripeUpdateSubscription: MutationResolvers['stripeUpdateSubscription'] = 
   return true
 }
 
-export default stripeUpdateSubscription
+export default stripeCreateSubscription

--- a/packages/server/graphql/private/typeDefs/_legacy.graphql
+++ b/packages/server/graphql/private/typeDefs/_legacy.graphql
@@ -450,7 +450,7 @@ type Mutation {
   """
   When stripe tells us a subscription was updated, update the details in our own DB
   """
-  stripeUpdateSubscription(
+  stripeCreateSubscription(
     """
     The stripe customer ID, or stripeId
     """
@@ -1122,7 +1122,7 @@ type JiraServerIssue implements TaskIntegration {
   The description converted into raw HTML
   """
   descriptionHTML: String!
-  
+
   """
   The timestamp the issue was last updated
   """

--- a/packages/server/graphql/public/mutations/createStripeSubscription.ts
+++ b/packages/server/graphql/public/mutations/createStripeSubscription.ts
@@ -45,7 +45,9 @@ const createStripeSubscription: MutationResolvers['createStripeSubscription'] = 
     // cannot updateDefaultPaymentMethod until it is attached to the customer
     await manager.updateDefaultPaymentMethod(customerId, paymentMethodId)
   } else {
-    customer = await manager.createCustomer(orgId, email, paymentMethodId)
+    const maybeCustomer = await manager.createCustomer(orgId, email, paymentMethodId)
+    if (maybeCustomer instanceof Error) return {error: {message: maybeCustomer.message}}
+    customer = maybeCustomer
   }
 
   const subscription = await manager.createTeamSubscription(customer.id, orgId, orgUsersCount)

--- a/packages/server/utils/stripe/StripeManager.ts
+++ b/packages/server/utils/stripe/StripeManager.ts
@@ -96,19 +96,23 @@ export default class StripeManager {
     paymentMethodId?: string | undefined,
     source?: string
   ) {
-    return this.stripe.customers.create({
-      email,
-      source,
-      payment_method: paymentMethodId,
-      invoice_settings: paymentMethodId
-        ? {
-            default_payment_method: paymentMethodId
-          }
-        : undefined,
-      metadata: {
-        orgId
-      }
-    })
+    try {
+      return await this.stripe.customers.create({
+        email,
+        source,
+        payment_method: paymentMethodId,
+        invoice_settings: paymentMethodId
+          ? {
+              default_payment_method: paymentMethodId
+            }
+          : undefined,
+        metadata: {
+          orgId
+        }
+      })
+    } catch (e) {
+      return e as Error
+    }
   }
 
   async createEnterpriseSubscription(


### PR DESCRIPTION
# Description

When a 3DS payment fails, that causes the subscription to go from incomplete to incomplete_expired.
We had a webhook handler that would set the `stripeSubscriptionId` to whatever was coming in from stripe, even if the incoming subscription was expired!
That chain of logic would attach an expired `stripeSubscriptionId` onto an organization, and when they tried to upgrade again, it would fail because they already had a subscription 🤮 

this checks to make sure the subscription is valid before updating the `Organization.stripeSubcriptionId`.
Additionally, i noticed that after an upgrade failed, if you click the upgrade button again, it doesn't do anything except remove the error message. That felt bad, so I fixed that logic.