### PR TITLE
fix: complete partial value for updateTaskPayload

### DIFF
--- a/packages/server/graphql/public/types/UpdateTaskPayload.ts
+++ b/packages/server/graphql/public/types/UpdateTaskPayload.ts
@@ -22,9 +22,15 @@ const UpdateTaskPayload: UpdateTaskPayloadResolvers = {
     return isPrivatized ? taskId : null
   },
 
-  addedNotification: async ({notificationsToAdd}, _args, {authToken}) => {
+  addedNotification: async ({notificationsToAdd}, _args, {authToken, dataLoader}) => {
     const viewerId = getUserId(authToken)
-    return notificationsToAdd?.find((notification) => notification.userId === viewerId) ?? null
+    const partial =
+      notificationsToAdd?.find((notification) => notification.userId === viewerId) ?? null
+    if (!partial) return null
+    const notification = await dataLoader
+      .get('notifications')
+      .loadNonNull<TaskInvolvesNotification>(partial.id)
+    return notification
   }
 }
 


### PR DESCRIPTION
# Description

uses the full payload from the DB instead of a partial (saw this bug come through in sentry)
