### PR TITLE
chore(metrics): add metrics to identify who attempte to upgrade organization

### DIFF
--- a/packages/server/graphql/public/mutations/createStripeSubscription.ts
+++ b/packages/server/graphql/public/mutations/createStripeSubscription.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe'
+import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
 import standardError from '../../../utils/standardError'
 import {getStripeManager} from '../../../utils/stripe'
@@ -50,6 +51,7 @@ const createStripeSubscription: MutationResolvers['createStripeSubscription'] = 
   const paymentIntent = latestInvoice.payment_intent as Stripe.PaymentIntent
   const clientSecret = paymentIntent.client_secret
 
+  analytics.organizationUpgradeAttempted(viewer, orgId)
   const data = {stripeSubscriptionClientSecret: clientSecret}
   return data
 }

--- a/packages/server/utils/analytics/analytics.ts
+++ b/packages/server/utils/analytics/analytics.ts
@@ -132,6 +132,7 @@ export type AnalyticsEvent =
   | 'Notification Email Sent'
   // org
   | 'Upgrade CTA Clicked'
+  | 'Organization Upgrade Attempted'
   | 'Organization Upgraded'
   | 'Downgrade Clicked'
   | 'Downgrade Continue Clicked'
@@ -504,6 +505,10 @@ class Analytics {
   //org
   clickedUpgradeCTA = (user: AnalyticsUser, upgradeCTALocation: UpgradeCTALocationEnumType) => {
     this.track(user, 'Upgrade CTA Clicked', {upgradeCTALocation})
+  }
+
+  organizationUpgradeAttempted = (user: AnalyticsUser, orgId: string) => {
+    this.track(user, 'Organization Upgrade Attempted', {orgId})
   }
 
   organizationUpgraded = (


### PR DESCRIPTION
# Description

We have a long-term bug where we lost track of the user who has performed self-serve upgrade (we just record `love@parabol.co` did that). This has caused issue like [this one](https://parabol.slack.com/archives/C03C3J42WDU/p1730223946941409).

This small PR is a walk around fix: we emit a new metric when a user attempted to upgrade. This way later in the data sanctum we can then join this new metric with the old `Organization Upgraded` metric to find the match.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
