### PR TITLE
chore: update public teams feature flag expiry date

### DIFF
--- a/packages/server/postgres/migrations/2025-01-28T18:45:26.843Z_update-public-teams-expiry-date.ts
+++ b/packages/server/postgres/migrations/2025-01-28T18:45:26.843Z_update-public-teams-expiry-date.ts
@@ -1,0 +1,21 @@
+import type {Kysely} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable('FeatureFlag')
+    .set({
+      expiresAt: '2025-03-31T00:00:00.000Z'
+    })
+    .where('featureName', '=', 'publicTeams')
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .updateTable('FeatureFlag')
+    .set({
+      expiresAt: '2025-01-31T00:00:00.000Z'
+    })
+    .where('featureName', '=', 'publicTeams')
+    .execute()
+}


### PR DESCRIPTION
The public teams feature flag expires at the end of Jan. We should update the expiry date for self hosted customers. 