### PR TITLE
fix: Enter Key Functionality in the Response Editor when @ symbol is …

### DIFF
--- a/packages/client/components/MentionDropdown.tsx
+++ b/packages/client/components/MentionDropdown.tsx
@@ -30,6 +30,9 @@ export default forwardRef(
 
     const enterHandler = () => {
       selectItem(selectedIndex)
+
+      if (items.length === 0) return false
+      return true
     }
 
     useEffect(() => setSelectedIndex(0), [items])
@@ -47,8 +50,7 @@ export default forwardRef(
         }
 
         if (event.key === 'Enter' || event.key === 'Tab') {
-          enterHandler()
-          return true
+          return enterHandler()
         }
         return false
       }


### PR DESCRIPTION
# Description

Fixes #10698
This MR addresses a bug in the Enter key functionality when typing "@" symbols followed by text in the editor. Specifically:
- Fixed the behavior where hitting Enter does not move to the next line when "@" and the following text share the same style (e.g., both bold or italic).
- Ensured that Enter key functionality correctly transitions between user selection and new line insertion based on whether a popup suggestion is available.
- Added logic to handle scenarios where no matches are found in the suggestion popup.

## Demo

https://github.com/user-attachments/assets/f36f3ceb-793b-4783-95bf-686d8777954d



## Testing Scenarios
Please validate the following scenarios to ensure the fix is comprehensive:

 - Scenario 1: Type "@" and select a username from the popup. Verify that hitting Enter selects the user as expected.
    - Step 1: Type "@"
    - Step 2: Start typing a username and select it from the popup.
    - Step 3: Hit Enter and ensure the user is inserted correctly.
 
- Scenario 2: Type "@" followed by text with no matching user and hit Enter. Ensure the cursor moves to the next line.
   - Step 1: Type "@nonexistent-text"
   - Step 2: Hit Enter and confirm the new line is created.

 - Scenario 3: Validate that no regressions occur with existing mention functionality:
   - Ensure the suggestion popup works as expected.
   - Ensure the popup hides when Escape is pressed.

## Final checklist
- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
