### PR TITLE
fix: discussion mentioned can be triggered by all meetings

### DIFF
--- a/packages/server/graphql/public/typeDefs/NotifyDiscussionMentioned.graphql
+++ b/packages/server/graphql/public/typeDefs/NotifyDiscussionMentioned.graphql
@@ -38,7 +38,7 @@ type NotifyDiscussionMentioned implements Notification {
   """
   The meeting the response was replied to in.
   """
-  meeting: TeamPromptMeeting!
+  meeting: NewMeeting!
 
   """
   The id of the reply comment

--- a/packages/server/graphql/public/types/NotifyDiscussionMentioned.ts
+++ b/packages/server/graphql/public/types/NotifyDiscussionMentioned.ts
@@ -1,11 +1,10 @@
-import MeetingTeamPrompt from '../../../database/types/MeetingTeamPrompt'
 import {NotifyDiscussionMentionedResolvers} from '../resolverTypes'
 
 const NotifyDiscussionMentioned: NotifyDiscussionMentionedResolvers = {
   __isTypeOf: ({type}) => type === 'DISCUSSION_MENTIONED',
   meeting: async ({meetingId}, _args, {dataLoader}) => {
     const meeting = await dataLoader.get('newMeetings').load(meetingId)
-    return meeting as MeetingTeamPrompt
+    return meeting
   },
   author: async ({authorId, commentId}, _args: unknown, {dataLoader}) => {
     const comment = await dataLoader.get('comments').load(commentId)


### PR DESCRIPTION
Notify discussion mentioned can get triggered by any meeting!

This is likely caused by the 2nd source of truth we had until now.