### PR TITLE
feat: add ai summary to demo

### DIFF
--- a/packages/client/modules/demo/initDB.ts
+++ b/packages/client/modules/demo/initDB.ts
@@ -527,6 +527,7 @@ const initNewMeeting = (
     votesRemaining: teamMembers.length * 5,
     phases: initPhases() as any[],
     summarySentAt: null,
+    summary: `The team are feeling the strain of too many meetings and over-packed sprints, which is stifling creativity, especially for the interns and junior staff. Clarifying processes, reducing unproductive group chats, and giving everyone more space to share ideas should help.`,
     totalVotes: MeetingSettingsThreshold.RETROSPECTIVE_TOTAL_VOTES_DEFAULT,
     maxVotesPerGroup: MeetingSettingsThreshold.RETROSPECTIVE_MAX_VOTES_PER_GROUP_DEFAULT,
     teamId: demoTeamId

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -179,7 +179,7 @@ class OpenAIServerManager {
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4',
+        model: 'gpt-4o',
         messages: [
           {
             role: 'user',
@@ -251,7 +251,7 @@ class OpenAIServerManager {
       )}, and the following reflection: "${reflection}", classify the reflection into the theme it fits in best. The reflection can only be added to one theme. Do not edit the reflection text. Your output should just be the theme name, and must be one of the themes I've provided.`
 
       const response = await this.openAIApi!.chat.completions.create({
-        model: 'gpt-4',
+        model: 'gpt-4o',
         messages: [
           {
             role: 'user',

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -179,7 +179,7 @@ class OpenAIServerManager {
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o',
+        model: 'gpt-4',
         messages: [
           {
             role: 'user',
@@ -251,7 +251,7 @@ class OpenAIServerManager {
       )}, and the following reflection: "${reflection}", classify the reflection into the theme it fits in best. The reflection can only be added to one theme. Do not edit the reflection text. Your output should just be the theme name, and must be one of the themes I've provided.`
 
       const response = await this.openAIApi!.chat.completions.create({
-        model: 'gpt-4o',
+        model: 'gpt-4',
         messages: [
           {
             role: 'user',


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/9861

<img width="600" alt="Screenshot 2024-08-23 at 16 11 57" src="https://github.com/user-attachments/assets/3f4c2862-7b82-42d7-9fed-116be54e5987">


### To test

- [ ] Create a retro demo and see an AI Summary rather than the loading text