### PR TITLE
fix(docker-external): workflow name fixed

### DIFF
--- a/.github/workflows/docker-external.yml
+++ b/.github/workflows/docker-external.yml
@@ -1,4 +1,4 @@
-name: Ironbank Image Upload
+name: Docker publish externally
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
# Description
Fixes name of the workflow to share Docker images externally