### PR TITLE
fix: Restrict Timeline Feed scrolling to its column on /me route

### DIFF
--- a/packages/client/components/MyDashboardTimeline.tsx
+++ b/packages/client/components/MyDashboardTimeline.tsx
@@ -20,6 +20,7 @@ const TimelineFeed = styled('div')({
   display: 'flex',
   justifyContent: 'center',
   flex: 1,
+  height: 'auto',
   paddingLeft: DashTimeline.MIN_PADDING,
   paddingRight: DashTimeline.MIN_PADDING,
   paddingTop: DashTimeline.MIN_PADDING
@@ -33,8 +34,7 @@ export const TimelineFeedItems = styled('div')({
 
 const FeedAndDrawer = styled('div')({
   display: 'flex',
-  height: '100%',
-  overflow: 'auto'
+  height: 'unset'
 })
 
 const MyDashboardTimeline = (props: Props) => {

--- a/packages/client/components/TimelineRightDrawer.tsx
+++ b/packages/client/components/TimelineRightDrawer.tsx
@@ -23,7 +23,7 @@ export const RightDrawer = styled('div')({
   minWidth: DashTimeline.TIMELINE_DRAWER_WIDTH,
   maxWidth: DashTimeline.TIMELINE_DRAWER_WIDTH,
   borderLeft: `1px solid ${PALETTE.SLATE_400}`,
-  height: '100%',
+  height: 'auto',
   padding: 16,
   [makeMinWidthMediaQuery(MIN_WIDTH)]: {
     display: 'block'


### PR DESCRIPTION
# Description
This PR fixes the issue where scrolling the Timeline Feed on the /me route would cause the "Active Tasks" column, to scroll as well. The Timeline Feed column now scrolls independently, ensuring the "Active Tasks" column remains static.

Fixes #10648
I had to remove the `overflow: 'auto'` from the FeedAndDrawer and add it to just the `TimelineFeed`

## Demo
https://github.com/user-attachments/assets/db9086f0-15bc-4009-a00c-ae07d8cfc681



## Testing scenarios
- [ ] Scenario A: Ensure the Timeline Feed scrolls independently.
   - Step 1: Navigate to the /me route.
   - Step 2: Populate the Timeline Feed with enough content to cause vertical overflow.
   - Step 3: Scroll within the Timeline Feed column and verify only that column is affected.

## Final checklist
- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
