### PR TITLE
fix: github pr template release test now with the correct Mattermost link

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_test.md
+++ b/.github/ISSUE_TEMPLATE/release_test.md
@@ -18,7 +18,7 @@ Run through this list at least once at [staging](https://action.parabol.fun):
 - [ ] Verified invite via mass link works (Team > Invite Button > Invite Link, visit URL in an incognito window)
 - [ ] Verified invite via email works. It will show as [logs in Datadog](https://app.datadoghq.com/logs?query=kube_namespace%3Aparabol%20env%3Astaging%20&cols=host%2Cservice&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1699266779323&to_ts=1699267679323&live=true).
 - [ ] Added Slack, verified meeting notifications (use `#t_product_actiontime`)
-- [ ] Added Mattermost, verified meeting notifications (check the test webhook in [Parabol Mattermost](https://mattermost.parabol.co/product/integrations/incoming_webhooks))
+- [ ] Added Mattermost, verified meeting notifications (check the test webhook in [Parabol Mattermost](https://mattermost.parabol.fun/parabol/integrations))
 - [ ] Added GitHub, verified issue created (use `ParabolInc/publictestrepo`)
 - [ ] Added Jira, verified issue created (use `parabol-2`)
 - [ ] Added GitLab, verified issue created


### PR DESCRIPTION
# Description

Fixes a broken link in the Github release test pr template

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....
