### PR TITLE
fix: stop series when team is no more

### DIFF
--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -3,6 +3,7 @@ import tracer from 'dd-trace'
 import ms from 'ms'
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
 import {DateTime, RRuleSet} from 'rrule-rust'
+import TeamMemberId from '../../../../client/shared/gqlIds/TeamMemberId'
 import {fromDateTime, toDateTime} from '../../../../client/shared/rruleUtil'
 import getRethink from '../../../database/rethinkDriver'
 import MeetingRetrospective, {
@@ -23,6 +24,7 @@ import safeCreateRetrospective from '../../mutations/helpers/safeCreateRetrospec
 import safeCreateTeamPrompt, {DEFAULT_PROMPT} from '../../mutations/helpers/safeCreateTeamPrompt'
 import safeEndRetrospective from '../../mutations/helpers/safeEndRetrospective'
 import safeEndTeamPrompt from '../../mutations/helpers/safeEndTeamPrompt'
+import {stopMeetingSeries} from '../../public/mutations/updateRecurrenceSettings'
 import {MutationResolvers} from '../resolverTypes'
 
 const startRecurringMeeting = async (
@@ -156,14 +158,22 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (
   await tracer.trace('processRecurrence.startActiveMeetingSeries', async () =>
     Promise.allSettled(
       activeMeetingSeries.map(async (meetingSeries) => {
-        const seriesTeam = await dataLoader.get('teams').loadNonNull(meetingSeries.teamId)
-        if (seriesTeam.isArchived || !seriesTeam.isPaid) {
+        const {teamId, id: meetingSeriesId, recurrenceRule, facilitatorId} = meetingSeries
+        const teamMemberId = TeamMemberId.join(teamId, facilitatorId)
+        const [seriesTeam, facilitatorTeamMemberId] = await Promise.all([
+          dataLoader.get('teams').loadNonNull(teamId),
+          dataLoader.get('teamMembers').loadNonNull(teamMemberId)
+        ])
+        if (seriesTeam.isArchived || !facilitatorTeamMemberId.isNotRemoved) {
+          return await stopMeetingSeries(meetingSeries)
+        }
+        if (!seriesTeam.isPaid) {
           return
         }
 
         const [seriesOrg, lastMeeting] = await Promise.all([
           dataLoader.get('organizations').loadNonNull(seriesTeam.orgId),
-          dataLoader.get('lastMeetingByMeetingSeriesId').load(meetingSeries.id)
+          dataLoader.get('lastMeetingByMeetingSeriesId').load(meetingSeriesId)
         ])
 
         if (seriesOrg.lockedAt) {
@@ -172,7 +182,7 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (
 
         // For meetings that should still be active, start the meeting and set its end time.
         // Any subscriptions are handled by the shared meeting start code
-        const rrule = RRuleSet.parse(meetingSeries.recurrenceRule)
+        const rrule = RRuleSet.parse(recurrenceRule)
 
         // Only get meetings that should currently be active, i.e. meetings that should have started
         // within the last 24 hours, started after the last meeting in the series, and started before
@@ -188,7 +198,7 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (
         )
         for (const startTime of newMeetingsStartTimes) {
           const err = await tracer.trace('startRecurringMeeting', async (span) => {
-            span?.addTags({meetingSeriesId: meetingSeries.id})
+            span?.addTags({meetingSeriesId})
             return startRecurringMeeting(
               meetingSeries,
               fromDateTime(startTime.toString(), rrule.tzid).toDate(),

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -160,11 +160,11 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (
       activeMeetingSeries.map(async (meetingSeries) => {
         const {teamId, id: meetingSeriesId, recurrenceRule, facilitatorId} = meetingSeries
         const teamMemberId = TeamMemberId.join(teamId, facilitatorId)
-        const [seriesTeam, facilitatorTeamMemberId] = await Promise.all([
+        const [seriesTeam, facilitatorTeamMember] = await Promise.all([
           dataLoader.get('teams').loadNonNull(teamId),
           dataLoader.get('teamMembers').loadNonNull(teamMemberId)
         ])
-        if (seriesTeam.isArchived || !facilitatorTeamMemberId.isNotRemoved) {
+        if (seriesTeam.isArchived || !facilitatorTeamMember.isNotRemoved) {
           return await stopMeetingSeries(meetingSeries)
         }
         if (!seriesTeam.isPaid) {

--- a/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
+++ b/packages/server/graphql/public/mutations/updateRecurrenceSettings.ts
@@ -88,7 +88,7 @@ const updateMeetingSeries = async (meetingSeries: MeetingSeries, newRecurrenceRu
   await Promise.all(updates)
 }
 
-const stopMeetingSeries = async (meetingSeries: MeetingSeries) => {
+export const stopMeetingSeries = async (meetingSeries: MeetingSeries) => {
   const r = await getRethink()
   const now = new Date()
 


### PR DESCRIPTION
# Description

In production we have a case where teams that are empty are still creating series, but the new meetings have no stages since there are no team members.

We have a 2nd case where archived teams could still have active meeting series. Once a team is archived, their series should be cancelled.