### PR TITLE
chore: make ai standups more concise and add context

### DIFF
--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -522,7 +522,7 @@ export const enum PollsAriaLabels {
 }
 
 export const enum AIExplainer {
-  STARTER = `AI generated summaries 🤖 are a premium feature. We'll share them with you for a few retros so you can see what they're like.`,
+  STARTER = `AI generated summaries 🤖 are a premium feature. We'll share them with you a few times so you can see what they're like.`,
   PREMIUM_MEETING = `Our friendly AI 🤖 is here to save you time by summarizing your meeting`,
   PREMIUM_REFLECTIONS = `Our friendly AI 🤖 is here to save you time by summarizing your reflections`
 }

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -522,7 +522,7 @@ export const enum PollsAriaLabels {
 }
 
 export const enum AIExplainer {
-  STARTER = `AI generated summaries 🤖 are a premium feature. We'll share them with you a few times so you can see what they're like.`,
+  STARTER = `AI generated summaries 🤖 are a premium feature, but we'll share a few summaries with you so you can see what they're like.`,
   PREMIUM_MEETING = `Our friendly AI 🤖 is here to save you time by summarizing your meeting`,
   PREMIUM_REFLECTIONS = `Our friendly AI 🤖 is here to save you time by summarizing your reflections`
 }

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -2,6 +2,7 @@ import {getTeamPromptResponsesByMeetingId} from '../../../postgres/queries/getTe
 import {TeamPromptMeeting} from '../../../postgres/types/Meeting'
 import OpenAIServerManager from '../../../utils/OpenAIServerManager'
 import {DataLoaderWorker} from '../../graphql'
+import isValid from '../../isValid'
 import canAccessAI from './canAccessAI'
 
 const generateStandupMeetingSummary = async (

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -19,7 +19,7 @@ const generateStandupMeetingSummary = async (
 
   const contentWithUsers = responses.map((response, idx) => ({
     content: response.plaintextContent,
-    user: users[idx]?.name ?? 'Anonymous'
+    user: users[idx]?.preferredName ?? 'Anonymous'
   }))
 
   if (contentWithUsers.length === 0) return

--- a/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
+++ b/packages/server/graphql/mutations/helpers/generateStandupMeetingSummary.ts
@@ -15,7 +15,7 @@ const generateStandupMeetingSummary = async (
   const responses = await getTeamPromptResponsesByMeetingId(meeting.id)
 
   const userIds = responses.map((response) => response.userId)
-  const users = await dataLoader.get('users').loadMany(userIds)
+  const users = (await dataLoader.get('users').loadMany(userIds)).filter(isValid)
 
   const contentWithUsers = responses.map((response, idx) => ({
     content: response.plaintextContent,

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -24,22 +24,20 @@ class OpenAIServerManager {
 
   async getStandupSummary(plaintextResponses: string[], meetingPrompt: string) {
     if (!this.openAIApi) return null
-    // :TODO: (jmtaber129): Include info about who made each response in the prompt, so that the LLM
-    // can include that in the response, e.g. "James is working on AI Summaries" vs. "Someone is
-    // working on AI Summaries".
-    const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". If there are multiple responses, the responses are delimited by the string "NEW_RESPONSE". Identify up to 5 themes found within the responses. For each theme, provide a 2 to 3 sentence summary. In the summaries, only include information specified in the responses. When referring to people in the output, do not assume their gender and default to using the pronouns "they" and "them".
+    // :TODO: (jmtaber129): Include info about who made each response in the prompt
+    const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". If there are multiple responses, the responses are delimited by the string "NEW_RESPONSE". Identify up to 3 key themes found within the responses. For each theme, provide a single concise sentence summary. Only include essential information from the responses. Use "they/them" pronouns when referring to people.
 
     Desired format:
-    - <theme title>: <theme summary>
-    - <theme title>: <theme summary>
-    - <theme title>: <theme summary>
+    - <theme>: <brief summary>
+    - <theme>: <brief summary>
+    - <theme>: <brief summary>
 
     Responses: """
     ${plaintextResponses.join('\nNEW_RESPONSE\n')}
     """`
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: 'gpt-4o',
         messages: [
           {
             role: 'user',
@@ -47,7 +45,7 @@ class OpenAIServerManager {
           }
         ],
         temperature: 0.7,
-        max_tokens: 1000,
+        max_tokens: 500,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0
@@ -454,5 +452,7 @@ Important: Respond with ONLY the title itself. Do not include any prefixes like 
     }
   }
 }
+
+export default OpenAIServerManager
 
 export default OpenAIServerManager

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -38,7 +38,6 @@ class OpenAIServerManager {
     Responses: """
     ${responses.map(({content, user}) => `${user}: ${content}`).join('\nNEW_RESPONSE\n')}
     """`
-    console.log('🚀 ~ prompt:', prompt)
 
     try {
       const response = await this.openAIApi.chat.completions.create({
@@ -457,7 +456,5 @@ Important: Respond with ONLY the title itself. Do not include any prefixes like 
     }
   }
 }
-
-export default OpenAIServerManager
 
 export default OpenAIServerManager

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -22,19 +22,24 @@ class OpenAIServerManager {
     })
   }
 
-  async getStandupSummary(plaintextResponses: string[], meetingPrompt: string) {
+  async getStandupSummary(
+    responses: Array<{content: string; user: string}>,
+    meetingPrompt: string
+  ) {
     if (!this.openAIApi) return null
-    // :TODO: (jmtaber129): Include info about who made each response in the prompt
-    const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". If there are multiple responses, the responses are delimited by the string "NEW_RESPONSE". Identify up to 3 key themes found within the responses. For each theme, provide a single concise sentence summary. Only include essential information from the responses. Use "they/them" pronouns when referring to people.
+
+    const prompt = `Below is a list of responses submitted by team members to the question "${meetingPrompt}". Each response includes the team member's name. Identify up to 3 key themes found within the responses. For each theme, provide a single concise sentence that includes who is working on what. Use "they/them" pronouns when referring to people.
 
     Desired format:
-    - <theme>: <brief summary>
-    - <theme>: <brief summary>
-    - <theme>: <brief summary>
+    - <theme>: <brief summary including names>
+    - <theme>: <brief summary including names>
+    - <theme>: <brief summary including names>
 
     Responses: """
-    ${plaintextResponses.join('\nNEW_RESPONSE\n')}
+    ${responses.map(({content, user}) => `${user}: ${content}`).join('\nNEW_RESPONSE\n')}
     """`
+    console.log('🚀 ~ prompt:', prompt)
+
     try {
       const response = await this.openAIApi.chat.completions.create({
         model: 'gpt-4o',


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/10676

This PR:

- Makes the standup AI summary more concise, reducing themes from 5 to 3, and making each paragraph shorter
- Updates the AI Explainer text so that it's not Retro specific
- Adds context of who said what in the Standup
- Upgrades the standup open ai model to gpt-4o from 4o-mini. It's still very fast, but better quality.

Note: when ending a standup locally, I run into this bug: https://github.com/ParabolInc/parabol/issues/8471

### To test

- [ ] Promote your user to Org Admin. Go to the org settings and turn on the standup feature flag from the UI
- [ ] Run a Standup, end the stand-up, and see that the AI Summary is more concise