### PR TITLE
fix: correct serialization of Task.content

### DIFF
--- a/packages/server/postgres/migrations/1728596434080_Task-phase2fixup.ts
+++ b/packages/server/postgres/migrations/1728596434080_Task-phase2fixup.ts
@@ -1,0 +1,20 @@
+import {Kysely, PostgresDialect, sql} from 'kysely'
+import getPg from '../getPg'
+
+export async function up() {
+  const pg = new Kysely<any>({
+    dialect: new PostgresDialect({
+      pool: getPg()
+    })
+  })
+
+  await pg
+    .updateTable('Task')
+    // coerce the serialized string to jsonb
+    .set({content: sql`(content #>> '{}')::jsonb`})
+    .execute()
+}
+
+export async function down() {
+  // noop
+}


### PR DESCRIPTION
# Description

The phase 2 migration serialized the `content` column 1 too many times.
This corrects that problem