### PR TITLE
feat: group timeline events by relative dates

### DIFF
--- a/packages/client/components/TimelineFeedList.tsx
+++ b/packages/client/components/TimelineFeedList.tsx
@@ -13,14 +13,37 @@ const ResultScroller = styled('div')({
   overflow: 'auto'
 })
 
+const DateHeaderContainer = styled('div')({
+  position: 'relative',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '16px 0',
+  margin: '8px 0',
+  '&::before, &::after': {
+    content: '""',
+    position: 'absolute',
+    top: '50%',
+    width: '42%',
+    height: '1px',
+    backgroundColor: 'rgb(226 232 240)' // slate-200
+  },
+  '&::before': {
+    left: 0
+  },
+  '&::after': {
+    right: 0
+  }
+})
+
 const DateHeader = styled('div')({
-  padding: '16px 0 8px',
-  fontSize: '1rem',
-  fontWeight: 600,
+  fontSize: '0.875rem', // 14px
+  fontWeight: 500,
   color: 'rgb(71 85 105)', // slate-600
-  position: 'sticky',
-  top: 0,
-  backgroundColor: 'white',
+  backgroundColor: 'rgb(248 250 252)', // slate-50
+  border: '1px solid rgb(226 232 240)', // slate-200
+  borderRadius: '9999px',
+  padding: '4px 12px',
   zIndex: 1
 })
 
