### PR TITLE
chore(postgres): Postgres upgraded to 15.7 and pgvector to 0.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: "write"
     services:
       postgres:
-        image: pgvector/pgvector:0.6.2-pg15
+        image: pgvector/pgvector:0.7.0-pg15
         # This env variables must be the same in the file PARABOL_BUILD_ENV_PATH
         env:
           POSTGRES_PASSWORD: "temppassword"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: "write"
     services:
       postgres:
-        image: pgvector/pgvector:0.6.2-pg15
+        image: pgvector/pgvector:0.7.0-pg15
         # This env variables must be the same in the file PARABOL_BUILD_ENV_PATH
         env:
           POSTGRES_PASSWORD: "temppassword"

--- a/docker/images/postgres/Dockerfile
+++ b/docker/images/postgres/Dockerfile
@@ -1,5 +1,5 @@
-FROM postgres:15.4
-ARG PGVECTOR_VERSION=v0.6.1
+FROM postgres:15.7
+ARG PGVECTOR_VERSION=v0.7.0
 ARG PSQL_MAJOR_VERSION=15
 
 ADD extensions /extensions

--- a/docker/images/postgres/Dockerfile
+++ b/docker/images/postgres/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:15.7
 ARG PGVECTOR_VERSION=v0.7.0
 ARG PSQL_MAJOR_VERSION=15
 
-ADD extensions /extensions
+COPY extensions /extensions
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/docker/stacks/single-tenant-host/docker-compose.yml
+++ b/docker/stacks/single-tenant-host/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   postgres:
     container_name: postgres
     profiles: ["databases"]
-    image: pgvector/pgvector:0.6.2-pg15
+    image: pgvector/pgvector:0.7.0-pg15
     restart: always
     env_file: .env
     environment:


### PR DESCRIPTION
# Description
Upgrades Postgres to 15.7 and PGVector to 0.7.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Docker image version for the `postgres` service to `pgvector:0.7.0-pg15` in multiple workflow files.
  - Dockerfile now uses `postgres:15.7` and `PGVECTOR_VERSION` updated to `v0.7.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->