### PR TITLE
fix: Fix crash in end checkin without pinned agenda items

### DIFF
--- a/packages/server/graphql/mutations/endCheckIn.ts
+++ b/packages/server/graphql/mutations/endCheckIn.ts
@@ -82,6 +82,7 @@ const clonePinnedAgendaItems = async (
   pinnedAgendaItems: AgendaItem[],
   dataLoader: DataLoaderInstance
 ) => {
+  if (!pinnedAgendaItems.length) return
   let curSortOrder = ''
   const clonedPins = pinnedAgendaItems.map((agendaItem) => {
     const agendaItemId = `${agendaItem.teamId}::${generateUID()}`


### PR DESCRIPTION
# Description

Postgres does not like inserts with empty lists.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

End a checkin without any pinned agenda items.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
