### PR TITLE
fix: Parabol poker task overwrites, ignore prototypes for equality check on tiptap

### DIFF
--- a/packages/client/components/ParabolScopingSearchResultItem.tsx
+++ b/packages/client/components/ParabolScopingSearchResultItem.tsx
@@ -13,6 +13,7 @@ import {PALETTE} from '~/styles/paletteV3'
 import {ParabolScopingSearchResultItem_task$key} from '../__generated__/ParabolScopingSearchResultItem_task.graphql'
 import {UpdatePokerScopeMutation as TUpdatePokerScopeMutation} from '../__generated__/UpdatePokerScopeMutation.graphql'
 import {useTipTapTaskEditor} from '../hooks/useTipTapTaskEditor'
+import {isEqualWhenSerialized} from '../shared/isEqualWhenSerialized'
 import {Threshold} from '../types/constEnums'
 import Checkbox from './Checkbox'
 import {TipTapEditor} from './promptResponse/TipTapEditor'
@@ -105,13 +106,11 @@ const ParabolScopingSearchResultItem = (props: Props) => {
       DeleteTaskMutation(atmosphere, {taskId: serviceTaskId})
       return
     }
-    const nextContent = JSON.stringify(editor.getJSON())
-    if (content === nextContent) {
-      return
-    }
+    const nextContentJSON = editor.getJSON()
+    if (isEqualWhenSerialized(nextContentJSON, JSON.parse(content))) return
     const updatedTask = {
       id: serviceTaskId,
-      content: nextContent
+      content: JSON.stringify(nextContentJSON)
     }
     UpdateTaskMutation(atmosphere, {updatedTask}, {})
   }

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import {Link} from '@mui/icons-material'
-import {Editor as EditorState} from '@tiptap/core'
+import {Editor} from '@tiptap/core'
 import {JSONContent} from '@tiptap/react'
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo} from 'react'
@@ -182,12 +182,12 @@ const TeamPromptResponseCard = (props: Props) => {
   const nonViewerEmptyResponsePlaceholder = isMeetingEnded ? 'No response' : 'No response yet...'
 
   const {onError, onCompleted, submitMutation, submitting} = useMutationProps()
-  const handleSubmit = useEventCallback((editorState: EditorState) => {
+  const handleSubmit = useEventCallback((editor: Editor) => {
     if (submitting) return
     submitMutation()
 
-    const content = JSON.stringify(editorState.getJSON())
-    const plaintextContent = editorState.getText()
+    const content = JSON.stringify(editor.getJSON())
+    const plaintextContent = editor.getText()
 
     UpsertTeamPromptResponseMutation(
       atmosphere,

--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -11,6 +11,7 @@ import UpdateCommentContentMutation from '~/mutations/UpdateCommentContentMutati
 import isTempId from '~/utils/relay/isTempId'
 import useEventCallback from '../hooks/useEventCallback'
 import {useTipTapCommentEditor} from '../hooks/useTipTapCommentEditor'
+import {isEqualWhenSerialized} from '../shared/isEqualWhenSerialized'
 import anonymousAvatar from '../styles/theme/images/anonymous-avatar.svg'
 import deletedAvatar from '../styles/theme/images/deleted-avatar-placeholder.svg'
 import {PARABOL_AI_USER_ID} from '../utils/constants'
@@ -95,12 +96,12 @@ const ThreadedCommentBase = (props: Props) => {
   const onSubmit = useEventCallback(() => {
     if (submitting || isTempId(commentId) || !editor || editor.isEmpty) return
     editor.setEditable(false)
-    const nextContent = JSON.stringify(editor.getJSON())
-    if (content === nextContent) return
+    const nextContentJSON = editor.getJSON()
+    if (isEqualWhenSerialized(nextContentJSON, JSON.parse(content))) return
     submitMutation()
     UpdateCommentContentMutation(
       atmosphere,
-      {commentId, content: nextContent, meetingId},
+      {commentId, content: JSON.stringify(nextContentJSON), meetingId},
       {onError, onCompleted}
     )
   })

--- a/packages/client/hooks/useTipTapEditorContent.ts
+++ b/packages/client/hooks/useTipTapEditorContent.ts
@@ -1,6 +1,6 @@
-import {Editor, generateHTML, JSONContent} from '@tiptap/react'
+import {Editor, JSONContent} from '@tiptap/react'
 import {useMemo, useRef} from 'react'
-import {serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
+import {isEqualWhenSerialized} from '../shared/isEqualWhenSerialized'
 
 export const useTipTapEditorContent = (content: string) => {
   const editorRef = useRef<Editor | null>(null)
@@ -8,14 +8,13 @@ export const useTipTapEditorContent = (content: string) => {
   // When receiving new content, it's important to make sure it's different from the current value
   // Unnecessary re-renders mess up things like the coordinates of the link menu
   const contentJSON = useMemo(() => {
-    const newContent = JSON.parse(content)
+    const newContentJSON = JSON.parse(content) as JSONContent
     // use HTML because text won't include data that we don't see (e.g. mentions) and JSON key order is non-deterministic >:-(
-    const oldHTML = editorRef.current ? editorRef.current.getHTML() : ''
-    const newHTML = generateHTML(newContent, serverTipTapExtensions)
-    if (oldHTML !== newHTML) {
-      contentJSONRef.current = newContent
+    const oldContentJSON = editorRef.current ? editorRef.current.getJSON() : {}
+    if (!isEqualWhenSerialized(newContentJSON, oldContentJSON)) {
+      contentJSONRef.current = newContentJSON
     }
-    return contentJSONRef.current as JSONContent
+    return contentJSONRef.current!
   }, [content])
 
   return [contentJSON, editorRef] as const

--- a/packages/client/hooks/useTipTapTaskEditor.ts
+++ b/packages/client/hooks/useTipTapTaskEditor.ts
@@ -19,9 +19,12 @@ export const useTipTapTaskEditor = (
     atmosphere?: Atmosphere
     teamId?: string
     readOnly?: boolean
+    // onBlur here vs. on the component means when the component mounts with new editor content
+    // (e.g. HeaderCard changes taskId) the onBlur won't fire, which is probably desireable
+    onBlur?: () => void
   }
 ) => {
-  const {atmosphere, teamId, readOnly} = options
+  const {atmosphere, teamId, readOnly, onBlur} = options
   const [contentJSON, editorRef] = useTipTapEditorContent(content)
   const [linkState, setLinkState] = useState<LinkMenuState>(null)
   editorRef.current = useEditor(
@@ -47,9 +50,10 @@ export const useTipTapTaskEditor = (
         })
       ],
       editable: !readOnly,
+      onBlur,
       autofocus: generateText(contentJSON, serverTipTapExtensions).length === 0
     },
-    [contentJSON, readOnly]
+    [contentJSON, readOnly, onBlur]
   )
   return {editor: editorRef.current, linkState, setLinkState}
 }

--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
@@ -16,6 +16,7 @@ import useMutationProps from '../../../../hooks/useMutationProps'
 import {useTipTapIcebreakerEditor} from '../../../../hooks/useTipTapIcebreakerEditor'
 import UpdateNewCheckInQuestionMutation from '../../../../mutations/UpdateNewCheckInQuestionMutation'
 import {useModifyCheckInQuestionMutation} from '../../../../mutations/useModifyCheckInQuestionMutation'
+import {isEqualWhenSerialized} from '../../../../shared/isEqualWhenSerialized'
 import {convertTipTapTaskContent} from '../../../../shared/tiptap/convertTipTapTaskContent'
 import {PALETTE} from '../../../../styles/paletteV3'
 import {Button} from '../../../../ui/Button/Button'
@@ -115,13 +116,17 @@ const NewCheckInQuestion = (props: Props) => {
     if (!editor) return
     const {isFocused} = editor
     if (!isFocused) {
-      const nextCheckInQuestion = JSON.stringify(editor.getJSON())
-      if (nextCheckInQuestion === checkInQuestion) return
+      const nextCheckInQuestionJSON = editor.getJSON()
+      if (
+        checkInQuestion &&
+        isEqualWhenSerialized(nextCheckInQuestionJSON, JSON.parse(checkInQuestion))
+      )
+        return
       UpdateNewCheckInQuestionMutation(
         atmosphere,
         {
           meetingId,
-          checkInQuestion: nextCheckInQuestion
+          checkInQuestion: JSON.stringify(nextCheckInQuestionJSON)
         },
         {onCompleted, onError}
       )

--- a/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
+++ b/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled'
 import {Editor} from '@tiptap/core'
 import graphql from 'babel-plugin-relay/macro'
-import areEqual from 'fbjs/lib/areEqual'
 import {memo, useEffect, useRef, useState} from 'react'
 import {useFragment} from 'react-relay'
 import {OutcomeCardContainer_task$key} from '~/__generated__/OutcomeCardContainer_task.graphql'
@@ -14,6 +13,7 @@ import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useTaskChildFocus from '../../../../hooks/useTaskChildFocus'
 import DeleteTaskMutation from '../../../../mutations/DeleteTaskMutation'
 import UpdateTaskMutation from '../../../../mutations/UpdateTaskMutation'
+import {isEqualWhenSerialized} from '../../../../shared/isEqualWhenSerialized'
 import OutcomeCard from '../../components/OutcomeCard/OutcomeCard'
 
 const Wrapper = styled('div')({
@@ -85,11 +85,11 @@ const OutcomeCardContainer = memo((props: Props) => {
       DeleteTaskMutation(atmosphere, {taskId})
       return
     }
-    const nextContent = JSON.stringify(editor.getJSON())
-    if (areEqual(JSON.parse(content), editor.getJSON())) return
+    const nextContentJSON = editor.getJSON()
+    if (isEqualWhenSerialized(JSON.parse(content), nextContentJSON)) return
     const updatedTask = {
       id: taskId,
-      content: nextContent
+      content: JSON.stringify(nextContentJSON)
     }
     UpdateTaskMutation(atmosphere, {updatedTask, area}, {})
   }

--- a/packages/client/shared/isEqualWhenSerialized.ts
+++ b/packages/client/shared/isEqualWhenSerialized.ts
@@ -1,0 +1,26 @@
+// Checks equality ignoring object order & prototypes
+export const isEqualWhenSerialized = (value1: unknown, value2: unknown): boolean => {
+  // Check for strict equality first
+  if (value1 === value2) return true
+
+  // Handle cases where one is null or undefined
+  if (value1 === null || value2 === null || value1 === undefined || value2 === undefined)
+    return false
+
+  // Fallback for other types (like functions, symbols, etc.)
+  if (typeof value1 !== 'object' || typeof value2 !== 'object') return false
+
+  const keys1 = Object.keys(value1)
+  const keys2 = Object.keys(value2)
+
+  // Check if both have the same number of keys
+  if (keys1.length !== keys2.length) return false
+
+  // Check if both have the same keys
+  if (!keys1.every((key) => keys2.includes(key))) return false
+
+  // Recursively check each key's value
+  return keys1.every((key) =>
+    isEqualWhenSerialized(value1[key as keyof typeof value1], value2[key as keyof typeof value2])
+  )
+}


### PR DESCRIPTION
# Description

Fixes #10606

There were 2 bugs triggering this:

1. When testing if TipTap JSON content had changed, the answer was always true because our equality check looked at prototypes, and tiptap uses a null prototype e.g. Object.create(null), whereas JSON.parse uses an Object prototypes `{}`. I wrote a custom equality checker & fixed the issue in all tiptap instances
2. the onBlur handler was firing after navigation. This even happened if we delayed navigation until after the blur event via `setImmediate`. I moved the `onBlur` from the component to the TipTap instance and now onBlur does not fire. This means if the user makes changes and then navigates away from that page without first blurring the content, the content will not get updated. I think this is the desired effect, as it's the same behavior as if they hit `Escape`.