### PR TITLE
feat: Support image resizing in TipTap

### DIFF
--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -201,14 +201,16 @@ const ReflectionCard = (props: Props) => {
   } = useTooltip<HTMLDivElement>(MenuPosition.UPPER_CENTER)
   const handleEditorFocus = () => {
     if (isTempId(reflectionId)) return
+    if (reflection.isEditing) {
+      return
+    }
+    updateIsEditing(true)
     EditReflectionMutation(atmosphere, {isEditing: true, meetingId, promptId})
   }
 
   const updateIsEditing = (isEditing: boolean) => {
     commitLocalUpdate(atmosphere, (store) => {
-      const reflection = store.get(reflectionId)
-      if (!reflection) return
-      reflection.setValue(isEditing, 'isEditing')
+      store.get(reflectionId)?.setValue(isEditing, 'isEditing')
     })
   }
 
@@ -244,16 +246,20 @@ const ReflectionCard = (props: Props) => {
       {content: contentStr, reflectionId},
       {onError, onCompleted}
     )
-    commitLocalUpdate(atmosphere, (store) => {
-      const reflection = store.get(reflectionId)
-      if (!reflection) return
-      reflection.setValue(false, 'isEditing')
-    })
   }
 
-  const handleEditorBlur = () => {
+  const handleEditorBlur = (e: React.FocusEvent<HTMLDivElement>) => {
     if (isTempId(reflectionId)) return
+    const newFocusedElement = e.relatedTarget as Node
+    const isClickInModal = !(
+      newFocusedElement === null || document.getElementById('root')?.contains(newFocusedElement)
+    )
+    // If they clicked in a modal, then ignore the blur event, we'll refocus the editor after the modal closes
+    if (isClickInModal) {
+      return
+    }
     handleContentUpdate()
+    updateIsEditing(false)
     EditReflectionMutation(atmosphere, {isEditing: false, meetingId, promptId})
   }
 

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -251,6 +251,8 @@ const ReflectionCard = (props: Props) => {
   const handleEditorBlur = (e: React.FocusEvent<HTMLDivElement>) => {
     if (isTempId(reflectionId)) return
     const newFocusedElement = e.relatedTarget as Node
+    // don't trigger a blur if a button inside the element is clicked
+    if (e.currentTarget.contains(newFocusedElement)) return
     const isClickInModal = !(
       newFocusedElement === null || document.getElementById('root')?.contains(newFocusedElement)
     )

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled'
 import {useEventCallback} from '@mui/material'
-import {generateHTML} from '@tiptap/core'
 import graphql from 'babel-plugin-relay/macro'
 import * as React from 'react'
 import {MutableRefObject, RefObject, useEffect, useRef, useState} from 'react'
@@ -12,7 +11,6 @@ import usePortal from '../../hooks/usePortal'
 import {useTipTapReflectionEditor} from '../../hooks/useTipTapReflectionEditor'
 import CreateReflectionMutation from '../../mutations/CreateReflectionMutation'
 import EditReflectionMutation from '../../mutations/EditReflectionMutation'
-import {serverTipTapExtensions} from '../../shared/tiptap/serverTipTapExtensions'
 import {Elevation} from '../../styles/elevation'
 import {BezierCurve, ZIndex} from '../../types/constEnums'
 import {cn} from '../../ui/cn'
@@ -101,7 +99,7 @@ const PhaseItemEditor = (props: Props) => {
     const {top, left} = getBBox(phaseEditorRef.current)!
     const cardInFlight = {
       transform: `translate(${left}px,${top}px)`,
-      html: generateHTML(contentJSON, serverTipTapExtensions),
+      html: editor.getHTML(),
       key: content,
       isStart: true
     }

--- a/packages/client/components/RetroReflectPhase/ReflectionStack.tsx
+++ b/packages/client/components/RetroReflectPhase/ReflectionStack.tsx
@@ -6,12 +6,7 @@ import {useFragment} from 'react-relay'
 import {ReflectionStack_meeting$key} from '~/__generated__/ReflectionStack_meeting.graphql'
 import {PhaseItemColumn_meeting$data} from '../../__generated__/PhaseItemColumn_meeting.graphql'
 import useExpandedReflections from '../../hooks/useExpandedReflections'
-import {
-  Breakpoint,
-  ElementHeight,
-  ElementWidth,
-  ReflectionStackPerspective
-} from '../../types/constEnums'
+import {ElementWidth, ReflectionStackPerspective} from '../../types/constEnums'
 import ReflectionCard from '../ReflectionCard/ReflectionCard'
 import ExpandedReflectionStack from './ExpandedReflectionStack'
 import ReflectionStackPlaceholder from './ReflectionStackPlaceholder'
@@ -25,22 +20,6 @@ interface Props {
   reflectionStack: readonly PhaseItemColumn_meeting$data['reflectionGroups'][0]['reflections'][0][]
   stackTopRef: RefObject<HTMLDivElement>
 }
-
-const CardStack = styled('div')({
-  alignItems: 'flex-start',
-  display: 'flex',
-  flex: 1,
-  margin: '0 0 24px', // stacked cards + row gutter = 6 + 6 + 12 = 24
-  position: 'relative',
-  justifyContent: 'center',
-  [`@media screen and (min-width: ${Breakpoint.SINGLE_REFLECTION_COLUMN}px)`]: {
-    minHeight: ElementHeight.REFLECTION_CARD_MAX
-  }
-})
-
-const CenteredCardStack = styled('div')({
-  position: 'relative'
-})
 
 const ReflectionWrapper = styled('div')<{idx: number}>(({idx}): any => {
   const multiple = Math.min(idx, 2)
@@ -94,9 +73,15 @@ const ReflectionStack = (props: Props) => {
           closePortal={collapse}
         />
       )}
+
       <div>
-        <CardStack data-cy={dataCy} onClick={expand} ref={stackRef}>
-          <CenteredCardStack>
+        <div
+          data-cy={dataCy}
+          onClick={expand}
+          ref={stackRef}
+          className='relative mb-6 flex flex-1 select-none items-start justify-center single-reflection-column:min-h-[104px]'
+        >
+          <div className='relative'>
             {reflectionStack.map((reflection, idx) => {
               return (
                 <ReflectionWrapper
@@ -115,8 +100,8 @@ const ReflectionStack = (props: Props) => {
                 </ReflectionWrapper>
               )
             })}
-          </CenteredCardStack>
-        </CardStack>
+          </div>
+        </div>
       </div>
     </React.Fragment>
   )

--- a/packages/client/hooks/useBlockResizer.tsx
+++ b/packages/client/hooks/useBlockResizer.tsx
@@ -1,0 +1,67 @@
+import {useRef} from 'react'
+import getIsDrag from '../utils/retroGroup/getIsDrag'
+import useEventCallback from './useEventCallback'
+
+const makeDrag = () => ({
+  isDrag: false,
+  startX: 0,
+  lastX: 0,
+  side: 'left'
+})
+export const useBlockResizer = (
+  width: number,
+  setWidth: (width: number) => void,
+  updateAttributes: (attrs: Record<string, any>) => void
+) => {
+  const dragRef = useRef(makeDrag())
+  const onMouseUp = useEventCallback((e: MouseEvent | TouchEvent) => {
+    if (e.type === 'touchend') {
+      document.removeEventListener('touchmove', onMouseMove)
+    } else {
+      document.removeEventListener('mousemove', onMouseMove)
+    }
+    updateAttributes({width})
+    dragRef.current = makeDrag()
+  })
+
+  const onMouseMove = useEventCallback((e: MouseEvent | TouchEvent) => {
+    // required to prevent address bar scrolling & other strange browser things on mobile view
+    e.preventDefault()
+    const isTouchMove = e.type === 'touchmove'
+    const {clientX} = isTouchMove ? (e as TouchEvent).touches[0]! : (e as MouseEvent)
+    const {current: drag} = dragRef
+    const wasDrag = drag.isDrag
+    if (!wasDrag) {
+      const isDrag = getIsDrag(clientX, 0, drag.startX, 0)
+      drag.isDrag = isDrag
+      if (!drag.isDrag) return
+    }
+    const sideCoefficient = drag.side === 'left' ? 1 : -1
+    const delta = (drag.lastX - clientX) * sideCoefficient
+    drag.lastX = clientX
+    const nextWidth = Math.max(48, width + delta)
+    setWidth(nextWidth)
+  })
+
+  const onMouseDown = useEventCallback(
+    (side: 'left' | 'right') =>
+      (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
+        const isTouchStart = e.type === 'touchstart'
+        if (isTouchStart) {
+          document.addEventListener('touchmove', onMouseMove)
+          document.addEventListener('touchend', onMouseUp, {once: true})
+        } else {
+          document.addEventListener('mousemove', onMouseMove)
+          document.addEventListener('mouseup', onMouseUp, {once: true})
+        }
+        const {clientX} = isTouchStart
+          ? (e as React.TouchEvent<HTMLDivElement>).touches[0]!
+          : (e as React.MouseEvent<HTMLDivElement>)
+        dragRef.current.side = side
+        dragRef.current.startX = clientX
+        dragRef.current.lastX = clientX
+        dragRef.current.isDrag = false
+      }
+  )
+  return {onMouseDown, onMouseMove, onMouseUp, width}
+}

--- a/packages/client/hooks/useBlockResizer.tsx
+++ b/packages/client/hooks/useBlockResizer.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react'
+import {useRef, type RefObject} from 'react'
 import getIsDrag from '../utils/retroGroup/getIsDrag'
 import useEventCallback from './useEventCallback'
 
@@ -11,7 +11,8 @@ const makeDrag = () => ({
 export const useBlockResizer = (
   width: number,
   setWidth: (width: number) => void,
-  updateAttributes: (attrs: Record<string, any>) => void
+  updateAttributes: (attrs: Record<string, any>) => void,
+  aspectRatioRef: RefObject<number>
 ) => {
   const dragRef = useRef(makeDrag())
   const onMouseUp = useEventCallback((e: MouseEvent | TouchEvent) => {
@@ -20,7 +21,8 @@ export const useBlockResizer = (
     } else {
       document.removeEventListener('mousemove', onMouseMove)
     }
-    updateAttributes({width})
+    const aspectRatio = aspectRatioRef.current!
+    updateAttributes({width, height: Math.round(width / aspectRatio)})
     dragRef.current = makeDrag()
   })
 

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -70,7 +70,7 @@ export const useTipTapReflectionEditor = (
           'To-do list': false
         }),
         Focus,
-        ImageUpload.configure({editorWidth: ElementWidth.REFLECTION_CARD}),
+        ImageUpload.configure({editorWidth: ElementWidth.REFLECTION_CARD, editorHeight: 112}),
         ImageBlock,
         LoomExtension,
         Placeholder.configure({

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -70,7 +70,7 @@ export const useTipTapReflectionEditor = (
           'To-do list': false
         }),
         Focus,
-        ImageUpload.configure({editorWidth: ElementWidth.REFLECTION_CARD, editorHeight: 112}),
+        ImageUpload.configure({editorWidth: ElementWidth.REFLECTION_CARD, editorHeight: 88}),
         ImageBlock,
         LoomExtension,
         Placeholder.configure({

--- a/packages/client/shared/tiptap/serverTipTapExtensions.ts
+++ b/packages/client/shared/tiptap/serverTipTapExtensions.ts
@@ -5,7 +5,7 @@ import {TaskItem} from '@tiptap/extension-task-item'
 import {TaskList} from '@tiptap/extension-task-list'
 import StarterKit from '@tiptap/starter-kit'
 import {LoomExtension} from '../../components/promptResponse/loomExtension'
-import ImageBlock from '../../tiptap/extensions/imageBlock/ImageBlock'
+import {ImageBlockBase} from '../../tiptap/extensions/imageBlock/ImageBlockBase'
 import {tiptapTagConfig} from '../../utils/tiptapTagConfig'
 import {ImageUploadBase} from './extensions/ImageUploadBase'
 
@@ -24,7 +24,7 @@ export const serverTipTapExtensions = [
     nested: true
   }),
   ImageUploadBase,
-  ImageBlock,
+  ImageBlockBase,
   LoomExtension,
   Mention.configure(mentionConfig),
   Mention.extend({name: 'taskTag'}).configure(tiptapTagConfig),

--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -235,17 +235,17 @@
     }
     &.ProseMirror-selectednode::after {
       content: '';
-      @apply absolute inset-0 h-full w-full rounded bg-[#2383e247];
+      @apply pointer-events-none absolute inset-0 h-full w-full select-none rounded bg-[#2383e247];
     }
   }
   .node-imageBlock {
     @apply relative;
     &.has-focus > div::after {
       content: '';
-      @apply absolute inset-0 h-full w-full bg-[#2383e247];
+      @apply pointer-events-none absolute inset-0 h-full w-full select-none bg-[#2383e247];
     }
     & img {
-      @apply overflow-hidden rounded-md border-2 border-transparent;
+      @apply overflow-hidden rounded-md;
     }
   }
 }

--- a/packages/client/tiptap/extensions/imageBlock/BlockResizer.tsx
+++ b/packages/client/tiptap/extensions/imageBlock/BlockResizer.tsx
@@ -1,0 +1,21 @@
+import {cn} from '../../../ui/cn'
+
+interface Props {
+  className?: string
+  onMouseDown: (e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => void
+}
+export const BlockResizer = (props: Props) => {
+  const {className, onMouseDown} = props
+  return (
+    <div
+      onMouseDown={onMouseDown}
+      onTouchStart={onMouseDown}
+      className={cn(
+        ' absolute top-0 flex h-full w-4 items-center justify-center opacity-0 transition-opacity group-hover:opacity-100',
+        className
+      )}
+    >
+      <div className='h-[25%] w-1 cursor-col-resize rounded-3xl border-[1px] border-white/90 bg-slate-900/60 '></div>
+    </div>
+  )
+}

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlock.ts
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlock.ts
@@ -1,28 +1,8 @@
-import {mergeAttributes, Range} from '@tiptap/core'
-import {Image} from '@tiptap/extension-image'
 import {ReactNodeViewRenderer} from '@tiptap/react'
+import {ImageBlockBase} from './ImageBlockBase'
 import {ImageBlockView} from './ImageBlockView'
 
-declare module '@tiptap/core' {
-  interface Commands<ReturnType> {
-    imageBlock: {
-      setImageBlock: (attributes: {src: string}) => ReturnType
-      setImageBlockAt: (attributes: {src: string; pos: number | Range}) => ReturnType
-      setImageBlockAlign: (align: 'left' | 'center' | 'right') => ReturnType
-      setImageBlockWidth: (width: number) => ReturnType
-    }
-  }
-}
-
-export const ImageBlock = Image.extend({
-  name: 'imageBlock',
-
-  group: 'block',
-
-  defining: true,
-
-  isolating: true,
-
+export const ImageBlock = ImageBlockBase.extend({
   addAttributes() {
     return {
       src: {
@@ -55,19 +35,6 @@ export const ImageBlock = Image.extend({
       }
     }
   },
-
-  parseHTML() {
-    return [
-      {
-        tag: 'img[src]:not([src^="data:"])'
-      }
-    ]
-  },
-
-  renderHTML({HTMLAttributes}) {
-    return ['img', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
-  },
-
   addCommands() {
     return {
       setImageBlock:
@@ -90,7 +57,7 @@ export const ImageBlock = Image.extend({
       setImageBlockWidth:
         (width) =>
         ({commands}) =>
-          commands.updateAttributes('imageBlock', {width: `${Math.max(0, Math.min(100, width))}%`})
+          commands.updateAttributes('imageBlock', {width})
     }
   },
 

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlock.ts
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlock.ts
@@ -12,11 +12,18 @@ export const ImageBlock = ImageBlockBase.extend({
           src: attributes.src
         })
       },
+      height: {
+        default: '100%',
+        parseHTML: (element) => element.getAttribute('height'),
+        renderHTML: (attributes) => ({
+          height: attributes.height
+        })
+      },
       width: {
         default: '100%',
-        parseHTML: (element) => element.getAttribute('data-width'),
+        parseHTML: (element) => element.getAttribute('width'),
         renderHTML: (attributes) => ({
-          'data-width': attributes.width
+          width: attributes.width
         })
       },
       align: {

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockBase.ts
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockBase.ts
@@ -30,6 +30,12 @@ export const ImageBlockBase = Image.extend({
   },
 
   renderHTML({HTMLAttributes}) {
-    return ['img', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
+    const align = HTMLAttributes['data-align']
+    const justify = align === 'left' ? 'start' : align === 'right' ? 'end' : 'center'
+    return [
+      'div',
+      {style: `width: 100%; display: flex; justify-content: ${justify};`},
+      ['img', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
+    ]
   }
 })

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockBase.ts
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockBase.ts
@@ -1,0 +1,35 @@
+import {mergeAttributes, Range} from '@tiptap/core'
+import {Image} from '@tiptap/extension-image'
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    imageBlock: {
+      setImageBlock: (attributes: {src: string}) => ReturnType
+      setImageBlockAt: (attributes: {src: string; pos: number | Range}) => ReturnType
+      setImageBlockAlign: (align: 'left' | 'center' | 'right') => ReturnType
+      setImageBlockWidth: (width: number) => ReturnType
+    }
+  }
+}
+
+export const ImageBlockBase = Image.extend({
+  name: 'imageBlock',
+
+  group: 'block',
+
+  defining: true,
+
+  isolating: true,
+
+  parseHTML() {
+    return [
+      {
+        tag: 'img[src]:not([src^="data:"])'
+      }
+    ]
+  },
+
+  renderHTML({HTMLAttributes}) {
+    return ['img', mergeAttributes(this.options.HTMLAttributes, HTMLAttributes)]
+  }
+})

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockBubbleMenu.tsx
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockBubbleMenu.tsx
@@ -1,0 +1,44 @@
+import FormatAlignCenterIcon from '@mui/icons-material/FormatAlignCenter'
+import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft'
+import FormatAlignRightIcon from '@mui/icons-material/FormatAlignRight'
+
+interface Props {
+  updateAttributes: (attributes: Record<string, any>) => void
+  align: 'left' | 'right' | 'center'
+  width: number
+}
+
+const buttons = [
+  {name: 'left', Icon: FormatAlignLeftIcon},
+  {name: 'center', Icon: FormatAlignCenterIcon},
+  {name: 'right', Icon: FormatAlignRightIcon}
+]
+export const ImageBlockBubbleMenu = (props: Props) => {
+  const {align, width, updateAttributes} = props
+  const scaleFactor = width > 100 ? 1 : width / 100
+  return (
+    <div
+      className='absolute right-1 top-1 flex origin-top-right items-center justify-center rounded bg-slate-800/60 text-white/80 opacity-0 transition-opacity group-hover:opacity-100
+'
+      style={{transform: `scale(${scaleFactor})`}}
+    >
+      {buttons.map(({name, Icon}) => {
+        return (
+          <button
+            key={name}
+            className='flex rounded bg-inherit p-[1px]'
+            onClick={() => {
+              if (align === name) return
+              updateAttributes({align: name})
+            }}
+          >
+            <Icon
+              data-highlighted={align === name}
+              className='cursor-pointer rounded p-1 data-highlighted:cursor-default data-highlighted:bg-slate-600/80'
+            />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
@@ -1,20 +1,16 @@
 import {NodeViewWrapper, type NodeViewProps} from '@tiptap/react'
-import {useCallback, useRef, useState} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 import {useBlockResizer} from '../../../hooks/useBlockResizer'
 import {cn} from '../../../ui/cn'
 import {BlockResizer} from './BlockResizer'
-
+import {ImageBlockBubbleMenu} from './ImageBlockBubbleMenu'
 export const ImageBlockView = (props: NodeViewProps) => {
   const {editor, getPos, node, updateAttributes} = props
   const imageWrapperRef = useRef<HTMLDivElement>(null)
-  const {src} = node.attrs
+  const {src, align} = node.attrs
 
   const alignClass =
-    node.attrs.align === 'left'
-      ? 'justify-start'
-      : node.attrs.align === 'right'
-        ? 'justify-end'
-        : 'justify-center'
+    align === 'left' ? 'justify-start' : align === 'right' ? 'justify-end' : 'justify-center'
 
   const onClick = useCallback(() => {
     editor.commands.setNodeSelection(getPos())
@@ -22,11 +18,17 @@ export const ImageBlockView = (props: NodeViewProps) => {
 
   const maxHeightRef = useRef<number | undefined>(editor.storage.imageUpload.editorHeight)
   const {current: maxHeight} = maxHeightRef
+  const aspectRatioRef = useRef(0)
   const ref = useRef<HTMLImageElement>(null)
   const [width, setWidth] = useState<number>(node.attrs.width || 0)
-  const {onMouseDown} = useBlockResizer(width, setWidth, updateAttributes)
+  const {onMouseDown} = useBlockResizer(width, setWidth, updateAttributes, aspectRatioRef)
   const onMouseDownLeft = onMouseDown('left')
   const onMouseDownRight = onMouseDown('right')
+  useEffect(() => {
+    if (width === node.attrs.width) return
+    // the attributes will change if another instance (e.g. a reflection in an expanded stack) edits them
+    setWidth(node.attrs.width)
+  }, [node.attrs.width])
   return (
     <NodeViewWrapper>
       <div className={cn('flex', alignClass)}>
@@ -40,14 +42,24 @@ export const ImageBlockView = (props: NodeViewProps) => {
             ref={ref}
             onLoad={(e) => {
               const img = e.target as HTMLImageElement
+              console.log('loaded', img.width, img.height, maxHeightRef.current)
               maxHeightRef.current = undefined
-              setWidth(img.width)
+              aspectRatioRef.current = img.width / img.height
+              if (img.width !== node.attrs.width) {
+                setWidth(img.width)
+                updateAttributes({width: img.width, height: img.height})
+              }
             }}
           />
-          {editor.isEditable && editor.isFocused && (
+          {editor.isEditable && (
             <>
               <BlockResizer className='left-0' onMouseDown={onMouseDownLeft} />
               <BlockResizer className='right-0' onMouseDown={onMouseDownRight} />
+              <ImageBlockBubbleMenu
+                align={align}
+                updateAttributes={updateAttributes}
+                width={width}
+              />
             </>
           )}
         </div>

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
@@ -9,11 +9,12 @@ export const ImageBlockView = (props: NodeViewProps) => {
   const imageWrapperRef = useRef<HTMLDivElement>(null)
   const {src} = node.attrs
 
-  const wrapperClassName = cn(
-    node.attrs.align === 'left' ? 'ml-0' : 'ml-auto',
-    node.attrs.align === 'right' ? 'mr-0' : 'mr-auto',
-    node.attrs.align === 'center' && 'mx-auto'
-  )
+  const alignClass =
+    node.attrs.align === 'left'
+      ? 'justify-start'
+      : node.attrs.align === 'right'
+        ? 'justify-end'
+        : 'justify-center'
 
   const onClick = useCallback(() => {
     editor.commands.setNodeSelection(getPos())
@@ -28,7 +29,7 @@ export const ImageBlockView = (props: NodeViewProps) => {
   const onMouseDownRight = onMouseDown('right')
   return (
     <NodeViewWrapper>
-      <div className={wrapperClassName}>
+      <div className={cn('flex', alignClass)}>
         <div contentEditable={false} ref={imageWrapperRef} className='group relative w-fit'>
           <img
             className='block'

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlockView.tsx
@@ -1,23 +1,11 @@
-import {Node} from '@tiptap/pm/model'
-import {Editor, NodeViewWrapper} from '@tiptap/react'
-import {useCallback, useRef} from 'react'
+import {NodeViewWrapper, type NodeViewProps} from '@tiptap/react'
+import {useCallback, useRef, useState} from 'react'
+import {useBlockResizer} from '../../../hooks/useBlockResizer'
 import {cn} from '../../../ui/cn'
+import {BlockResizer} from './BlockResizer'
 
-interface ImageBlockViewProps {
-  editor: Editor
-  getPos: () => number
-  node: Node
-  updateAttributes: (attrs: Record<string, string>) => void
-}
-
-export const ImageBlockView = (props: ImageBlockViewProps) => {
-  const {editor, getPos, node} = props as ImageBlockViewProps & {
-    node: Node & {
-      attrs: {
-        src: string
-      }
-    }
-  }
+export const ImageBlockView = (props: NodeViewProps) => {
+  const {editor, getPos, node, updateAttributes} = props
   const imageWrapperRef = useRef<HTMLDivElement>(null)
   const {src} = node.attrs
 
@@ -31,11 +19,36 @@ export const ImageBlockView = (props: ImageBlockViewProps) => {
     editor.commands.setNodeSelection(getPos())
   }, [getPos, editor.commands])
 
+  const maxHeightRef = useRef<number | undefined>(editor.storage.imageUpload.editorHeight)
+  const {current: maxHeight} = maxHeightRef
+  const ref = useRef<HTMLImageElement>(null)
+  const [width, setWidth] = useState<number>(node.attrs.width || 0)
+  const {onMouseDown} = useBlockResizer(width, setWidth, updateAttributes)
+  const onMouseDownLeft = onMouseDown('left')
+  const onMouseDownRight = onMouseDown('right')
   return (
     <NodeViewWrapper>
-      <div className={wrapperClassName} style={{width: node.attrs.width}}>
-        <div contentEditable={false} ref={imageWrapperRef}>
-          <img className='block' src={src} alt='' onClick={onClick} />
+      <div className={wrapperClassName}>
+        <div contentEditable={false} ref={imageWrapperRef} className='group relative w-fit'>
+          <img
+            className='block'
+            src={src}
+            alt=''
+            onClick={onClick}
+            style={{maxHeight, width: width === 0 ? undefined : width}}
+            ref={ref}
+            onLoad={(e) => {
+              const img = e.target as HTMLImageElement
+              maxHeightRef.current = undefined
+              setWidth(img.width)
+            }}
+          />
+          {editor.isEditable && editor.isFocused && (
+            <>
+              <BlockResizer className='left-0' onMouseDown={onMouseDownLeft} />
+              <BlockResizer className='right-0' onMouseDown={onMouseDownRight} />
+            </>
+          )}
         </div>
       </div>
     </NodeViewWrapper>

--- a/packages/client/tiptap/extensions/imageUpload/ImageUpload.ts
+++ b/packages/client/tiptap/extensions/imageUpload/ImageUpload.ts
@@ -3,16 +3,18 @@ import {EventEmitter} from 'eventemitter3'
 import {ImageUploadBase} from '../../../shared/tiptap/extensions/ImageUploadBase'
 import {ImageUploadView} from './ImageUploadView'
 
-export const ImageUpload = ImageUploadBase.extend<{editorWidth: number}>({
+export const ImageUpload = ImageUploadBase.extend<{editorWidth: number; editorHeight: number}>({
   addOptions() {
     return {
-      editorWidth: 300
+      editorWidth: 300,
+      editorHeight: 112
     }
   },
   addStorage(this) {
     return {
       emitter: new EventEmitter(),
-      editorWidth: this.options.editorWidth
+      editorWidth: this.options.editorWidth,
+      editorHeight: this.options.editorHeight
     }
   },
 


### PR DESCRIPTION
# Description

Images are too big for reflections. This sets the default max height to the height of the editor. It then persists width & height to the node so images will take up the right amount of space before the image loads so there's no content shifting