### PR TITLE
fix: Remove duplicate org users

### DIFF
--- a/packages/server/__tests__/autoJoin.test.ts
+++ b/packages/server/__tests__/autoJoin.test.ts
@@ -74,7 +74,7 @@ const signUpVerified = async (email: string) => {
   }
 }
 
-test.skip('autoJoin on multiple teams does not create duplicate `OrganizationUser`s', async () => {
+test('autoJoin on multiple teams does not create duplicate `OrganizationUser`s', async () => {
   const domain = `${faker.internet.domainWord()}.parabol.fun`
 
   const email = `${faker.internet.userName()}@${domain}`.toLowerCase()

--- a/packages/server/billing/helpers/adjustUserCount.ts
+++ b/packages/server/billing/helpers/adjustUserCount.ts
@@ -78,16 +78,14 @@ const addUser = async (orgIds: string[], user: IUser, dataLoader: DataLoaderWork
     .insertInto('OrganizationUser')
     .values(docs)
     .onConflict((oc) =>
-      oc
-        .constraint('unique_org_user')
-        .doUpdateSet({
-          joinedAt: sql`CURRENT_TIMESTAMP`,
-          removedAt: null,
-          inactive: false,
-          role: null,
-          suggestedTier: null,
-          tier: (eb) => eb.ref('excluded.tier')
-        })
+      oc.constraint('unique_org_user').doUpdateSet({
+        joinedAt: sql`CURRENT_TIMESTAMP`,
+        removedAt: null,
+        inactive: false,
+        role: null,
+        suggestedTier: null,
+        tier: (eb) => eb.ref('excluded.tier')
+      })
     )
     .execute()
   await Promise.all(

--- a/packages/server/postgres/migrations/1725438336254_addOrganizationUserUniqueConstraint.ts
+++ b/packages/server/postgres/migrations/1725438336254_addOrganizationUserUniqueConstraint.ts
@@ -1,0 +1,45 @@
+import {Kysely, PostgresDialect, sql} from 'kysely'
+import getPg from '../getPg'
+
+export async function up() {
+  const pg = new Kysely<any>({
+    dialect: new PostgresDialect({
+      pool: getPg()
+    })
+  })
+
+  // get rid of duplicates
+  // no kysely here, because I tested the SQL directly and don't want to touch it
+  await sql`
+    DELETE FROM "OrganizationUser" d USING "OrganizationUser" k
+    WHERE d."userId" = k."userId"
+      AND d."orgId" = k."orgId"
+      AND (
+        -- keep non-removed over removed
+        (k."removedAt" IS NULL AND d."removedAt" IS NOT NULL)
+        -- or removed later
+        OR (k."removedAt" IS NOT NULL
+           AND d."removedAt" IS NOT NULL
+           AND (k."removedAt" > d."removedAt"
+               OR ((k."removedAt" = d."removedAt") AND k.id > d.id)
+           )
+        )
+        -- or newer non-removed
+        OR (k."removedAt" IS NULL AND d."removedAt" IS NULL AND k.id > d.id)
+      );
+  `.execute(pg)
+
+  await pg.schema
+    .alterTable('OrganizationUser')
+    .addUniqueConstraint('unique_org_user', ['orgId', 'userId'])
+    .execute()
+}
+
+export async function down() {
+  const pg = new Kysely<any>({
+    dialect: new PostgresDialect({
+      pool: getPg()
+    })
+  })
+  await pg.schema.alterTable('OrganizationUser').dropConstraint('unique_org_user').execute()
+}


### PR DESCRIPTION

# Description

Fixes #9302
Add a constraint that forbids duplicate organization users. There is no need to have multiple entries as the join/leave events are already captured in OrganizationUserAudit.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

- [ ] Remove a user Joe from an organization
- [ ] Add Joe again
- [ ] check that Joe can see the org correctly

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
