### PR TITLE
fix(orgAdmins): Billing leaders should not see all teams in the org

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
@@ -27,9 +27,6 @@ const query = graphql`
         isViewerLead
         name
         orgId
-        organization {
-          isBillingLeader
-        }
         teamMembers(sortBy: "preferredName") {
           id
           isNotRemoved
@@ -56,9 +53,8 @@ export const OrgTeamMembers = (props: Props) => {
   } = useDialogState()
 
   if (!team) return null
-  const {isViewerLead, isOrgAdmin: isViewerOrgAdmin, teamMembers, organization} = team
-  const {isBillingLeader} = organization
-  const showMenuButton = isViewerLead || isBillingLeader || isViewerOrgAdmin
+  const {isViewerLead, isOrgAdmin: isViewerOrgAdmin, teamMembers} = team
+  const showMenuButton = isViewerLead || isViewerOrgAdmin
 
   return (
     <div className='max-w-4xl pb-4'>

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -19,7 +19,6 @@ const OrgTeams = (props: Props) => {
       fragment OrgTeams_organization on Organization {
         id
         isOrgAdmin
-        isBillingLeader
         featureFlags {
           publicTeams
         }
@@ -38,9 +37,9 @@ const OrgTeams = (props: Props) => {
     isOpen: isAddTeamDialogOpened
   } = useDialogState()
 
-  const {allTeams, isBillingLeader, isOrgAdmin, featureFlags} = organization
+  const {allTeams, isOrgAdmin, featureFlags} = organization
   const hasPublicTeamsFlag = featureFlags.publicTeams
-  const showAllTeams = isBillingLeader || isOrgAdmin || hasPublicTeamsFlag
+  const showAllTeams = isOrgAdmin || hasPublicTeamsFlag
   return (
     <div className='max-w-4xl pb-4'>
       <div className='flex items-center justify-center py-1'>

--- a/packages/server/graphql/public/types/Organization.ts
+++ b/packages/server/graphql/public/types/Organization.ts
@@ -56,15 +56,14 @@ const Organization: OrganizationResolvers = {
 
   allTeams: async ({id: orgId}, _args, {dataLoader, authToken}) => {
     const viewerId = getUserId(authToken)
-    const [allTeamsOnOrg, organization, isOrgAdmin, isBillingLeader] = await Promise.all([
+    const [allTeamsOnOrg, organization, isOrgAdmin] = await Promise.all([
       dataLoader.get('teamsByOrgIds').load(orgId),
       dataLoader.get('organizations').loadNonNull(orgId),
-      isUserOrgAdmin(viewerId, orgId, dataLoader),
-      isUserBillingLeader(viewerId, orgId, dataLoader)
+      isUserOrgAdmin(viewerId, orgId, dataLoader)
     ])
     const sortedTeamsOnOrg = allTeamsOnOrg.sort((a, b) => a.name.localeCompare(b.name))
     const hasPublicTeamsFlag = !!organization.featureFlags?.includes('publicTeams')
-    if (isBillingLeader || isOrgAdmin || isSuperUser(authToken) || hasPublicTeamsFlag) {
+    if (isOrgAdmin || isSuperUser(authToken) || hasPublicTeamsFlag) {
       const viewerTeams = sortedTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
       const otherTeams = sortedTeamsOnOrg.filter((team) => !authToken.tms.includes(team.id))
       return [...viewerTeams, ...otherTeams]


### PR DESCRIPTION
# Description

Fixes #10080 

## Testing scenarios

- [ ] Billing lead
  - Go to `http://localhost:3000/me/organizations/xxxx/teams`
  - Can only see the teams the billing lead is in
  - Click into a team, can delete the team

- [ ] Org Admin
  - Go to `http://localhost:3000/me/organizations/xxxx/teams`
  - Can see all teams within the org
  - Click into any teams, can delete them

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
