### PR TITLE
fix: isPaid flag when moving teams to 0-team org

### DIFF
--- a/packages/server/graphql/mutations/moveTeamToOrg.ts
+++ b/packages/server/graphql/mutations/moveTeamToOrg.ts
@@ -75,7 +75,7 @@ const moveToOrg = async (
   // RESOLUTION
   const updates = {
     orgId,
-    isPaid: !!isPaidResult?.isPaid,
+    isPaid: isPaidResult?.isPaid ?? true,
     tier: org.tier,
     trialStartDate: org.trialStartDate,
     updatedAt: new Date()


### PR DESCRIPTION
# Description

handles orgs without an unarchived team