### PR TITLE
chore: remove signUpDestinationTeam

### DIFF
--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -25,7 +25,6 @@ const mutation = graphql`
       }
       isNewUser
       user {
-        hasSignUpDestinationTeamFlag: featureFlag(featureName: "signUpDestinationTeam")
         teams {
           id
         }
@@ -57,10 +56,7 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
         handleSuccessfulLogin(loginWithGoogle)
         const authToken = acceptTeamInvitation?.authToken || loginWithGoogle.authToken!
         atmosphere.setAuthToken(authToken)
-        const redirectPath =
-          isNewUser && user?.hasSignUpDestinationTeamFlag
-            ? `/team/${user?.teams?.[0]?.id}`
-            : '/meetings'
+        const redirectPath = '/meetings'
 
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,

--- a/packages/client/mutations/LoginWithGoogleMutation.ts
+++ b/packages/client/mutations/LoginWithGoogleMutation.ts
@@ -23,12 +23,6 @@ const mutation = graphql`
       error {
         message
       }
-      isNewUser
-      user {
-        teams {
-          id
-        }
-      }
       ...handleSuccessfulLogin_UserLogInPayload @relay(mask: false)
     }
     # Validation occurs statically https://github.com/graphql/graphql-js/issues/1334
@@ -50,7 +44,7 @@ const LoginWithGoogleMutation: StandardMutation<TLoginWithGoogleMutation, Histor
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, loginWithGoogle} = res
       onCompleted({loginWithGoogle}, errors)
-      const {error: uiError, user, isNewUser} = loginWithGoogle
+      const {error: uiError} = loginWithGoogle
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {
         handleSuccessfulLogin(loginWithGoogle)

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -42,7 +42,7 @@ const SignUpWithPasswordMutation: StandardMutation<
     onError,
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, signUpWithPassword} = res
-      const {error: uiError, user} = signUpWithPassword
+      const {error: uiError} = signUpWithPassword
       onCompleted({signUpWithPassword}, errors)
       handleAcceptTeamInvitationErrors(atmosphere, acceptTeamInvitation)
       if (!uiError && !errors) {

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -26,7 +26,6 @@ const mutation = graphql`
         message
       }
       user {
-        hasSignUpDestinationTeamFlag: featureFlag(featureName: "signUpDestinationTeam")
         teams {
           id
         }
@@ -55,10 +54,7 @@ const SignUpWithPasswordMutation: StandardMutation<
         handleSuccessfulLogin(signUpWithPassword)
         const authToken = acceptTeamInvitation?.authToken || signUpWithPassword.authToken!
         atmosphere.setAuthToken(authToken)
-
-        const redirectPath = user?.hasSignUpDestinationTeamFlag
-          ? `/team/${user?.teams?.[0]?.id}`
-          : '/meetings'
+        const redirectPath = '/meetings'
 
         handleAuthenticationRedirect(acceptTeamInvitation, {
           atmosphere,

--- a/packages/client/mutations/SignUpWithPasswordMutation.ts
+++ b/packages/client/mutations/SignUpWithPasswordMutation.ts
@@ -25,11 +25,6 @@ const mutation = graphql`
       error {
         message
       }
-      user {
-        teams {
-          id
-        }
-      }
       ...handleSuccessfulLogin_UserLogInPayload @relay(mask: false)
     }
     acceptTeamInvitation(invitationToken: $invitationToken) @include(if: $isInvitation) {

--- a/packages/client/mutations/VerifyEmailMutation.ts
+++ b/packages/client/mutations/VerifyEmailMutation.ts
@@ -15,11 +15,6 @@ const mutation = graphql`
       error {
         message
       }
-      user {
-        teams {
-          id
-        }
-      }
       ...handleSuccessfulLogin_UserLogInPayload @relay(mask: false)
     }
     acceptTeamInvitation(invitationToken: $invitationToken) @include(if: $isInvitation) {
@@ -38,7 +33,6 @@ const VerifyEmailMutation: StandardMutation<TSignUpWithPasswordMutation, History
     onError,
     onCompleted: (res, errors) => {
       const {acceptTeamInvitation, verifyEmail} = res
-      const {user} = verifyEmail
       const authToken = acceptTeamInvitation?.authToken ?? verifyEmail.authToken
       onCompleted({verifyEmail}, errors)
       if (authToken) {

--- a/packages/client/mutations/VerifyEmailMutation.ts
+++ b/packages/client/mutations/VerifyEmailMutation.ts
@@ -16,7 +16,6 @@ const mutation = graphql`
         message
       }
       user {
-        hasSignUpDestinationTeam: featureFlag(featureName: "signUpDestinationTeam")
         teams {
           id
         }
@@ -45,10 +44,7 @@ const VerifyEmailMutation: StandardMutation<TSignUpWithPasswordMutation, History
       if (authToken) {
         handleSuccessfulLogin(verifyEmail)
         atmosphere.setAuthToken(authToken)
-
-        const redirectPath = user?.hasSignUpDestinationTeam
-          ? `/team/${user?.teams?.[0]?.id}`
-          : '/meetings'
+        const redirectPath = '/meetings'
 
         handleAuthenticationRedirect(acceptTeamInvitation, {atmosphere, history, redirectPath})
       }


### PR DESCRIPTION
We were testing whether redirecting new users to the team page would increase sign-ups. This isn't being tested now, so let's remove the code.

We agreed to remove this feature flag and the code here: https://parabol.slack.com/archives/C836NA350/p1727801752709289 