### PR TITLE
fix: supprt jsx runtime in SSR

### DIFF
--- a/scripts/webpack/dev.servers.config.js
+++ b/scripts/webpack/dev.servers.config.js
@@ -40,7 +40,9 @@ module.exports = {
     alias: {
       '~': path.join(CLIENT_ROOT),
       'parabol-server': SERVER_ROOT,
-      'parabol-client': CLIENT_ROOT
+      'parabol-client': CLIENT_ROOT,
+      // this is for radix-ui, we import & transform ESM packages, but they can't find react/jsx-runtime
+      'react/jsx-runtime': require.resolve('react/jsx-runtime')
     },
     extensions: ['.mjs', '.js', '.json', '.ts', '.tsx', '.graphql'],
     unsafeCache: true,

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -65,7 +65,9 @@ module.exports = (config) => {
       alias: {
         '~': CLIENT_ROOT,
         'parabol-client': CLIENT_ROOT,
-        'parabol-server': SERVER_ROOT
+        'parabol-server': SERVER_ROOT,
+        // this is for radix-ui, we import & transform ESM packages, but they can't find react/jsx-runtime
+        'react/jsx-runtime': require.resolve('react/jsx-runtime')
       },
       extensions: ['.mjs', '.js', '.json', '.ts', '.tsx', '.graphql'],
       // this is run outside the server dir, but we want to favor using modules from the server dir


### PR DESCRIPTION
# Description

no-deps requires the jsx-runtime, so we add that to the server bundler as well