### PR TITLE
feat: Add lastSeenAt to organization members CSV export

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -1,4 +1,5 @@
 import graphql from 'babel-plugin-relay/macro'
+import {format} from 'date-fns'
 import type {Parser as JSON2CSVParser} from 'json2csv'
 import Parser from 'json2csv/lib/JSON2CSVParser' // only grab the sync parser
 import React, {useCallback, useMemo, useState} from 'react'
@@ -121,12 +122,16 @@ const OrgMembers = (props: Props) => {
   const exportToCSV = async () => {
     const rows = organizationUsers.edges.map((orgUser, idx) => {
       const {node} = orgUser
+      const formattedLastSeenAt = node.user.lastSeenAt
+        ? format(new Date(node.user.lastSeenAt), 'yyyy-MM-dd')
+        : 'Never'
       return {
         Row: idx,
         Name: node.user.preferredName,
         Email: node.user.email,
         Inactive: node.inactive,
-        'Billing Lead': node.role === 'BILLING_LEADER'
+        'Billing Lead': node.role === 'BILLING_LEADER',
+        'Last Seen At': formattedLastSeenAt
       }
     })
     const parser = new Parser({withBOM: true, eol: '\n'}) as JSON2CSVParser<any>


### PR DESCRIPTION
# Description

The field is visible in the member list, so it should be in the CSV export as well.

## Testing scenarios

- Export the member list to CSV and see the last seen at field in the export

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
