### PR TITLE
feat: Enable connecting to different GitLab integration providers

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -134,6 +134,7 @@
           "TemplateScale": "../../postgres/types/index#TemplateScale as TemplateScaleDB",
           "TemplateScaleRef": "../../postgres/types/index#TemplateScaleRef as TemplateScaleRefDB",
           "Threadable": "./types/Threadable#ThreadableSource",
+          "OrgIntegrationProviders": "./types/OrgIntegrationProviders#OrgIntegrationProvidersSource",
           "OrganizationUser": "../../postgres/types/index#OrganizationUser as OrganizationUserDB",
           "PokerMeeting": "../../database/types/MeetingPoker#default as MeetingPoker",
           "PokerMeetingMember": "../../database/types/MeetingPokerMeetingMember#default as PokerMeetingMemberDB",

--- a/codegen.json
+++ b/codegen.json
@@ -49,6 +49,7 @@
           "SetSlackNotificationPayload": "./types/SetSlackNotificationPayload#SetSlackNotificationPayloadSource",
           "SetDefaultSlackChannelSuccess": "./types/SetDefaultSlackChannelSuccess#SetDefaultSlackChannelSuccessSource",
           "AddCommentSuccess": "./types/AddCommentSuccess#AddCommentSuccessSource",
+          "AddIntegrationProviderSuccess": "./types/AddIntegrationProviderSuccess#AddIntegrationProviderSuccessSource",
           "DeleteCommentSuccess": "./types/DeleteCommentSuccess#DeleteCommentSuccessSource",
           "UpdateCommentContentSuccess": "./types/UpdateCommentContentSuccess#UpdateCommentContentSuccessSource",
           "AddSlackAuthPayload": "./types/AddSlackAuthPayload#AddSlackAuthPayloadSource",

--- a/packages/client/components/Dashboard/DashSidebar.tsx
+++ b/packages/client/components/Dashboard/DashSidebar.tsx
@@ -9,6 +9,7 @@ import {
   AUTHENTICATION_PAGE,
   BILLING_PAGE,
   MEMBERS_PAGE,
+  ORG_INTEGRATIONS_PAGE,
   ORG_SETTINGS_PAGE,
   TEAMS_PAGE
 } from '../../utils/constants'
