### PR TITLE
chore: remove feature flag owner

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -13,6 +13,7 @@
         "mappers": {
           "AddFeatureFlagSuccess": "./types/AddFeatureFlagSuccess#AddFeatureFlagSuccessSource",
           "ApplyFeatureFlagSuccess": "./types/ApplyFeatureFlagSuccess#ApplyFeatureFlagSuccessSource",
+          "RemoveFeatureFlagOwnerSuccess": "./types/RemoveFeatureFlagOwnerSuccess#RemoveFeatureFlagOwnerSuccessSource",
           "DeleteFeatureFlagSuccess": "./types/DeleteFeatureFlagSuccess#DeleteFeatureFlagSuccessSource",
           "UpdateFeatureFlagSuccess": "./types/UpdateFeatureFlagSuccess#UpdateFeatureFlagSuccessSource",
           "ChangeEmailDomainSuccess": "./types/ChangeEmailDomainSuccess#ChangeEmailDomainSuccessSource",

--- a/packages/server/graphql/private/mutations/removeFeatureFlagOwner.ts
+++ b/packages/server/graphql/private/mutations/removeFeatureFlagOwner.ts
@@ -1,0 +1,107 @@
+import getKysely from '../../../postgres/getKysely'
+import getUsersByDomain from '../../../postgres/queries/getUsersByDomain'
+import {getUsersByEmails} from '../../../postgres/queries/getUsersByEmails'
+import {getUserId} from '../../../utils/authorization'
+import standardError from '../../../utils/standardError'
+import {MutationResolvers} from '../resolverTypes'
+
+const removeFeatureFlagOwner: MutationResolvers['removeFeatureFlagOwner'] = async (
+  _source,
+  {flagName, subjects},
+  {authToken}
+) => {
+  const pg = getKysely()
+
+  const viewerId = getUserId(authToken)
+
+  const subjectKeys = Object.keys(subjects)
+
+  if (subjectKeys.length === 0) {
+    return standardError(new Error('At least one subject type must be provided'), {
+      userId: viewerId
+    })
+  }
+
+  const featureFlag = await pg
+    .selectFrom('FeatureFlag')
+    .select(['id', 'scope'])
+    .where('featureName', '=', flagName)
+    .executeTakeFirst()
+
+  if (!featureFlag) {
+    return standardError(new Error('Feature flag not found'), {userId: viewerId})
+  }
+
+  const {id: featureFlagId, scope} = featureFlag
+
+  const userIds: string[] = []
+  const teamIds: string[] = []
+  const orgIds: string[] = []
+
+  if (scope === 'User') {
+    if (subjects.emails) {
+      const users = await getUsersByEmails(subjects.emails)
+      userIds.push(...users.map((user) => user.id))
+    }
+
+    if (subjects.domains) {
+      for (const domain of subjects.domains) {
+        const domainUsers = await getUsersByDomain(domain)
+        userIds.push(...domainUsers.map((user) => user.id))
+      }
+    }
+
+    if (subjects.userIds) {
+      userIds.push(...subjects.userIds)
+    }
+  } else if (scope === 'Team') {
+    if (subjects.teamIds) {
+      teamIds.push(...subjects.teamIds)
+    }
+  } else if (scope === 'Organization') {
+    if (subjects.orgIds) {
+      orgIds.push(...subjects.orgIds)
+    }
+  }
+
+  let deletedCount = 0
+
+  if (scope === 'User' && userIds.length > 0) {
+    const result = await pg
+      .deleteFrom('FeatureFlagOwner')
+      .where('featureFlagId', '=', featureFlagId)
+      .where('userId', 'in', userIds)
+      .executeTakeFirst()
+    deletedCount = result?.numDeletedRows ?? 0
+  } else if (scope === 'Team' && teamIds.length > 0) {
+    const result = await pg
+      .deleteFrom('FeatureFlagOwner')
+      .where('featureFlagId', '=', featureFlagId)
+      .where('teamId', 'in', teamIds)
+      .executeTakeFirst()
+    deletedCount = result?.numDeletedRows ?? 0
+  } else if (scope === 'Organization' && orgIds.length > 0) {
+    const result = await pg
+      .deleteFrom('FeatureFlagOwner')
+      .where('featureFlagId', '=', featureFlagId)
+      .where('orgId', 'in', orgIds)
+      .executeTakeFirst()
+    deletedCount = result?.numDeletedRows ?? 0
+  }
+
+  if (deletedCount === 0) {
+    return standardError(
+      new Error('No feature flag owners were removed. Check the scope and subjects provided.')
+    )
+  }
+
+  return {
+    featureFlagId,
+    removedCount: deletedCount,
+    userIds: scope === 'User' ? userIds : [],
+    teamIds: scope === 'Team' ? teamIds : [],
+    orgIds: scope === 'Organization' ? orgIds : []
+  }
+}
+
+export default removeFeatureFlagOwner

--- a/packages/server/graphql/private/mutations/removeFeatureFlagOwner.ts
+++ b/packages/server/graphql/private/mutations/removeFeatureFlagOwner.ts
@@ -98,9 +98,9 @@ const removeFeatureFlagOwner: MutationResolvers['removeFeatureFlagOwner'] = asyn
   return {
     featureFlagId,
     removedCount: deletedCount,
-    userIds: scope === 'User' ? userIds : [],
-    teamIds: scope === 'Team' ? teamIds : [],
-    orgIds: scope === 'Organization' ? orgIds : []
+    userIds: scope === 'User' ? userIds : null,
+    teamIds: scope === 'Team' ? teamIds : null,
+    orgIds: scope === 'Organization' ? orgIds : null
   }
 }
 

