### PR TITLE
fix: rebasing migrations

### DIFF
--- a/.config/kyselyMigrations.ts
+++ b/.config/kyselyMigrations.ts
@@ -5,6 +5,6 @@ export const migrations = {
   getMigrationPrefix: () => `${new Date().toISOString()}_`,
   migrationFolder: './packages/server/postgres/migrations',
   migrationTableSchema: 'public',
-  migrationTableName: '_migration',
+  migrationTableName: '_migrationV2',
   migrationLockTableName: '_migrationLock'
 }

--- a/packages/server/postgres/README.md
+++ b/packages/server/postgres/README.md
@@ -38,6 +38,12 @@ To rebase:
 - Table options
   - Exclude Patterns: Tables: `_*` (excludes `_migration`, `_migrationLock`)
 
+4. `yarn kysely migrate:make init` to create a new initial migration
+5. Copy the contents of the old `_init.ts` migration to the new file you just created & just replace the SQL.
+   At the beginning of the file, update the old `migrationTableName` so we delete the old migration table
+6. Delete all old migrations
+7. Increment the table version number in `kyselyMigrations.ts` for `migrationTableName`, e.g. `_migrationV3`
+
 ### Queries
 
 - [Queries](./queries/README.md)

--- a/packages/server/postgres/migrations/2025-01-08T00:27:52.203Z_init.ts
+++ b/packages/server/postgres/migrations/2025-01-08T00:27:52.203Z_init.ts
@@ -8,7 +8,11 @@ export async function up(db: Kysely<any>): Promise<void> {
     AND tablename = 'User'
 	);`.execute(db)
   // if the DB already exists then do not initialize
-  if (hasUserTable.rows[0].exists) return
+  if (hasUserTable.rows[0].exists) {
+    // migrationTableName should have been incremented, so delete the previous table
+    await db.schema.dropTable('_migration').execute()
+    return
+  }
   const {CDN_BASE_URL, FILE_STORE_PROVIDER} = process.env
   if (!FILE_STORE_PROVIDER) throw new Error('Missng Env: FILE_STORE_PROVIDER')
 


### PR DESCRIPTION
# Description

Our new migrator is _really_ strict & won't run any migrations if it detects that previous migration files do not exist.
So, for rebasing I came up with the strategy of changing the name of the table. That way the migrator assumes no migrations have run yet & won't throw any errors. Then, inside the migration we delete the old _migration table.