### PR TITLE
chore(docker-stack): force network to be called parabol on the single-tenant compose stack

### DIFF
--- a/docker/stacks/single-tenant-host/docker-compose.yml
+++ b/docker/stacks/single-tenant-host/docker-compose.yml
@@ -198,3 +198,4 @@ services:
       - parabol-network
 networks:
   parabol-network:
+    name: parabol


### PR DESCRIPTION
# Description
Forces the Docker network to be named `parabol` when running the single-tenant Docker compose stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker Compose configuration to improve network identification with a new name attribute for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->