### PR TITLE
chore(rethinkdb): phase 4 of RetroReflection, RetroReflectionGroup and TimelineEvent

### DIFF
--- a/packages/server/postgres/migrations/1720517256158_TimelineEvent-phase4.ts
+++ b/packages/server/postgres/migrations/1720517256158_TimelineEvent-phase4.ts
@@ -1,0 +1,15 @@
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+export async function up() {
+  await connectRethinkDB()
+  try {
+    await r.tableDrop('TimelineEvent').run()
+  } catch (error) {
+    // table already dropped
+  }
+}
+
+export async function down() {
+  // No migration down
+}

--- a/packages/server/postgres/migrations/1720517631974_RetroReflectionGroup-phase4.ts
+++ b/packages/server/postgres/migrations/1720517631974_RetroReflectionGroup-phase4.ts
@@ -1,0 +1,15 @@
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+export async function up() {
+  await connectRethinkDB()
+  try {
+    await r.tableDrop('RetroReflectionGroup').run()
+  } catch (error) {
+    // table already dropped
+  }
+}
+
+export async function down() {
+  // No migration down
+}

--- a/packages/server/postgres/migrations/1720518455750_RetroReflection-phase4.ts
+++ b/packages/server/postgres/migrations/1720518455750_RetroReflection-phase4.ts
@@ -1,0 +1,15 @@
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+export async function up() {
+  await connectRethinkDB()
+  try {
+    await r.tableDrop('RetroReflection').run()
+  } catch (error) {
+    // table already dropped
+  }
+}
+
+export async function down() {
+  // No migration down
+}


### PR DESCRIPTION
# Description

These three tables represent almost 50% of the storage and almost 55% of the documents for RethinkDB. They are not used anymore since almost two weeks for TimelineEvent and RetroReflection, and a month for RetroReflectionGroup. We are not writing new data to them and if we find any problem we should fix it in PostgreSQL.

This PR allows us to reduce backup and restoration time. We shouldn't need to delete any more tables until we are done with the migration, but these three are good candidates. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Migrated database to drop the `TimelineEvent`, `RetroReflectionGroup`, and `RetroReflection` tables using RethinkDB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->