### PR TITLE
fix: images keep size before loading

### DIFF
--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -226,7 +226,7 @@ const PhaseItemEditor = (props: Props) => {
                 >
                   <div
                     className={cn(
-                      'ProseMirror flex max-h-28 min-h-4 w-full items-center px-4 pt-3 leading-none',
+                      'ProseMirror flex max-h-28 min-h-4 w-full flex-col items-start justify-center px-4 pt-3 leading-none',
                       disableAnonymity ? 'pb-0' : 'pb-3'
                     )}
                     dangerouslySetInnerHTML={{__html: card.html}}

--- a/packages/client/hooks/useBlockResizer.tsx
+++ b/packages/client/hooks/useBlockResizer.tsx
@@ -10,9 +10,9 @@ const makeDrag = () => ({
 })
 export const useBlockResizer = (
   width: number,
-  setWidth: (width: number) => void,
   updateAttributes: (attrs: Record<string, any>) => void,
-  aspectRatioRef: RefObject<number>
+  aspectRatioRef: RefObject<number>,
+  maxWidth: number
 ) => {
   const dragRef = useRef(makeDrag())
   const onMouseUp = useEventCallback((e: MouseEvent | TouchEvent) => {
@@ -41,8 +41,8 @@ export const useBlockResizer = (
     const sideCoefficient = drag.side === 'left' ? 1 : -1
     const delta = (drag.lastX - clientX) * sideCoefficient
     drag.lastX = clientX
-    const nextWidth = Math.max(48, width + delta)
-    setWidth(nextWidth)
+    const nextWidth = Math.min(maxWidth, Math.max(48, width + delta))
+    updateAttributes({width: nextWidth, height: Math.round(nextWidth / aspectRatioRef.current!)})
   })
 
   const onMouseDown = useEventCallback(

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -70,7 +70,10 @@ export const useTipTapReflectionEditor = (
           'To-do list': false
         }),
         Focus,
-        ImageUpload.configure({editorWidth: ElementWidth.REFLECTION_CARD, editorHeight: 88}),
+        ImageUpload.configure({
+          editorWidth: ElementWidth.REFLECTION_CARD - 16 * 2,
+          editorHeight: 88
+        }),
         ImageBlock,
         LoomExtension,
         Placeholder.configure({

--- a/packages/client/tiptap/extensions/imageBlock/ImageBlock.ts
+++ b/packages/client/tiptap/extensions/imageBlock/ImageBlock.ts
@@ -13,14 +13,14 @@ export const ImageBlock = ImageBlockBase.extend({
         })
       },
       height: {
-        default: '100%',
+        default: undefined,
         parseHTML: (element) => element.getAttribute('height'),
         renderHTML: (attributes) => ({
           height: attributes.height
         })
       },
       width: {
-        default: '100%',
+        default: undefined,
         parseHTML: (element) => element.getAttribute('width'),
         renderHTML: (attributes) => ({
           width: attributes.width


### PR DESCRIPTION
# Description

Surprisingly, writing directly to the HTMLAttributes is fast enough so we don't need to maintain a local state while allowing per-pixel resizing.

this also sets the img.width and img.height properties so before the image loads, it takes up space