### PR TITLE
chore(client): when a release happens, links to the specific tag version

### DIFF
--- a/packages/client/hooks/useServiceWorkerUpdater.ts
+++ b/packages/client/hooks/useServiceWorkerUpdater.ts
@@ -21,7 +21,7 @@ const useServiceWorkerUpdater = () => {
         action: {
           label: `See what's changed`,
           callback: () => {
-            const url = 'https://github.com/ParabolInc/parabol/releases'
+            const url = `https://github.com/ParabolInc/parabol/releases/tag/v${__APP_VERSION__}`
             window.open(url, '_blank', 'noopener')?.focus()
           }
         }


### PR DESCRIPTION
# Description

Fixes #9930 

Tested using an on-demand-env. I started it on 7.37.8, upgraded to 7.38.0 without this change, so the link was to [releases](https://github.com/ParabolInc/parabol/releases/), then upgraded to a Docker generated on this branch and the link was pointing to [v7.38.1](https://github.com/ParabolInc/parabol/releases/tag/v7.38.1)