### PR TITLE
fix: reset retro group safely

### DIFF
--- a/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
+++ b/packages/server/graphql/mutations/resetRetroMeetingToGroupStage.ts
@@ -110,13 +110,14 @@ const resetRetroMeetingToGroupStage = {
         .where('discussionId', 'in', discussionIdsToDelete)
         .execute()
     }
+    if (reflectionGroupIds.length > 0) {
+      await pg
+        .updateTable('RetroReflectionGroup')
+        .set({voterIds: [], discussionPromptQuestion: null})
+        .where('id', 'in', reflectionGroupIds)
+        .execute()
+    }
     await pg
-      .with('ResetGroups', (qb) =>
-        qb
-          .updateTable('RetroReflectionGroup')
-          .set({voterIds: [], discussionPromptQuestion: null})
-          .where('id', 'in', reflectionGroupIds)
-      )
       .with('ResetMeetingMember', (qb) =>
         qb
           .updateTable('MeetingMember')


### PR DESCRIPTION
# Description

ensures there are groups before running query