### PR TITLE
fix: check signal for build exit code

### DIFF
--- a/scripts/prod.js
+++ b/scripts/prod.js
@@ -4,10 +4,10 @@ const cp = require('child_process')
 const runChild = (cmd) => {
   return new Promise((resolve, reject) => {
     const build = cp.exec(cmd).on('exit', (code, signal) => {
-      if (code !== 0) {
-        reject(new Error(`Received non-zero exit code ${code}`))
-      } else if (signal) {
+      if (signal) {
         reject(new Error(`Received signal ${signal}`))
+      } else if (code !== 0) {
+        reject(new Error(`Received non-zero exit code ${code}`))
       } else {
         resolve()
       }


### PR DESCRIPTION
If we receive a signal, the exit code is undefined and thus != 0. Change the order to catch this correctly.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of signals in the control flow, ensuring signal-related errors are prioritised over non-zero exit codes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->