### PR TITLE
fix: kill mattermost plugin dev server on pm2 kill

### DIFF
--- a/packages/mattermost-plugin/scripts/hmrServer.js
+++ b/packages/mattermost-plugin/scripts/hmrServer.js
@@ -1,0 +1,20 @@
+require('sucrase/register')
+require('../../../scripts/webpack/utils/dotenv')
+const path = require('path')
+const webpack = require('webpack')
+const WebpackDevServer = require('webpack-dev-server/lib/Server')
+const waitForFileExists = require('../../../scripts/waitForFileExists').default
+
+const hmrServer = async () => {
+  const mattermostPluginConfig = require('../webpack.config')
+  const mattermostPluginCompiler = webpack(mattermostPluginConfig)
+  const mattermostServer = new WebpackDevServer({...mattermostPluginConfig.devServer}, mattermostPluginCompiler)
+
+  const queryMapExists = await waitForFileExists(path.join(__dirname, '../../../queryMap.json'), 20000)
+  if (!queryMapExists) throw Error('QueryMap Not Available. Run `yarn relay:build`')
+
+  await mattermostServer.start(3002, 'localhost')
+}
+
+hmrServer()
+

--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -98,8 +98,8 @@ module.exports = {
     },
     {
       name: 'Mattermost Plugin Dev Server',
-      script: 'yarn workspace parabol-mattermost-plugin dev',
-      instances: 1
+      script: './scripts/hmrServer.js',
+      cwd: 'packages/mattermost-plugin'
     }
   ].map((app) => ({
     env_production: {


### PR DESCRIPTION

# Description

Fixes #10645 
Start the hot module reload (hmr) dev server for the mattermost plugin manually so that pm2 properly cleans it up.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
