### PR TITLE
feat(misc): add timer control to more meeting phases

### DIFF
--- a/packages/client/components/ActionMeetingAgendaItems.tsx
+++ b/packages/client/components/ActionMeetingAgendaItems.tsx
@@ -19,6 +19,7 @@ import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import MeetingTopBar from './MeetingTopBar'
 import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PhaseWrapper from './PhaseWrapper'
+import StageTimerDisplay from './StageTimerDisplay'
 
 interface Props extends ActionMeetingPhaseProps {
   meeting: ActionMeetingAgendaItems_meeting$key
@@ -57,6 +58,8 @@ const ActionMeetingAgendaItems = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment ActionMeetingAgendaItems_meeting on ActionMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
         showSidebar
         endedAt
         facilitatorUserId
@@ -97,6 +100,7 @@ const ActionMeetingAgendaItems = (props: Props) => {
             <StyledHeading>{content}</StyledHeading>
           </AgendaVerbatim>
           <StyledCopy>{`${preferredName}, what do you need?`}</StyledCopy>
+          <StageTimerDisplay meeting={meeting} />
           <ThreadColumn isDesktop={isDesktop}>
             <DiscussionThreadRoot
               meetingContentRef={meetingContentRef}

--- a/packages/client/components/ActionMeetingUpdates.tsx
+++ b/packages/client/components/ActionMeetingUpdates.tsx
@@ -13,6 +13,7 @@ import MeetingHeaderAndPhase from './MeetingHeaderAndPhase'
 import MeetingPhaseWrapper from './MeetingPhaseWrapper'
 import MeetingTopBar from './MeetingTopBar'
 import PhaseWrapper from './PhaseWrapper'
+import StageTimerDisplay from './StageTimerDisplay'
 import PhaseCompleteTag from './Tag/PhaseCompleteTag'
 import TaskColumns from './TaskColumns/TaskColumns'
 
@@ -41,6 +42,8 @@ const ActionMeetingUpdates = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment ActionMeetingUpdates_meeting on ActionMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
         ...ActionMeetingUpdatesPrompt_meeting
         id
         endedAt
@@ -106,6 +109,7 @@ const ActionMeetingUpdates = (props: Props) => {
         </MeetingTopBar>
         <PhaseWrapper>
           <PhaseCompleteTag isComplete={isPhaseComplete} />
+          <StageTimerDisplay meeting={meeting} />
           <StyledColumnsWrapper>
             <InnerColumnsWrapper>
               <TaskColumns

--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -19,6 +19,7 @@ import findStageAfterId from '~/utils/meetings/findStageAfterId'
 import {NewMeetingPhaseTypeEnum} from '../__generated__/MeetingControlBar_meeting.graphql'
 import useClickConfirmation from '../hooks/useClickConfirmation'
 import {bottomBarShadow, desktopBarShadow} from '../styles/elevation'
+import showTimerInPhase from '../utils/showTimerInPhase'
 import BottomControlBarReady from './BottomControlBarReady'
 import BottomControlBarRejoin from './BottomControlBarRejoin'
 import BottomControlBarTips from './BottomControlBarTips'
@@ -124,13 +125,12 @@ const MeetingControlBar = (props: Props) => {
   const {phaseType} = localPhase
   const {id: localStageId, isComplete} = localStage
   const isCheckIn = phaseType === 'checkin'
-  const isRetro = meetingType === 'retrospective'
   const isPoker = meetingType === 'poker'
   const getPossibleButtons = () => {
     const buttons = ['tips']
     if (!isFacilitating && !isCheckIn && !isComplete && !isPoker) buttons.push('ready')
     if (!isFacilitating && localStageId !== facilitatorStageId) buttons.push('rejoin')
-    if (isFacilitating && isRetro && !isCheckIn && !isComplete) buttons.push('timer')
+    if (isFacilitating && !isComplete && showTimerInPhase(phaseType)) buttons.push('timer')
     if ((isFacilitating || isPoker) && findStageAfterId(phases, localStageId)) buttons.push('next')
     if (isFacilitating) buttons.push('end')
     return buttons.map((key) => ({key}))
@@ -204,7 +204,7 @@ const MeetingControlBar = (props: Props) => {
                 <StageTimerControl
                   {...tranProps}
                   cancelConfirm={cancelConfirm}
-                  defaultTimeLimit={DEFAULT_TIME_LIMIT[phaseType]}
+                  defaultTimeLimit={DEFAULT_TIME_LIMIT[phaseType] ?? 1}
                   meeting={meeting}
                 />
               )

--- a/packages/client/components/PokerEstimatePhase.tsx
+++ b/packages/client/components/PokerEstimatePhase.tsx
@@ -19,6 +19,7 @@ import PhaseHeaderTitle from './PhaseHeaderTitle'
 import PokerEstimateHeaderCard from './PokerEstimateHeaderCard'
 import {PokerMeetingPhaseProps} from './PokerMeeting'
 import ResponsiveDashSidebar from './ResponsiveDashSidebar'
+import StageTimerDisplay from './StageTimerDisplay'
 
 const StyledMeetingHeaderAndPhase = styled(MeetingHeaderAndPhase)<{isOpen: boolean}>(
   ({isOpen}) => ({
@@ -53,6 +54,8 @@ const PokerEstimatePhase = (props: Props) => {
   const meeting = useFragment(
     graphql`
       fragment PokerEstimatePhase_meeting on PokerMeeting {
+        ...StageTimerDisplay_meeting
+        ...StageTimerControl_meeting
         ...EstimatePhaseArea_meeting
         id
         endedAt
@@ -103,6 +106,7 @@ const PokerEstimatePhase = (props: Props) => {
           <ErrorBoundary>
             <PokerEstimateHeaderCard stage={localStage} />
           </ErrorBoundary>
+          <StageTimerDisplay meeting={meeting} />
           <EstimateAreaWrapper>
             <EstimatePhaseArea gotoStageId={gotoStageId} meeting={meeting} />
           </EstimateAreaWrapper>

--- a/packages/client/utils/showTimerInPhase.ts
+++ b/packages/client/utils/showTimerInPhase.ts
@@ -1,0 +1,15 @@
+import {NewMeetingPhaseTypeEnum} from '~/__generated__/ActionMeeting_meeting.graphql'
+
+const noTimerPhases: NewMeetingPhaseTypeEnum[] = [
+  'lobby',
+  'checkin',
+  'firstcall',
+  'lastcall',
+  'SUMMARY'
+]
+
+const showTimerInPhase = (phaseType: NewMeetingPhaseTypeEnum): boolean => {
+  return !noTimerPhases.includes(phaseType)
+}
+
+export default showTimerInPhase


### PR DESCRIPTION
# Description
Originated from [this Slack message](https://parabol.slack.com/archives/C03LL1JRFH8/p1727731167093669)

## Demo
<img width="1274" alt="Screenshot 2024-10-01 at 12 24 01" src="https://github.com/user-attachments/assets/9f29d583-5efb-4774-9d68-a9cecfc5a4c0">

## Testing scenarios

- [ ] Poker meeting estimate phase
  - Start a poker meeting
  - Add some item to estimate
  - Advance to the estimate phase
  - See you can start a timer

- [ ] Action meeting agenda item phase
  - Start an action meeting
  - Add some agenda items
  - Advance to the agenda item phase
  - See you can start a timer

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
