### PR TITLE
chore: upgrade from gpt-3.5-turbo to gpt-4o-mini

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -51,7 +51,7 @@ class OpenAIServerManager {
     """`
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o-mini',
         messages: [
           {
             role: 'user',
@@ -86,7 +86,7 @@ class OpenAIServerManager {
     """`
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o-mini',
         messages: [
           {
             role: 'user',
@@ -136,7 +136,7 @@ class OpenAIServerManager {
       .join('\n')}`
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o-mini',
         messages: [
           {
             role: 'user',
@@ -208,7 +208,7 @@ class OpenAIServerManager {
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-3.5-turbo-0125',
+        model: 'gpt-4o-mini',
         messages: [
           {
             role: 'user',


### PR DESCRIPTION
# Description

`gpt-4o-mini` is [more powerful yet cheaper](https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/) than `gpt-3.5-turbo`

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced AI capabilities by upgrading the underlying model from `gpt-3.5-turbo` to `gpt-4o-mini` for improved performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->