### PR TITLE
fix: threadParent can exist outside comment table

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:server": "yarn workspace parabol-server test"
   },
   "resolutions": {
-    "typescript": "^5.3.3",
+    "typescript": "^5.6.2",
     "hoist-non-react-statics": "^3.3.0",
     "@types/react": "16.9.11",
     "@types/react-dom": "16.9.4",
@@ -126,7 +126,7 @@
     "tailwindcss": "^3.2.7",
     "terser-webpack-plugin": "^5.3.9",
     "ts-loader": "9.2.6",
-    "typescript": "^5.3.3",
+    "typescript": "^5.6.2",
     "typescript-eslint": "^8.3.0",
     "vscode-apollo-relay": "^1.5.0",
     "webpack": "^5.89.0",

--- a/packages/client/hooks/useSortNewReflectionGroup.ts
+++ b/packages/client/hooks/useSortNewReflectionGroup.ts
@@ -31,7 +31,7 @@ const useSortNewReflectionGroup = (
           ) as string
           reflectionGroup.setValue(parseInt(smallestSubColumnIdx), 'subColumnIdx')
         } else {
-          subColumnIdxCounts[currentSubColumnIdx] += 1
+          subColumnIdxCounts[currentSubColumnIdx]! += 1
         }
       })
     })

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -62,8 +62,7 @@ const OrgMembers = (props: Props) => {
   )
   const {data} = paginationRes
   const {viewer} = data
