### PR TITLE
chore: parallelize codecheck

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -7,11 +7,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  PARABOL_BUILD_ENV_PATH: docker/images/parabol-ubi/environments/pipeline
 jobs:
   style-check:
-    runs-on: ubuntu-8cores
+    runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -1,0 +1,41 @@
+name: Style Check
+on:
+  push:
+    branches-ignore:
+      - "release-please--**"
+      - "release/v**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+env:
+  PARABOL_BUILD_ENV_PATH: docker/images/parabol-ubi/environments/pipeline
+jobs:
+  style-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: package.json
+          # Caching yarn dir & running yarn install is too slow
+          # Instead, we aggressively cache node_modules below to avoid calling install
+      - name: Get cached node modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+          key: node_modules-${{ runner.arch }}-${{ env.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install node_modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
+
+      - name: Check Code Quality
+        run: yarn codecheck

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -11,7 +11,7 @@ env:
   PARABOL_BUILD_ENV_PATH: docker/images/parabol-ubi/environments/pipeline
 jobs:
   style-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-8cores
     permissions:
       contents: "read"
       id-token: "write"
@@ -25,6 +25,13 @@ jobs:
           node-version-file: package.json
           # Caching yarn dir & running yarn install is too slow
           # Instead, we aggressively cache node_modules below to avoid calling install
+
+      - name: Setup environment variables
+        run: |
+          NODE_VERSION=$(jq -r -j '.engines.node|ltrimstr("^")' package.json)
+          echo NODE_VERSION=$NODE_VERSION >> $GITHUB_ENV
+          echo NODE_VERSION=$NODE_VERSION
+
       - name: Get cached node modules
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
       - name: Kysely Codegen
         run: yarn pg:generate
 
-      - name: Check Code Quality
-        run: yarn codecheck
+      - name: Typecheck
+        run: yarn typecheck
 
       - name: Run server tests
         run: yarn test:server -- --reporters=default --reporters=jest-junit

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "nx run-many --target=typecheck",
     "lintcheck": "nx run-many --target=lint:check",
     "stylecheck": "nx run-many --target=prettier:check",
-    "codecheck": "concurrently --names \"typecheck,lintcheck,stylecheck\" \"yarn typecheck\" \"yarn lintcheck\" \"yarn stylecheck\" ",
+    "codecheck": "concurrently --names \"lintcheck,stylecheck\" \"yarn lintcheck\" \"yarn stylecheck\" ",
     "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
     "precommit": "nx run-many --target=precommit --parallel=1",
     "postcheckout": "node scripts/generateGraphQLArtifacts.js &>/dev/null &",


### PR DESCRIPTION
codecheck currently takes 2 mins!
The bulk of that is prettier.
We could replace prettier + eslint with biome. It runs in 2 seconds!
Unfortunately, we require prettier-plugin-tailwindcss on the frontend.
Until biome offers support for tailwind class sorting (https://github.com/biomejs/biome/issues/1274) we can't switch.

As an alternative, we can run prettier & eslint in parallel to the testing suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Introduced a GitHub Actions workflow for style checks to ensure code quality on push events.
  - Renamed "Check Code Quality" step to "Typecheck" in the test workflow to focus on type checking.
  - Updated the `codecheck` script in `package.json` to remove `typecheck`, simplifying the script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->