### PR TITLE
chore: clarify when Google Cloud credentials are required

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,7 @@ AI_EMBEDDER_WORKERS='1'
 CDN_BASE_URL=''
 # FILE_STORE_PROVIDER: local | s3 | gcs
 FILE_STORE_PROVIDER='local'
+# Google Cloud credentials are required to use FILE_STORE_PROVIDER='gcs'
 # GOOGLE_GCS_BUCKET='BUCKET_NAME'
 
 # CHRONOS
@@ -97,9 +98,10 @@ REDIS_URL='redis://localhost:6379'
 # GOOGLE
 # Google Analytics Tracking ID
 # GA_TRACKING_ID=''
-# GOOGLE_CLOUD_CLIENT_EMAIL='key_GOOGLE_CLOUD_CLIENT_EMAIL'
-# GOOGLE_CLOUD_PRIVATE_KEY='key_GOOGLE_CLOUD_PRIVATE_KEY'
-# GOOGLE_CLOUD_PRIVATE_KEY_ID='key_GOOGLE_CLOUD_PRIVATE_KEY_ID'
+# GOOGLE_CLOUD_CLIENT_EMAIL=''
+# GOOGLE_CLOUD_PRIVATE_KEY=''
+# GOOGLE_CLOUD_PRIVATE_KEY_ID=''
+# Google Cloud credentials are required to use the GCP Natural Language API.
 # Disable Google Cloud Natural Language API for generating retro group titles
 # DISABLE_GOOGLE_CLOUD_NATURAL_LANGUAGE='true'
 


### PR DESCRIPTION
# Description

Clarifies when GOOGLE_CLOUD vars must be set:

- To use the GCP Natural Language API. The error message is more detailed.
- To use Google Cloud Storage as file store provider.

