### PR TITLE
fix(misc): show full length of agenda item text when hovering

### DIFF
--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -121,7 +121,7 @@ const MeetingSubnavItem = (props: Props) => {
             {children}
           </ItemLabel>
         </TooltipTrigger>
-        <TooltipContent>{children}</TooltipContent>
+        <TooltipContent className='text-xs'>{children}</TooltipContent>
       </Tooltip>
       <ItemMeta>{metaContent}</ItemMeta>
     </ItemRoot>

--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -1,8 +1,11 @@
 import styled from '@emotion/styled'
-import React, {ReactNode, useRef} from 'react'
+import React, {ReactNode, useRef, useState} from 'react'
 import useScrollIntoView from '../hooks/useScrollIntoVIew'
 import {PALETTE} from '../styles/paletteV3'
 import {NavSidebar} from '../types/constEnums'
+import {Tooltip} from '../ui/Tooltip/Tooltip'
+import {TooltipContent} from '../ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '../ui/Tooltip/TooltipTrigger'
 
 const lineHeight = NavSidebar.SUB_LINE_HEIGHT
 
@@ -88,6 +91,16 @@ const MeetingSubnavItem = (props: Props) => {
   } = props
   const ref = useRef(null)
   useScrollIntoView(ref, isActive)
+  const [openTooltip, setOpenTooltip] = useState(false)
+
+  const handleMouseEnter = () => {
+    setOpenTooltip(true)
+  }
+
+  const handleMouseLeave = () => {
+    setOpenTooltip(false)
+  }
+
   return (
     <ItemRoot
       ref={ref}
@@ -98,7 +111,18 @@ const MeetingSubnavItem = (props: Props) => {
       isUnsyncedFacilitatorStage={isUnsyncedFacilitatorStage}
       onClick={!isDisabled ? onClick : undefined}
     >
-      <ItemLabel isComplete={isComplete}>{children}</ItemLabel>
+      <Tooltip open={openTooltip}>
+        <TooltipTrigger asChild>
+          <ItemLabel
+            isComplete={isComplete}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            {children}
+          </ItemLabel>
+        </TooltipTrigger>
+        <TooltipContent>{children}</TooltipContent>
+      </Tooltip>
       <ItemMeta>{metaContent}</ItemMeta>
     </ItemRoot>
   )

--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import React, {ReactNode, useRef, useState} from 'react'
+import React, {ReactNode, useRef} from 'react'
 import useScrollIntoView from '../hooks/useScrollIntoVIew'
 import {PALETTE} from '../styles/paletteV3'
 import {NavSidebar} from '../types/constEnums'
@@ -91,15 +91,6 @@ const MeetingSubnavItem = (props: Props) => {
   } = props
   const ref = useRef(null)
   useScrollIntoView(ref, isActive)
-  const [openTooltip, setOpenTooltip] = useState(false)
-
-  const handleMouseEnter = () => {
-    setOpenTooltip(true)
-  }
-
-  const handleMouseLeave = () => {
-    setOpenTooltip(false)
-  }
 
   return (
     <ItemRoot
@@ -111,15 +102,9 @@ const MeetingSubnavItem = (props: Props) => {
       isUnsyncedFacilitatorStage={isUnsyncedFacilitatorStage}
       onClick={!isDisabled ? onClick : undefined}
     >
-      <Tooltip open={openTooltip}>
+      <Tooltip>
         <TooltipTrigger asChild>
-          <ItemLabel
-            isComplete={isComplete}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-          >
-            {children}
-          </ItemLabel>
+          <ItemLabel isComplete={isComplete}>{children}</ItemLabel>
         </TooltipTrigger>
         <TooltipContent className='text-xs'>{children}</TooltipContent>
       </Tooltip>

--- a/packages/client/components/MeetingSubnavItem.tsx
+++ b/packages/client/components/MeetingSubnavItem.tsx
@@ -91,6 +91,9 @@ const MeetingSubnavItem = (props: Props) => {
   } = props
   const ref = useRef(null)
   useScrollIntoView(ref, isActive)
+  const labelRef = useRef<HTMLDivElement>(null)
+  const isOverflowing =
+    labelRef.current && labelRef.current.scrollWidth > labelRef.current.clientWidth
 
   return (
     <ItemRoot
@@ -104,9 +107,11 @@ const MeetingSubnavItem = (props: Props) => {
     >
       <Tooltip>
         <TooltipTrigger asChild>
-          <ItemLabel isComplete={isComplete}>{children}</ItemLabel>
+          <ItemLabel ref={labelRef} isComplete={isComplete}>
+            {children}
+          </ItemLabel>
         </TooltipTrigger>
-        <TooltipContent className='text-xs'>{children}</TooltipContent>
+        {isOverflowing && <TooltipContent className='text-xs'>{children}</TooltipContent>}
       </Tooltip>
       <ItemMeta>{metaContent}</ItemMeta>
     </ItemRoot>

--- a/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
+++ b/packages/client/modules/teamDashboard/components/AgendaItem/AgendaItem.tsx
@@ -238,7 +238,9 @@ const AgendaItem = (props: Props) => {
         />
       </AgendaItemStyles>
       {tooltipPortal(
-        pinned ? `Unpin "${content}" from every check-in` : `Pin "${content}" to every check-in`
+        pinned
+          ? `Unpin this agenda topic from every check-in`
+          : `Pin this agenda topic to every check-in`
       )}
     </>
   )


### PR DESCRIPTION
## Demo
![2024-09-17 10 22 13](https://github.com/user-attachments/assets/dedfbd11-7ec6-4329-8f7a-689568f7c594)


![2024-09-17 10 23 13](https://github.com/user-attachments/assets/072bc397-af33-41bc-bd34-3a90c8a09bff)



## Testing scenarios
- [ ] Agenda Item at team dash
  - Hover an agenda item at team dash page
  - See full length of the text in the tooltip
  - Delete/Pin/Unpin still works

- [ ] Agenda Item in check-in meeting
  - Hover an agenda item in a check-in meeting
  - See full length of the text in the tooltip
  - Delete/Pin/Unpin still works

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
