### PR TITLE
fix(orgAdmins): archived teams should be removed from the OrgTeams view

### DIFF
--- a/packages/client/mutations/ArchiveTeamMutation.ts
+++ b/packages/client/mutations/ArchiveTeamMutation.ts
@@ -106,6 +106,7 @@ export const archiveTeamTeamUpdater: SharedUpdater<ArchiveTeamMutation_team$data
   const orgs = viewer.getLinkedRecords('organizations')!
   orgs.forEach((org) => {
     safeRemoveNodeFromArray(teamId, org, 'teams')
+    safeRemoveNodeFromArray(teamId, org, 'allTeams')
   })
 
   const notification = payload.getLinkedRecord('notification')


### PR DESCRIPTION
# Description

Fixes #10076 

## Demo
![2024-08-19 14 46 35](https://github.com/user-attachments/assets/7e797d16-4a2e-4111-9ae7-d6f2c99ed97e)



## Testing scenarios
- [ ] Archive team from org admin page
  - Go to `http://localhost:3000/me/organizations/xxx/teams` as a team/billing lead or org admin
  - Click into a. team
  - Click to top-right drop down menu and select "Delete Team"
  - In the opened-up modal, type the team name and click the red button
  - Observe the page falls back to `http://localhost:3000/me/organizations/xxx/teams` and the archived team has been removed from the list

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
