### PR TITLE
feat: org feature flags UI

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgDetails.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgDetails.tsx
@@ -1,19 +1,41 @@
+import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {Suspense} from 'react'
+import React, {Suspense, useState} from 'react'
 import {useFragment} from 'react-relay'
 import {OrgDetails_organization$key} from '../../../../__generated__/OrgDetails_organization.graphql'
 import Avatar from '../../../../components/Avatar/Avatar'
 import EditableAvatar from '../../../../components/EditableAvatar/EditableAvatar'
 import EditableOrgName from '../../../../components/EditableOrgName'
 import OrgAvatarInput from '../../../../components/OrgAvatarInput'
+import Panel from '../../../../components/Panel/Panel'
+import Toggle from '../../../../components/Toggle/Toggle'
 import useModal from '../../../../hooks/useModal'
+import {PALETTE} from '../../../../styles/paletteV3'
 import defaultOrgAvatar from '../../../../styles/theme/images/avatar-organization.svg'
+import {ElementWidth, Layout} from '../../../../types/constEnums'
 import OrganizationDetails from '../Organization/OrganizationDetails'
 import OrgBillingDangerZone from './OrgBillingDangerZone'
+import OrgFeatures from './OrgFeatures'
 
 type Props = {
   organizationRef: OrgDetails_organization$key
 }
