### PR TITLE
feat: add use ai to org

### DIFF
--- a/packages/server/database/types/Organization.ts
+++ b/packages/server/database/types/Organization.ts
@@ -15,6 +15,7 @@ interface Input {
   updatedAt?: Date
   showConversionModal?: boolean
   payLaterClickCount?: number
+  useAI?: boolean
 }
 
 export default class Organization {
@@ -37,6 +38,7 @@ export default class Organization {
   trialStartDate?: Date | null
   scheduledLockAt?: Date | null
   lockedAt?: Date | null
+  useAI: boolean
   updatedAt: Date
   constructor(input: Input) {
     const {
@@ -50,7 +52,8 @@ export default class Organization {
       showConversionModal,
       payLaterClickCount,
       picture,
-      tier
+      tier,
+      useAI
     } = input
     this.id = id || generateUID()
     this.activeDomain = activeDomain
@@ -63,5 +66,6 @@ export default class Organization {
     this.picture = picture
     this.showConversionModal = showConversionModal === null ? undefined : showConversionModal
     this.payLaterClickCount = payLaterClickCount || 0
+    this.useAI = useAI ?? true
   }
 }

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -163,6 +163,12 @@ type Organization {
   """
   picture: URL
   tier: TierEnum!
+
+  """
+  Whether the org has access to AI features
+  """
+  useAI: Boolean!
+
   billingTier: TierEnum!
 
   """

--- a/packages/server/postgres/migrations/2024-10-31T14:42:16.120Z_add-use-ai-to-orgs.ts
+++ b/packages/server/postgres/migrations/2024-10-31T14:42:16.120Z_add-use-ai-to-orgs.ts
@@ -1,0 +1,59 @@
+import {Kysely, sql} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('Organization')
+    .addColumn('useAI', 'boolean', (col) => col.notNull().defaultTo(true))
+    .execute()
+
+  await db
+    .updateTable('Organization')
+    .set({useAI: false})
+    .where(
+      'id',
+      'in',
+      db
+        .selectFrom('FeatureFlagOwner')
+        .innerJoin('FeatureFlag', 'FeatureFlag.id', 'FeatureFlagOwner.featureFlagId')
+        .where('FeatureFlag.featureName', '=', 'noAISummary')
+        .select('FeatureFlagOwner.orgId')
+    )
+    .execute()
+
+  await db
+    .deleteFrom('FeatureFlagOwner')
+    .where(
+      'featureFlagId',
+      'in',
+      db.selectFrom('FeatureFlag').select('id').where('featureName', '=', 'noAISummary')
+    )
+    .execute()
+
+  await db.deleteFrom('FeatureFlag').where('featureName', '=', 'noAISummary').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  const [flagId] = await db
+    .insertInto('FeatureFlag')
+    .values({
+      featureName: 'noAISummary',
+      description: 'Disable AI features for this organization',
+      expiresAt: new Date('2074-01-31T00:00:00.000Z'),
+      scope: 'Organization'
+    })
+    .returning('id')
+    .execute()
+
+  await db
+    .insertInto('FeatureFlagOwner')
+    .columns(['featureFlagId', 'orgId'])
+    .expression(
+      db
+        .selectFrom('Organization')
+        .select([sql`${flagId.id}::uuid`.as('featureFlagId'), 'id as orgId'])
+        .where('useAI', '=', false)
+    )
+    .execute()
+
+  await db.schema.alterTable('Organization').dropColumn('useAI').execute()
+}


### PR DESCRIPTION
This PR replaces `noAISummary` flag with `useAI` on the org table. 

`noAISummary` is confusing because:

1. It removes all AI features, not just the AI Summary 
2. It's not a feature flag, but it's being used as a feature flag
3. The negative form of `noAISummary` instead of `aiSummary` is confusing 

This PR adds `useAI` to the org table instead. By default, it's true. If an org has `noAISummary` flag turned on, this migration will make sure that `useAI` is false.

This PR won't be merged until a subsequent PR replaces the `noAISummary` checks with the `useAI` check.

### To test

- [ ] Run the migration and see that `useAI` is on by default and off for orgs that had `noAISummary` turned on
