### PR TITLE
fix: catch error if user tries to join meeting twice

### DIFF
--- a/packages/client/hooks/useAutoCheckIn.ts
+++ b/packages/client/hooks/useAutoCheckIn.ts
@@ -1,5 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
-import {useEffect} from 'react'
+import {useEffect, useRef} from 'react'
 import {readInlineData} from 'relay-runtime'
 import {useAutoCheckIn_meeting$key} from '~/__generated__/useAutoCheckIn_meeting.graphql'
 import JoinMeetingMutation from '../mutations/JoinMeetingMutation'
@@ -12,6 +12,7 @@ const useAutoCheckIn = (meetingRef: useAutoCheckIn_meeting$key) => {
   const {history, location} = useRouter()
   const router = {history, location}
   const queryKey = 'useAutoCheckIn'
+  const hasCalledJoinedRef = useRef(false)
   useEffect(() => {
     const meeting = readInlineData(
       graphql`
@@ -33,7 +34,8 @@ const useAutoCheckIn = (meetingRef: useAutoCheckIn_meeting$key) => {
     }
     if (viewerMeetingMember) {
       subscribeToMeeting()
-    } else if (!endedAt) {
+    } else if (!endedAt && !hasCalledJoinedRef.current) {
+      hasCalledJoinedRef.current = true
       JoinMeetingMutation(
         atmosphere,
         {meetingId},

--- a/packages/server/graphql/mutations/joinMeeting.ts
+++ b/packages/server/graphql/mutations/joinMeeting.ts
@@ -71,7 +71,12 @@ const joinMeeting = {
     const teamMemberId = toTeamMemberId(teamId, viewerId)
     const teamMember = await dataLoader.get('teamMembers').loadNonNull(teamMemberId)
     const meetingMember = createMeetingMember(meeting, teamMember)
-    await pg.insertInto('MeetingMember').values(meetingMember).execute()
+    try {
+      await pg.insertInto('MeetingMember').values(meetingMember).execute()
+    } catch {
+      return {error: {message: 'Could not join meeting'}}
+    }
+
     const addStageToPhase = async (
       stage: CheckInStage | UpdatesStage | TeamPromptResponseStage,
       phaseType: NewMeetingPhase['phaseType']


### PR DESCRIPTION
# Description

Sentry started reporting a new error: `duplicate key value violates unique constraint "MeetingMember_pkey"`.
This is called because `joinMeeting` must be getting called by the same user multiple times.
To prevent this, I stopped the client from issuing multiple calls & stopped the server in case the meeting member was already created.

