### PR TITLE
fix: if not exists on meetingsCount

### DIFF
--- a/packages/server/postgres/migrations/1729696433080_addMeetingsCountToInsight.ts
+++ b/packages/server/postgres/migrations/1729696433080_addMeetingsCountToInsight.ts
@@ -6,7 +6,7 @@ export async function up() {
   await client.connect()
   await client.query(`
     ALTER TABLE "Insight"
-    ADD COLUMN "meetingsCount" INTEGER NOT NULL DEFAULT 0;
+    ADD COLUMN IF NOT EXISTS "meetingsCount" INTEGER NOT NULL DEFAULT 0;
   `)
   await client.end()
 }


### PR DESCRIPTION
# Description

`1728596433080_addMeetingsCountToInsight` was already pushed to prod, but now the migration exists with a new name.
this fixes that