### PR TITLE
fix: summary does not load indefinitely if there are no votes

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -47,7 +47,7 @@ const WholeMeetingSummary = (props: Props) => {
     const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
     const hasMoreThanOneReflection = reflections?.length && reflections.length > 1
     if (!hasMoreThanOneReflection || !organization.useAI || !hasAiApiKey) return null
-    if (!wholeMeetingSummary) return <WholeMeetingSummaryLoading />
+    if (wholeMeetingSummary === undefined) return <WholeMeetingSummaryLoading /> // summary is undefined if it hasn't been generated yet. it's null if unsuccessful
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   } else if (meeting.__typename === 'TeamPromptMeeting') {
     const {summary: wholeMeetingSummary, responses, organization} = meeting

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -22,6 +22,7 @@ const WholeMeetingSummary = (props: Props) => {
         __typename
         id
         summary
+        isLoadingSummary
         organization {
           hasStandupAISummaryFlag: featureFlag(featureName: "standupAISummary")
           useAI
@@ -47,7 +48,7 @@ const WholeMeetingSummary = (props: Props) => {
     const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
     const hasMoreThanOneReflection = reflections?.length && reflections.length > 1
     if (!hasMoreThanOneReflection || !organization.useAI || !hasAiApiKey) return null
-    if (wholeMeetingSummary === '') return <WholeMeetingSummaryLoading /> // summary is undefined if it hasn't been generated yet. it's null if unsuccessful
+    if (isLoadingSummary) return <WholeMeetingSummaryLoading />
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   } else if (meeting.__typename === 'TeamPromptMeeting') {
     const {summary: wholeMeetingSummary, responses, organization} = meeting

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -22,12 +22,12 @@ const WholeMeetingSummary = (props: Props) => {
         __typename
         id
         summary
-        isLoadingSummary
         organization {
           hasStandupAISummaryFlag: featureFlag(featureName: "standupAISummary")
           useAI
         }
         ... on RetrospectiveMeeting {
+          isLoadingSummary
           reflectionGroups(sortBy: voteCount) {
             reflections {
               id

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -44,7 +44,7 @@ const WholeMeetingSummary = (props: Props) => {
     meetingRef
   )
   if (meeting.__typename === 'RetrospectiveMeeting') {
-    const {summary: wholeMeetingSummary, reflectionGroups, organization} = meeting
+    const {reflectionGroups, organization, isLoadingSummary} = meeting
     const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
     const hasMoreThanOneReflection = reflections?.length && reflections.length > 1
     if (!hasMoreThanOneReflection || !organization.useAI || !hasAiApiKey) return null

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/WholeMeetingSummary.tsx
@@ -47,7 +47,7 @@ const WholeMeetingSummary = (props: Props) => {
     const reflections = reflectionGroups?.flatMap((group) => group.reflections) // reflectionCount hasn't been calculated yet so check reflections length
     const hasMoreThanOneReflection = reflections?.length && reflections.length > 1
     if (!hasMoreThanOneReflection || !organization.useAI || !hasAiApiKey) return null
-    if (wholeMeetingSummary === undefined) return <WholeMeetingSummaryLoading /> // summary is undefined if it hasn't been generated yet. it's null if unsuccessful
+    if (wholeMeetingSummary === '') return <WholeMeetingSummaryLoading /> // summary is undefined if it hasn't been generated yet. it's null if unsuccessful
     return <WholeMeetingSummaryResult meetingRef={meeting} />
   } else if (meeting.__typename === 'TeamPromptMeeting') {
     const {summary: wholeMeetingSummary, responses, organization} = meeting

--- a/packages/server/graphql/mutations/helpers/generateRetroSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateRetroSummary.ts
@@ -5,6 +5,12 @@ import {DataLoaderWorker} from '../../graphql'
 import canAccessAI from './canAccessAI'
 import {transformRetroToAIFormat} from './transformRetroToAIFormat'
 
+const setSummaryToNull = async (meetingId: string) => {
+  const pg = getKysely()
+  await pg.updateTable('NewMeeting').set({summary: null}).where('id', '=', meetingId).execute()
+  return null
+}
+
 export const generateRetroSummary = async (
   meetingId: string,
   dataLoader: DataLoaderWorker,
@@ -15,11 +21,13 @@ export const generateRetroSummary = async (
 
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   const isAISummaryAccessible = await canAccessAI(team, 'retrospective', dataLoader)
-  if (!isAISummaryAccessible) return null
+  if (!isAISummaryAccessible) {
+    return setSummaryToNull(meetingId)
+  }
 
   const transformedMeeting = await transformRetroToAIFormat(meetingId, dataLoader)
   if (!transformedMeeting || transformedMeeting.length === 0) {
-    return null
+    return setSummaryToNull(meetingId)
   }
 
   const yamlData = yaml.dump(transformedMeeting, {
@@ -28,7 +36,9 @@ export const generateRetroSummary = async (
 
   const manager = new OpenAIServerManager()
   const newSummary = await manager.generateSummary(yamlData, prompt)
-  if (!newSummary) return null
+  if (!newSummary) {
+    return setSummaryToNull(meetingId)
+  }
 
   const pg = getKysely()
   await pg

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -112,7 +112,8 @@ const safeEndRetrospective = async ({
       endedAt: sql`CURRENT_TIMESTAMP`,
       phases: JSON.stringify(phases),
       usedReactjis: JSON.stringify(insights.usedReactjis),
-      engagement: insights.engagement
+      engagement: insights.engagement,
+      summary: '' // empty string signals "loading" to the client
     })
     .where('id', '=', meetingId)
     .executeTakeFirst()

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -113,7 +113,7 @@ const safeEndRetrospective = async ({
       phases: JSON.stringify(phases),
       usedReactjis: JSON.stringify(insights.usedReactjis),
       engagement: insights.engagement,
-      summary: '' // empty string signals "loading" to the client
+      summary: '<loading>' // set as "<loading>" while the AI summary is being generated
     })
     .where('id', '=', meetingId)
     .executeTakeFirst()

--- a/packages/server/graphql/public/typeDefs/RetrospectiveMeeting.graphql
+++ b/packages/server/graphql/public/typeDefs/RetrospectiveMeeting.graphql
@@ -68,6 +68,11 @@ type RetrospectiveMeeting implements NewMeeting {
   facilitator: TeamMember!
 
   """
+  If the AI generated summary is loading
+  """
+  isLoadingSummary: Boolean!
+
+  """
   The team members that were active during the time of the meeting
   """
   meetingMembers: [RetrospectiveMeetingMember!]!

--- a/packages/server/graphql/public/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/public/types/RetrospectiveMeeting.ts
@@ -14,6 +14,7 @@ const RetrospectiveMeeting: RetrospectiveMeetingResolvers = {
     const res = await dataLoader.get('meetingMembersByMeetingId').load(meetingId)
     return res as RetroMeetingMember[]
   },
+  isLoadingSummary: ({summary}) => summary === '<loading>',
   reflectionCount: ({reflectionCount}) => reflectionCount || 0,
   reflectionGroup: async ({id: meetingId}, {reflectionGroupId}, {dataLoader}) => {
     const reflectionGroup = await dataLoader.get('retroReflectionGroups').load(reflectionGroupId)

--- a/packages/server/graphql/public/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/public/types/RetrospectiveMeeting.ts
@@ -14,6 +14,7 @@ const RetrospectiveMeeting: RetrospectiveMeetingResolvers = {
     const res = await dataLoader.get('meetingMembersByMeetingId').load(meetingId)
     return res as RetroMeetingMember[]
   },
+  summary: ({summary}) => (summary === '<loading>' ? null : summary),
   isLoadingSummary: ({summary}) => summary === '<loading>',
   reflectionCount: ({reflectionCount}) => reflectionCount || 0,
   reflectionGroup: async ({id: meetingId}, {reflectionGroupId}, {dataLoader}) => {


### PR DESCRIPTION
Demo: https://www.loom.com/share/974d623e1e5f4864bc0fbd4947cac20b

Fix https://github.com/ParabolInc/parabol/issues/10499

In prod, if the AI summary fails to generate because of a problem with ChatGPT or because the retro doesn't have any votes so `generateRetroSummary` doesn't have any valid reflection groups, the AI meeting summary will load indefinitely.

In this PR, if we fail to generate the AI summary, we won't show the loading UI indefinitely.

### AC

- [ ] If there is a valid AI summary, we see the loading UI followed by the summary
- [ ] If there is not a valid AI summary, e.g. when there are no votes on any reflection groups, we don't see an AI summary