+
+const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
+  maxWidth: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
+}))
+
+const PanelRow = styled('div')({
+  borderTop: `1px solid ${PALETTE.SLATE_300}`,
+  padding: Layout.ROW_GUTTER
+})
+
+const FeatureRow = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: 8
+})
 
 const OrgDetails = (props: Props) => {
   const {organizationRef} = props
@@ -46,6 +68,13 @@ const OrgDetails = (props: Props) => {
   const orgName = name ?? 'Unknown'
   const {togglePortal, modalPortal} = useModal()
 
+  // Add state for toggles
+  const [showAIFeatures, setShowAIFeatures] = useState(false)
+  const [suggestGroups, setSuggestGroups] = useState(false)
+  const [publicTeams, setPublicTeams] = useState(false)
+  const [standUpAISummary, setStandUpAISummary] = useState(false)
+  const [relatedDiscussions, setRelatedDiscussions] = useState(false)
+
   return (
     <Suspense fallback={''}>
       <div className='mb-4 flex w-full items-center'>
@@ -66,6 +95,44 @@ const OrgDetails = (props: Props) => {
           <OrganizationDetails createdAt={createdAt} billingTier={billingTier} tier={tier} />
         </div>
       </div>
+
+      {/* <StyledPanel isWide label='AI Features'>
+        <PanelRow>
+          <FeatureRow>
+            <span>Show AI Features</span>
+            <Toggle active={showAIFeatures} onClick={() => setShowAIFeatures(!showAIFeatures)} />
+          </FeatureRow>
+        </PanelRow>
+      </StyledPanel> */}
+      <OrgFeatures />
+
+      <StyledPanel isWide label='Organization Feature Flags'>
+        <PanelRow>
+          <FeatureRow>
+            <span>Suggest Groups</span>
+            <Toggle active={suggestGroups} onClick={() => setSuggestGroups(!suggestGroups)} />
+          </FeatureRow>
+          <FeatureRow>
+            <span>Public Teams</span>
+            <Toggle active={publicTeams} onClick={() => setPublicTeams(!publicTeams)} />
+          </FeatureRow>
+          <FeatureRow>
+            <span>StandUp AI Summary</span>
+            <Toggle
+              active={standUpAISummary}
+              onClick={() => setStandUpAISummary(!standUpAISummary)}
+            />
+          </FeatureRow>
+          <FeatureRow>
+            <span>Related Discussions</span>
+            <Toggle
+              active={relatedDiscussions}
+              onClick={() => setRelatedDiscussions(!relatedDiscussions)}
+            />
+          </FeatureRow>
+        </PanelRow>
+      </StyledPanel>
+
       <OrgBillingDangerZone organization={organization} isWide />
     </Suspense>
   )

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgDetails.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgDetails.tsx
@@ -1,41 +1,21 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
-import React, {Suspense, useState} from 'react'
+import React, {Suspense} from 'react'
 import {useFragment} from 'react-relay'
 import {OrgDetails_organization$key} from '../../../../__generated__/OrgDetails_organization.graphql'
 import Avatar from '../../../../components/Avatar/Avatar'
 import EditableAvatar from '../../../../components/EditableAvatar/EditableAvatar'
 import EditableOrgName from '../../../../components/EditableOrgName'
 import OrgAvatarInput from '../../../../components/OrgAvatarInput'
-import Panel from '../../../../components/Panel/Panel'
-import Toggle from '../../../../components/Toggle/Toggle'
 import useModal from '../../../../hooks/useModal'
-import {PALETTE} from '../../../../styles/paletteV3'
 import defaultOrgAvatar from '../../../../styles/theme/images/avatar-organization.svg'
-import {ElementWidth, Layout} from '../../../../types/constEnums'
 import OrganizationDetails from '../Organization/OrganizationDetails'
 import OrgBillingDangerZone from './OrgBillingDangerZone'
+import OrgFeatureFlags from './OrgFeatureFlags'
 import OrgFeatures from './OrgFeatures'
 
 type Props = {
   organizationRef: OrgDetails_organization$key
 }
-
-const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
-  maxWidth: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
-}))
-
-const PanelRow = styled('div')({
-  borderTop: `1px solid ${PALETTE.SLATE_300}`,
-  padding: Layout.ROW_GUTTER
-})
-
-const FeatureRow = styled('div')({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  marginBottom: 8
-})
 
 const OrgDetails = (props: Props) => {
   const {organizationRef} = props
@@ -68,13 +48,6 @@ const OrgDetails = (props: Props) => {
   const orgName = name ?? 'Unknown'
   const {togglePortal, modalPortal} = useModal()
 
-  // Add state for toggles
-  const [showAIFeatures, setShowAIFeatures] = useState(false)
-  const [suggestGroups, setSuggestGroups] = useState(false)
-  const [publicTeams, setPublicTeams] = useState(false)
-  const [standUpAISummary, setStandUpAISummary] = useState(false)
-  const [relatedDiscussions, setRelatedDiscussions] = useState(false)
-
   return (
     <Suspense fallback={''}>
       <div className='mb-4 flex w-full items-center'>
@@ -96,43 +69,8 @@ const OrgDetails = (props: Props) => {
         </div>
       </div>
 
-      {/* <StyledPanel isWide label='AI Features'>
-        <PanelRow>
-          <FeatureRow>
-            <span>Show AI Features</span>
-            <Toggle active={showAIFeatures} onClick={() => setShowAIFeatures(!showAIFeatures)} />
-          </FeatureRow>
-        </PanelRow>
-      </StyledPanel> */}
       <OrgFeatures />
-
-      <StyledPanel isWide label='Organization Feature Flags'>
-        <PanelRow>
-          <FeatureRow>
-            <span>Suggest Groups</span>
-            <Toggle active={suggestGroups} onClick={() => setSuggestGroups(!suggestGroups)} />
-          </FeatureRow>
-          <FeatureRow>
-            <span>Public Teams</span>
-            <Toggle active={publicTeams} onClick={() => setPublicTeams(!publicTeams)} />
-          </FeatureRow>
-          <FeatureRow>
-            <span>StandUp AI Summary</span>
-            <Toggle
-              active={standUpAISummary}
-              onClick={() => setStandUpAISummary(!standUpAISummary)}
-            />
-          </FeatureRow>
-          <FeatureRow>
-            <span>Related Discussions</span>
-            <Toggle
-              active={relatedDiscussions}
-              onClick={() => setRelatedDiscussions(!relatedDiscussions)}
-            />
-          </FeatureRow>
-        </PanelRow>
-      </StyledPanel>
-
+      <OrgFeatureFlags />
       <OrgBillingDangerZone organization={organization} isWide />
     </Suspense>
   )

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled'
+import {Info as InfoIcon} from '@mui/icons-material'
+import React, {useState} from 'react'
+import Panel from '../../../../components/Panel/Panel'
+import Toggle from '../../../../components/Toggle/Toggle'
+import {PALETTE} from '../../../../styles/paletteV3'
+import {ElementWidth, Layout} from '../../../../types/constEnums'
+import {Tooltip} from '../../../../ui/Tooltip/Tooltip'
+import {TooltipContent} from '../../../../ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '../../../../ui/Tooltip/TooltipTrigger'
+
+const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
+  maxWidth: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
+}))
+
+const PanelRow = styled('div')({
+  borderTop: `1px solid ${PALETTE.SLATE_300}`,
+  padding: Layout.ROW_GUTTER
+})
+
+const FeatureRow = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: 8
+})
+
+const FeatureNameGroup = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4
+})
+
+const features = [
+  {
+    id: 'suggestGroups',
+    name: 'Suggest Groups',
+    tooltip:
+      'Get AI-powered suggestions for creating new groups based on team activity and collaboration patterns'
+  },
+  {
+    id: 'publicTeams',
+    name: 'Public Teams',
+    tooltip: 'Allow teams to be discoverable by anyone in your organization'
+  },
+  {
+    id: 'standupAISummary',
+    name: 'Stand-Up AI Summary',
+    tooltip: 'Automatically generate summaries of your team standups using AI'
+  },
+  {
+    id: 'relatedDiscussions',
+    name: 'Related Discussions',
+    tooltip: 'See AI-suggested related discussions and threads across your organization'
+  }
+]
+
+const OrgFeatureFlags = () => {
+  const [featureStates, setFeatureStates] = useState<Record<string, boolean>>({
+    suggestGroups: false,
+    publicTeams: false,
+    standupAISummary: false,
+    relatedDiscussions: false
+  })
+
+  const handleToggle = (featureId: string) => {
+    setFeatureStates((prev) => ({
+      ...prev,
+      [featureId]: !prev[featureId]
+    }))
+  }
+
+  return (
+    <StyledPanel isWide label='Organization Feature Flags'>
+      <PanelRow>
+        {features.map((feature) => (
+          <FeatureRow key={feature.id}>
+            <FeatureNameGroup>
+              <span>{feature.name}</span>
+              <Tooltip>
+                <TooltipTrigger className='bg-transparent hover:cursor-pointer'>
+                  <InfoIcon className='h-4 w-4 text-slate-600' />
+                </TooltipTrigger>
+                <TooltipContent>{feature.tooltip}</TooltipContent>
+              </Tooltip>
+            </FeatureNameGroup>
+            <Toggle active={featureStates[feature.id]!} onClick={() => handleToggle(feature.id)} />
+          </FeatureRow>
+        ))}
+      </PanelRow>
+    </StyledPanel>
+  )
+}
+
+export default OrgFeatureFlags

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatures.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatures.tsx
@@ -1,9 +1,13 @@
 import styled from '@emotion/styled'