@@ -190,7 +213,9 @@ const TimelineFeedList = (props: Props) => {
     <ResultScroller>
       {groupedFreeHistory.groups.map(({date, events, label}) => (
         <div key={date.toISOString()}>
-          <DateHeader>{label}</DateHeader>
+          <DateHeaderContainer>
+            <DateHeader>{label}</DateHeader>
+          </DateHeaderContainer>
           {events.map(({node: timelineEvent}) => (
             <TimelineEvent key={timelineEvent.id} timelineEvent={timelineEvent} />
           ))}

--- a/packages/client/components/TimelineFeedList.tsx
+++ b/packages/client/components/TimelineFeedList.tsx
@@ -4,6 +4,7 @@ import {useMemo} from 'react'
 import {usePaginationFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
 import useLoadNextOnScrollBottom from '~/hooks/useLoadNextOnScrollBottom'
+import {TimelineGroup, getTimeGroup} from '~/utils/date/timelineGroups'
 import {TimelineFeedListPaginationQuery} from '../__generated__/TimelineFeedListPaginationQuery.graphql'
 import {TimelineFeedList_query$key} from '../__generated__/TimelineFeedList_query.graphql'
 import TimelineEvent from './TimelineEvent'
@@ -12,42 +13,6 @@ import TimelineHistoryLockedCard from './TimelineHistoryLockedCard'
 const ResultScroller = styled('div')({
   overflow: 'auto'
 })
-
-interface TimelineGroup {
-  date: Date
-  events: any[]
-  label: string
-}
-
-const getTimeGroup = (date: Date): {date: Date; label: string} => {
-  const now = new Date()
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const yesterday = new Date(today)
-  yesterday.setDate(yesterday.getDate() - 1)
-  const lastWeek = new Date(today)
-  lastWeek.setDate(lastWeek.getDate() - 7)
-  const lastMonth = new Date(today)
-  lastMonth.setMonth(lastMonth.getMonth() - 1)
-  const last3Months = new Date(today)
-  last3Months.setMonth(last3Months.getMonth() - 3)
-  const last6Months = new Date(today)
-  last6Months.setMonth(last6Months.getMonth() - 6)
-
-  if (date >= today) {
-    return {date: today, label: '🌅 Today'}
-  } else if (date >= yesterday) {
-    return {date: yesterday, label: '🌙 Yesterday'}
-  } else if (date >= lastWeek) {
-    return {date: lastWeek, label: '📅 This week'}
-  } else if (date >= lastMonth) {
-    return {date: lastMonth, label: '📆 This month'}
-  } else if (date >= last3Months) {
-    return {date: last3Months, label: '🗓️ Past 3 months'}
-  } else if (date >= last6Months) {
-    return {date: last6Months, label: '📚 Past 6 months'}
-  }
-  return {date: last6Months, label: '🏛️ Ancient history'}
-}
 
 interface Props {
   queryRef: TimelineFeedList_query$key

--- a/packages/client/components/TimelineFeedList.tsx
+++ b/packages/client/components/TimelineFeedList.tsx
@@ -13,40 +13,6 @@ const ResultScroller = styled('div')({
   overflow: 'auto'
 })
 
-const DateHeaderContainer = styled('div')({
-  position: 'relative',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  padding: '16px 0',
-  margin: '8px 0',
-  '&::before, &::after': {
-    content: '""',
-    position: 'absolute',
-    top: '50%',
-    width: '42%',
-    height: '1px',
-    backgroundColor: 'rgb(226 232 240)' // slate-200
-  },
-  '&::before': {
-    left: 0
-  },
-  '&::after': {
-    right: 0
-  }
-})
-
-const DateHeader = styled('div')({
-  fontSize: '0.875rem', // 14px
-  fontWeight: 500,
-  color: 'rgb(71 85 105)', // slate-600
-  backgroundColor: 'rgb(248 250 252)', // slate-50
-  border: '1px solid rgb(226 232 240)', // slate-200
-  borderRadius: '9999px',
-  padding: '4px 12px',
-  zIndex: 1
-})
-
 interface TimelineGroup {
   date: Date
   events: any[]
@@ -213,9 +179,13 @@ const TimelineFeedList = (props: Props) => {
     <ResultScroller>
       {groupedFreeHistory.groups.map(({date, events, label}) => (
         <div key={date.toISOString()}>
-          <DateHeaderContainer>
-            <DateHeader>{label}</DateHeader>
-          </DateHeaderContainer>
+          <div className='my-2 flex items-center gap-4 py-4'>
+            <div className='h-[1px] flex-1 bg-slate-400' />
+            <div className='bg-slate-50 rounded-full border border-slate-200 px-3 py-1 text-sm font-medium text-slate-600'>
+              {label}
+            </div>
+            <div className='h-[1px] flex-1 bg-slate-400' />
+          </div>
           {events.map(({node: timelineEvent}) => (
             <TimelineEvent key={timelineEvent.id} timelineEvent={timelineEvent} />
           ))}

--- a/packages/client/utils/date/relativeDate.ts
+++ b/packages/client/utils/date/relativeDate.ts
@@ -6,12 +6,12 @@
 import humanizeDuration from 'humanize-duration'
 import plural from '../plural'
 
-const SECOND = 1000
-const MIN = SECOND * 60
-const HOUR = MIN * 60
-const DAY = HOUR * 24
-const YEAR = DAY * 365
-const MONTH = DAY * 30
+export const SECOND = 1000
+export const MIN = SECOND * 60
+export const HOUR = MIN * 60
+export const DAY = HOUR * 24
+export const YEAR = DAY * 365
+export const MONTH = DAY * 30
 
 interface Opts {
   max?: number

--- a/packages/client/utils/date/timelineGroups.ts
+++ b/packages/client/utils/date/timelineGroups.ts
@@ -1,0 +1,45 @@
+import {DAY, MONTH} from './relativeDate'
+
+interface TimelineGroup {
+  date: Date
+  events: any[]
+  label: string
+}
+
+export interface TimelineGrouping {
+  date: Date
+  label: string
+}
+
+const getStartOfDay = (date: Date): Date => {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+export const getTimeGroup = (date: Date): TimelineGrouping => {
+  const now = new Date()
+  const today = getStartOfDay(now)
+  const yesterday = new Date(today.getTime() - DAY)
+  const lastWeek = new Date(today.getTime() - 7 * DAY)
+  const lastMonth = new Date(today.getTime() - 30 * DAY)
+  const last3Months = new Date(today.getTime() - 3 * MONTH)
+  const last6Months = new Date(today.getTime() - 6 * MONTH)
+
+  const compareDate = getStartOfDay(date)
+
+  if (compareDate >= today) {
+    return {date: today, label: '🌅 Today'}
+  } else if (compareDate >= yesterday) {
+    return {date: yesterday, label: '🌙 Yesterday'}
+  } else if (compareDate >= lastWeek) {
+    return {date: lastWeek, label: '📅 This week'}
+  } else if (compareDate >= lastMonth) {
+    return {date: lastMonth, label: '📆 This month'}
+  } else if (compareDate >= last3Months) {
+    return {date: last3Months, label: '🗓️ Past 3 months'}
+  } else if (compareDate >= last6Months) {
+    return {date: last6Months, label: '📚 Past 6 months'}
+  }
+  return {date: last6Months, label: '🏛️ Ancient history'}
+}
+
+export type {TimelineGroup}


### PR DESCRIPTION
# Description

Fixes [this bet](https://www.notion.so/parabol/2025-T1-Shape-Up-Cycle-6-1613b8ee3774808883e1dd03932724a5?pvs=4#1613b8ee37748144b055d7d63a21e8cd):

> The “Scrum Knights” found our Timeline view to be cluttered. Let’s improve its organization by adding headers that group activities by time. Ideally we can determine an appropriate header frequency when presenting the meeting history (days, weeks, or months) dynamically.

## Demo

<img width="1248" alt="Screenshot 2025-01-20 at 17 32 27" src="https://github.com/user-attachments/assets/b63913ed-2fdc-419b-bd9e-f7686a900af1" />


## Testing scenarios

- [ ] Grouped timeline
  - Go to http://localhost:3000/me
  - See timeline events grouped by relative date headers

- [ ] Locked history
  - Go to http://localhost:3000/me with a `starter` team & locked histories
  - Scroll down and still see the locked history card

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