@@ -122,6 +123,11 @@ const DashSidebar = (props: Props) => {
                   icon={'work'}
                   href={`/me/organizations/${orgId}/${ORG_SETTINGS_PAGE}`}
                   label={'Organization Settings'}
+                />
+                <NavItem
+                  icon={'appRegistration'}
+                  href={`/me/organizations/${orgId}/${ORG_INTEGRATIONS_PAGE}`}
+                  label={'Integration Settings'}
                 />
                 <NavItem
                   icon={'key'}

--- a/packages/client/components/Dashboard/LeftDashNavItem.tsx
+++ b/packages/client/components/Dashboard/LeftDashNavItem.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import {
   AccountBox,
   Add,
+  AppRegistration,
   ArrowBack,
   AutoAwesome,
   CreditScore,
@@ -72,6 +73,7 @@ const iconLookup = {
   groups: <Groups fontSize='inherit' />,
   warning: <Warning fontSize='inherit' />,
   work: <WorkOutline fontSize='inherit' />,
+  appRegistration: <AppRegistration fontSize='inherit' />,
   timeline: <Timeline fontSize='inherit' />,
   key: <Key fontSize='inherit' />
 }

--- a/packages/client/components/Dashboard/MobileDashSidebar.tsx
+++ b/packages/client/components/Dashboard/MobileDashSidebar.tsx
@@ -10,6 +10,7 @@ import {
   AUTHENTICATION_PAGE,
   BILLING_PAGE,
   MEMBERS_PAGE,
+  ORG_INTEGRATIONS_PAGE,
   ORG_SETTINGS_PAGE,
   TEAMS_PAGE
 } from '../../utils/constants'
@@ -168,6 +169,12 @@ const MobileDashSidebar = (props: Props) => {
                 icon={'work'}
                 href={`/me/organizations/${orgId}/${ORG_SETTINGS_PAGE}`}
                 label={'Organization Settings'}
+              />
+              <NavItem
+                onClick={handleMenuClick}
+                icon={'appRegistration'}
+                href={`/me/organizations/${orgId}/${ORG_INTEGRATIONS_PAGE}`}
+                label={'Integration Settings'}
               />
               <NavItem
                 onClick={handleMenuClick}

--- a/packages/client/components/Settings/SettingsWrapper.tsx
+++ b/packages/client/components/Settings/SettingsWrapper.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled'
-import {SETTINGS_MAX_WIDTH, SETTINGS_NARROW_MAX_WIDTH} from '../../utils/constants'
+import {Layout} from '../../types/constEnums'
 
 const SettingsWrapper = styled('div')<{narrow?: boolean}>(({narrow}) => ({
   display: 'flex',
   flexDirection: 'column',
   margin: '0 auto',
-  maxWidth: narrow ? SETTINGS_NARROW_MAX_WIDTH : SETTINGS_MAX_WIDTH,
+  maxWidth: narrow ? Layout.SETTINGS_NARROW_MAX_WIDTH : Layout.SETTINGS_MAX_WIDTH,
   width: '100%'
 }))
 

--- a/packages/client/components/Settings/SettingsWrapper.tsx
+++ b/packages/client/components/Settings/SettingsWrapper.tsx
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled'
+import {SETTINGS_MAX_WIDTH, SETTINGS_NARROW_MAX_WIDTH} from '../../utils/constants'
 
 const SettingsWrapper = styled('div')<{narrow?: boolean}>(({narrow}) => ({
   display: 'flex',
   flexDirection: 'column',
   margin: '0 auto',
-  maxWidth: narrow ? 644 : 768,
+  maxWidth: narrow ? SETTINGS_NARROW_MAX_WIDTH : SETTINGS_MAX_WIDTH,
   width: '100%'
 }))
 

--- a/packages/client/modules/teamDashboard/components/ProviderRow/AtlassianProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/AtlassianProviderRow.tsx
@@ -10,7 +10,7 @@ import {MenuPosition} from '../../../../hooks/useCoords'
 import useMenu from '../../../../hooks/useMenu'
 import useMutationProps, {MenuMutationProps} from '../../../../hooks/useMutationProps'
 import {AuthToken} from '../../../../types/AuthToken'
-import {ExternalLinks, Providers} from '../../../../types/constEnums'
+import {ExternalLinks} from '../../../../types/constEnums'
 import AtlassianClientManager, {ERROR_POPUP_CLOSED} from '../../../../utils/AtlassianClientManager'
 import ProviderRow from './ProviderRow'
 
@@ -96,8 +96,8 @@ const AtlassianProviderRow = (props: Props) => {
         submitting={submitting}
         togglePortal={togglePortal}
         menuRef={originRef}
-        providerName={Providers.ATLASSIAN_NAME}
-        providerDescription={Providers.ATLASSIAN_DESC}
+        providerName='Atlassian'
+        providerDescription='Use Jira Cloud Issues from within Parabol.'
         providerLogo={<AtlassianProviderLogo />}
         error={errorMessage}
       />

--- a/packages/client/modules/teamDashboard/components/ProviderRow/AtlassianProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/AtlassianProviderRow.tsx
@@ -10,7 +10,7 @@ import {MenuPosition} from '../../../../hooks/useCoords'
 import useMenu from '../../../../hooks/useMenu'
 import useMutationProps, {MenuMutationProps} from '../../../../hooks/useMutationProps'
 import {AuthToken} from '../../../../types/AuthToken'
-import {ExternalLinks} from '../../../../types/constEnums'
+import {ExternalLinks, Providers} from '../../../../types/constEnums'
 import AtlassianClientManager, {ERROR_POPUP_CLOSED} from '../../../../utils/AtlassianClientManager'
 import ProviderRow from './ProviderRow'
 
@@ -96,8 +96,8 @@ const AtlassianProviderRow = (props: Props) => {
         submitting={submitting}
         togglePortal={togglePortal}
         menuRef={originRef}
-        providerName='Atlassian'
-        providerDescription='Use Jira Cloud Issues from within Parabol.'
+        providerName={Providers.ATLASSIAN_NAME}
+        providerDescription={Providers.ATLASSIAN_DESC}
         providerLogo={<AtlassianProviderLogo />}
         error={errorMessage}
       />

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
@@ -89,6 +89,8 @@ const GitLabProviderRow = (props: Props) => {
   const connectedProviderId = auth?.provider?.id
   const availableProviders = [...(cloudProvider ? [cloudProvider] : []), ...sharedProviders]
 
+  if (availableProviders.length === 0) return null
+
   return (
     <>
       <div className='relative my-4 flex w-full shrink-0 flex-col justify-start rounded bg-white shadow-card'>

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
@@ -138,7 +138,7 @@ const GitLabProviderRow = (props: Props) => {
                           </>
                         ) : (
                           <FlatButton
-                            className='min-w-9 border-slate-400 py-0 text-sm font-semibold text-slate-700'
+                            className='min-w-[36px] border-slate-400 pl-0 pr-0 text-sm font-semibold text-slate-700'
                             onClick={togglePortal}
                             ref={menuRef}
                           >

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
@@ -1,15 +1,101 @@
+import styled from '@emotion/styled'
+import {Done as DoneIcon, MoreVert as MoreVertIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {GitLabProviderRow_viewer$key} from '../../../../__generated__/GitLabProviderRow_viewer.graphql'
+import FlatButton from '../../../../components/FlatButton'
 import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
+import ProviderActions from '../../../../components/ProviderActions'
+import RowInfo from '../../../../components/Row/RowInfo'
+import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useBreakpoint from '../../../../hooks/useBreakpoint'
 import {MenuPosition} from '../../../../hooks/useCoords'
 import useMenu from '../../../../hooks/useMenu'
 import useMutationProps from '../../../../hooks/useMutationProps'
+import {cardShadow} from '../../../../styles/elevation'
+import {PALETTE} from '../../../../styles/paletteV3'
+import {Breakpoint, Layout} from '../../../../types/constEnums'
 import GitLabClientManager from '../../../../utils/GitLabClientManager'
+import ConnectButton from './ConnectButton'
 import GitLabConfigMenu from './GitLabConfigMenu'
-import ProviderRow from './ProviderRow'
+
+const MenuButton = styled(FlatButton)({
+  borderColor: PALETTE.SLATE_400,
+  color: PALETTE.SLATE_700,
+  fontSize: 14,
+  fontWeight: 600,
+  minWidth: 36,
+  paddingLeft: 0,
+  paddingRight: 0
+})
+
+const SmallMenuButton = styled(MenuButton)({
+  minWidth: 30
+})
+
+const StatusWrapper = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  paddingRight: 25
+})
+
+const StatusLabel = styled('div')({
+  color: PALETTE.SLATE_700,
+  fontSize: 14,
+  fontWeight: 600,
+  paddingLeft: 6
+})
+
+const StatusIcon = styled('div')({
+  svg: {
+    fontSize: 18
+  },
+  width: 18,
+  height: 18,
+  color: PALETTE.SUCCESS_LIGHT
+})
+
+const MenuSmallIcon = styled(MoreVertIcon)({
+  svg: {
+    fontSize: 18
+  },
+  width: 18,
+  height: 18
+})
+
+const ProviderName = styled('div')({
+  color: PALETTE.SLATE_700,
+  fontSize: 16,
+  fontWeight: 600,
+  lineHeight: '24px',
+  alignItems: 'center',
+  display: 'flex',
+  marginRight: 16,
+  verticalAlign: 'middle'
+})
+
+const ProviderCard = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  backgroundColor: 'white',
+  borderRadius: 4,
+  boxShadow: cardShadow,
+  flexShrink: 0,
+  justifyContent: 'flex-start',
+  margin: '16px 0',
+  padding: 0,
+  position: 'relative',
+  width: '100%'
+})
+
+const CardTop = styled('div')({
+  display: 'flex',
+  justifyContent: 'flex-start',
+  padding: Layout.ROW_GUTTER,
+  paddingBottom: 0
+})
 
 interface Props {
   teamId: string
@@ -22,10 +108,16 @@ graphql`
       gitlab {
         auth {
           provider {
+            id
             scope
           }
         }
         cloudProvider {
+          id
+          clientId
+          serverBaseUrl
+        }
+        sharedProviders {
           id
           clientId
           serverBaseUrl
@@ -56,6 +148,7 @@ const GitLabProviderRow = (props: Props) => {
     menuProps,
     togglePortal
   } = useMenu(MenuPosition.UPPER_RIGHT)
+  const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
 
   const viewer = useFragment(
     graphql`
@@ -70,22 +163,109 @@ const GitLabProviderRow = (props: Props) => {
   const {teamMember} = viewer
   const {integrations} = teamMember!
   const {gitlab} = integrations
-  const {auth, cloudProvider} = gitlab
-  if (!cloudProvider) return null
-  const {clientId, id: cloudProviderId, serverBaseUrl} = cloudProvider
+  const {auth, cloudProvider, sharedProviders} = gitlab
+  const connected = !!auth
+  const connectedProviderId = auth?.provider?.id
+  const showCloudProvider =
+    cloudProvider && (!connected || cloudProvider.id === connectedProviderId)
 
   return (
     <>
-      <ProviderRow
-        connected={!!auth}
-        onConnectClick={() => openOAuth(cloudProviderId, clientId, serverBaseUrl)}
-        submitting={submitting}
-        togglePortal={togglePortal}
-        menuRef={menuRef}
-        providerName={'GitLab'}
-        providerDescription={'Use GitLab Issues from within Parabol'}
-        providerLogo={<GitLabProviderLogo />}
-      />
+      <ProviderCard>
+        <CardTop>
+          <GitLabProviderLogo />
+          <div className='flex w-full flex-col'>
+            {showCloudProvider && (
+              <div className='flex w-full flex-row pb-4'>
+                <RowInfo>
+                  <ProviderName>GitLab</ProviderName>
+                  <RowInfoCopy>Use GitLab Issues from within Parabol.</RowInfoCopy>
+                </RowInfo>
+                <ProviderActions>
+                  {!connected && (
+                    <ConnectButton
+                      onConnectClick={() =>
+                        openOAuth(
+                          cloudProvider.id,
+                          cloudProvider.clientId,
+                          cloudProvider.serverBaseUrl
+                        )
+                      }
+                      submitting={submitting}
+                    />
+                  )}
+                  {cloudProvider.id === connectedProviderId && (
+                    <>
+                      {isDesktop ? (
+                        <>
+                          <StatusWrapper>
+                            <StatusIcon>
+                              <DoneIcon />
+                            </StatusIcon>
+                            <StatusLabel>Connected</StatusLabel>
+                          </StatusWrapper>
+                          <SmallMenuButton onClick={togglePortal} ref={menuRef}>
+                            <MenuSmallIcon>
+                              <MoreVertIcon />
+                            </MenuSmallIcon>
+                          </SmallMenuButton>
+                        </>
+                      ) : (
+                        <MenuButton onClick={togglePortal} ref={menuRef}>
+                          <MoreVertIcon />
+                        </MenuButton>
+                      )}
+                    </>
+                  )}
+                </ProviderActions>
+              </div>
+            )}
+            {sharedProviders.map(({id, serverBaseUrl, clientId}) => {
+              const showProvider = !connected || id === connectedProviderId
+              if (!showProvider) return null
+              return (
+                <div key={id} className='flex w-full flex-row pb-4'>
+                  <RowInfo>
+                    <ProviderName>{serverBaseUrl.replace(/https:\/\//, '')}</ProviderName>
+                    <RowInfoCopy>Connect to your own GitLab server.</RowInfoCopy>
+                  </RowInfo>
+                  <ProviderActions>
+                    {!connected && (
+                      <ConnectButton
+                        onConnectClick={() => openOAuth(id, clientId, serverBaseUrl)}
+                        submitting={submitting}
+                      />
+                    )}
+                    {id === connectedProviderId && (
+                      <>
+                        {isDesktop ? (
+                          <>
+                            <StatusWrapper>
+                              <StatusIcon>
+                                <DoneIcon />
+                              </StatusIcon>
+                              <StatusLabel>Connected</StatusLabel>
+                            </StatusWrapper>
+                            <SmallMenuButton onClick={togglePortal} ref={menuRef}>
+                              <MenuSmallIcon>
+                                <MoreVertIcon />
+                              </MenuSmallIcon>
+                            </SmallMenuButton>
+                          </>
+                        ) : (
+                          <MenuButton onClick={togglePortal} ref={menuRef}>
+                            <MoreVertIcon />
+                          </MenuButton>
+                        )}
+                      </>
+                    )}
+                  </ProviderActions>
+                </div>
+              )
+            })}
+          </div>
+        </CardTop>
+      </ProviderCard>
       {menuPortal(
         <GitLabConfigMenu menuProps={menuProps} mutationProps={mutationProps} teamId={teamId} />
       )}

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import {Done as DoneIcon, MoreVert as MoreVertIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
@@ -14,88 +13,10 @@ import useBreakpoint from '../../../../hooks/useBreakpoint'
 import {MenuPosition} from '../../../../hooks/useCoords'
 import useMenu from '../../../../hooks/useMenu'
 import useMutationProps from '../../../../hooks/useMutationProps'
-import {cardShadow} from '../../../../styles/elevation'
-import {PALETTE} from '../../../../styles/paletteV3'
-import {Breakpoint, Layout} from '../../../../types/constEnums'
+import {Breakpoint} from '../../../../types/constEnums'
 import GitLabClientManager from '../../../../utils/GitLabClientManager'
 import ConnectButton from './ConnectButton'
 import GitLabConfigMenu from './GitLabConfigMenu'
-
-const MenuButton = styled(FlatButton)({
-  borderColor: PALETTE.SLATE_400,
-  color: PALETTE.SLATE_700,
-  fontSize: 14,
-  fontWeight: 600,
-  minWidth: 36,
-  paddingLeft: 0,
-  paddingRight: 0
-})
-
-const SmallMenuButton = styled(MenuButton)({
-  minWidth: 30
-})
-
-const StatusWrapper = styled('div')({
-  display: 'flex',
-  alignItems: 'center',
-  paddingRight: 25
-})
-
-const StatusLabel = styled('div')({
-  color: PALETTE.SLATE_700,
-  fontSize: 14,
-  fontWeight: 600,
-  paddingLeft: 6
-})
-
-const StatusIcon = styled('div')({
-  svg: {
-    fontSize: 18
-  },
-  width: 18,
-  height: 18,
-  color: PALETTE.SUCCESS_LIGHT
-})
-
-const MenuSmallIcon = styled(MoreVertIcon)({
-  svg: {
-    fontSize: 18
-  },
-  width: 18,
-  height: 18
-})
-
-const ProviderName = styled('div')({
-  color: PALETTE.SLATE_700,
-  fontSize: 16,
-  fontWeight: 600,
-  lineHeight: '24px',
-  alignItems: 'center',
-  display: 'flex',
-  marginRight: 16,
-  verticalAlign: 'middle'
-})
-
-const ProviderCard = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  backgroundColor: 'white',
-  borderRadius: 4,
-  boxShadow: cardShadow,
-  flexShrink: 0,
-  justifyContent: 'flex-start',
-  margin: '16px 0',
-  padding: 0,
-  position: 'relative',
-  width: '100%'
-})
-
-const CardTop = styled('div')({
-  display: 'flex',
-  justifyContent: 'flex-start',
-  padding: Layout.ROW_GUTTER,
-  paddingBottom: 0
-})
 
 interface Props {
   teamId: string
@@ -166,68 +87,29 @@ const GitLabProviderRow = (props: Props) => {
   const {auth, cloudProvider, sharedProviders} = gitlab
   const connected = !!auth
   const connectedProviderId = auth?.provider?.id
-  const showCloudProvider =
-    cloudProvider && (!connected || cloudProvider.id === connectedProviderId)
+  const availableProviders = [...(cloudProvider ? [cloudProvider] : []), ...sharedProviders]
 
   return (
     <>
-      <ProviderCard>
-        <CardTop>
+      <div className='relative my-4 flex w-full shrink-0 flex-col justify-start rounded bg-white shadow-card'>
+        <div className='flex justify-start p-row-gutter pb-0'>
           <GitLabProviderLogo />
           <div className='flex w-full flex-col'>
-            {showCloudProvider && (
-              <div className='flex w-full flex-row pb-4'>
-                <RowInfo>
-                  <ProviderName>GitLab</ProviderName>
-                  <RowInfoCopy>Use GitLab Issues from within Parabol.</RowInfoCopy>
-                </RowInfo>
-                <ProviderActions>
-                  {!connected && (
-                    <ConnectButton
-                      onConnectClick={() =>
-                        openOAuth(
-                          cloudProvider.id,
-                          cloudProvider.clientId,
-                          cloudProvider.serverBaseUrl
-                        )
-                      }
-                      submitting={submitting}
-                    />
-                  )}
-                  {cloudProvider.id === connectedProviderId && (
-                    <>
-                      {isDesktop ? (
-                        <>
-                          <StatusWrapper>
-                            <StatusIcon>
-                              <DoneIcon />
-                            </StatusIcon>
-                            <StatusLabel>Connected</StatusLabel>
-                          </StatusWrapper>
-                          <SmallMenuButton onClick={togglePortal} ref={menuRef}>
-                            <MenuSmallIcon>
-                              <MoreVertIcon />
-                            </MenuSmallIcon>
-                          </SmallMenuButton>
-                        </>
-                      ) : (
-                        <MenuButton onClick={togglePortal} ref={menuRef}>
-                          <MoreVertIcon />
-                        </MenuButton>
-                      )}
-                    </>
-                  )}
-                </ProviderActions>
-              </div>
-            )}
-            {sharedProviders.map(({id, serverBaseUrl, clientId}) => {
+            {availableProviders.map(({id, serverBaseUrl, clientId}) => {
               const showProvider = !connected || id === connectedProviderId
+              const isCloudProvider = cloudProvider?.id === id
               if (!showProvider) return null
               return (
                 <div key={id} className='flex w-full flex-row pb-4'>
                   <RowInfo>
-                    <ProviderName>{serverBaseUrl.replace(/https:\/\//, '')}</ProviderName>
-                    <RowInfoCopy>Connect to your own GitLab server.</RowInfoCopy>
+                    <div className='mr-4 flex items-center align-middle font-semibold leading-6 text-slate-700'>
+                      {isCloudProvider ? 'GitLab' : serverBaseUrl.replace(/https:\/\//, '')}
+                    </div>
+                    <RowInfoCopy>
+                      {isCloudProvider
+                        ? 'Use GitLab Issues from within Parabol.'
+                        : 'Connect to your own GitLab server.'}
+                    </RowInfoCopy>
                   </RowInfo>
                   <ProviderActions>
                     {!connected && (
@@ -240,22 +122,28 @@ const GitLabProviderRow = (props: Props) => {
                       <>
                         {isDesktop ? (
                           <>
-                            <StatusWrapper>
-                              <StatusIcon>
-                                <DoneIcon />
-                              </StatusIcon>
-                              <StatusLabel>Connected</StatusLabel>
-                            </StatusWrapper>
-                            <SmallMenuButton onClick={togglePortal} ref={menuRef}>
-                              <MenuSmallIcon>
-                                <MoreVertIcon />
-                              </MenuSmallIcon>
-                            </SmallMenuButton>
+                            <div className='flex items-center pr-6'>
+                              <DoneIcon className='h-[18px] w-[18px] text-lg text-success-light' />
+                              <div className='pl-[6px] text-sm font-semibold text-slate-700'>
+                                Connected
+                              </div>
+                            </div>
+                            <FlatButton
+                              className='min-w-[30px] border-slate-400 pl-0 pr-0 text-sm font-semibold text-slate-700'
+                              onClick={togglePortal}
+                              ref={menuRef}
+                            >
+                              <MoreVertIcon className='h-[18px] w-[18px] text-lg' />
+                            </FlatButton>
                           </>
                         ) : (
-                          <MenuButton onClick={togglePortal} ref={menuRef}>
+                          <FlatButton
+                            className='min-w-9 border-slate-400 py-0 text-sm font-semibold text-slate-700'
+                            onClick={togglePortal}
+                            ref={menuRef}
+                          >
                             <MoreVertIcon />
-                          </MenuButton>
+                          </FlatButton>
                         )}
                       </>
                     )}
@@ -264,8 +152,8 @@ const GitLabProviderRow = (props: Props) => {
               )
             })}
           </div>
-        </CardTop>
-      </ProviderCard>
+        </div>
+      </div>
       {menuPortal(
         <GitLabConfigMenu menuProps={menuProps} mutationProps={mutationProps} teamId={teamId} />
       )}

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsPanel.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsPanel.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {FormEvent} from 'react'
+import React, {FormEvent, useEffect} from 'react'
 import {useFragment} from 'react-relay'
 import {MSTeamsPanel_viewer$key} from '~/__generated__/MSTeamsPanel_viewer.graphql'
 import {MenuPosition} from '~/hooks/useCoords'
@@ -105,6 +105,12 @@ const MSTeamsPanel = (props: Props) => {
       }
     }
   })
+  // because we render this panel also when isConnectClicked, we cannot guarantee the serverWebhookUrl is correct on first render
+  useEffect(() => {
+    if (serverWebhookUrl && !fields.webhookUrl.value) {
+      fields.webhookUrl.resetValue(serverWebhookUrl)
+    }
+  }, [serverWebhookUrl])
 
   const {
     submitting,

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsProviderRow.tsx
@@ -18,13 +18,11 @@ interface Props {
 }
 
 graphql`
-  fragment MSTeamsProviderRowTeamMember on TeamMember {
-    integrations {
-      msTeams {
-        auth {
-          provider {
-            id
-          }
+  fragment MSTeamsProviderRowTeamMemberIntegrations on TeamMemberIntegrations {
+    msTeams {
+      auth {
+        provider {
+          id
         }
       }
     }
@@ -37,7 +35,9 @@ const MSTeamsProviderRow = (props: Props) => {
       fragment MSTeamsProviderRow_viewer on User {
         ...MSTeamsPanel_viewer
         teamMember(teamId: $teamId) {
-          ...MSTeamsProviderRowTeamMember @relay(mask: false)
+          integrations {
+            ...MSTeamsProviderRowTeamMemberIntegrations @relay(mask: false)
+          }
         }
       }
     `,

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MattermostPanel.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import {Info as InfoIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
-import React, {FormEvent} from 'react'
+import React, {FormEvent, useEffect} from 'react'
 import {useFragment} from 'react-relay'
 import {MattermostPanel_viewer$key} from '~/__generated__/MattermostPanel_viewer.graphql'
 import {MenuPosition} from '~/hooks/useCoords'
@@ -119,6 +119,12 @@ const MattermostPanel = (props: Props) => {
       }
     }
   })
+  // because we render this panel also when isConnectClicked, we cannot guarantee the serverWebhookUrl is correct on first render
+  useEffect(() => {
+    if (serverWebhookUrl && !fields.webhookUrl.value) {
+      fields.webhookUrl.resetValue(serverWebhookUrl)
+    }
+  }, [serverWebhookUrl])
 
   const {
     submitting,

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MattermostProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MattermostProviderRow.tsx
@@ -18,13 +18,11 @@ interface Props {
 }
 
 graphql`
-  fragment MattermostProviderRowTeamMember on TeamMember {
-    integrations {
-      mattermost {
-        auth {
-          provider {
-            id
-          }
+  fragment MattermostProviderRowTeamMemberIntegrations on TeamMemberIntegrations {
+    mattermost {
+      auth {
+        provider {
+          id
         }
       }
     }
@@ -37,7 +35,9 @@ const MattermostProviderRow = (props: Props) => {
       fragment MattermostProviderRow_viewer on User {
         ...MattermostPanel_viewer
         teamMember(teamId: $teamId) {
-          ...MattermostProviderRowTeamMember @relay(mask: false)
+          integrations {
+            ...MattermostProviderRowTeamMemberIntegrations @relay(mask: false)
+          }
         }
       }
     `,

--- a/packages/client/modules/teamDashboard/components/ProviderRow/ProviderRowBase.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/ProviderRowBase.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import {Done as DoneIcon, MoreVert as MoreVertIcon} from '@mui/icons-material'
 import React from 'react'
 import FlatButton from '../../../../components/FlatButton'
@@ -6,84 +5,7 @@ import ProviderActions from '../../../../components/ProviderActions'
 import RowInfo from '../../../../components/Row/RowInfo'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
 import useBreakpoint from '../../../../hooks/useBreakpoint'
-import {cardShadow} from '../../../../styles/elevation'
-import {PALETTE} from '../../../../styles/paletteV3'
-import {Breakpoint, Layout} from '../../../../types/constEnums'
-
-const MenuButton = styled(FlatButton)({
-  borderColor: PALETTE.SLATE_400,
-  color: PALETTE.SLATE_700,
-  fontSize: 14,
-  fontWeight: 600,
-  minWidth: 36,
-  paddingLeft: 0,
-  paddingRight: 0
-})
-
-const SmallMenuButton = styled(MenuButton)({
-  minWidth: 30
-})
-
-const StatusWrapper = styled('div')({
-  display: 'flex',
-  alignItems: 'center',
-  paddingRight: 25
-})
-
-const StatusLabel = styled('div')({
-  color: PALETTE.SLATE_700,
-  fontSize: 14,
-  fontWeight: 600,
-  paddingLeft: 6
-})
-
-const StatusIcon = styled('div')({
-  svg: {
-    fontSize: 18
-  },
-  width: 18,
-  height: 18,
-  color: PALETTE.SUCCESS_LIGHT
-})
-
-const MenuSmallIcon = styled(MoreVertIcon)({
-  svg: {
-    fontSize: 18
-  },
-  width: 18,
-  height: 18
-})
-
-const ProviderName = styled('div')({
-  color: PALETTE.SLATE_700,
-  fontSize: 16,
-  fontWeight: 600,
-  lineHeight: '24px',
-  alignItems: 'center',
-  display: 'flex',
-  marginRight: 16,
-  verticalAlign: 'middle'
-})
-
-const ProviderCard = styled('div')({
-  display: 'flex',
-  flexDirection: 'column',
-  backgroundColor: 'white',
-  borderRadius: 4,
-  boxShadow: cardShadow,
-  flexShrink: 0,
-  justifyContent: 'flex-start',
-  margin: '16px 0',
-  padding: 0,
-  position: 'relative',
-  width: '100%'
-})
-
-const CardTop = styled('div')({
-  display: 'flex',
-  justifyContent: 'flex-start',
-  padding: Layout.ROW_GUTTER
-})
+import {Breakpoint} from '../../../../types/constEnums'
 
 export interface ProviderRowBaseProps {
   connected: boolean
@@ -111,11 +33,13 @@ const ProviderRowBase = (props: ProviderRowBaseProps) => {
   } = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   return (
-    <ProviderCard>
-      <CardTop>
+    <div className='relative my-4 flex w-full shrink-0 flex-col justify-start rounded bg-white shadow-card'>
+      <div className='flex justify-start p-row-gutter'>
         {providerLogo}
         <RowInfo>
-          <ProviderName>{providerName}</ProviderName>
+          <div className='mr-4 flex items-center align-middle font-semibold leading-6 text-slate-700'>
+            {providerName}
+          </div>
           <RowInfoCopy>{providerDescription} </RowInfoCopy>
           {!!error && (
             <div className='text-sm text-tomato-500 [&_a]:font-semibold [&_a]:text-tomato-500 [&_a]:underline'>
@@ -129,29 +53,33 @@ const ProviderRowBase = (props: ProviderRowBaseProps) => {
             <>
               {isDesktop ? (
                 <>
-                  <StatusWrapper>
-                    <StatusIcon>
-                      <DoneIcon />
-                    </StatusIcon>
-                    <StatusLabel>Connected</StatusLabel>
-                  </StatusWrapper>
-                  <SmallMenuButton onClick={togglePortal} ref={menuRef}>
-                    <MenuSmallIcon>
-                      <MoreVertIcon />
-                    </MenuSmallIcon>
-                  </SmallMenuButton>
+                  <div className='flex items-center pr-[25px]'>
+                    <DoneIcon className='h-[18px] w-[18px] text-lg text-success-light' />
+                    <div className='pl-[6px] text-sm font-semibold text-slate-700'>Connected</div>
+                  </div>
+                  <FlatButton
+                    className='min-w-[30px] border-slate-400 pl-0 pr-0 text-sm font-semibold text-slate-700'
+                    onClick={togglePortal}
+                    ref={menuRef}
+                  >
+                    <MoreVertIcon className='h-[18px] w-[18px] text-lg' />
+                  </FlatButton>
                 </>
               ) : (
-                <MenuButton onClick={togglePortal} ref={menuRef}>
+                <FlatButton
+                  className='min-w-9 border-slate-400 py-0 text-sm font-semibold text-slate-700'
+                  onClick={togglePortal}
+                  ref={menuRef}
+                >
                   <MoreVertIcon />
-                </MenuButton>
+                </FlatButton>
               )}
             </>
           )}
         </ProviderActions>
-      </CardTop>
+      </div>
       {children}
-    </ProviderCard>
+    </div>
   )
 }
 

--- a/packages/client/modules/teamDashboard/components/ProviderRow/ProviderRowBase.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/ProviderRowBase.tsx
@@ -67,7 +67,7 @@ const ProviderRowBase = (props: ProviderRowBaseProps) => {
                 </>
               ) : (
                 <FlatButton
-                  className='min-w-9 border-slate-400 py-0 text-sm font-semibold text-slate-700'
+                  className='min-w-[36px] border-slate-400 pl-0 pr-0 text-sm font-semibold text-slate-700'
                   onClick={togglePortal}
                   ref={menuRef}
                 >

--- a/packages/client/modules/teamDashboard/components/ProviderRow/ProviderRowBase.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/ProviderRowBase.tsx
@@ -85,24 +85,14 @@ const CardTop = styled('div')({
   padding: Layout.ROW_GUTTER
 })
 
-const HowItWorksLink = styled('a')({
-  color: PALETTE.SKY_500,
-  cursor: 'pointer',
-  textDecoration: 'underline',
-  ':hover, :focus, :active': {
-    color: PALETTE.SKY_600
-  }
-})
-
 export interface ProviderRowBaseProps {
   connected: boolean
   togglePortal: () => void
   menuRef: React.MutableRefObject<HTMLButtonElement | null> // TODO: make generic menu component
   providerName: string
-  providerDescription: string
+  providerDescription: React.ReactElement | string
   providerLogo: React.ReactElement
   children?: React.ReactElement | false
-  seeHowItWorksUrl?: string
   connectButton: React.ReactElement
   error?: React.ReactElement | string
 }
@@ -117,7 +107,6 @@ const ProviderRowBase = (props: ProviderRowBaseProps) => {
     providerName,
     providerDescription,
     providerLogo,
-    seeHowItWorksUrl,
     children
   } = props
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
@@ -127,17 +116,7 @@ const ProviderRowBase = (props: ProviderRowBaseProps) => {
         {providerLogo}
         <RowInfo>
           <ProviderName>{providerName}</ProviderName>
-          <RowInfoCopy>
-            {providerDescription}.{' '}
-            {seeHowItWorksUrl && (
-              <>
-                <HowItWorksLink href={seeHowItWorksUrl} target='_blank' rel='noreferrer'>
-                  See how it works
-                </HowItWorksLink>
-                .
-              </>
-            )}
-          </RowInfoCopy>
+          <RowInfoCopy>{providerDescription} </RowInfoCopy>
           {!!error && (
             <div className='text-sm text-tomato-500 [&_a]:font-semibold [&_a]:text-tomato-500 [&_a]:underline'>
               {error}

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingDangerZone.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgBillingDangerZone.tsx
@@ -49,7 +49,16 @@ const OrgBillingDangerZone = (props: Props) => {
   )
   const {history} = useRouter()
   const {id, isBillingLeader, billingTier} = organization
-  if (!isBillingLeader) return null
+  if (!isBillingLeader)
+    return (
+      <StyledPanel isWide={isWide} label='Danger Zone'>
+        <PanelRow>
+          <div className='text-slate-700'>
+            {'Only the billing leader can manage this organization'}
+          </div>
+        </PanelRow>
+      </StyledPanel>
+    )
   const isStarter = billingTier === 'starter'
   const isTeam = billingTier === 'team'
 

--- a/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/Organization.tsx
@@ -7,6 +7,7 @@ import {
   AUTHENTICATION_PAGE,
   BILLING_PAGE,
   MEMBERS_PAGE,
+  ORG_INTEGRATIONS_PAGE,
   ORG_SETTINGS_PAGE,
   TEAMS_PAGE
 } from '../../../../utils/constants'
@@ -26,6 +27,11 @@ const OrgTeamMembers = lazy(
 )
 
 const OrgDetails = lazy(() => import(/* webpackChunkName: 'OrgDetails' */ './OrgDetails'))
+
+const OrgIntegrations = lazy(
+  () => import(/* webpackChunkName: 'OrgIntegrations' */ '../OrgIntegrations/OrgIntegrations')
+)
+
 const Authentication = lazy(
   () =>
     import(
@@ -46,6 +52,7 @@ const query = graphql`
         ...OrgPlansAndBillingRoot_organization
         ...OrgDetails_organization
         ...OrgTeams_organization
+        ...OrgIntegrations_organization
         isBillingLeader
       }
     }
@@ -84,6 +91,11 @@ const Organization = (props: Props) => {
           exact
           path={`${match.url}/${ORG_SETTINGS_PAGE}`}
           render={(p) => <OrgDetails {...p} organizationRef={organization} />}
+        />
+        <Route
+          exact
+          path={`${match.url}/${ORG_INTEGRATIONS_PAGE}`}
+          render={(p) => <OrgIntegrations {...p} organizationRef={organization} />}
         />
         <Route
           exact

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/AddGitLabProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/AddGitLabProviderDialog.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useMutationProps from '../../../../hooks/useMutationProps'
+import AddIntegrationProviderMutation from '../../../../mutations/AddIntegrationProviderMutation'
+import UpsertGitLabProviderDialog from './UpsertGitLabProviderDialog'
+
+type Props = {
+  orgId: string
+  isOpen: boolean
+  onClose: () => void
+}
+
+const AddGitLabProviderDialog = (props: Props) => {
+  const {orgId, isOpen, onClose} = props
+  const atmosphere = useAtmosphere()
+  const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
+
+  const onUpsert = (serverBaseUrl: string, clientId: string, clientSecret: string) => {
+    if (submitting) return
+
+    submitMutation()
+    AddIntegrationProviderMutation(
+      atmosphere,
+      {
+        input: {
+          orgId,
+          service: 'gitlab',
+          authStrategy: 'oauth2',
+          scope: 'org',
+          oAuth2ProviderMetadataInput: {
+            serverBaseUrl,
+            clientId,
+            clientSecret
+          }
+        }
+      },
+      {
+        onError,
+        onCompleted: () => {
+          onCompleted()
+          onClose()
+        }
+      }
+    )
+  }
+
+  return (
+    <UpsertGitLabProviderDialog
+      isOpen={isOpen}
+      defaults={{
+        serverBaseUrl: '',
+        clientId: '',
+        clientSecret: ''
+      }}
+      onUpsert={onUpsert}
+      onClose={onClose}
+      error={error}
+    />
+  )
+}
+
+export default AddGitLabProviderDialog

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/EditGitLabProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/EditGitLabProviderDialog.tsx
@@ -1,0 +1,76 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {EditGitLabProviderDialog_integrationProvider$key} from '../../../../__generated__/EditGitLabProviderDialog_integrationProvider.graphql'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useMutationProps from '../../../../hooks/useMutationProps'
+import UpdateIntegrationProviderMutation from '../../../../mutations/UpdateIntegrationProviderMutation'
+import UpsertGitLabProviderDialog from './UpsertGitLabProviderDialog'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+  integrationProviderRef: EditGitLabProviderDialog_integrationProvider$key
+}
+
+const EditGitLabProviderDialog = (props: Props) => {
+  const {isOpen, onClose, integrationProviderRef} = props
+
+  const IntegrationProvider = useFragment(
+    graphql`
+      fragment EditGitLabProviderDialog_integrationProvider on IntegrationProviderOAuth2 {
+        id
+        serverBaseUrl
+        clientId
+      }
+    `,
+    integrationProviderRef
+  )
+  const {id, serverBaseUrl, clientId} = IntegrationProvider
+
+  const atmosphere = useAtmosphere()
+
+  const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
+
+  const onUpsert = (serverBaseUrl: string, clientId: string, clientSecret: string) => {
+    if (submitting) return
+
+    submitMutation()
+    UpdateIntegrationProviderMutation(
+      atmosphere,
+      {
+        provider: {
+          id,
+          oAuth2ProviderMetadataInput: {
+            serverBaseUrl,
+            clientId,
+            clientSecret
+          }
+        }
+      },
+      {
+        onError,
+        onCompleted: () => {
+          onCompleted()
+          onClose()
+        }
+      }
+    )
+  }
+
+  return (
+    <UpsertGitLabProviderDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      defaults={{
+        serverBaseUrl,
+        clientId,
+        clientSecret: ''
+      }}
+      onUpsert={onUpsert}
+      error={error}
+    />
+  )
+}
+
+export default EditGitLabProviderDialog

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
@@ -2,266 +2,74 @@ import {MoreVert as MoreVertIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
-import {GitLabProviderRow_organization$key} from '../../../../__generated__/GitLabProviderRow_organization.graphql'
-import ErrorAlert from '../../../../components/ErrorAlert/ErrorAlert'
+import {GitLabProviderRow_integrationProvider$key} from '../../../../__generated__/GitLabProviderRow_integrationProvider.graphql'
 import FlatButton from '../../../../components/FlatButton'
-import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
-import BasicInput from '../../../../components/InputField/BasicInput'
-import PrimaryButton from '../../../../components/PrimaryButton'
 import ProviderActions from '../../../../components/ProviderActions'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
-import useAtmosphere from '../../../../hooks/useAtmosphere'
-import useForm from '../../../../hooks/useForm'
-import useMutationProps from '../../../../hooks/useMutationProps'
-import AddIntegrationProviderMutation from '../../../../mutations/AddIntegrationProviderMutation'
-import UpdateIntegrationProviderMutation from '../../../../mutations/UpdateIntegrationProviderMutation'
-import {Dialog} from '../../../../ui/Dialog/Dialog'
-import {DialogContent} from '../../../../ui/Dialog/DialogContent'
-import {DialogTitle} from '../../../../ui/Dialog/DialogTitle'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
-import linkify from '../../../../utils/linkify'
-import makeAppURL from '../../../../utils/makeAppURL'
-import Legitity from '../../../../validation/Legitity'
-import CopyShortLink from '../../../meeting/components/CopyShortLink/CopyShortLink'
-import ProviderRowActionButton from '../../../teamDashboard/components/ProviderRow/ProviderRowActionButton'
+import {Menu} from '../../../../ui/Menu/Menu'
+import {MenuContent} from '../../../../ui/Menu/MenuContent'
+import {MenuItem} from '../../../../ui/Menu/MenuItem'
+import EditGitLabProviderDialog from './EditGitLabProviderDialog'
+import RemoveIntegrationProviderDialog from './RemoveIntegrationProviderDialog'
 
 type Props = {
-  organizationRef: GitLabProviderRow_organization$key
+  integrationProviderRef: GitLabProviderRow_integrationProvider$key
 }
 
 const GitLabProviderRow = (props: Props) => {
-  const {organizationRef} = props
-  const atmosphere = useAtmosphere()
-  const organization = useFragment(
+  const {integrationProviderRef} = props
+  const integrationProvider = useFragment(
     graphql`
-      fragment GitLabProviderRow_organization on Organization {
-        orgId: id
-        viewerOrganizationUser {
-          id
-          role
-        }
-        integrationProviders {
-          gitlab {
-            id
-            serverBaseUrl
-            clientId
-          }
-        }
+      fragment GitLabProviderRow_integrationProvider on IntegrationProviderOAuth2 {
+        id
+        serverBaseUrl
+        ...EditGitLabProviderDialog_integrationProvider
+        ...RemoveIntegrationProviderDialog_integrationProvider
       }
     `,
-    organizationRef
+    integrationProviderRef
   )
-  const {orgId, viewerOrganizationUser} = organization
-  const isOrgAdmin = viewerOrganizationUser?.role === 'ORG_ADMIN'
+  const {id, serverBaseUrl} = integrationProvider
 
-  const {open, close, isOpen} = useDialogState()
-  const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
-
-  const redirectUri = makeAppURL(window.location.origin, 'auth/gitlab')
-  const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
-
-  const {fields, onChange, validateField} = useForm({
-    serverBaseUrl: {
-      getDefault: () => '',
-      validate: (rawInput: string) => {
-        return new Legitity(rawInput).test((maybeUrl) => {
-          if (!maybeUrl) return 'Please enter a server base URL'
-          const links = linkify.match(maybeUrl)
-          return !links ? 'Not looking too linky' : ''
-        })
-      }
-    },
-    clientId: {
-      getDefault: () => '',
-      validate: (clientId: string) => {
-        return new Legitity(clientId).required('Please enter a client ID')
-      }
-    },
-    clientSecret: {
-      getDefault: () => '',
-      validate: (clientSecret: string) => {
-        return new Legitity(clientSecret).required('Please enter a client secret')
-      }
-    }
-  })
-
-  const onSubmit = () => {
-    if (submitting) return
-    const validation = validateField()
-    if (Object.values(validation).some(({error}) => error)) return
-
-    submitMutation()
-    if (!selectedProviderId) {
-      AddIntegrationProviderMutation(
-        atmosphere,
-        {
-          input: {
-            orgId,
-            service: 'gitlab',
-            authStrategy: 'oauth2',
-            scope: 'org',
-            oAuth2ProviderMetadataInput: {
-              serverBaseUrl: fields.serverBaseUrl.value,
-              clientId: fields.clientId.value,
-              clientSecret: fields.clientSecret.value
-            }
-          }
-        },
-        {
-          onError,
-          onCompleted: () => {
-            onCompleted()
-            close()
-          }
-        }
-      )
-    } else {
-      UpdateIntegrationProviderMutation(
-        atmosphere,
-        {
-          provider: {
-            id: selectedProviderId,
-            oAuth2ProviderMetadataInput: {
-              serverBaseUrl: fields.serverBaseUrl.value,
-              clientId: fields.clientId.value,
-              clientSecret: fields.clientSecret.value
-            }
-          }
-        },
-        {
-          onError,
-          onCompleted: () => {
-            onCompleted()
-            close()
-          }
-        }
-      )
-    }
-  }
-  const onEdit = (providerId: string, serverBaseUrl: string, clientId: string) => {
-    setSelectedProviderId(providerId)
-    fields.serverBaseUrl.resetValue(serverBaseUrl)
-    fields.clientId.resetValue(clientId)
-    open()
-  }
+  const {isOpen: isEditOpen, open: openEdit, close: closeEdit} = useDialogState()
+  const {isOpen: isDeleteOpen, open: openDelete, close: closeDelete} = useDialogState()
 
   return (
     <>
-      <div className='my-4 flex flex-col rounded bg-white shadow-card'>
-        <div className='flex-center flex items-center p-4'>
-          <GitLabProviderLogo />
-          <div className='flex flex-col px-4'>
-            <div className='font-semibold text-slate-700'>GitLab</div>
-            <RowInfoCopy>Add private servers for use by your teams.</RowInfoCopy>
+      <div key={id} className='flex-center flex items-center border-t border-slate-300 p-4'>
+        <div className='flex flex-col px-2'>
+          <div className='font-semibold text-slate-700'>
+            {serverBaseUrl.replace(/https:\/\//, '')}
           </div>
-          {isOrgAdmin && (
-            <ProviderActions>
-              <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
-            </ProviderActions>
-          )}
+          <RowInfoCopy></RowInfoCopy>
         </div>
-        {organization.integrationProviders.gitlab.map(({id, serverBaseUrl, clientId}) => (
-          <div key={id} className='flex-center flex items-center border-t border-slate-300 p-4'>
-            <div className='flex flex-col px-2'>
-              <div className='font-semibold text-slate-700'>
-                {serverBaseUrl.replace(/https:\/\//, '')}
-              </div>
-              <RowInfoCopy></RowInfoCopy>
-            </div>
-            {isOrgAdmin && (
-              <ProviderActions>
-                <FlatButton className='p-2' onClick={() => onEdit(id, serverBaseUrl, clientId)}>
-                  <MoreVertIcon />
-                </FlatButton>
-              </ProviderActions>
-            )}
-          </div>
-        ))}
-      </div>
-      <Dialog isOpen={isOpen} onClose={close}>
-        <DialogContent>
-          <DialogTitle className='flex items-center'>
-            <GitLabProviderLogo />
-            <div className='ml-2'>Add GitLab Server</div>
-          </DialogTitle>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              onSubmit()
-            }}
+        <ProviderActions>
+          <Menu
+            modal={false}
+            trigger={
+              <FlatButton className='p-2'>
+                <MoreVertIcon />
+              </FlatButton>
+            }
           >
-            <div className='pt-6 pb-2'>
-              In the <b>Admin Area</b>, <b>Applications</b> add a <b>New application</b> with the
-              following settings
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36'>Name</div>
-              <div>Parabol</div>
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36'>Callback URL</div>
-              <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36'>Trusted</div>
-              <div>Yes or No</div>
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36'>Confidential</div>
-              <div>Yes</div>
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36'>Scopes</div>
-              <div>
-                <b>api</b> (Access the authenticated user's API)
-              </div>
-            </div>
-            <div className='pt-6 pb-2'>
-              Press <b>Save application</b> and enter the <b>Application ID</b> and <b>Secret</b>{' '}
-              below
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36 shrink-0'>Server base URL</div>
-              <div className='flex w-full flex-col'>
-                <BasicInput
-                  {...fields.serverBaseUrl}
-                  onChange={onChange}
-                  name='serverBaseUrl'
-                  placeholder='https://gitlab.example.com'
-                />
-              </div>
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36 shrink-0'>Application ID</div>
-              <div className='flex w-full flex-col'>
-                <BasicInput
-                  {...fields.clientId}
-                  onChange={onChange}
-                  name='clientId'
-                  placeholder='Enter your Application ID here...'
-                />
-              </div>
-            </div>
-            <div className='flex items-center p-2'>
-              <div className='w-36 shrink-0'>Secret</div>
-              <div className='flex w-full flex-col'>
-                <BasicInput
-                  {...fields.clientSecret}
-                  onChange={onChange}
-                  name='clientSecret'
-                  placeholder='Enter your Secret here...'
-                />
-              </div>
-            </div>
-            {error && <ErrorAlert message={error.message} />}
-            <div className='flex justify-end pt-6'>
-              <PrimaryButton type='submit' onClick={onSubmit}>
-                Save
-              </PrimaryButton>
-            </div>
-          </form>
-        </DialogContent>
-      </Dialog>
+            <MenuContent>
+              <MenuItem onClick={openEdit}>Edit</MenuItem>
+              <MenuItem onClick={openDelete}>Delete</MenuItem>
+            </MenuContent>
+          </Menu>
+        </ProviderActions>
+      </div>
+      <EditGitLabProviderDialog
+        isOpen={isEditOpen}
+        onClose={closeEdit}
+        integrationProviderRef={integrationProvider}
+      />
+      <RemoveIntegrationProviderDialog
+        isOpen={isDeleteOpen}
+        onClose={closeDelete}
+        integrationProviderRef={integrationProvider}
+      />
     </>
   )
 }

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
@@ -1,0 +1,212 @@
+import {MoreVert as MoreVertIcon} from '@mui/icons-material'
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {GitLabProviderRow_organization$key} from '../../../../__generated__/GitLabProviderRow_organization.graphql'
+import FlatButton from '../../../../components/FlatButton'
+import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
+import BasicInput from '../../../../components/InputField/BasicInput'
+import PrimaryButton from '../../../../components/PrimaryButton'
+import ProviderActions from '../../../../components/ProviderActions'
+import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useMutationProps from '../../../../hooks/useMutationProps'
+import AddIntegrationProviderMutation from '../../../../mutations/AddIntegrationProviderMutation'
+import UpdateIntegrationProviderMutation from '../../../../mutations/UpdateIntegrationProviderMutation'
+import {Dialog} from '../../../../ui/Dialog/Dialog'
+import {DialogContent} from '../../../../ui/Dialog/DialogContent'
+import {DialogTitle} from '../../../../ui/Dialog/DialogTitle'
+import {useDialogState} from '../../../../ui/Dialog/useDialogState'
+import makeAppURL from '../../../../utils/makeAppURL'
+import CopyShortLink from '../../../meeting/components/CopyShortLink/CopyShortLink'
+import ProviderRowActionButton from '../../../teamDashboard/components/ProviderRow/ProviderRowActionButton'
+
+type Props = {
+  organizationRef: GitLabProviderRow_organization$key
+}
+
+const GitLabProviderRow = (props: Props) => {
+  const {organizationRef} = props
+  const atmosphere = useAtmosphere()
+  const organization = useFragment(
+    graphql`
+      fragment GitLabProviderRow_organization on Organization {
+        orgId: id
+        integrationProviders {
+          gitlab {
+            id
+            serverBaseUrl
+            clientId
+          }
+        }
+      }
+    `,
+    organizationRef
+  )
+  const {orgId} = organization
+  const {open, close, isOpen} = useDialogState()
+  const {onError, onCompleted} = useMutationProps()
+
+  const redirectUri = makeAppURL(window.location.origin, 'auth/gitlab')
+  const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
+  const [serverBaseUrl, setServerBaseUrl] = React.useState('')
+  const [clientId, setClientId] = React.useState('')
+  const [clientSecret, setClientSecret] = React.useState('')
+
+  const submit = () => {
+    if (!selectedProviderId) {
+      AddIntegrationProviderMutation(
+        atmosphere,
+        {
+          input: {
+            orgId,
+            service: 'gitlab',
+            authStrategy: 'oauth2',
+            scope: 'org',
+            oAuth2ProviderMetadataInput: {
+              serverBaseUrl,
+              clientId,
+              clientSecret
+            }
+          }
+        },
+        {
+          onError,
+          onCompleted
+        }
+      )
+    } else {
+      UpdateIntegrationProviderMutation(
+        atmosphere,
+        {
+          provider: {
+            id: selectedProviderId,
+            oAuth2ProviderMetadataInput: {
+              serverBaseUrl,
+              clientId,
+              clientSecret
+            }
+          }
+        },
+        {
+          onError,
+          onCompleted
+        }
+      )
+    }
+  }
+  const edit = (providerId: string, serverBaseUrl: string, clientId: string) => {
+    setSelectedProviderId(providerId)
+    setServerBaseUrl(serverBaseUrl)
+    setClientId(clientId)
+    setClientSecret('')
+    open()
+  }
+
+  return (
+    <>
+      <div className='my-4 flex flex-col rounded bg-white p-4 shadow-card'>
+        <div className='flex-center flex items-center'>
+          <GitLabProviderLogo />
+          <div className='flex flex-col px-4'>
+            <div className='font-semibold text-slate-700'>GitLab</div>
+            <RowInfoCopy>Add private servers for use by your teams.</RowInfoCopy>
+          </div>
+          <ProviderActions>
+            <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
+          </ProviderActions>
+        </div>
+        {organization.integrationProviders.gitlab.map(({id, serverBaseUrl, clientId}) => (
+          <div key={id} className='flex-center flex items-center pt-4'>
+            <div className='flex flex-col px-4'>
+              <div className='font-semibold text-slate-700'>
+                {serverBaseUrl.replace(/https:\/\//, '')}
+              </div>
+              <RowInfoCopy></RowInfoCopy>
+            </div>
+            <ProviderActions>
+              <FlatButton onClick={() => edit(id, serverBaseUrl, clientId)}>
+                <MoreVertIcon />
+              </FlatButton>
+            </ProviderActions>
+          </div>
+        ))}
+      </div>
+      <Dialog isOpen={isOpen} onClose={close}>
+        <DialogContent>
+          <DialogTitle className='flex items-center'>
+            <GitLabProviderLogo />
+            <div className='ml-2'>Add GitLab Server</div>
+          </DialogTitle>
+          <div className='pt-6 pb-2'>
+            In the <b>Admin Area</b>, <b>Applications</b> add a <b>New application</b> with the
+            following settings
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Name</div>
+            <div>Parabol</div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Callback URL</div>
+            <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Trusted</div>
+            <div>Yes or No</div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Confidential</div>
+            <div>Yes</div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Scopes</div>
+            <div>
+              <b>api</b> (Access the authenticated user's API)
+            </div>
+          </div>
+          <div className='pt-6 pb-2'>
+            Press <b>Save application</b> and enter the <b>Application ID</b> and <b>Secret</b>{' '}
+            below
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36 shrink-0'>Server base URL</div>
+            <BasicInput
+              className='flex shrink'
+              value={serverBaseUrl}
+              onChange={(e) => setServerBaseUrl(e.target.value)}
+              error=''
+              name='Server base URL'
+              placeholder='https://gitlab.example.com'
+            />
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36 shrink-0'>Application ID</div>
+            <BasicInput
+              className='flex shrink'
+              value={clientId}
+              onChange={(e) => setClientId(e.target.value)}
+              error=''
+              name='Application ID'
+              placeholder='Enter your Application ID here...'
+            />
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36 shrink-0'>Secret</div>
+            <BasicInput
+              value={clientSecret}
+              onChange={(e) => setClientSecret(e.target.value)}
+              error=''
+              name='Secret'
+              placeholder='Enter your Secret here...'
+            />
+          </div>
+          <div className='flex justify-end pt-6'>
+            <PrimaryButton onClick={submit}>Save</PrimaryButton>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+export default GitLabProviderRow

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
@@ -32,6 +32,10 @@ const GitLabProviderRow = (props: Props) => {
     graphql`
       fragment GitLabProviderRow_organization on Organization {
         orgId: id
+        viewerOrganizationUser {
+          id
+          role
+        }
         integrationProviders {
           gitlab {
             id
@@ -43,7 +47,9 @@ const GitLabProviderRow = (props: Props) => {
     `,
     organizationRef
   )
-  const {orgId} = organization
+  const {orgId, viewerOrganizationUser} = organization
+  const isOrgAdmin = viewerOrganizationUser?.role === 'ORG_ADMIN'
+
   const {open, close, isOpen} = useDialogState()
   const {onError, onCompleted} = useMutationProps()
 
@@ -112,9 +118,11 @@ const GitLabProviderRow = (props: Props) => {
             <div className='font-semibold text-slate-700'>GitLab</div>
             <RowInfoCopy>Add private servers for use by your teams.</RowInfoCopy>
           </div>
-          <ProviderActions>
-            <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
-          </ProviderActions>
+          {isOrgAdmin && (
+            <ProviderActions>
+              <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
+            </ProviderActions>
+          )}
         </div>
         {organization.integrationProviders.gitlab.map(({id, serverBaseUrl, clientId}) => (
           <div key={id} className='flex-center flex items-center pt-4'>
@@ -124,11 +132,13 @@ const GitLabProviderRow = (props: Props) => {
               </div>
               <RowInfoCopy></RowInfoCopy>
             </div>
-            <ProviderActions>
-              <FlatButton onClick={() => edit(id, serverBaseUrl, clientId)}>
-                <MoreVertIcon />
-              </FlatButton>
-            </ProviderActions>
+            {isOrgAdmin && (
+              <ProviderActions>
+                <FlatButton onClick={() => edit(id, serverBaseUrl, clientId)}>
+                  <MoreVertIcon />
+                </FlatButton>
+              </ProviderActions>
+            )}
           </div>
         ))}
       </div>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
@@ -3,6 +3,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
 import {GitLabProviderRow_organization$key} from '../../../../__generated__/GitLabProviderRow_organization.graphql'
+import ErrorAlert from '../../../../components/ErrorAlert/ErrorAlert'
 import FlatButton from '../../../../components/FlatButton'
 import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
 import BasicInput from '../../../../components/InputField/BasicInput'
@@ -10,6 +11,7 @@ import PrimaryButton from '../../../../components/PrimaryButton'
 import ProviderActions from '../../../../components/ProviderActions'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useForm from '../../../../hooks/useForm'
 import useMutationProps from '../../../../hooks/useMutationProps'
 import AddIntegrationProviderMutation from '../../../../mutations/AddIntegrationProviderMutation'
 import UpdateIntegrationProviderMutation from '../../../../mutations/UpdateIntegrationProviderMutation'
@@ -17,7 +19,9 @@ import {Dialog} from '../../../../ui/Dialog/Dialog'
 import {DialogContent} from '../../../../ui/Dialog/DialogContent'
 import {DialogTitle} from '../../../../ui/Dialog/DialogTitle'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
+import linkify from '../../../../utils/linkify'
 import makeAppURL from '../../../../utils/makeAppURL'
+import Legitity from '../../../../validation/Legitity'
 import CopyShortLink from '../../../meeting/components/CopyShortLink/CopyShortLink'
 import ProviderRowActionButton from '../../../teamDashboard/components/ProviderRow/ProviderRowActionButton'
 
@@ -51,15 +55,42 @@ const GitLabProviderRow = (props: Props) => {
   const isOrgAdmin = viewerOrganizationUser?.role === 'ORG_ADMIN'
 
   const {open, close, isOpen} = useDialogState()
-  const {onError, onCompleted} = useMutationProps()
+  const {onError, onCompleted, submitting, submitMutation, error} = useMutationProps()
 
   const redirectUri = makeAppURL(window.location.origin, 'auth/gitlab')
   const [selectedProviderId, setSelectedProviderId] = React.useState<string | null>(null)
-  const [serverBaseUrl, setServerBaseUrl] = React.useState('')
-  const [clientId, setClientId] = React.useState('')
-  const [clientSecret, setClientSecret] = React.useState('')
 
-  const submit = () => {
+  const {fields, onChange, validateField} = useForm({
+    serverBaseUrl: {
+      getDefault: () => '',
+      validate: (rawInput: string) => {
+        return new Legitity(rawInput).test((maybeUrl) => {
+          if (!maybeUrl) return 'Please enter a server base URL'
+          const links = linkify.match(maybeUrl)
+          return !links ? 'Not looking too linky' : ''
+        })
+      }
+    },
+    clientId: {
+      getDefault: () => '',
+      validate: (clientId: string) => {
+        return new Legitity(clientId).required('Please enter a client ID')
+      }
+    },
+    clientSecret: {
+      getDefault: () => '',
+      validate: (clientSecret: string) => {
+        return new Legitity(clientSecret).required('Please enter a client secret')
+      }
+    }
+  })
+
+  const onSubmit = () => {
+    if (submitting) return
+    const validation = validateField()
+    if (Object.values(validation).some(({error}) => error)) return
+
+    submitMutation()
     if (!selectedProviderId) {
       AddIntegrationProviderMutation(
         atmosphere,
@@ -70,15 +101,18 @@ const GitLabProviderRow = (props: Props) => {
             authStrategy: 'oauth2',
             scope: 'org',
             oAuth2ProviderMetadataInput: {
-              serverBaseUrl,
-              clientId,
-              clientSecret
+              serverBaseUrl: fields.serverBaseUrl.value,
+              clientId: fields.clientId.value,
+              clientSecret: fields.clientSecret.value
             }
           }
         },
         {
           onError,
-          onCompleted
+          onCompleted: () => {
+            onCompleted()
+            close()
+          }
         }
       )
     } else {
@@ -88,31 +122,33 @@ const GitLabProviderRow = (props: Props) => {
           provider: {
             id: selectedProviderId,
             oAuth2ProviderMetadataInput: {
-              serverBaseUrl,
-              clientId,
-              clientSecret
+              serverBaseUrl: fields.serverBaseUrl.value,
+              clientId: fields.clientId.value,
+              clientSecret: fields.clientSecret.value
             }
           }
         },
         {
           onError,
-          onCompleted
+          onCompleted: () => {
+            onCompleted()
+            close()
+          }
         }
       )
     }
   }
-  const edit = (providerId: string, serverBaseUrl: string, clientId: string) => {
+  const onEdit = (providerId: string, serverBaseUrl: string, clientId: string) => {
     setSelectedProviderId(providerId)
-    setServerBaseUrl(serverBaseUrl)
-    setClientId(clientId)
-    setClientSecret('')
+    fields.serverBaseUrl.resetValue(serverBaseUrl)
+    fields.clientId.resetValue(clientId)
     open()
   }
 
   return (
     <>
-      <div className='my-4 flex flex-col rounded bg-white p-4 shadow-card'>
-        <div className='flex-center flex items-center'>
+      <div className='my-4 flex flex-col rounded bg-white shadow-card'>
+        <div className='flex-center flex items-center p-4'>
           <GitLabProviderLogo />
           <div className='flex flex-col px-4'>
             <div className='font-semibold text-slate-700'>GitLab</div>
@@ -125,8 +161,8 @@ const GitLabProviderRow = (props: Props) => {
           )}
         </div>
         {organization.integrationProviders.gitlab.map(({id, serverBaseUrl, clientId}) => (
-          <div key={id} className='flex-center flex items-center pt-4'>
-            <div className='flex flex-col px-4'>
+          <div key={id} className='flex-center flex items-center border-t border-slate-300 p-4'>
+            <div className='flex flex-col px-2'>
               <div className='font-semibold text-slate-700'>
                 {serverBaseUrl.replace(/https:\/\//, '')}
               </div>
@@ -134,7 +170,7 @@ const GitLabProviderRow = (props: Props) => {
             </div>
             {isOrgAdmin && (
               <ProviderActions>
-                <FlatButton onClick={() => edit(id, serverBaseUrl, clientId)}>
+                <FlatButton className='p-2' onClick={() => onEdit(id, serverBaseUrl, clientId)}>
                   <MoreVertIcon />
                 </FlatButton>
               </ProviderActions>
@@ -148,71 +184,82 @@ const GitLabProviderRow = (props: Props) => {
             <GitLabProviderLogo />
             <div className='ml-2'>Add GitLab Server</div>
           </DialogTitle>
-          <div className='pt-6 pb-2'>
-            In the <b>Admin Area</b>, <b>Applications</b> add a <b>New application</b> with the
-            following settings
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36'>Name</div>
-            <div>Parabol</div>
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36'>Callback URL</div>
-            <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36'>Trusted</div>
-            <div>Yes or No</div>
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36'>Confidential</div>
-            <div>Yes</div>
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36'>Scopes</div>
-            <div>
-              <b>api</b> (Access the authenticated user's API)
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              onSubmit()
+            }}
+          >
+            <div className='pt-6 pb-2'>
+              In the <b>Admin Area</b>, <b>Applications</b> add a <b>New application</b> with the
+              following settings
             </div>
-          </div>
-          <div className='pt-6 pb-2'>
-            Press <b>Save application</b> and enter the <b>Application ID</b> and <b>Secret</b>{' '}
-            below
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36 shrink-0'>Server base URL</div>
-            <BasicInput
-              className='flex shrink'
-              value={serverBaseUrl}
-              onChange={(e) => setServerBaseUrl(e.target.value)}
-              error=''
-              name='Server base URL'
-              placeholder='https://gitlab.example.com'
-            />
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36 shrink-0'>Application ID</div>
-            <BasicInput
-              className='flex shrink'
-              value={clientId}
-              onChange={(e) => setClientId(e.target.value)}
-              error=''
-              name='Application ID'
-              placeholder='Enter your Application ID here...'
-            />
-          </div>
-          <div className='flex items-center p-2'>
-            <div className='w-36 shrink-0'>Secret</div>
-            <BasicInput
-              value={clientSecret}
-              onChange={(e) => setClientSecret(e.target.value)}
-              error=''
-              name='Secret'
-              placeholder='Enter your Secret here...'
-            />
-          </div>
-          <div className='flex justify-end pt-6'>
-            <PrimaryButton onClick={submit}>Save</PrimaryButton>
-          </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36'>Name</div>
+              <div>Parabol</div>
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36'>Callback URL</div>
+              <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36'>Trusted</div>
+              <div>Yes or No</div>
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36'>Confidential</div>
+              <div>Yes</div>
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36'>Scopes</div>
+              <div>
+                <b>api</b> (Access the authenticated user's API)
+              </div>
+            </div>
+            <div className='pt-6 pb-2'>
+              Press <b>Save application</b> and enter the <b>Application ID</b> and <b>Secret</b>{' '}
+              below
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36 shrink-0'>Server base URL</div>
+              <div className='flex w-full flex-col'>
+                <BasicInput
+                  {...fields.serverBaseUrl}
+                  onChange={onChange}
+                  name='serverBaseUrl'
+                  placeholder='https://gitlab.example.com'
+                />
+              </div>
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36 shrink-0'>Application ID</div>
+              <div className='flex w-full flex-col'>
+                <BasicInput
+                  {...fields.clientId}
+                  onChange={onChange}
+                  name='clientId'
+                  placeholder='Enter your Application ID here...'
+                />
+              </div>
+            </div>
+            <div className='flex items-center p-2'>
+              <div className='w-36 shrink-0'>Secret</div>
+              <div className='flex w-full flex-col'>
+                <BasicInput
+                  {...fields.clientSecret}
+                  onChange={onChange}
+                  name='clientSecret'
+                  placeholder='Enter your Secret here...'
+                />
+              </div>
+            </div>
+            {error && <ErrorAlert message={error.message} />}
+            <div className='flex justify-end pt-6'>
+              <PrimaryButton type='submit' onClick={onSubmit}>
+                Save
+              </PrimaryButton>
+            </div>
+          </form>
         </DialogContent>
       </Dialog>
     </>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
@@ -1,3 +1,4 @@
+import {Add as AddIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import React from 'react'
 import {useFragment} from 'react-relay'
@@ -5,6 +6,8 @@ import {GitLabProviders_organization$key} from '../../../../__generated__/GitLab
 import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
 import ProviderActions from '../../../../components/ProviderActions'
 import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
+import useBreakpoint from '../../../../hooks/useBreakpoint'
+import {Breakpoint} from '../../../../types/constEnums'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
 import ProviderRowActionButton from '../../../teamDashboard/components/ProviderRow/ProviderRowActionButton'
 import AddGitLabProviderDialog from './AddGitLabProviderDialog'
@@ -40,6 +43,8 @@ const GitLabProviders = (props: Props) => {
   const isOrgAdmin = viewerOrganizationUser?.role === 'ORG_ADMIN'
   const {isOpen, open, close} = useDialogState()
 
+  const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
+
   return (
     <>
       <div className='my-4 flex flex-col rounded bg-white shadow-card'>
@@ -50,11 +55,9 @@ const GitLabProviders = (props: Props) => {
             <RowInfoCopy>Add private servers for use by your teams.</RowInfoCopy>
           </div>
           <ProviderActions>
-            {isOrgAdmin ? (
-              <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
-            ) : (
-              <ProviderRowActionButton disabled>Add Server</ProviderRowActionButton>
-            )}
+            <ProviderRowActionButton onClick={open} disabled={!isOrgAdmin}>
+              {isDesktop ? 'Add Server' : <AddIcon />}
+            </ProviderRowActionButton>
           </ProviderActions>
         </div>
         {isOrgAdmin &&

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
@@ -49,15 +49,18 @@ const GitLabProviders = (props: Props) => {
             <div className='font-semibold text-slate-700'>GitLab</div>
             <RowInfoCopy>Add private servers for use by your teams.</RowInfoCopy>
           </div>
-          {isOrgAdmin && (
-            <ProviderActions>
+          <ProviderActions>
+            {isOrgAdmin ? (
               <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
-            </ProviderActions>
-          )}
+            ) : (
+              <ProviderRowActionButton disabled>Add Server</ProviderRowActionButton>
+            )}
+          </ProviderActions>
         </div>
-        {organization.integrationProviders.gitlab.map((provider) => (
-          <GitLabProviderRow key={provider.id} integrationProviderRef={provider} />
-        ))}
+        {isOrgAdmin &&
+          organization.integrationProviders.gitlab.map((provider) => (
+            <GitLabProviderRow key={provider.id} integrationProviderRef={provider} />
+          ))}
       </div>
       <AddGitLabProviderDialog orgId={orgId} isOpen={isOpen} onClose={close} />
     </>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
@@ -1,0 +1,67 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import {GitLabProviders_organization$key} from '../../../../__generated__/GitLabProviders_organization.graphql'
+import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
+import ProviderActions from '../../../../components/ProviderActions'
+import RowInfoCopy from '../../../../components/Row/RowInfoCopy'
+import {useDialogState} from '../../../../ui/Dialog/useDialogState'
+import ProviderRowActionButton from '../../../teamDashboard/components/ProviderRow/ProviderRowActionButton'
+import AddGitLabProviderDialog from './AddGitLabProviderDialog'
+import GitLabProviderRow from './GitLabProviderRow'
+
+type Props = {
+  organizationRef: GitLabProviders_organization$key
+}
+
+const GitLabProviders = (props: Props) => {
+  const {organizationRef} = props
+  const organization = useFragment(
+    graphql`
+      fragment GitLabProviders_organization on Organization {
+        orgId: id
+        viewerOrganizationUser {
+          id
+          role
+        }
+        integrationProviders {
+          gitlab {
+            ...GitLabProviderRow_integrationProvider
+            id
+            serverBaseUrl
+            clientId
+          }
+        }
+      }
+    `,
+    organizationRef
+  )
+  const {orgId, viewerOrganizationUser} = organization
+  const isOrgAdmin = viewerOrganizationUser?.role === 'ORG_ADMIN'
+  const {isOpen, open, close} = useDialogState()
+
+  return (
+    <>
+      <div className='my-4 flex flex-col rounded bg-white shadow-card'>
+        <div className='flex-center flex items-center p-4'>
+          <GitLabProviderLogo />
+          <div className='flex flex-col px-4'>
+            <div className='font-semibold text-slate-700'>GitLab</div>
+            <RowInfoCopy>Add private servers for use by your teams.</RowInfoCopy>
+          </div>
+          {isOrgAdmin && (
+            <ProviderActions>
+              <ProviderRowActionButton onClick={open}>Add Server</ProviderRowActionButton>
+            </ProviderActions>
+          )}
+        </div>
+        {organization.integrationProviders.gitlab.map((provider) => (
+          <GitLabProviderRow key={provider.id} integrationProviderRef={provider} />
+        ))}
+      </div>
+      <AddGitLabProviderDialog orgId={orgId} isOpen={isOpen} onClose={close} />
+    </>
+  )
+}
+
+export default GitLabProviders

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviders.tsx
@@ -17,6 +17,17 @@ type Props = {
   organizationRef: GitLabProviders_organization$key
 }
 
+graphql`
+  fragment GitLabProviders_orgIntegrationProviders on OrgIntegrationProviders {
+    gitlab {
+      ...GitLabProviderRow_integrationProvider
+      id
+      serverBaseUrl
+      clientId
+    }
+  }
+`
+
 const GitLabProviders = (props: Props) => {
   const {organizationRef} = props
   const organization = useFragment(
@@ -28,12 +39,7 @@ const GitLabProviders = (props: Props) => {
           role
         }
         integrationProviders {
-          gitlab {
-            ...GitLabProviderRow_integrationProvider
-            id
-            serverBaseUrl
-            clientId
-          }
+          ...GitLabProviders_orgIntegrationProviders @relay(mask: false)
         }
       }
     `,

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
@@ -1,0 +1,44 @@
+import graphql from 'babel-plugin-relay/macro'
+import React, {Suspense} from 'react'
+import {useFragment} from 'react-relay'
+import {OrgIntegrations_organization$key} from '../../../../__generated__/OrgIntegrations_organization.graphql'
+import {Loader} from '../../../../utils/relay/renderLoader'
+import GitLabProviderRow from './GitLabProviderRow'
+
+type Props = {
+  organizationRef: OrgIntegrations_organization$key
+}
+
+const OrgIntegrations = (props: Props) => {
+  const {organizationRef} = props
+  const organization = useFragment(
+    graphql`
+      fragment OrgIntegrations_organization on Organization {
+        id
+        ...GitLabProviderRow_organization
+        createdAt
+        tier
+      }
+    `,
+    organizationRef
+  )
+
+  return (
+    <Suspense fallback={<Loader />}>
+      <div className='flex w-full flex-wrap px-4'>
+        <div className='w-[768px] max-w-[768px]'>
+          <h1>Integration Settings</h1>
+          <div className='text-base text-slate-700'>
+            Configure organization-level integrations that can be used by teams across your
+            organization.
+            <br />
+            See the team integration tab for team-level connections.
+          </div>
+          <GitLabProviderRow organizationRef={organization} />
+        </div>
+      </div>
+    </Suspense>
+  )
+}
+
+export default OrgIntegrations

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
@@ -3,7 +3,7 @@ import React, {Suspense} from 'react'
 import {useFragment} from 'react-relay'
 import {OrgIntegrations_organization$key} from '../../../../__generated__/OrgIntegrations_organization.graphql'
 import {Loader} from '../../../../utils/relay/renderLoader'
-import GitLabProviderRow from './GitLabProviderRow'
+import GitLabProviders from './GitLabProviders'
 
 type Props = {
   organizationRef: OrgIntegrations_organization$key
@@ -15,7 +15,7 @@ const OrgIntegrations = (props: Props) => {
     graphql`
       fragment OrgIntegrations_organization on Organization {
         id
-        ...GitLabProviderRow_organization
+        ...GitLabProviders_organization
         createdAt
         tier
         viewerOrganizationUser {
@@ -45,7 +45,7 @@ const OrgIntegrations = (props: Props) => {
           ) : (
             <div className='text-slate-700'>Only organization admins can manage integrations.</div>
           )}
-          <GitLabProviderRow organizationRef={organization} />
+          <GitLabProviders organizationRef={organization} />
         </div>
       </div>
     </Suspense>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
@@ -2,7 +2,6 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
 import {useFragment} from 'react-relay'
 import {OrgIntegrations_organization$key} from '../../../../__generated__/OrgIntegrations_organization.graphql'
-import {Layout} from '../../../../types/constEnums'
 import {Loader} from '../../../../utils/relay/renderLoader'
 import GitLabProviders from './GitLabProviders'
 
@@ -34,9 +33,7 @@ const OrgIntegrations = (props: Props) => {
   return (
     <Suspense fallback={<Loader />}>
       <div className='flex w-full flex-wrap'>
-        <div
-          className={`w-[${Layout.SETTINGS_MAX_WIDTH}px] max-w-[${Layout.SETTINGS_MAX_WIDTH}px]`}
-        >
+        <div className='w-[768px] max-w-[768px]'>
           <h1>Integration Settings</h1>
           {isOrgAdmin ? (
             <div className='text-base text-slate-700'>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
@@ -18,22 +18,33 @@ const OrgIntegrations = (props: Props) => {
         ...GitLabProviderRow_organization
         createdAt
         tier
+        viewerOrganizationUser {
+          id
+          role
+        }
       }
     `,
     organizationRef
   )
+
+  const {viewerOrganizationUser} = organization
+  const isOrgAdmin = viewerOrganizationUser?.role === 'ORG_ADMIN'
 
   return (
     <Suspense fallback={<Loader />}>
       <div className='flex w-full flex-wrap px-4'>
         <div className='w-[768px] max-w-[768px]'>
           <h1>Integration Settings</h1>
-          <div className='text-base text-slate-700'>
-            Configure organization-level integrations that can be used by teams across your
-            organization.
-            <br />
-            See the team integration tab for team-level connections.
-          </div>
+          {isOrgAdmin ? (
+            <div className='text-base text-slate-700'>
+              Configure organization-level integrations that can be used by teams across your
+              organization.
+              <br />
+              See the team integration tab for team-level connections.
+            </div>
+          ) : (
+            <div className='text-slate-700'>Only organization admins can manage integrations.</div>
+          )}
           <GitLabProviderRow organizationRef={organization} />
         </div>
       </div>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/OrgIntegrations.tsx
@@ -2,6 +2,7 @@ import graphql from 'babel-plugin-relay/macro'
 import React, {Suspense} from 'react'
 import {useFragment} from 'react-relay'
 import {OrgIntegrations_organization$key} from '../../../../__generated__/OrgIntegrations_organization.graphql'
+import {Layout} from '../../../../types/constEnums'
 import {Loader} from '../../../../utils/relay/renderLoader'
 import GitLabProviders from './GitLabProviders'
 
@@ -32,8 +33,10 @@ const OrgIntegrations = (props: Props) => {
 
   return (
     <Suspense fallback={<Loader />}>
-      <div className='flex w-full flex-wrap px-4'>
-        <div className='w-[768px] max-w-[768px]'>
+      <div className='flex w-full flex-wrap'>
+        <div
+          className={`w-[${Layout.SETTINGS_MAX_WIDTH}px] max-w-[${Layout.SETTINGS_MAX_WIDTH}px]`}
+        >
           <h1>Integration Settings</h1>
           {isOrgAdmin ? (
             <div className='text-base text-slate-700'>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/RemoveIntegrationProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/RemoveIntegrationProviderDialog.tsx
@@ -46,7 +46,7 @@ const RemoveIntegrationProviderDialog = (props: Props) => {
   const {onCompleted, onError} = useMutationProps()
 
   const handleClick = () => {
-    close()
+    onClose()
     RemoveIntegrationProviderMutation(atmosphere, {providerId}, {onCompleted, onError})
   }
   const prettyService = prettifyService(service)

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/RemoveIntegrationProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/RemoveIntegrationProviderDialog.tsx
@@ -1,0 +1,75 @@
+import graphql from 'babel-plugin-relay/macro'
+import React from 'react'
+import {useFragment} from 'react-relay'
+import useAtmosphere from '~/hooks/useAtmosphere'
+import {RemoveIntegrationProviderDialog_integrationProvider$key} from '../../../../__generated__/RemoveIntegrationProviderDialog_integrationProvider.graphql'
+import PrimaryButton from '../../../../components/PrimaryButton'
+import useMutationProps from '../../../../hooks/useMutationProps'
+import RemoveIntegrationProviderMutation from '../../../../mutations/RemoveIntegrationProviderMutation'
+import {Dialog} from '../../../../ui/Dialog/Dialog'
+import {DialogContent} from '../../../../ui/Dialog/DialogContent'
+import {DialogTitle} from '../../../../ui/Dialog/DialogTitle'
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  integrationProviderRef: RemoveIntegrationProviderDialog_integrationProvider$key
+}
+
+const prettifyService = (service: string) => {
+  switch (service) {
+    case 'gitlab':
+      return 'GitLab'
+    case 'github':
+      return 'GitHub'
+    default:
+      return service.charAt(0).toUpperCase() + service.slice(1)
+  }
+}
+
+const RemoveIntegrationProviderDialog = (props: Props) => {
+  const atmosphere = useAtmosphere()
+  const {isOpen, onClose, integrationProviderRef} = props
+  const integrationProvider = useFragment(
+    graphql`
+      fragment RemoveIntegrationProviderDialog_integrationProvider on IntegrationProvider {
+        id
+        service
+        ... on IntegrationProviderOAuth2 {
+          serverBaseUrl
+        }
+      }
+    `,
+    integrationProviderRef
+  )
+  const {id: providerId, service, serverBaseUrl} = integrationProvider
+  const {onCompleted, onError} = useMutationProps()
+
+  const handleClick = () => {
+    close()
+    RemoveIntegrationProviderMutation(atmosphere, {providerId}, {onCompleted, onError})
+  }
+  const prettyService = prettifyService(service)
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose}>
+      <DialogContent>
+        <DialogTitle className='flex items-center'>Are you sure?</DialogTitle>
+        <div className='pt-6 pb-2'>
+          If you remove this{' '}
+          <b>
+            {prettyService}
+            {serverBaseUrl && ` (${serverBaseUrl.replace(/https:\/\//, '')})`}
+          </b>{' '}
+          integration, it will no longer be available to any teams.
+        </div>
+        <div className='flex justify-end pt-6'>
+          <PrimaryButton type='submit' onClick={handleClick}>
+            Remove {prettyService} integration
+          </PrimaryButton>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default RemoveIntegrationProviderDialog

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/UpsertGitLabProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/UpsertGitLabProviderDialog.tsx
@@ -81,9 +81,15 @@ const UpsertGitLabProviderDialog = (props: Props) => {
             <div className='w-36'>Name</div>
             <div>Parabol</div>
           </div>
-          <div className='flex items-center p-2'>
+          <div className='flex items-center px-2'>
             <div className='w-36'>Redirect URI</div>
-            <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
+            <CopyShortLink
+              className='h-10 rounded border border-dashed px-2'
+              icon='link'
+              url={redirectUri}
+              title='Redirect URL'
+              tooltip='Copied Redirect URL'
+            />
           </div>
           <div className='flex items-center p-2'>
             <div className='w-36'>Trusted</div>

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/UpsertGitLabProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/UpsertGitLabProviderDialog.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import ErrorAlert from '../../../../components/ErrorAlert/ErrorAlert'
+import GitLabProviderLogo from '../../../../components/GitLabProviderLogo'
+import BasicInput from '../../../../components/InputField/BasicInput'
+import PrimaryButton from '../../../../components/PrimaryButton'
+import useForm from '../../../../hooks/useForm'
+import {Dialog} from '../../../../ui/Dialog/Dialog'
+import {DialogContent} from '../../../../ui/Dialog/DialogContent'
+import {DialogTitle} from '../../../../ui/Dialog/DialogTitle'
+import linkify from '../../../../utils/linkify'
+import makeAppURL from '../../../../utils/makeAppURL'
+import Legitity from '../../../../validation/Legitity'
+import CopyShortLink from '../../../meeting/components/CopyShortLink/CopyShortLink'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+  defaults: {
+    serverBaseUrl: string
+    clientId: string
+    clientSecret: string
+  }
+  onUpsert: (serverBaseUrl: string, clientId: string, clientSecret: string) => void
+  error?: {message: string}
+}
+
+const UpsertGitLabProviderDialog = (props: Props) => {
+  const {isOpen, onClose, defaults, onUpsert, error} = props
+
+  const redirectUri = makeAppURL(window.location.origin, 'auth/gitlab')
+  const {fields, onChange, validateField} = useForm({
+    serverBaseUrl: {
+      getDefault: () => defaults.serverBaseUrl,
+      validate: (rawInput: string) => {
+        return new Legitity(rawInput).test((maybeUrl) => {
+          if (!maybeUrl) return 'Please enter a server base URL'
+          const links = linkify.match(maybeUrl)
+          return !links ? 'Not looking too linky' : ''
+        })
+      }
+    },
+    clientId: {
+      getDefault: () => defaults.clientId,
+      validate: (clientId: string) => {
+        return new Legitity(clientId).required('Please enter a client ID')
+      }
+    },
+    clientSecret: {
+      getDefault: () => defaults.clientSecret,
+      validate: (clientSecret: string) => {
+        return new Legitity(clientSecret).required('Please enter a client secret')
+      }
+    }
+  })
+
+  const onSubmit = () => {
+    const validation = validateField()
+    if (Object.values(validation).some(({error}) => error)) return
+    onUpsert(fields.serverBaseUrl.value, fields.clientId.value, fields.clientSecret.value)
+    onClose?.()
+  }
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose}>
+      <DialogContent>
+        <DialogTitle className='flex items-center'>
+          <GitLabProviderLogo />
+          <div className='ml-2'>Add GitLab Server</div>
+        </DialogTitle>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            onSubmit()
+          }}
+        >
+          <div className='pt-6 pb-2'>
+            In the <b>Admin Area</b>, <b>Applications</b> add a <b>New application</b> with the
+            following settings
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Name</div>
+            <div>Parabol</div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Callback URL</div>
+            <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Trusted</div>
+            <div>Yes or No</div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Confidential</div>
+            <div>Yes</div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36'>Scopes</div>
+            <div>
+              <b>api</b> (Access the authenticated user's API)
+            </div>
+          </div>
+          <div className='pt-6 pb-2'>
+            Press <b>Save application</b> and enter the <b>Application ID</b> and <b>Secret</b>{' '}
+            below
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36 shrink-0'>Server base URL</div>
+            <div className='flex w-full flex-col'>
+              <BasicInput
+                {...fields.serverBaseUrl}
+                onChange={onChange}
+                name='serverBaseUrl'
+                placeholder='https://gitlab.example.com'
+              />
+            </div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36 shrink-0'>Application ID</div>
+            <div className='flex w-full flex-col'>
+              <BasicInput
+                {...fields.clientId}
+                onChange={onChange}
+                name='clientId'
+                placeholder='Enter your Application ID here...'
+              />
+            </div>
+          </div>
+          <div className='flex items-center p-2'>
+            <div className='w-36 shrink-0'>Secret</div>
+            <div className='flex w-full flex-col'>
+              <BasicInput
+                {...fields.clientSecret}
+                onChange={onChange}
+                name='clientSecret'
+                placeholder='Enter your Secret here...'
+              />
+            </div>
+          </div>
+          {error && <ErrorAlert message={error.message} />}
+          <div className='flex justify-end pt-6'>
+            <PrimaryButton type='submit' onClick={onSubmit}>
+              Save
+            </PrimaryButton>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default UpsertGitLabProviderDialog

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/UpsertGitLabProviderDialog.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/UpsertGitLabProviderDialog.tsx
@@ -82,7 +82,7 @@ const UpsertGitLabProviderDialog = (props: Props) => {
             <div>Parabol</div>
           </div>
           <div className='flex items-center p-2'>
-            <div className='w-36'>Callback URL</div>
+            <div className='w-36'>Redirect URI</div>
             <CopyShortLink url={redirectUri} title='Redirect URL' tooltip='Copy Redirect URL' />
           </div>
           <div className='flex items-center p-2'>

--- a/packages/client/mutations/AddIntegrationProviderMutation.ts
+++ b/packages/client/mutations/AddIntegrationProviderMutation.ts
@@ -18,6 +18,13 @@ graphql`
         tenantId
       }
     }
+    teamMemberIntegrations {
+      ...MattermostProviderRowTeamMemberIntegrations @relay(mask: false)
+      ...MSTeamsProviderRowTeamMemberIntegrations @relay(mask: false)
+    }
+    orgIntegrationProviders {
+      ...GitLabProviders_orgIntegrationProviders @relay(mask: false)
+    }
   }
 `
 

--- a/packages/client/mutations/AddIntegrationProviderMutation.ts
+++ b/packages/client/mutations/AddIntegrationProviderMutation.ts
@@ -4,9 +4,11 @@ import {AddIntegrationProviderMutation as TAddIntegrationProviderMutation} from 
 import {StandardMutation} from '../types/relayMutations'
 
 graphql`
-  fragment AddIntegrationProviderMutation_team on AddIntegrationProviderSuccess {
+  fragment AddIntegrationProviderMutation_organization on AddIntegrationProviderSuccess {
     provider {
       id
+      teamId
+      orgId
       ... on IntegrationProviderWebhook {
         webhookUrl
       }
@@ -27,7 +29,7 @@ const mutation = graphql`
           message
         }
       }
-      ...AddIntegrationProviderMutation_team @relay(mask: false)
+      ...AddIntegrationProviderMutation_organization @relay(mask: false)
     }
   }
 `

--- a/packages/client/mutations/AddTeamMemberIntegrationAuthMutation.ts
+++ b/packages/client/mutations/AddTeamMemberIntegrationAuthMutation.ts
@@ -27,11 +27,13 @@ const mutation = graphql`
         teamMember {
           ...GitLabProviderRowTeamMember
           ...ScopePhaseAreaGitLab_teamMember
-          ...MattermostProviderRowTeamMember
           ...JiraServerProviderRowTeamMember
           ...AzureDevOpsProviderRowTeamMember
-          ...MSTeamsProviderRowTeamMember
           ...GcalProviderRowTeamMember
+          integrations {
+            ...MattermostProviderRowTeamMemberIntegrations
+            ...MSTeamsProviderRowTeamMemberIntegrations
+          }
         }
       }
     }

--- a/packages/client/mutations/RemoveIntegrationProviderMutation.ts
+++ b/packages/client/mutations/RemoveIntegrationProviderMutation.ts
@@ -3,6 +3,7 @@ import {commitMutation} from 'react-relay'
 import {RemoveIntegrationProviderMutation as TRemoveIntegrationProviderMutation} from '../__generated__/RemoveIntegrationProviderMutation.graphql'
 import {StandardMutation} from '../types/relayMutations'
 
+/* TODO we should update these somehow
 graphql`
   fragment RemoveIntegrationProviderMutation_team on RemoveIntegrationProviderSuccess {
     teamMember {
@@ -12,6 +13,7 @@ graphql`
     }
   }
 `
+*/
 
 const mutation = graphql`
   mutation RemoveIntegrationProviderMutation($providerId: ID!) {
@@ -21,7 +23,6 @@ const mutation = graphql`
           message
         }
       }
-      ...RemoveIntegrationProviderMutation_team @relay(mask: false)
     }
   }
 `

--- a/packages/client/mutations/RemoveIntegrationProviderMutation.ts
+++ b/packages/client/mutations/RemoveIntegrationProviderMutation.ts
@@ -3,21 +3,22 @@ import {commitMutation} from 'react-relay'
 import {RemoveIntegrationProviderMutation as TRemoveIntegrationProviderMutation} from '../__generated__/RemoveIntegrationProviderMutation.graphql'
 import {StandardMutation} from '../types/relayMutations'
 
-/* TODO we should update these somehow
 graphql`
-  fragment RemoveIntegrationProviderMutation_team on RemoveIntegrationProviderSuccess {
-    teamMember {
-      ...MattermostProviderRowTeamMember @relay(mask: false)
-      ...GitLabProviderRowTeamMember @relay(mask: false)
-      ...MSTeamsProviderRowTeamMember @relay(mask: false)
+  fragment RemoveIntegrationProviderMutation_organization on RemoveIntegrationProviderSuccess {
+    teamMemberIntegrations {
+      ...MattermostProviderRowTeamMemberIntegrations @relay(mask: false)
+      ...MSTeamsProviderRowTeamMemberIntegrations @relay(mask: false)
+    }
+    orgIntegrationProviders {
+      ...GitLabProviders_orgIntegrationProviders @relay(mask: false)
     }
   }
 `
-*/
 
 const mutation = graphql`
   mutation RemoveIntegrationProviderMutation($providerId: ID!) {
     removeIntegrationProvider(providerId: $providerId) {
+      ...RemoveIntegrationProviderMutation_organization
       ... on ErrorPayload {
         error {
           message

--- a/packages/client/mutations/RemoveTeamMemberIntegrationAuthMutation.ts
+++ b/packages/client/mutations/RemoveTeamMemberIntegrationAuthMutation.ts
@@ -7,11 +7,13 @@ graphql`
   fragment RemoveTeamMemberIntegrationAuthMutation_team on RemoveTeamMemberIntegrationAuthSuccess {
     teamMember {
       ...GitLabProviderRowTeamMember
-      ...MattermostProviderRowTeamMember
       ...JiraServerProviderRowTeamMember
       ...AzureDevOpsProviderRowTeamMember
-      ...MSTeamsProviderRowTeamMember
       ...GcalProviderRowTeamMember
+      integrations {
+        ...MattermostProviderRowTeamMemberIntegrations
+        ...MSTeamsProviderRowTeamMemberIntegrations
+      }
     }
   }
 `

--- a/packages/client/shared/gqlIds/OrgIntegrationProvidersId.ts
+++ b/packages/client/shared/gqlIds/OrgIntegrationProvidersId.ts
@@ -1,0 +1,6 @@
+const OrgIntegrationProvidersId = {
+  join: (orgId: string) => `orgIntegrationProviders:${orgId}`,
+  split: (id: string) => id.split(':')[1]!
+}
+
+export default OrgIntegrationProvidersId

--- a/packages/client/subscriptions/OrganizationSubscription.ts
+++ b/packages/client/subscriptions/OrganizationSubscription.ts
@@ -51,6 +51,9 @@ const subscription = graphql`
       UpgradeToTeamTierSuccess {
         ...UpgradeToTeamTierFrag_organization @relay(mask: false)
       }
+      RemoveIntegrationProviderSuccess {
+        ...RemoveIntegrationProviderMutation_organization @relay(mask: false)
+      }
       RemoveOrgUserPayload {
         ...RemoveOrgUserMutation_organization @relay(mask: false)
       }
@@ -76,8 +79,8 @@ const onNextHandlers = {
 const updateHandlers = {
   AddOrgPayload: addOrgMutationOrganizationUpdater,
   ArchiveOrganizationPayload: archiveOrganizationOrganizationUpdater,
-  SetOrgUserRoleSuccess: setOrgUserRoleAddedOrganizationUpdater,
   RemoveOrgUserPayload: removeOrgUserOrganizationUpdater,
+  SetOrgUserRoleSuccess: setOrgUserRoleAddedOrganizationUpdater,
   UpdateTemplateScopeSuccess: updateTemplateScopeOrganizationUpdater
 } as const
 

--- a/packages/client/subscriptions/OrganizationSubscription.ts
+++ b/packages/client/subscriptions/OrganizationSubscription.ts
@@ -27,6 +27,9 @@ const subscription = graphql`
   subscription OrganizationSubscription {
     organizationSubscription {
       fieldName
+      AddIntegrationProviderSuccess {
+        ...AddIntegrationProviderMutation_organization @relay(mask: false)
+      }
       AddOrgPayload {
         ...AddOrgMutation_organization @relay(mask: false)
       }

--- a/packages/client/subscriptions/TeamSubscription.ts
+++ b/packages/client/subscriptions/TeamSubscription.ts
@@ -181,9 +181,6 @@ const subscription = graphql`
       OldUpgradeToTeamTierPayload {
         ...OldUpgradeToTeamTierMutation_team @relay(mask: false)
       }
-      AddIntegrationProviderSuccess {
-        ...AddIntegrationProviderMutation_team @relay(mask: false)
-      }
     }
   }
 `

--- a/packages/client/tailwindTheme.ts
+++ b/packages/client/tailwindTheme.ts
@@ -153,7 +153,11 @@ export default {
         '700': '#444258',
         '800': '#2D2D39',
         '900': '#1C1C21'
-      }
+      },
+      'success-light': '#2db553',
+      starter: '#F2E1F7',
+      team: '#CBECF0',
+      enterprise: '#FFE2E0'
     },
     keyframes: {
       overlayShow: {

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -193,6 +193,7 @@ export const enum Layout {
   LAYOUT_GRID = 8, // 1x
   ROW_GUTTER = 16, // 2x
   SETTINGS_MAX_WIDTH = 768,
+  SETTINGS_NARROW_MAX_WIDTH = 644,
   TASK_COLUMNS_MAX_WIDTH = 1360
 }
 

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -293,21 +293,21 @@ export const enum Pricing {
 
 export const enum Providers {
   ATLASSIAN_NAME = 'Atlassian',
-  ATLASSIAN_DESC = 'Use Jira Cloud Issues from within Parabol',
+  ATLASSIAN_DESC = 'Use Jira Cloud Issues from within Parabol.',
   JIRA_SERVER_NAME = 'Jira Server',
-  JIRA_SERVER_DESC = 'Use Jira Server Issues from within Parabol',
+  JIRA_SERVER_DESC = 'Use Jira Server Issues from within Parabol.',
   GITHUB_NAME = 'GitHub',
   GCAL_NAME = 'Google Calendar',
-  GCAL_DESC = 'Create Google Calendar events from within Parabol',
-  GITHUB_DESC = 'Use GitHub Issues from within Parabol',
+  GCAL_DESC = 'Create Google Calendar events from within Parabol.',
+  GITHUB_DESC = 'Use GitHub Issues from within Parabol.',
   GITHUB_SCOPE = 'read:org,repo',
   GITLAB_SCOPE = 'api',
   MATTERMOST_NAME = 'Mattermost',
-  MATTERMOST_DESC = 'Push notifications to Mattermost',
+  MATTERMOST_DESC = 'Push notifications to Mattermost.',
   SLACK_NAME = 'Slack',
-  SLACK_DESC = 'Push notifications to Slack',
+  SLACK_DESC = 'Push notifications to Slack.',
   AZUREDEVOPS_NAME = 'Azure DevOps',
-  AZUREDEVOPS_DESC = 'Use Azure DevOps Issues from within Parabol',
+  AZUREDEVOPS_DESC = 'Use Azure DevOps Issues from within Parabol.',
   MSTEAMS_NAME = 'Microsoft Teams',
   MSTEAMS_DESC = 'Push notifications to Microsoft Teams'
 }

--- a/packages/client/ui/AlertDialog/AlertDialogContent.tsx
+++ b/packages/client/ui/AlertDialog/AlertDialogContent.tsx
@@ -21,3 +21,4 @@ const AlertDialogContent = React.forwardRef<
   </AlertDialogPortal>
 ))
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+export {AlertDialogContent}

--- a/packages/client/ui/AlertDialog/AlertDialogTitle.tsx
+++ b/packages/client/ui/AlertDialog/AlertDialogTitle.tsx
@@ -13,3 +13,4 @@ const AlertDialogTitle = React.forwardRef<
   />
 ))
 AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+export {AlertDialogTitle}

--- a/packages/client/ui/Dialog/Dialog.tsx
+++ b/packages/client/ui/Dialog/Dialog.tsx
@@ -2,8 +2,8 @@ import * as RadixDialog from '@radix-ui/react-dialog'
 import * as React from 'react'
 
 interface DialogProps extends React.ComponentPropsWithoutRef<typeof RadixDialog.Root> {
-  isOpen: boolean
-  onClose: () => void
+  isOpen?: boolean
+  onClose?: () => void
   children: React.ReactNode
 }
 
@@ -14,7 +14,7 @@ export const Dialog = (props: DialogProps) => {
       open={isOpen}
       onOpenChange={(newOpen) => {
         if (!newOpen) {
-          onClose()
+          onClose?.()
         }
       }}
       {...other}

--- a/packages/client/ui/Dialog/DialogTrigger.tsx
+++ b/packages/client/ui/Dialog/DialogTrigger.tsx
@@ -1,0 +1,11 @@
+import * as RadixDialog from '@radix-ui/react-dialog'
+import React from 'react'
+
+export const DialogTrigger = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentPropsWithoutRef<typeof RadixDialog.Trigger>
+>(({className, children, ...props}, ref) => (
+  <RadixDialog.Trigger asChild ref={ref} {...props}>
+    {children}
+  </RadixDialog.Trigger>
+))

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -96,7 +96,11 @@ export const BILLING_PAGE = 'billing'
 export const MEMBERS_PAGE = 'members'
 export const TEAMS_PAGE = 'teams'
 export const ORG_SETTINGS_PAGE = 'settings'
+export const ORG_INTEGRATIONS_PAGE = 'integrations'
 export const AUTHENTICATION_PAGE = 'authentication'
+
+export const SETTINGS_NARROW_MAX_WIDTH = 644
+export const SETTINGS_MAX_WIDTH = 768
 
 /* Stripe */
 // changing this does NOT change it in stripe, it just changes the UI

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -99,9 +99,6 @@ export const ORG_SETTINGS_PAGE = 'settings'
 export const ORG_INTEGRATIONS_PAGE = 'integrations'
 export const AUTHENTICATION_PAGE = 'authentication'
 
-export const SETTINGS_NARROW_MAX_WIDTH = 644
-export const SETTINGS_MAX_WIDTH = 768
-
 /* Stripe */
 // changing this does NOT change it in stripe, it just changes the UI
 export const MONTHLY_PRICE = 8

--- a/packages/server/dataloader/integrationAuthLoaders.ts
+++ b/packages/server/dataloader/integrationAuthLoaders.ts
@@ -82,7 +82,9 @@ export const sharedIntegrationProviders = (parent: RootDataLoader) => {
       ) as TIntegrationProvider[][]
     },
     {
-      ...parent.dataLoaderOptions
+      ...parent.dataLoaderOptions,
+      cacheKeyFn: ({service, orgIds, teamIds}) =>
+        `${service}-${orgIds.toSorted().join(',')}-${teamIds.toSorted().join(',')}`
     }
   )
 }

--- a/packages/server/graphql/mutations/addIntegrationProvider.ts
+++ b/packages/server/graphql/mutations/addIntegrationProvider.ts
@@ -92,9 +92,6 @@ const addIntegrationProvider = {
       return {error: {message: 'Exactly 1 metadata provider is expected'}}
     }
 
-    const resolvedOrgId =
-      orgId || (teamId ? (await dataLoader.get('teams').loadNonNull(teamId)).orgId : null)
-
     // RESOLUTION
     const providerId = await upsertIntegrationProvider({
       authStrategy,
@@ -109,11 +106,15 @@ const addIntegrationProvider = {
           : {orgId: null, teamId})
     })
 
-    const data = {providerId}
-    if (resolvedOrgId) {
+    const data = {
+      providerId,
+      orgId,
+      teamId
+    }
+    if (orgId) {
       publish(
         SubscriptionChannel.ORGANIZATION,
-        resolvedOrgId,
+        orgId,
         'AddIntegrationProviderSuccess',
         data,
         subOptions

--- a/packages/server/graphql/mutations/removeIntegrationProvider.ts
+++ b/packages/server/graphql/mutations/removeIntegrationProvider.ts
@@ -7,7 +7,7 @@ import {GQLContext} from '../graphql'
 import RemoveIntegrationProviderPayload from '../types/RemoveIntegrationProviderPayload'
 
 const removeIntegrationProvider = {
-  name: 'RemoveIntegrationProvider',
+  name: 'removeIntegrationProvider',
   type: new GraphQLNonNull(RemoveIntegrationProviderPayload),
   description: 'Remove an Integration Provider, and any associated tokens',
   args: {
@@ -37,14 +37,17 @@ const removeIntegrationProvider = {
         return {error: {message: 'Must be a member of the organization that created the provider'}}
       }
       if (scope === 'team' && !isTeamMember(authToken, teamId!)) {
-        return {error: {message: 'Must be on the team that created the provider'}}
+        const team = await dataLoader.get('teams').load(teamId!)
+        if (!team || !isUserOrgAdmin(viewerId, team.orgId, dataLoader)) {
+          return {error: {message: 'Must be on the team that created the provider'}}
+        }
       }
     }
 
     // RESOLUTION
     await removeIntegrationProviderQuery(providerDbId)
 
-    const data = {userId: viewerId, teamId}
+    const data = {userId: viewerId}
     return data
   }
 }

--- a/packages/server/graphql/public/mutations/updateIntegrationProvider.ts
+++ b/packages/server/graphql/public/mutations/updateIntegrationProvider.ts
@@ -117,22 +117,6 @@ const updateIntegrationProvider: MutationResolvers['updateIntegrationProvider'] 
     })
     .where('id', '=', providerDbId)
     .execute()
-  /*
-  await upsertIntegrationProvider({
-    id: providerId,
-    ...oAuth2ProviderMetadataInput,
-    ...webhookProviderMetadataInput,
-    service,
-    authStrategy,
-    scope: scope as IntegrationProviderScopeEnum | null ,
-    ...(scope === 'global'
-      ? {orgId: null, teamId: null}
-      : scope === 'org'
-        ? {orgId, teamId: null}
-        : {orgId: null, teamId})
-  })
-  */
-
   if (currentProvider.service === 'mattermost') {
     const {webhookUrl} = currentProvider
     const newWebhookUrl = webhookProviderMetadataInput?.webhookUrl

--- a/packages/server/graphql/public/mutations/updateIntegrationProvider.ts
+++ b/packages/server/graphql/public/mutations/updateIntegrationProvider.ts
@@ -1,6 +1,6 @@
 import IntegrationProviderId from 'parabol-client/shared/gqlIds/IntegrationProviderId'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
-import upsertIntegrationProvider from '../../../postgres/queries/upsertIntegrationProvider'
+import getKysely from '../../../postgres/getKysely'
 import {getUserId, isSuperUser, isTeamMember, isUserOrgAdmin} from '../../../utils/authorization'
 import publish from '../../../utils/publish'
 import {MSTeamsNotifier} from '../../mutations/helpers/notifications/MSTeamsNotifier'
@@ -16,6 +16,7 @@ const updateIntegrationProvider: MutationResolvers['updateIntegrationProvider'] 
   const viewerId = getUserId(authToken)
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
+  const pg = getKysely()
 
   const {
     id: providerId,
@@ -28,18 +29,15 @@ const updateIntegrationProvider: MutationResolvers['updateIntegrationProvider'] 
 
   // INPUT VALIDATION
   const providerDbId = IntegrationProviderId.split(providerId)
-  const currentProvider = await dataLoader.get('integrationProviders').load(providerDbId)
-  dataLoader.get('integrationProviders').clear(providerDbId)
+  const currentProvider = await pg
+    .selectFrom('IntegrationProvider')
+    .selectAll()
+    .where('id', '=', providerDbId)
+    .executeTakeFirst()
   if (!currentProvider) {
     return {error: {message: 'Invalid provider ID'}}
   }
-  const {
-    teamId: oldTeamId,
-    orgId: oldOrgId,
-    scope: oldScope,
-    service,
-    authStrategy
-  } = currentProvider
+  const {teamId: oldTeamId, orgId: oldOrgId, scope: oldScope, authStrategy} = currentProvider
 
   const [oldTeam, newTeam] = await Promise.all([
     oldTeamId ? dataLoader.get('teams').load(oldTeamId) : null,
@@ -88,49 +86,74 @@ const updateIntegrationProvider: MutationResolvers['updateIntegrationProvider'] 
   if (oAuth2ProviderMetadataInput && webhookProviderMetadataInput) {
     return {error: {message: 'Provided 2 metadata types, expected 1'}}
   }
-  if (!oAuth2ProviderMetadataInput && !webhookProviderMetadataInput) {
-    return {error: {message: 'Provided 0 metadata types, expected 1'}}
+  if (authStrategy === 'webhook') {
+    if (!webhookProviderMetadataInput) {
+      return {error: {message: 'Expected webhook metadata'}}
+    }
+  } else if (authStrategy === 'oauth2') {
+    if (!oAuth2ProviderMetadataInput) {
+      return {error: {message: 'Expected OAuth2 metadata'}}
+    }
+  } else {
+    return {error: {message: 'Unsupported authStrategy'}}
   }
 
-  const resolvedOrgId =
-    newOrgId || (newTeamId ? (await dataLoader.get('teams').loadNonNull(newTeamId)).orgId : null)
-  const scope = newScope || oldScope
+  const teamId = newTeamId || oldTeamId
+  const orgId = newOrgId || oldOrgId
+  const scope = newScope ?? oldScope
 
   // RESOLUTION
+  await pg
+    .updateTable('IntegrationProvider')
+    .set({
+      ...oAuth2ProviderMetadataInput,
+      ...webhookProviderMetadataInput,
+      scope,
+      ...(scope === 'global'
+        ? {orgId: null, teamId: null}
+        : scope === 'org'
+          ? {orgId, teamId: null}
+          : {orgId: null, teamId})
+    })
+    .where('id', '=', providerDbId)
+    .execute()
+  /*
   await upsertIntegrationProvider({
+    id: providerId,
     ...oAuth2ProviderMetadataInput,
     ...webhookProviderMetadataInput,
     service,
     authStrategy,
-    scope: newScope,
+    scope: scope as IntegrationProviderScopeEnum | null ,
     ...(scope === 'global'
       ? {orgId: null, teamId: null}
       : scope === 'org'
-        ? {orgId: newOrgId!, teamId: null}
-        : {orgId: null, teamId: newTeamId!})
+        ? {orgId, teamId: null}
+        : {orgId: null, teamId})
   })
+  */
 
   if (currentProvider.service === 'mattermost') {
     const {webhookUrl} = currentProvider
     const newWebhookUrl = webhookProviderMetadataInput?.webhookUrl
-    if (newTeamId && newWebhookUrl && newWebhookUrl !== webhookUrl) {
+    if (teamId && newWebhookUrl && newWebhookUrl !== webhookUrl) {
       Object.assign(currentProvider, webhookProviderMetadataInput)
-      await MattermostNotifier.integrationUpdated(dataLoader, newTeamId, viewerId)
+      await MattermostNotifier.integrationUpdated(dataLoader, teamId, viewerId)
     }
   }
   if (currentProvider.service === 'msTeams') {
     const {webhookUrl} = currentProvider
     const newWebhookUrl = webhookProviderMetadataInput?.webhookUrl
-    if (newTeamId && newWebhookUrl && newWebhookUrl !== webhookUrl) {
+    if (teamId && newWebhookUrl && newWebhookUrl !== webhookUrl) {
       Object.assign(currentProvider, webhookProviderMetadataInput)
-      await MSTeamsNotifier.integrationUpdated(dataLoader, newTeamId, viewerId)
+      await MSTeamsNotifier.integrationUpdated(dataLoader, teamId, viewerId)
     }
   }
   const data = {userId: viewerId, providerId: providerDbId}
-  if (resolvedOrgId) {
+  if (orgId) {
     publish(
       SubscriptionChannel.ORGANIZATION,
-      resolvedOrgId,
+      orgId,
       'UpdateIntegrationProviderSuccess',
       data,
       subOptions

--- a/packages/server/graphql/public/typeDefs/AddIntegrationProviderSuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/AddIntegrationProviderSuccess.graphql
@@ -3,4 +3,14 @@ type AddIntegrationProviderSuccess {
   The provider that was added
   """
   provider: IntegrationProvider!
+
+  """
+  The updated set of organization integration providers if there were changes
+  """
+  orgIntegrationProviders: OrgIntegrationProviders
+
+  """
+  Updated team member integrations if there were changes
+  """
+  teamMemberIntegrations: TeamMemberIntegrations
 }

--- a/packages/server/graphql/public/typeDefs/IntegrationProviderMetadataInputOAuth2.graphql
+++ b/packages/server/graphql/public/typeDefs/IntegrationProviderMetadataInputOAuth2.graphql
@@ -20,5 +20,5 @@ input IntegrationProviderMetadataInputOAuth2 {
   """
   The tenant id to give to the provider
   """
-  tenantId: String!
+  tenantId: String
 }

--- a/packages/server/graphql/public/typeDefs/OrgIntegrationProviders.graphql
+++ b/packages/server/graphql/public/typeDefs/OrgIntegrationProviders.graphql
@@ -1,0 +1,14 @@
+"""
+Custom integration providers for this organization
+"""
+type OrgIntegrationProviders {
+  """
+  composite
+  """
+  id: ID!
+
+  """
+  Organization specific GitLab integrations
+  """
+  gitlab: [IntegrationProviderOAuth2!]!
+}

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -185,4 +185,9 @@ type Organization {
   Empty if all domains are allowed
   """
   approvedDomains: [String!]!
+
+  """
+  Custom integration providers with organization scope
+  """
+  integrationProviders: OrgIntegrationProviders!
 }

--- a/packages/server/graphql/public/typeDefs/OrganizationSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/OrganizationSubscriptionPayload.graphql
@@ -1,5 +1,6 @@
 type OrganizationSubscriptionPayload {
   fieldName: String!
+  AddIntegrationProviderSuccess: AddIntegrationProviderSuccess
   AddOrgPayload: AddOrgPayload
   ArchiveOrganizationPayload: ArchiveOrganizationPayload
   DowngradeToStarterPayload: DowngradeToStarterPayload

--- a/packages/server/graphql/public/typeDefs/OrganizationSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/OrganizationSubscriptionPayload.graphql
@@ -4,14 +4,15 @@ type OrganizationSubscriptionPayload {
   AddOrgPayload: AddOrgPayload
   ArchiveOrganizationPayload: ArchiveOrganizationPayload
   DowngradeToStarterPayload: DowngradeToStarterPayload
+  OldUpdateCreditCardPayload: OldUpdateCreditCardPayload
+  OldUpgradeToTeamTierPayload: OldUpgradeToTeamTierPayload
   PayLaterPayload: PayLaterPayload
+  RemoveIntegrationProviderSuccess: RemoveIntegrationProviderSuccess
   RemoveOrgUserPayload: RemoveOrgUserPayload
   SetOrgUserRoleSuccess: SetOrgUserRoleSuccess
-  OldUpdateCreditCardPayload: OldUpdateCreditCardPayload
   UpdateCreditCardPayload: UpdateCreditCardPayload
-  UpdateOrgPayload: UpdateOrgPayload
-  OldUpgradeToTeamTierPayload: OldUpgradeToTeamTierPayload
-  UpgradeToTeamTierSuccess: UpgradeToTeamTierSuccess
   UpdateIntegrationProviderSuccess: UpdateIntegrationProviderSuccess
+  UpdateOrgPayload: UpdateOrgPayload
   UpdateTemplateScopeSuccess: UpdateTemplateScopeSuccess
+  UpgradeToTeamTierSuccess: UpgradeToTeamTierSuccess
 }

--- a/packages/server/graphql/public/typeDefs/RemoveIntegrationProviderSuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/RemoveIntegrationProviderSuccess.graphql
@@ -1,6 +1,16 @@
 type RemoveIntegrationProviderSuccess {
   """
-  The user who updated TeamMemberIntegrationAuth object
+  The ID of the integration provider that was removed
   """
-  user: User!
+  providerId: ID!
+
+  """
+  The updated set of organization integration providers if there were changes
+  """
+  orgIntegrationProviders: OrgIntegrationProviders
+
+  """
+  Updated team member integrations if there were changes
+  """
+  teamMemberIntegrations: TeamMemberIntegrations
 }

--- a/packages/server/graphql/public/typeDefs/RemoveIntegrationProviderSuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/RemoveIntegrationProviderSuccess.graphql
@@ -1,10 +1,5 @@
 type RemoveIntegrationProviderSuccess {
   """
-  The team member with the updated auth
-  """
-  teamMember: TeamMember!
-
-  """
   The user who updated TeamMemberIntegrationAuth object
   """
   user: User!

--- a/packages/server/graphql/public/typeDefs/TeamSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamSubscriptionPayload.graphql
@@ -4,7 +4,6 @@ type TeamSubscriptionPayload {
   AddAgendaItemPayload: AddAgendaItemPayload
   AddAtlassianAuthPayload: AddAtlassianAuthPayload
   AddGitHubAuthPayload: AddGitHubAuthPayload
-  AddIntegrationProviderSuccess: AddIntegrationProviderSuccess
   AddSlackAuthPayload: AddSlackAuthPayload
   AddTeamPayload: AddTeamPayload
   ArchiveTeamPayload: ArchiveTeamPayload

--- a/packages/server/graphql/public/typeDefs/UpdateIntegrationProviderSuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/UpdateIntegrationProviderSuccess.graphql
@@ -3,9 +3,4 @@ type UpdateIntegrationProviderSuccess {
   The provider that was updated
   """
   provider: IntegrationProvider!
-
-  """
-  The user who updated IntegrationProvider object
-  """
-  user: User!
 }

--- a/packages/server/graphql/public/types/AddIntegrationProviderSuccess.ts
+++ b/packages/server/graphql/public/types/AddIntegrationProviderSuccess.ts
@@ -1,0 +1,24 @@
+import {getUserId} from '../../../utils/authorization'
+import {AddIntegrationProviderSuccessResolvers} from '../resolverTypes'
+
+export type AddIntegrationProviderSuccessSource = {
+  providerId: number
+  orgId?: string
+  teamId?: string
+}
+
+const AddIntegrationProviderSuccess: AddIntegrationProviderSuccessResolvers = {
+  provider: async ({providerId}, _args, {dataLoader}) => {
+    return dataLoader.get('integrationProviders').loadNonNull(providerId)
+  },
+  orgIntegrationProviders: ({orgId}) => {
+    return orgId ? {orgId} : null
+  },
+  teamMemberIntegrations: async ({teamId}, _args, {authToken}) => {
+    if (!teamId) return null
+    const viewerId = getUserId(authToken)
+    return {teamId, userId: viewerId}
+  }
+}
+
+export default AddIntegrationProviderSuccess

--- a/packages/server/graphql/public/types/GitLabIntegration.ts
+++ b/packages/server/graphql/public/types/GitLabIntegration.ts
@@ -36,9 +36,10 @@ const GitLabIntegration: GitLabIntegrationResolvers = {
   sharedProviders: async ({teamId}, _args, {dataLoader}) => {
     const team = await dataLoader.get('teams').loadNonNull(teamId)
     const {orgId} = team
-    return dataLoader
+    const sharedProviders = await dataLoader
       .get('sharedIntegrationProviders')
       .load({service: 'gitlab', orgIds: [orgId], teamIds: [teamId]})
+    return sharedProviders.filter(({scope}) => scope !== 'global')
   },
 
   gitlabSearchQueries: async () => [],

--- a/packages/server/graphql/public/types/OrgIntegrationProviders.ts
+++ b/packages/server/graphql/public/types/OrgIntegrationProviders.ts
@@ -1,0 +1,21 @@
+import OrgIntegrationProvidersId from '../../../../client/shared/gqlIds/OrgIntegrationProvidersId'
+import {getUserId, isUserInOrg} from '../../../utils/authorization'
+import {OrgIntegrationProvidersResolvers} from '../resolverTypes'
+
+export type OrgIntegrationProvidersSource = {
+  orgId: string
+}
+const OrgIntegrationProviders: OrgIntegrationProvidersResolvers = {
+  id: ({orgId}) => OrgIntegrationProvidersId.join(orgId),
+
+  gitlab: async ({orgId}, _args, {authToken, dataLoader}) => {
+    const viewerId = getUserId(authToken)
+    if (!isUserInOrg(viewerId, orgId, dataLoader)) return []
+    const providers = await dataLoader
+      .get('sharedIntegrationProviders')
+      .load({service: 'gitlab', orgIds: [orgId], teamIds: []})
+    return providers.filter((provider) => provider.scope === 'org')
+  }
+}
+
+export default OrgIntegrationProviders

--- a/packages/server/graphql/public/types/Organization.ts
+++ b/packages/server/graphql/public/types/Organization.ts
@@ -129,7 +129,8 @@ const Organization: OrganizationResolvers = {
       (organizationUser) =>
         organizationUser.role === 'BILLING_LEADER' || organizationUser.role === 'ORG_ADMIN'
     )
-  }
+  },
+  integrationProviders: ({id: orgId}) => ({orgId})
 }
 
 export default Organization

--- a/packages/server/graphql/public/types/UpdateIntegrationProviderSuccess.ts
+++ b/packages/server/graphql/public/types/UpdateIntegrationProviderSuccess.ts
@@ -2,15 +2,11 @@ import {UpdateIntegrationProviderSuccessResolvers} from '../resolverTypes'
 
 export type UpdateIntegrationProviderSuccessSource = {
   providerId: number
-  userId: string
 }
 
 const UpdateIntegrationProviderSuccess: UpdateIntegrationProviderSuccessResolvers = {
   provider: async ({providerId}, _args, {dataLoader}) => {
     return dataLoader.get('integrationProviders').loadNonNull(providerId)
-  },
-  user: async ({userId}, _args, {dataLoader}) => {
-    return dataLoader.get('users').loadNonNull(userId)
   }
 }
 

--- a/packages/server/graphql/types/IntegrationProviderMetadataInputOAuth2.ts
+++ b/packages/server/graphql/types/IntegrationProviderMetadataInputOAuth2.ts
@@ -24,7 +24,7 @@ export const IntegrationProviderMetadataInputOAuth2 = new GraphQLInputObjectType
       description: 'The client secret to give to the provider'
     },
     tenantId: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: 'The tenant id to give to the provider'
     }
   })

--- a/packages/server/graphql/types/RemoveIntegrationProviderPayload.ts
+++ b/packages/server/graphql/types/RemoveIntegrationProviderPayload.ts
@@ -1,21 +1,11 @@
 import {GraphQLNonNull, GraphQLObjectType} from 'graphql'
-import toTeamMemberId from '../../../client/utils/relay/toTeamMemberId'
 import {GQLContext} from '../graphql'
-import TeamMember from './TeamMember'
 import User from './User'
 import makeMutationPayload from './makeMutationPayload'
 
 export const RemoveIntegrationProviderSuccess = new GraphQLObjectType<any, GQLContext>({
   name: 'RemoveIntegrationProviderSuccess',
   fields: () => ({
-    teamMember: {
-      type: new GraphQLNonNull(TeamMember),
-      description: 'The team member with the updated auth',
-      resolve: ({teamId, userId}, _args, {dataLoader}) => {
-        const teamMemberId = toTeamMemberId(teamId, userId)
-        return dataLoader.get('teamMembers').load(teamMemberId)
-      }
-    },
     user: {
       type: new GraphQLNonNull(User),
       description: 'The user who updated TeamMemberIntegrationAuth object',

--- a/packages/server/postgres/queries/upsertIntegrationProvider.ts
+++ b/packages/server/postgres/queries/upsertIntegrationProvider.ts
@@ -9,7 +9,7 @@ import {
 interface IUpsertIntegrationProviderInput {
   service: IntegrationProviderServiceEnum
   authStrategy: IntegrationProviderAuthStrategyEnum
-  scope?: IntegrationProviderScopeEnum | null
+  scope?: IntegrationProviderScopeEnum | null | undefined
   clientId?: string
   tenantId?: string
   clientSecret?: string

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,9 @@ module.exports = {
         'icon-md-40': '40px',
         'icon-md-48': '48px'
       },
+      padding: {
+        'row-gutter': '16px',
+      },
       boxShadow: {
         card: 'rgba(0,0,0,.2) 0px 2px 1px -1px, rgba(0,0,0,.14) 0px 1px 1px 0px, rgba(0,0,0,.12) 0px 1px 3px 0px',
         'card-1':


### PR DESCRIPTION
# Description

Fixes #10024 
[Please include a summary of the changes and the related issue]

## Demo

https://www.loom.com/share/a5a3aa15f716401cb2e3d5458fcda8a0?sid=fa83daa9-4e18-4c98-bf83-ec348a778ea1

## Testing scenarios

- [ ] Test UI with existing team webhook integrations (Mattermost and MS Teams)
  test adding, removing, updating and see the changes reflected in UI

- [ ] Test UI with 1 or more dummy GitLab integration providers
  add, remove and edit the providers
  test as org admin and without rights

- [ ] Add a real GitLab integration provider and connect to it via the team integrations page

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the `GitLabProviderRow` component to display multiple GitLab instances and their connection statuses.
  - Introduced a new `ProviderCard` layout for clearer presentation of provider information and actions.
  
- **Bug Fixes**
  - Improved the handling of the `tenantId` field in the GraphQL API, allowing it to be optional for greater flexibility in submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->