--- a/packages/server/graphql/private/mutations/removeFeatureFlagOwner.ts
+++ b/packages/server/graphql/private/mutations/removeFeatureFlagOwner.ts
@@ -72,21 +72,21 @@ const removeFeatureFlagOwner: MutationResolvers['removeFeatureFlagOwner'] = asyn
       .where('featureFlagId', '=', featureFlagId)
       .where('userId', 'in', userIds)
       .executeTakeFirst()
-    deletedCount = result?.numDeletedRows ?? 0
+    deletedCount = Number(result?.numDeletedRows ?? 0)
   } else if (scope === 'Team' && teamIds.length > 0) {
     const result = await pg
       .deleteFrom('FeatureFlagOwner')
       .where('featureFlagId', '=', featureFlagId)
       .where('teamId', 'in', teamIds)
       .executeTakeFirst()
-    deletedCount = result?.numDeletedRows ?? 0
+    deletedCount = Number(result?.numDeletedRows ?? 0)
   } else if (scope === 'Organization' && orgIds.length > 0) {
     const result = await pg
       .deleteFrom('FeatureFlagOwner')
       .where('featureFlagId', '=', featureFlagId)
       .where('orgId', 'in', orgIds)
       .executeTakeFirst()
-    deletedCount = result?.numDeletedRows ?? 0
+    deletedCount = Number(result?.numDeletedRows ?? 0)
   }
 
   if (deletedCount === 0) {

--- a/packages/server/graphql/private/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/private/typeDefs/Mutation.graphql
@@ -39,6 +39,20 @@ type Mutation {
   ): ApplyFeatureFlagPayload!
 
   """
+  Remove a feature flag from specified subjects (users, teams, or organizations)
+  """
+  removeFeatureFlagOwner(
+    """
+    The name of the feature flag to remove
+    """
+    flagName: String!
+    """
+    The subjects from which the feature flag will be removed
+    """
+    subjects: SubjectsInput!
+  ): RemoveFeatureFlagOwnerPayload!
+
+  """
   Delete an existing feature flag
   """
   deleteFeatureFlag(

--- a/packages/server/graphql/private/typeDefs/RemoveFeatureFlagOwnerSuccess.graphql
+++ b/packages/server/graphql/private/typeDefs/RemoveFeatureFlagOwnerSuccess.graphql
@@ -1,0 +1,21 @@
+"""
+Successful result of removing a feature flag owner
+"""
+type RemoveFeatureFlagOwnerSuccess {
+  """
+  The feature flag that was removed
+  """
+  featureFlag: FeatureFlag!
+  """
+  The feature flag was removed from the following users
+  """
+  users: [User!]
+  """
+  The feature flag was removed from the following teams
+  """
+  teams: [Team!]
+  """
+  The feature flag was removed from the following organizations
+  """
+  organizations: [Organization!]
+}

--- a/packages/server/graphql/private/typeDefs/RemoveFeatureFlagOwnerSuccess.graphql
+++ b/packages/server/graphql/private/typeDefs/RemoveFeatureFlagOwnerSuccess.graphql
@@ -18,4 +18,8 @@ type RemoveFeatureFlagOwnerSuccess {
   The feature flag was removed from the following organizations
   """
   organizations: [Organization!]
+  """
+  The number of subjects the feature flag was removed from
+  """
+  removedCount: Int!
 }

--- a/packages/server/graphql/private/typeDefs/RemoveFeatureFlagPayload.graphql
+++ b/packages/server/graphql/private/typeDefs/RemoveFeatureFlagPayload.graphql
@@ -1,0 +1,4 @@
+"""
+Return value for removeFeatureFlagOwner, which could be an error or success
+"""
+union RemoveFeatureFlagOwnerPayload = ErrorPayload | RemoveFeatureFlagOwnerSuccess

--- a/packages/server/graphql/private/types/RemoveFeatureFlagOwnerSuccess.ts
+++ b/packages/server/graphql/private/types/RemoveFeatureFlagOwnerSuccess.ts
@@ -6,6 +6,7 @@ export type RemoveFeatureFlagOwnerSuccessSource = {
   userIds: string[] | null
   teamIds: string[] | null
   orgIds: string[] | null
+  removedCount: number
 }
 
 const RemoveFeatureFlagOwnerSuccess: RemoveFeatureFlagOwnerSuccessResolvers = {
@@ -23,7 +24,8 @@ const RemoveFeatureFlagOwnerSuccess: RemoveFeatureFlagOwnerSuccessResolvers = {
   organizations: async ({orgIds}, _args, {dataLoader}) => {
     if (!orgIds) return null
     return (await dataLoader.get('organizations').loadMany(orgIds)).filter(isValid)
-  }
+  },
+  removedCount: ({removedCount}) => removedCount
 }
 
 export default RemoveFeatureFlagOwnerSuccess

--- a/packages/server/graphql/private/types/RemoveFeatureFlagOwnerSuccess.ts
+++ b/packages/server/graphql/private/types/RemoveFeatureFlagOwnerSuccess.ts
@@ -1,0 +1,29 @@
+import isValid from '../../isValid'
+import {RemoveFeatureFlagOwnerSuccessResolvers} from '../resolverTypes'
+
+export type RemoveFeatureFlagOwnerSuccessSource = {
+  featureFlagId: string
+  userIds: string[] | null
+  teamIds: string[] | null
+  orgIds: string[] | null
+}
+
+const RemoveFeatureFlagOwnerSuccess: RemoveFeatureFlagOwnerSuccessResolvers = {
+  featureFlag: async ({featureFlagId}, _args, {dataLoader}) => {
+    return dataLoader.get('featureFlags').loadNonNull(featureFlagId)
+  },
+  users: async ({userIds}, _args, {dataLoader}) => {
+    if (!userIds) return null
+    return (await dataLoader.get('users').loadMany(userIds)).filter(isValid)
+  },
+  teams: async ({teamIds}, _args, {dataLoader}) => {
+    if (!teamIds) return null
+    return (await dataLoader.get('teams').loadMany(teamIds)).filter(isValid)
+  },
+  organizations: async ({orgIds}, _args, {dataLoader}) => {
+    if (!orgIds) return null
+    return (await dataLoader.get('organizations').loadMany(orgIds)).filter(isValid)
+  }
+}
+
+export default RemoveFeatureFlagOwnerSuccess


### PR DESCRIPTION
With this PR, we can remove feature flag owners. I prefer creating a new mutation rather than updating `applyFeatureFlag` because I think it's better to have distinct names to make it clearer for the sales team. 

### To Test

Add a feature flag, apply a feature flag to a subject, e.g. an orgId, and the remove it like so:

```
mutation { 
  removeFeatureFlagOwner(flagName: "hasSingleColumnStandupsFlag", subjects: {
    orgIds: ["AQQ5zJw652"]
  }
  ) {
    __typename
    ... on RemoveFeatureFlagOwnerSuccess {
      organizations {
  name
        featureFlag(featureName: "hasSingleColumnStandupsFlag")
      }
    }
    ... on ErrorPayload {
      error {
        message
      }
    }  
  }
}
```