### PR TITLE
fix: multiple slack notifications

### DIFF
--- a/packages/server/dataloader/integrationAuthLoaders.ts
+++ b/packages/server/dataloader/integrationAuthLoaders.ts
@@ -187,6 +187,7 @@ export const slackNotificationsByTeamIdAndEvent = (parent: RootDataLoader) => {
       .flat()
 
     return keys.map((key) => {
+      const usedChannelIds = new Set<string>()
       return res
         .filter((doc) => doc.teamId === key.teamId && doc.event === key.event)
         .map((notification) => {
@@ -200,6 +201,11 @@ export const slackNotificationsByTeamIdAndEvent = (parent: RootDataLoader) => {
           }
         })
         .filter(isValid)
+        .filter(({channelId}) => {
+          if (!channelId || usedChannelIds.has(channelId)) return false
+          usedChannelIds.add(channelId)
+          return true
+        })
     })
   })
 }


### PR DESCRIPTION
# Description

forgot to filter out duplicate channelIds on the SlackNotification dataloader when refactoring to PG.