-  const {organization} = viewer
-  if (!organization) return null
+  const organization = viewer.organization!
   const {organizationUsers, name: orgName, isBillingLeader} = organization
   const billingLeaderCount = organizationUsers.edges.reduce(
     (count, {node}) =>

--- a/packages/client/utils/handleSuccessfulLogin.ts
+++ b/packages/client/utils/handleSuccessfulLogin.ts
@@ -18,13 +18,13 @@ graphql`
 `
 
 type Payload = Omit<handleSuccessfulLogin_UserLogInPayload$data, ' $fragmentType'>
-type GA4SignUpEventEmissionRequiredArgs = {
+export type GA4SignUpEventEmissionRequiredArgs = {
   isNewUser: boolean
   userId: string
   isPatient0: boolean
 }
 
-const emitGA4SignUpEvent = (args: GA4SignUpEventEmissionRequiredArgs) => {
+export const emitGA4SignUpEvent = (args: GA4SignUpEventEmissionRequiredArgs) => {
   const {isNewUser, userId, isPatient0} = args
   if (isNewUser) {
     ReactGA.event('sign_up', {
@@ -37,7 +37,7 @@ const emitGA4SignUpEvent = (args: GA4SignUpEventEmissionRequiredArgs) => {
   }
 }
 
-const handleSuccessfulLogin = (payload: Payload) => {
+export const handleSuccessfulLogin = (payload: Payload) => {
   const email = payload?.user?.email
   const userId = payload?.user?.id
   if (!email || !userId) return
@@ -46,5 +46,3 @@ const handleSuccessfulLogin = (payload: Payload) => {
   const isNewUser = payload?.isNewUser ?? false
   emitGA4SignUpEvent({isNewUser, userId, isPatient0: payload.user.isPatient0})
 }
-
-export {GA4SignUpEventEmissionRequiredArgs, emitGA4SignUpEvent, handleSuccessfulLogin}

--- a/packages/embedder/ai_models/ModelManager.ts
+++ b/packages/embedder/ai_models/ModelManager.ts
@@ -17,8 +17,8 @@ export class ModelManager {
   generationModels: Map<string, AbstractGenerationModel>
   getEmbedder(tableName?: EmbeddingsTableName): AbstractEmbeddingsModel {
     return tableName
-      ? this.embeddingModels.get(tableName)
-      : this.embeddingModels.values().next().value
+      ? this.embeddingModels.get(tableName)!
+      : this.embeddingModels.values().next().value!
   }
 
   private parseModelEnvVars(envVar: 'AI_EMBEDDING_MODELS' | 'AI_GENERATION_MODELS'): ModelConfig[] {

--- a/packages/embedder/package.json
+++ b/packages/embedder/package.json
@@ -33,8 +33,7 @@
     "openapi-fetch": "^0.10.0",
     "sucrase": "^3.32.0",
     "ts-jest": "^29.1.0",
-    "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "^5.3.3"
+    "ts-node-dev": "^1.0.0-pre.44"
   },
   "dependencies": {
     "dd-trace": "^4.2.0",

--- a/packages/gql-executor/package.json
+++ b/packages/gql-executor/package.json
@@ -22,8 +22,7 @@
     "babel-plugin-inline-import": "^3.0.0",
     "chokidar": "^3.3.1",
     "sucrase": "^3.32.0",
-    "ts-node-dev": "^1.0.0-pre.44",
-    "typescript": "^5.3.3"
+    "ts-node-dev": "^1.0.0-pre.44"
   },
   "dependencies": {
     "dd-trace": "^4.2.0",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -12,7 +12,6 @@
   "devDependencies": {
     "@playwright/test": "^1.34.3",
     "lint-staged": "^12.3.3",
-    "ts-app-env": "^1.4.2",
-    "typescript": "^5.3.3"
+    "ts-app-env": "^1.4.2"
   }
 }

--- a/packages/server/fileStorage/LocalFileStoreManager.ts
+++ b/packages/server/fileStorage/LocalFileStoreManager.ts
@@ -20,7 +20,7 @@ export default class LocalFileStoreManager extends FileStoreManager {
   protected async putFile(file: ArrayBufferLike, fullPath: string) {
     const fsAbsLocation = path.join(process.cwd(), fullPath)
     await fs.promises.mkdir(path.dirname(fsAbsLocation), {recursive: true})
-    await fs.promises.writeFile(fsAbsLocation, Buffer.from(file))
+    await fs.promises.writeFile(fsAbsLocation, Buffer.from(file) as any)
     return this.getPublicFileLocation(fullPath)
   }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -66,7 +66,6 @@
     "sucrase": "^3.32.0",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.2",
-    "typescript": "^5.3.3",
     "url-loader": "4.1.1",
     "vscode-apollo-relay": "^1.5.0",
     "webpack-bundle-analyzer": "4.3.0",

--- a/packages/server/parseBody.ts
+++ b/packages/server/parseBody.ts
@@ -14,7 +14,11 @@ const parseBody = <T = Json>({
     let buffer: Buffer
     res.onData((ab, isLast) => {
       const curBuf = Buffer.from(ab)
-      buffer = buffer ? Buffer.concat([buffer, curBuf]) : isLast ? curBuf : Buffer.concat([curBuf])
+      buffer = buffer
+        ? Buffer.concat([buffer as any, curBuf])
+        : isLast
+          ? curBuf
+          : Buffer.concat([curBuf as any])
       if (isLast) {
         try {
           resolve(parser(buffer))

--- a/packages/server/parseFormBody.ts
+++ b/packages/server/parseFormBody.ts
@@ -29,7 +29,11 @@ const parseRes = (res: HttpResponse) => {
     let buffer: Buffer
     res.onData((ab, isLast) => {
       const curBuf = Buffer.from(ab)
-      buffer = buffer ? Buffer.concat([buffer, curBuf]) : isLast ? curBuf : Buffer.concat([curBuf])
+      buffer = buffer
+        ? Buffer.concat([buffer as any, curBuf])
+        : isLast
+          ? curBuf
+          : Buffer.concat([curBuf as any])
       // give an extra MB for the rest of the payload
       if (buffer.length > Threshold.MAX_AVATAR_FILE_SIZE * 2) resolve(null)
       if (isLast) resolve(buffer)

--- a/packages/server/postgres/migrations/1726174443131_dropThreadParentId.ts
+++ b/packages/server/postgres/migrations/1726174443131_dropThreadParentId.ts
@@ -1,0 +1,27 @@
+import {Kysely, PostgresDialect} from 'kysely'
+import {Client} from 'pg'
+import getPg from '../getPg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  // threadParentId can exist outside comment table (task, poll, etc)
+  await client.query(
+    `ALTER TABLE "Comment" DROP CONSTRAINT IF EXISTS fk_threadParentId;` /* Do good magic */
+  )
+  await client.end()
+}
+
+export async function down() {
+  const pg = new Kysely<any>({
+    dialect: new PostgresDialect({
+      pool: getPg()
+    })
+  })
+  await pg.schema
+    .alterTable('Comment')
+    .addForeignKeyConstraint('fk_threadParentId', ['threadParentId'], 'Comment', ['id'])
+    .onDelete('set null')
+    .execute()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -22460,10 +22460,10 @@ typescript-eslint@^8.3.0:
     "@typescript-eslint/parser" "8.3.0"
     "@typescript-eslint/utils" "8.3.0"
 
-"typescript@^3 || ^4", typescript@^5.3.3, typescript@^5.5.4:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
+"typescript@^3 || ^4", typescript@^5.3.3, typescript@^5.5.4, typescript@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
 uWebSockets.js@uNetworking/uWebSockets.js#v20.34.0:
   version "20.34.0"


### PR DESCRIPTION
# Description

threadParentId exists on Task, too, so we can't use it as a foreign key just on Comment.

Also bumped the version of typescript since we were a few behind & i started getting errors when using the vscode version vs. our workspace version.