### PR TITLE
fix: show public teams

### DIFF
--- a/packages/server/graphql/public/types/Organization.ts
+++ b/packages/server/graphql/public/types/Organization.ts
@@ -90,7 +90,7 @@ const Organization: OrganizationResolvers = {
       dataLoader.get('teamsByOrgIds').load(orgId),
       dataLoader.get('featureFlagByOwnerId').load({ownerId: orgId, featureName: 'publicTeams'})
     ])
-    if (!isSuperUser(authToken) || !hasPublicTeamsFlag) return []
+    if (!isSuperUser(authToken) && !hasPublicTeamsFlag) return []
     const publicTeams = allTeamsOnOrg.filter((team) => !isTeamMember(authToken, team.id))
     return publicTeams
   },


### PR DESCRIPTION
Public teams were showing up for super users, e.g. Parabol's org, but not for other orgs that have the flag turned on. This fixes that.

See slack thread: https://parabol.slack.com/archives/C4JAUUZ9P/p1732789118369329