+import {Info as InfoIcon} from '@mui/icons-material'
 import React, {useState} from 'react'
 import Panel from '../../../../components/Panel/Panel'
 import Toggle from '../../../../components/Toggle/Toggle'
 import {PALETTE} from '../../../../styles/paletteV3'
 import {ElementWidth, Layout} from '../../../../types/constEnums'
+import {Tooltip} from '../../../../ui/Tooltip/Tooltip'
+import {TooltipContent} from '../../../../ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '../../../../ui/Tooltip/TooltipTrigger'
 
 const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
   maxWidth: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
@@ -21,6 +25,12 @@ const FeatureRow = styled('div')({
   marginBottom: 8
 })
 
+const FeatureNameGroup = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4
+})
+
 const OrgFeatures = () => {
   const [showAIFeatures, setShowAIFeatures] = useState(false)
 
@@ -28,7 +38,15 @@ const OrgFeatures = () => {
     <StyledPanel isWide label='AI Features'>
       <PanelRow>
         <FeatureRow>
-          <span>Show AI Features</span>
+          <FeatureNameGroup>
+            <span>Show AI Features</span>
+            <Tooltip>
+              <TooltipTrigger className='bg-transparent hover:cursor-pointer'>
+                <InfoIcon className='h-4 w-4 text-slate-600' />
+              </TooltipTrigger>
+              <TooltipContent>Enable AI-powered features across your organization</TooltipContent>
+            </Tooltip>
+          </FeatureNameGroup>
           <Toggle active={showAIFeatures} onClick={() => setShowAIFeatures(!showAIFeatures)} />
         </FeatureRow>
       </PanelRow>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatures.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatures.tsx
@@ -1,24 +1,38 @@
+import styled from '@emotion/styled'
 import React, {useState} from 'react'
+import Panel from '../../../../components/Panel/Panel'
 import Toggle from '../../../../components/Toggle/Toggle'
+import {PALETTE} from '../../../../styles/paletteV3'
+import {ElementWidth, Layout} from '../../../../types/constEnums'
+
+const StyledPanel = styled(Panel)<{isWide: boolean}>(({isWide}) => ({
+  maxWidth: isWide ? ElementWidth.PANEL_WIDTH : 'inherit'
+}))
+
+const PanelRow = styled('div')({
+  borderTop: `1px solid ${PALETTE.SLATE_300}`,
+  padding: Layout.ROW_GUTTER
+})
+
+const FeatureRow = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: 8
+})
 
 const OrgFeatures = () => {
   const [showAIFeatures, setShowAIFeatures] = useState(false)
 
   return (
-    <div className='relative my-4 w-full rounded bg-white shadow-md'>
-      <div className='flex w-full items-center'>
-        <div className='px-4 py-2 text-sm font-semibold uppercase'>AI Features</div>
-        <div className='flex h-[44px] flex-1 justify-end px-4 py-2 leading-[44px]'></div>
-      </div>
-      <div className='w-full'>
-        <div className='border-t border-slate-300 p-4'>
-          <div className='mb-2 flex items-center justify-between'>
-            <span>Show AI Features</span>
-            <Toggle active={showAIFeatures} onClick={() => setShowAIFeatures(!showAIFeatures)} />
-          </div>
-        </div>
-      </div>
-    </div>
+    <StyledPanel isWide label='AI Features'>
+      <PanelRow>
+        <FeatureRow>
+          <span>Show AI Features</span>
+          <Toggle active={showAIFeatures} onClick={() => setShowAIFeatures(!showAIFeatures)} />
+        </FeatureRow>
+      </PanelRow>
+    </StyledPanel>
   )
 }
 

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatures.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatures.tsx
@@ -1,0 +1,25 @@
+import React, {useState} from 'react'
+import Toggle from '../../../../components/Toggle/Toggle'
+
+const OrgFeatures = () => {
+  const [showAIFeatures, setShowAIFeatures] = useState(false)
+
+  return (
+    <div className='relative my-4 w-full rounded bg-white shadow-md'>
+      <div className='flex w-full items-center'>
+        <div className='px-4 py-2 text-sm font-semibold uppercase'>AI Features</div>
+        <div className='flex h-[44px] flex-1 justify-end px-4 py-2 leading-[44px]'></div>
+      </div>
+      <div className='w-full'>
+        <div className='border-t border-slate-300 p-4'>
+          <div className='mb-2 flex items-center justify-between'>
+            <span>Show AI Features</span>
+            <Toggle active={showAIFeatures} onClick={() => setShowAIFeatures(!showAIFeatures)} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default OrgFeatures


### PR DESCRIPTION
![Screenshot 2024-10-31 at 14 25 30](https://github.com/user-attachments/assets/df3b4129-d42c-47cc-a04b-67fb41444fce)


Show org features and feature flags. This is just the UI with hardcoded flags. Next, I'll get the flags from the db to make the data dynamic.

The tooltip info will be the description of the feature flag.

### To test

- [ ] Go to org settings. Does the UI look acceptable?