### PR TITLE
fix: Shorten chunk names for Mattermost plugin

### DIFF
--- a/packages/mattermost-plugin/prod.webpack.config.js
+++ b/packages/mattermost-plugin/prod.webpack.config.js
@@ -1,4 +1,4 @@
-const { ModuleFederationPlugin } = require("webpack").container;
+const webpack = require('webpack')
 const TerserPlugin = require('terser-webpack-plugin')
 const path = require('path')
 const getProjectRoot = require('../../scripts/webpack/utils/getProjectRoot')
@@ -7,6 +7,14 @@ const PROJECT_ROOT = getProjectRoot()
 const PLUGIN_ROOT = path.join(PROJECT_ROOT, 'packages', 'mattermost-plugin')
 const CLIENT_ROOT = path.join(PROJECT_ROOT, 'packages', 'client')
 const buildPath = path.join(PROJECT_ROOT, 'build')
+
+// strip everything till the last node_modules directory in path
+const normalizeName = (pathData) => {
+  const name = pathData.chunk.name || pathData.chunk.id
+  return name
+  .replace(/.*node_modules/g, "")
+  .trim().replace(/ +/g, "-")
+}
 
 const clientTransformRules = (pluginRoot) => {
   return [
@@ -59,8 +67,8 @@ module.exports = (config) => {
       path: buildPath,
       publicPath: "auto",
       filename: 'mattermost-plugin_[name]_[contenthash].js',
-      chunkFilename: 'mattermost-plugin_[name]_[contenthash].js',
-      assetModuleFilename: 'mattermost-plugin_[name]_[contenthash][ext]'
+      chunkFilename: (pathData) => (`mattermost-plugin_${normalizeName(pathData)}_[contenthash].js`),
+      assetModuleFilename: 'mattermost-plugin_asset_[name]_[contenthash][ext]'
     },
     resolve: {
       alias: {
@@ -95,7 +103,7 @@ module.exports = (config) => {
       ]
     },
     plugins: [
-      new ModuleFederationPlugin({
+      new webpack.container.ModuleFederationPlugin({
         name: "parabol",
         filename: "mattermost-plugin-entry.js",
         exposes: {

--- a/packages/mattermost-plugin/webpack.config.js
+++ b/packages/mattermost-plugin/webpack.config.js
@@ -53,6 +53,8 @@ module.exports = {
   },
   output: {
     publicPath: "auto",
+    filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
   },
   resolve: {
     alias: {


### PR DESCRIPTION
# Description
Fixes #10657
Some systems have a very limited NAME_MAX for filenames (143), so let's strip some not so useful parts of the chunk names.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
