### PR TITLE
fix: use period end instead of due at

### DIFF
--- a/packages/client/modules/userDashboard/components/InvoiceRow/InvoiceRow.tsx
+++ b/packages/client/modules/userDashboard/components/InvoiceRow/InvoiceRow.tsx
@@ -64,7 +64,7 @@ const InvoiceRow = (props: Props) => {
     graphql`
       fragment InvoiceRow_invoice on Invoice {
         id
-        dueAt
+        periodEndAt
         total
         payUrl
         status
@@ -72,7 +72,7 @@ const InvoiceRow = (props: Props) => {
     `,
     invoiceRef
   )
-  const {dueAt, total, payUrl, status} = invoice
+  const {periodEndAt, total, payUrl, status} = invoice
   const isEstimate = status === 'UPCOMING'
 
   return (
@@ -88,8 +88,8 @@ const InvoiceRow = (props: Props) => {
           <InfoRow>
             <InvoiceTitle>
               {status === 'UPCOMING'
-                ? `Due on ${makeDateString(dueAt)}`
-                : `${makeDateString(dueAt)}`}
+                ? `Due on ${makeDateString(periodEndAt)}`
+                : `${makeDateString(periodEndAt)}`}
             </InvoiceTitle>
             <InfoRowRight>
               <InvoiceAmount>

--- a/packages/server/graphql/public/fields/invoices.ts
+++ b/packages/server/graphql/public/fields/invoices.ts
@@ -40,26 +40,26 @@ export const invoices: NonNullable<UserResolvers['invoices']> = async (
   ])
   const parabolUpcomingInvoice: Invoice = {
     id: `upcoming_${orgId}`,
-    dueAt: fromEpochSeconds(upcomingInvoice.due_date!),
+    periodEndAt: fromEpochSeconds(upcomingInvoice.period_end!),
     total: upcomingInvoice.total,
     payUrl: session.url,
     status: 'UPCOMING'
   }
 
   const parabolPastInvoices: Invoice[] = invoices.data.map((stripeInvoice) => {
-    const {id, due_date, total, status: stripeStatus} = stripeInvoice
+    const {id, period_end, total, status: stripeStatus} = stripeInvoice
     const status: InvoiceStatusEnum =
       stripeStatus === 'uncollectible' ? 'FAILED' : stripeStatus === 'paid' ? 'PAID' : 'PENDING'
     return {
       id,
-      dueAt: fromEpochSeconds(due_date!),
+      periodEndAt: fromEpochSeconds(period_end!),
       total,
       payUrl: session.url,
       status
     }
   })
   const edges = [parabolUpcomingInvoice, ...parabolPastInvoices].map((node) => ({
-    cursor: node.dueAt,
+    cursor: node.periodEndAt,
     node
   }))
   const firstEdge = edges[0]

--- a/packages/server/graphql/public/typeDefs/Invoice.graphql
+++ b/packages/server/graphql/public/typeDefs/Invoice.graphql
@@ -8,9 +8,9 @@ type Invoice {
   id: ID!
 
   """
-  The datetime the invoice is due
+  The datetime the invoice period has ended
   """
-  dueAt: DateTime!
+  periodEndAt: DateTime!
 
   """
   The total amount for the invoice (in USD)


### PR DESCRIPTION
# Description

I mistakenly used due_at, which can be null if the payment type is automatic.
switched to period_end.