### PR TITLE
chore(rethinkdb): delete ununsed tables and remove them from the backupOrganization mutation

### DIFF
--- a/packages/server/graphql/private/mutations/backupOrganization.ts
+++ b/packages/server/graphql/private/mutations/backupOrganization.ts
@@ -171,9 +171,6 @@ const backupOrganization: MutationResolvers['backupOrganization'] = async (_sour
     agendaItem: (r.table('AgendaItem').getAll(r.args(teamIds), {index: 'teamId'}) as any)
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('AgendaItem').insert(items)),
-    atlassianAuth: (r.table('AtlassianAuth').getAll(r.args(teamIds), {index: 'teamId'}) as any)
-      .coerceTo('array')
-      .do((items: RValue) => r.db(DESTINATION).table('AtlassianAuth').insert(items)),
     invoice: (r.table('Invoice').filter((row: RDatum) => r(orgIds).contains(row('orgId'))) as any)
       .coerceTo('array')
       .do((items: RValue) => r.db(DESTINATION).table('Invoice').insert(items)),

--- a/packages/server/postgres/migrations/1720794118729_deleteUnusedRethinkDBTables.ts
+++ b/packages/server/postgres/migrations/1720794118729_deleteUnusedRethinkDBTables.ts
@@ -9,7 +9,6 @@ export async function up() {
   await r.tableDrop('Provider').run()
   await r.tableDrop('AtlassianAuth').run()
   await r.tableDrop('FailedAuthRequest').run()
-  await r.tableDrop('Organization').run()
 }
 
 export async function down() {

--- a/packages/server/postgres/migrations/1720794118729_deleteUnusedRethinkDBTables.ts
+++ b/packages/server/postgres/migrations/1720794118729_deleteUnusedRethinkDBTables.ts
@@ -1,0 +1,17 @@
+import {r} from 'rethinkdb-ts'
+import connectRethinkDB from '../../database/connectRethinkDB'
+
+export async function up() {
+  await connectRethinkDB()
+  await r.tableDrop('ScheduledJob').run()
+  await r.tableDrop('SAML').run()
+  await r.tableDrop('SlackIntegration').run()
+  await r.tableDrop('Provider').run()
+  await r.tableDrop('AtlassianAuth').run()
+  await r.tableDrop('FailedAuthRequest').run()
+  await r.tableDrop('Organization').run()
+}
+
+export async function down() {
+  // No migration down
+}


### PR DESCRIPTION
# Description

Deletes all unused/migrated tables from RethinkDB. It clarifies what is truly migrated and what is not.

- **ScheduledJob:** migrated in [v7.22.1](https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#7221-2024-03-14).
- **FailedAuthRequest:** migrated in [v7.22.1](https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#7221-2024-03-14).
- **SAML:** migrated in [v6.122.0](https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#61220-2023-sep-27).
- **SlackIntegration:** [deprecated in Dec 2020](https://github.com/ParabolInc/parabol/blob/5aee8e492879c4b7bd344b72383b4a373c05a795/packages/server/database/migrations/20190521222803-slack.js#L2).
- **Provider:** migrated in [v6.2.0](https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#620-2021-mar-03-1)
- **AtlassianAuth:** migrated in [v6.21.0](https://github.com/ParabolInc/parabol/blob/master/CHANGELOG.md#6210-2021-jul-15). It was still being backed up on the backupOrganization mutation. Removed from there too.

Organization table is not deleted, as it has been migrated this week. No rush, this PR is just to clean old stuff.

Doing a search, using VSCode, on my workspace with `table('TABLE_NAME')`, ignoring everything in `**/migrations` does not find anything for the tables proposed for deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the `backupOrganization` functionality by removing the obsolete `atlassianAuth` field, ensuring smoother data processing.
  
- **Chores**
	- Added a new migration script to delete unused RethinkDB tables, optimising database management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->