### PR TITLE
fix: Fetching more than 200 Azure DevOps issues

### DIFF
--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -425,21 +425,23 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     const workItems = [] as WorkItem[]
     let firstError: Error | undefined
     const uri = `https://${instanceId}/_apis/wit/workitemsbatch?api-version=7.1-preview.1`
-    const payload = !!fields
-      ? {ids: workItemIds, fields: fields}
-      : {ids: workItemIds, $expand: 'Links'}
-    const res = await this.post<WorkItemBatchResponse>(uri, payload)
-    if (res instanceof Error) {
-      if (!firstError) {
-        firstError = res
-      }
-    } else {
-      const mappedWorkItems = (res.value as WorkItem[]).map((workItem) => {
-        return {
-          ...workItem
+    // we can fetch at most 200 items at once VS403474
+    for (let i = 0; i < workItemIds.length; i += 200) {
+      const ids = workItemIds.slice(i, i + 200)
+      const payload = !!fields ? {ids, fields: fields} : {ids, $expand: 'Links'}
+      const res = await this.post<WorkItemBatchResponse>(uri, payload)
+      if (res instanceof Error) {
+        if (!firstError) {
+          firstError = res
         }
-      })
-      workItems.push(...mappedWorkItems)
+      } else {
+        const mappedWorkItems = (res.value as WorkItem[]).map((workItem) => {
+          return {
+            ...workItem
+          }
+        })
+        workItems.push(...mappedWorkItems)
+      }
     }
     return {error: firstError, workItems: workItems}
   }


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced work item fetching from Azure DevOps with improved pagination, allowing retrieval of larger sets of work items without exceeding API limits.

- **Bug Fixes**
	- Improved error handling to capture the first encountered error during work item fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->