### PR TITLE
feat(orgAdmin): search in org members page

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -82,19 +82,19 @@ const OrgMembers = (props: Props) => {
     setSearchInput(e.target.value)
   }, [])
 
-  const filteredOrganizationUsers = useMemo(() => {
-    const searchLower = searchInput.toLowerCase()
+  const filteredOrgUsers = useMemo(() => {
+    const cleanedSearchInput = searchInput.toLowerCase().trim()
     return organizationUsers.edges
       .map(({node}) => node)
       .filter(
         (user) =>
-          user.user.preferredName.toLowerCase().includes(searchLower) ||
-          user.user.email.toLowerCase().includes(searchLower)
+          user.user.preferredName.toLowerCase().includes(cleanedSearchInput) ||
+          user.user.email.toLowerCase().includes(cleanedSearchInput)
       )
   }, [organizationUsers.edges, searchInput])
 
   const finalOrgUsers = useMemo(() => {
-    return [...filteredOrganizationUsers].sort((a, b) => {
+    return [...filteredOrgUsers].sort((a, b) => {
       if (sortBy === 'lastSeenAt') {
         const aDate = a.user.lastSeenAt ? new Date(a.user.lastSeenAt) : new Date(0)
         const bDate = b.user.lastSeenAt ? new Date(b.user.lastSeenAt) : new Date(0)
@@ -108,7 +108,7 @@ const OrgMembers = (props: Props) => {
       }
       return 0
     })
-  }, [filteredOrganizationUsers, sortBy, sortDirection])
+  }, [filteredOrgUsers, sortBy, sortDirection])
 
   const handleSort = (column: keyof User) => {
     if (sortBy === column) {

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -159,7 +159,6 @@ const OrgMembers = (props: Props) => {
         </div>
       </div>
 
-      {/* Update search bar */}
       <div className='mb-4'>
         <input
           type='text'


### PR DESCRIPTION
# Description

Fixes #10185 

## Demo

![2024-09-03 14 53 53](https://github.com/user-attachments/assets/1700f2c9-6d3b-4f2f-9877-c7f0511c30e5)


## Testing scenarios

- [ ] Search by name
  - Go to org members page: `http://localhost:3000/me/organizations/xxxx/members`
  - Type something in the search bar
  - Observed name matched members present

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
