### PR TITLE
fix: bugs in TipTap Reflection editor

### DIFF
--- a/packages/client/components/GroupingKanban.tsx
+++ b/packages/client/components/GroupingKanban.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import {captureException} from '@sentry/minimal'
 import graphql from 'babel-plugin-relay/macro'
 import {RefObject, useEffect, useMemo, useRef, useState} from 'react'
@@ -12,6 +11,7 @@ import useModal from '../hooks/useModal'
 import useSpotlightSimulatedDrag from '../hooks/useSpotlightSimulatedDrag'
 import useThrottledEvent from '../hooks/useThrottledEvent'
 import {Breakpoint, Times} from '../types/constEnums'
+import {cn} from '../ui/cn'
 import PortalProvider from './AtmosphereProvider/PortalProvider'
 import GroupingKanbanColumn from './GroupingKanbanColumn'
 import ReflectWrapperDesktop from './RetroReflectPhase/ReflectWrapperDesktop'
@@ -23,18 +23,6 @@ interface Props {
   phaseRef: RefObject<HTMLDivElement>
 }
 
-const ColumnsBlock = styled('div')<{isDesktop: boolean}>(({isDesktop}) => ({
-  alignItems: 'center',
-  display: 'flex',
-  flex: '1',
-  flexDirection: 'column',
-  height: '100%',
-  justifyContent: 'center',
-  margin: '0',
-  overflow: 'auto',
-  padding: isDesktop ? '0 0 16px' : undefined,
-  width: '100%'
-}))
 export type SwipeColumn = (offset: number) => void
 const GroupingKanban = (props: Props) => {
   const {meeting: meetingRef, phaseRef} = props
@@ -191,7 +179,12 @@ const GroupingKanban = (props: Props) => {
 
   return (
     <PortalProvider>
-      <ColumnsBlock isDesktop={isDesktop}>
+      <div
+        className={cn(
+          'm-0 flex h-full w-full flex-1 flex-col items-center justify-center overflow-auto',
+          isDesktop && 'px-4'
+        )}
+      >
         <ColumnWrapper
           setActiveIdx={setActiveIdx}
           activeIdx={activeIdx}
@@ -215,7 +208,7 @@ const GroupingKanban = (props: Props) => {
             />
           ))}
         </ColumnWrapper>
-      </ColumnsBlock>
+      </div>
       {modalPortal(
         <SpotlightModal
           closeSpotlight={closePortal}

--- a/packages/client/components/GroupingKanbanColumn.tsx
+++ b/packages/client/components/GroupingKanbanColumn.tsx
@@ -158,8 +158,8 @@ const GroupingKanbanColumn = (props: Props) => {
   return (
     <div
       className={`relative ml-2 mr-2 flex h-full min-w-[320px] flex-1
-    flex-col content-start rounded-lg bg-slate-300 p-0 transition-all duration-100 ease-out first-of-type:ml-4 last-of-type:mr-4
-    single-reflection-column:max-w-min
+    flex-col content-start rounded-lg bg-slate-300 p-0 transition-all duration-100 ease-out first-of-type:ml-4
+    last-of-type:mr-4 single-reflection-column:max-w-min
     ${isLengthExpanded ? '' : 'single-reflection-column:h-[calc(100%-56px)]'}
     max-w-min`}
       ref={columnRef}

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -313,7 +313,7 @@ const ReflectionCard = (props: Props) => {
       >
         <TipTapEditor
           className={cn(
-            'flex min-h-4 w-full items-center px-4 pt-3 leading-4',
+            'flex min-h-4 w-full px-4 pt-3',
             isClipped ? 'max-h-11' : 'max-h-28',
             disableAnonymity ? 'pb-0' : 'pb-3',
             readOnly

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -309,14 +309,12 @@ const ReflectionCard = (props: Props) => {
 
       <div
         ref={scrollRef}
-        className={cn(
-          'relative w-full overflow-auto text-sm leading-5 text-slate-700',
-          isClipped ? 'max-h-11' : 'max-h-[104px]'
-        )}
+        className={cn('relative w-full overflow-auto text-sm leading-4 text-slate-700')}
       >
         <TipTapEditor
           className={cn(
             'flex min-h-4 w-full items-center px-4 pt-3 leading-4',
+            isClipped ? 'max-h-11' : 'max-h-28',
             disableAnonymity ? 'pb-0' : 'pb-3',
             readOnly
               ? phaseType === 'discuss' || phaseType === 'vote'

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -233,10 +233,15 @@ const ReflectionCard = (props: Props) => {
     }
     const nextContentJSON = editor.getJSON()
     if (isEqualWhenSerialized(nextContentJSON, JSON.parse(content))) return
+    const contentStr = JSON.stringify(nextContentJSON)
+    if (contentStr.length > 2000) {
+      onError(new Error('Reflection is too long'))
+      return
+    }
     submitMutation()
     UpdateReflectionContentMutation(
       atmosphere,
-      {content: JSON.stringify(nextContentJSON), reflectionId},
+      {content: contentStr, reflectionId},
       {onError, onCompleted}
     )
     commitLocalUpdate(atmosphere, (store) => {

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -321,11 +321,7 @@ const ReflectionCard = (props: Props) => {
             'flex min-h-4 w-full px-4 pt-3',
             isClipped ? 'max-h-11' : 'max-h-28',
             disableAnonymity ? 'pb-0' : 'pb-3',
-            readOnly
-              ? phaseType === 'discuss' || phaseType === 'vote'
-                ? 'select-text'
-                : 'select-none'
-              : undefined
+            readOnly ? (phaseType === 'discuss' ? 'select-text' : 'select-none') : undefined
           )}
           editor={editor}
           linkState={linkState}

--- a/packages/client/components/ReflectionCard/ReflectionCardAuthor.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCardAuthor.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import {PALETTE} from '../../styles/paletteV3'
 
 const Author = styled('div')({
-  padding: '12px 16px',
+  padding: '8px 16px',
   color: PALETTE.SLATE_600,
   fontSize: 14,
   fontWeight: 700,

--- a/packages/client/components/RetroGroupPhase.tsx
+++ b/packages/client/components/RetroGroupPhase.tsx
@@ -103,7 +103,8 @@ const RetroGroupPhase = (props: Props) => {
 
   return (
     <>
-      <MeetingContent ref={callbackRef}>
+      {/* select-none is for Safari. Repro: drag a card & see the whole area get highlighted */}
+      <MeetingContent ref={callbackRef} className='select-none'>
         <MeetingHeaderAndPhase hideBottomBar={!!endedAt}>
           <MeetingTopBar
             avatarGroup={avatarGroup}

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -191,7 +191,7 @@ const PhaseItemEditor = (props: Props) => {
       <ReflectionCardRoot data-cy={dataCy} ref={phaseEditorRef} className=''>
         <TipTapEditor
           className={cn(
-            'flex max-h-28 min-h-0 items-center overflow-auto px-4 pt-3 leading-4',
+            'flex max-h-28 min-h-0 overflow-auto px-4 pt-3',
             disableAnonymity ? 'pb-0' : 'pb-3'
           )}
           editor={editor}
@@ -220,7 +220,7 @@ const PhaseItemEditor = (props: Props) => {
                 >
                   <div
                     className={cn(
-                      'ProseMirror flex max-h-28 min-h-4 w-full items-center px-4 pt-3 leading-4',
+                      'ProseMirror flex max-h-28 min-h-4 w-full items-center px-4 pt-3 leading-none',
                       disableAnonymity ? 'pb-0' : 'pb-3'
                     )}
                     dangerouslySetInnerHTML={{__html: card.html}}

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -82,6 +82,14 @@ const PhaseItemEditor = (props: Props) => {
     if (!editor || editor.isEmpty) return
     const contentJSON = editor?.getJSON()
     const content = JSON.stringify(contentJSON)
+    if (content.length > 2000) {
+      atmosphere.eventEmitter.emit('addSnackbar', {
+        key: 'reflectionTooLong',
+        message: 'Reflection is too long',
+        autoDismiss: 5
+      })
+      return
+    }
     const input = {
       content,
       meetingId,

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -79,7 +79,7 @@ const PhaseItemEditor = (props: Props) => {
   const {disableAnonymity, viewerMeetingMember, teamId} = meeting
   const {onCompleted, onError, submitMutation} = useMutationProps()
   const handleSubmit = useEventCallback(() => {
-    if (!editor) return
+    if (!editor || editor.isEmpty) return
     const contentJSON = editor?.getJSON()
     const content = JSON.stringify(contentJSON)
     const input = {
@@ -188,10 +188,10 @@ const PhaseItemEditor = (props: Props) => {
   if (!editor) return null
   return (
     <>
-      <ReflectionCardRoot data-cy={dataCy} ref={phaseEditorRef} className='max-h-28 overflow-auto'>
+      <ReflectionCardRoot data-cy={dataCy} ref={phaseEditorRef} className=''>
         <TipTapEditor
           className={cn(
-            'flex min-h-0 items-center px-4 pt-3 leading-4',
+            'flex max-h-28 min-h-0 items-center overflow-auto px-4 pt-3 leading-4',
             disableAnonymity ? 'pb-0' : 'pb-3'
           )}
           editor={editor}
@@ -209,19 +209,22 @@ const PhaseItemEditor = (props: Props) => {
           {cardsInFlightRef.current.map((card) => {
             return (
               <CardInFlightStyles
-                className='max-h-28 overflow-auto'
+                className=''
                 key={card.key}
                 transform={card.transform}
                 isStart={card.isStart}
                 onTransitionEnd={removeCardInFlight(card.key)}
               >
                 <div
-                  className={cn(
-                    'flex min-h-0 items-center px-4 pt-3 text-sm leading-4',
-                    disableAnonymity ? 'pb-0' : 'pb-3'
-                  )}
+                  className={cn('relative w-full overflow-auto text-sm leading-4 text-slate-700')}
                 >
-                  <div className='ProseMirror' dangerouslySetInnerHTML={{__html: card.html}}></div>
+                  <div
+                    className={cn(
+                      'ProseMirror flex max-h-28 min-h-4 w-full items-center px-4 pt-3 leading-4',
+                      disableAnonymity ? 'pb-0' : 'pb-3'
+                    )}
+                    dangerouslySetInnerHTML={{__html: card.html}}
+                  ></div>
                 </div>
                 {disableAnonymity && (
                   <ReflectionCardAuthor>

--- a/packages/client/components/promptResponse/TipTapEditor.tsx
+++ b/packages/client/components/promptResponse/TipTapEditor.tsx
@@ -33,7 +33,7 @@ export const TipTapEditor = (props: Props) => {
         ref={ref as any}
         {...rest}
         editor={editor}
-        className={cn('min-h-10 px-4 text-sm leading-5', className)}
+        className={cn('min-h-10 px-4 text-sm leading-none', className)}
       />
     </>
   )

--- a/packages/client/components/promptResponse/TipTapLinkMenu.tsx
+++ b/packages/client/components/promptResponse/TipTapLinkMenu.tsx
@@ -131,12 +131,13 @@ export const TipTapLinkMenu = (props: Props) => {
       <Popover.Trigger asChild />
       <Popover.Portal>
         <Popover.Content
+          asChild
           onOpenAutoFocus={(e) => {
             // necessary for link preview to prevent focusing the first button
             e.preventDefault()
           }}
         >
-          <div className='absolute left-0 top-0' style={{transform: getTransform()}}>
+          <div className='absolute left-0 top-0 z-10' style={{transform: getTransform()}}>
             {linkState === 'edit' && (
               <TipTapLinkEditor
                 initialUrl={link}

--- a/packages/client/hooks/useResizeObserver.ts
+++ b/packages/client/hooks/useResizeObserver.ts
@@ -14,7 +14,14 @@ const useResizeObserver = (
   cb: ResizeObserverCallback,
   ref?: RefObject<HTMLDivElement | HTMLElement>
 ) => {
-  const eventCb = useEventCallback(cb)
+  const eventCb = useEventCallback((entries, observer) => {
+    requestAnimationFrame(() => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return
+      }
+      cb(entries, observer)
+    })
+  })
   useEffect(() => {
     if (!ref || !ref.current) return
     const resizeObserver = new ResizeObserver(eventCb)

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -13,7 +13,6 @@ import {mentionConfig, serverTipTapExtensions} from '../shared/tiptap/serverTipT
 import {BlurOnSubmit} from '../utils/tiptap/BlurOnSubmit'
 import {tiptapEmojiConfig} from '../utils/tiptapEmojiConfig'
 import {tiptapMentionConfig} from '../utils/tiptapMentionConfig'
-import {tiptapTagConfig} from '../utils/tiptapTagConfig'
 
 const isValid = <T>(obj: T | undefined | null | boolean): obj is T => {
   return !!obj
@@ -47,7 +46,6 @@ export const useTipTapReflectionEditor = (
             return placeholderRef.current || '*New Reflection*'
           }
         }),
-        Mention.extend({name: 'taskTag'}).configure(tiptapTagConfig),
         Mention.configure(
           atmosphere && teamId ? tiptapMentionConfig(atmosphere, teamId) : mentionConfig
         ),

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -1,4 +1,5 @@
 import {SearchAndReplace} from '@sereneinserenade/tiptap-search-and-replace'
+import CharacterCount from '@tiptap/extension-character-count'
 import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
 import {Extension, generateText, useEditor} from '@tiptap/react'
@@ -57,6 +58,10 @@ export const useTipTapReflectionEditor = (
           }
         }),
         SearchAndReplace.configure(),
+        CharacterCount.configure({
+          // this is a rough estimate because we store the JSON content as a string, not plaintext
+          limit: 1900
+        }),
         onEnter &&
           Extension.create({
             name: 'commentKeyboardShortcuts',

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -18,9 +18,18 @@ const isValid = <T>(obj: T | undefined | null | boolean): obj is T => {
   return !!obj
 }
 
-const isCursorInListItem = (editor: Editor) => {
-  // Check if the parent node of the selection is a bullet list item
-  return editor.state.selection.$from.node(-1).type.name === 'listItem'
+const isCursorMakingNode = (editor: Editor) => {
+  const from = editor.state.selection.$from
+  const nodeType = from.node().type.name
+  const parentType = from.node(-1).type.name
+  /*
+    Support cases (nodeType/parentType):
+      - Headings (heading/doc)
+      - Bullet Lists (paragraph/listItem)
+      - Blockquotes (paragraph/blockQuote)
+      - CodeBlocks (codeBlock/doc)
+  */
+  return !(nodeType === 'paragraph' && parentType === 'doc')
 }
 
 export const useTipTapReflectionEditor = (
@@ -72,8 +81,8 @@ export const useTipTapReflectionEditor = (
             addKeyboardShortcuts(this) {
               return {
                 Enter: () => {
-                  const isMakingList = isCursorInListItem(this.editor)
-                  if (isMakingList) return false
+                  const isMakingNode = isCursorMakingNode(this.editor)
+                  if (isMakingNode) return false
                   onEnter()
                   return true
                 }
@@ -90,8 +99,8 @@ export const useTipTapReflectionEditor = (
             addKeyboardShortcuts(this) {
               return {
                 Enter: () => {
-                  const isMakingList = isCursorInListItem(this.editor)
-                  if (isMakingList) return false
+                  const isMakingNode = isCursorMakingNode(this.editor)
+                  if (isMakingNode) return false
                   this.editor.commands.blur()
                   return true
                 },

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailReflectionCard.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/EmailReflectionCard.tsx
@@ -30,7 +30,8 @@ const contentStyle = {
   verticalAlign: 'top',
   width: 188,
   minWidth: 188,
-  maxWidth: 188
+  maxWidth: 188,
+  wordBreak: 'break-all'
 } as React.CSSProperties
 
 const reflectionCardFooter = {

--- a/packages/client/mutations/NavigateMeetingMutation.ts
+++ b/packages/client/mutations/NavigateMeetingMutation.ts
@@ -130,7 +130,11 @@ export const navigateMeetingTeamUpdater: SharedUpdater<NavigateMeetingMutation_t
     const viewerPhaseType = meeting
       .getLinkedRecord('localPhase')!
       .getValue('phaseType') as NewMeetingPhaseTypeEnum
-    if (!isInterruptingChickenPhase(viewerPhaseType) || !isViewerTyping()) {
+    if (
+      (!isInterruptingChickenPhase(viewerPhaseType) || !isViewerTyping()) &&
+      // if i have spotlight open, i don't want the facilitator to move me around
+      !meeting.getValue('spotlightReflectionId')
+    ) {
       setLocalStageAndPhase(store, meetingId, facilitatorStageId)
     }
   }

--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -170,6 +170,11 @@
 
 .ProseMirror {
   width: 100%;
+  blockquote {
+    border-left: 3px solid theme(colors.slate.500);
+    margin: 1.5rem 0;
+    padding-left: 1rem;
+  }
 }
 
 .ProseMirror .search-result {

--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -220,6 +220,7 @@
 .ProseMirror p {
   margin-block-start: 4px;
   margin-block-end: 4px;
+  line-height: 1rem;
 }
 
 hr.ProseMirror-selectednode {

--- a/packages/client/utils/smartGroup/getTitleFromComputedGroup.ts
+++ b/packages/client/utils/smartGroup/getTitleFromComputedGroup.ts
@@ -8,6 +8,11 @@ const MIN_ENTITIES = 2
 const MAX_CHARS = 30
 const MIN_SALIENCE = 0.1
 
+export const makeGroupTitleFromPlaintext = (plaintextContent?: string) => {
+  if (!plaintextContent) return ''
+  return plaintextContent.trim().slice(0, MAX_CHARS).replace(/\n\n/g, ' ')
+}
+
 type DistanceArray = number[]
 const getNameFromLemma = (
   lemma: string,
@@ -65,8 +70,7 @@ const getTitleFromComputedGroup = (
   if (titleArr.length === 0) {
     const [firstReflection] = reflections
     if (!firstReflection) return 'Unknown Topic'
-    const text = firstReflection.plaintextContent
-    const maxStr = text.trim().slice(0, MAX_CHARS)
+    const maxStr = makeGroupTitleFromPlaintext(firstReflection.plaintextContent)
     const lastSpace = maxStr.lastIndexOf(' ')
     const wordsOrMax = lastSpace === -1 ? maxStr : maxStr.slice(0, lastSpace).trim()
     return wordsOrMax || 'New Topic' // New Topic should never occur unless str value is falsy

--- a/packages/server/graphql/mutations/helpers/generateAIGroupTitle.ts
+++ b/packages/server/graphql/mutations/helpers/generateAIGroupTitle.ts
@@ -1,4 +1,5 @@
 import {SubscriptionChannel} from 'parabol-client/types/constEnums'
+import {makeGroupTitleFromPlaintext} from '../../../../client/utils/smartGroup/getTitleFromComputedGroup'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
@@ -18,7 +19,7 @@ const generateAIGroupTitle = async (
 ) => {
   const manager = new OpenAIServerManager()
   const aiTitle = await manager.generateGroupTitle(reflections)
-  const newTitle = aiTitle ?? reflections[0]?.plaintextContent ?? ''
+  const newTitle = aiTitle ?? makeGroupTitleFromPlaintext(reflections[0]?.plaintextContent)
   if (!newTitle) standardError(new Error('Failed to generate AI title'))
   await updateSmartGroupTitle(reflectionGroupId, newTitle)
   dataLoader.get('retroReflectionGroups').clear(reflectionGroupId)

--- a/packages/server/graphql/mutations/helpers/updateGroupTitle.ts
+++ b/packages/server/graphql/mutations/helpers/updateGroupTitle.ts
@@ -1,4 +1,5 @@
 import getGroupSmartTitle from '../../../../client/utils/smartGroup/getGroupSmartTitle'
+import {makeGroupTitleFromPlaintext} from '../../../../client/utils/smartGroup/getTitleFromComputedGroup'
 import getKysely from '../../../postgres/getKysely'
 import {DataLoaderWorker} from '../../graphql'
 import {RetroReflection} from '../../public/resolverTypes'
@@ -18,7 +19,7 @@ const updateGroupTitle = async (input: Input) => {
   const {reflections, reflectionGroupId, meetingId, teamId, dataLoader} = input
   if (reflections.length === 1) {
     // For single reflection, use its content as the title
-    const newTitle = reflections[0].plaintextContent
+    const newTitle = makeGroupTitleFromPlaintext(reflections[0].plaintextContent)
     await updateSmartGroupTitle(reflectionGroupId, newTitle)
     return
   }


### PR DESCRIPTION
# Description

This fixes the following bugs discovered during the retro we had on staging before Christmas:
- Scroll container on unanonymous reflections does not include name
- Hitting # does not suggest Task Tags
- Headings on Reflections have proper line-height
- Link Modal pops up on top of Reflection
- Block quotes have style
- An error pops up when the reflection JSON length exceeds 2000 chars
- On safari, draggin a reflection doesn't trigger highlighting around the whole phase
- If user 1 has spotlight open & the facilitator navigates back a phase, user 1 doesn't automatically follow the facilitator
- When making a heading, list, codeblock or block quote, hitting enter does not submit. You must hit Enter 1 time to get out out of the mark, then again to submit
- Group titles remove linebreaks
- Long words and links get wrapped for emails
- Cannot submit an empty reflection
- Vote phase is user-select: none (does not show a caret when hovering a card)