### PR TITLE
chore: Add migration for shared secret integration provider

### DIFF
--- a/packages/server/postgres/migrations/1729269619262_addSharedSecretIntegrationProvider.ts
+++ b/packages/server/postgres/migrations/1729269619262_addSharedSecretIntegrationProvider.ts
@@ -1,0 +1,48 @@
+import {Client} from 'pg'
+import getPgConfig from '../getPgConfig'
+
+export async function up() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+  DO $$
+  BEGIN
+    ALTER TYPE "IntegrationProviderAuthStrategyEnum" ADD VALUE IF NOT EXISTS 'sharedSecret';
+    ALTER TABLE "IntegrationProvider"
+      ADD COLUMN IF NOT EXISTS "sharedSecret" VARCHAR(255);
+
+    ALTER TABLE "TeamMemberIntegrationAuth"
+      ADD COLUMN IF NOT EXISTS "channel" VARCHAR(255);
+  END $$;
+  `)
+  await client.end()
+}
+
+export async function down() {
+  const client = new Client(getPgConfig())
+  await client.connect()
+  await client.query(`
+  DO $$
+  BEGIN
+    DELETE FROM "IntegrationProvider" WHERE "authStrategy" = 'sharedSecret';
+    ALTER TYPE "IntegrationProviderAuthStrategyEnum" RENAME TO "IntegrationProviderAuthStrategyEnumA_delete";
+
+    CREATE TYPE "IntegrationProviderAuthStrategyEnum" AS ENUM (
+      'pat',
+      'oauth2',
+      'webhook',
+      'oauth1'
+    );
+
+    ALTER TABLE "IntegrationProvider"
+      DROP COLUMN IF EXISTS "sharedSecret",
+      ALTER COLUMN "authStrategy" TYPE "IntegrationProviderAuthStrategyEnum" USING "authStrategy"::text::"IntegrationProviderAuthStrategyEnum";
+
+    DROP TYPE "IntegrationProviderAuthStrategyEnumA_delete";
+
+    ALTER TABLE "TeamMemberIntegrationAuth"
+      DROP COLUMN IF EXISTS "channel";
+  END $$;
+  `)
+  await client.end()
+}


### PR DESCRIPTION
# Description

Preparations for #10360
For mattermost notifications we need to store a shared key and the server url in the integration provider. To make it explicit I added a new field for the key. The serverBaseURL field is already very fitting, so reusing that one.
Unlike the previous webhook integration, the provider will be used on org or global scope and does not have the channel information. This needs to go into the integration auth.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
