### PR TITLE
fix(orgAdmin): user should be able to remove themselves from the org

### DIFF
--- a/packages/client/components/OrgAdminActionMenu.tsx
+++ b/packages/client/components/OrgAdminActionMenu.tsx
@@ -62,10 +62,11 @@ export const OrgAdminActionMenu = (props: Props) => {
   const {viewerId} = atmosphere
   const {role, user} = organizationUser
   const {id: userId} = user
+  const isSelf = viewerId === userId
   const orgAdminCount = billingLeaders.filter(
     (billingLeader) => billingLeader.role === 'ORG_ADMIN'
   ).length
-  const canEdit = isViewerOrgAdmin || (isViewerBillingLeaderPlus && role !== 'ORG_ADMIN')
+  const canEdit = isSelf || isViewerOrgAdmin || (isViewerBillingLeaderPlus && role !== 'ORG_ADMIN')
   const isViewerLastOrgAdmin = isViewerOrgAdmin && orgAdminCount === 1
   const isViewerLastRole = isViewerBillingLeaderPlus && billingLeaders.length === 1
 
@@ -80,7 +81,6 @@ export const OrgAdminActionMenu = (props: Props) => {
 
   const isOrgAdmin = role === 'ORG_ADMIN'
   const isBillingLeader = role === 'BILLING_LEADER'
-  const isSelf = viewerId === userId
   const roleName = role === 'ORG_ADMIN' ? 'Org Admin' : 'Billing Leader'
   const canRemoveRole =
     role &&


### PR DESCRIPTION
# Description

Fixes [🔒the issue](https://parabol.slack.com/archives/C4JAUUZ9P/p1725887797276709) where user cannot remove themselves from the org

## Demo
<img width="1330" alt="Screenshot 2024-09-09 at 13 51 41" src="https://github.com/user-attachments/assets/b9282baf-3f05-4704-bfa7-995b2c31b8dc">

## Testing scenarios

- [ ] User remove themselves
  - Logged in as a normal user without billing leader or org admin role
  - Go to `http://localhost:3000/me/organizations/xxxx/members`
  - Observe the 3-dot menu icon at the user row
  - Click it and see you can remove yourself

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
