### PR TITLE
chore(web-server): reconnect window can be manually set but keeps a 60s default value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ FILE_STORE_PROVIDER='local'
 # GOOGLE_GCS_BUCKET='BUCKET_NAME'
 
 # WEB SERVER
-# Time window used by the web server to kick its users off
+# Time window used by the web server to kick its users off. In milliseconds.
 # WEB_SERVER_RECONNECT_WINDOW=''
 
 # CHRONOS

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ FILE_STORE_PROVIDER='local'
 # Google Cloud credentials are required to use FILE_STORE_PROVIDER='gcs'
 # GOOGLE_GCS_BUCKET='BUCKET_NAME'
 
+# WEB SERVER
+# Time window used by the web server to kick its users off
+# WEB_SERVER_RECONNECT_WINDOW=''
+
 # CHRONOS
 CHRONOS_PULSE_EMAIL=''
 CHRONOS_PULSE_CHANNEL=''

--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,8 @@ FILE_STORE_PROVIDER='local'
 # GOOGLE_GCS_BUCKET='BUCKET_NAME'
 
 # WEB SERVER
-# Time window used by the web server to kick its users off. In milliseconds.
-# WEB_SERVER_RECONNECT_WINDOW=''
+# Time window, in seconds, used by the web server to kick its users off. If empty, it has a default value.
+# WEB_SERVER_RECONNECT_WINDOW='60'
 
 # CHRONOS
 CHRONOS_PULSE_EMAIL=''

--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ FILE_STORE_PROVIDER='local'
 # GOOGLE_GCS_BUCKET='BUCKET_NAME'
 
 # WEB SERVER
-# Time window, in seconds, used by the web server to kick its users off. If empty, it has a default value.
+# Time window, in seconds, used by the web server to kick its users off. If empty or not declared it defaults to 60.
 # WEB_SERVER_RECONNECT_WINDOW='60'
 
 # CHRONOS

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -35,11 +35,11 @@ tracer.use('ioredis').use('http').use('pg')
 
 process.on('SIGTERM', async (signal) => {
   const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
-    ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10)
+    ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000
     : 60_000 // ms
 
   Logger.log(
-    `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown of ${RECONNECT_WINDOW}.`
+    `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown of ${RECONNECT_WINDOW}ms.`
   )
   await Promise.allSettled(
     Object.values(activeClients.store).map(async (connectionContext) => {

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -25,6 +25,10 @@ import {createStaticFileHandler} from './staticFileHandler'
 import {Logger} from './utils/Logger'
 import SAMLHandler from './utils/SAMLHandler'
 
+const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
+  ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000
+  : 60_000 // ms
+
 tracer.init({
   service: `web`,
   appsec: process.env.DD_APPSEC_ENABLED === 'true',
@@ -34,10 +38,6 @@ tracer.init({
 tracer.use('ioredis').use('http').use('pg')
 
 process.on('SIGTERM', async (signal) => {
-  const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
-    ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000
-    : 60_000 // ms
-
   Logger.log(
     `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown of ${RECONNECT_WINDOW}ms.`
   )

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -34,10 +34,13 @@ tracer.init({
 tracer.use('ioredis').use('http').use('pg')
 
 process.on('SIGTERM', async (signal) => {
+  const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
+  ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10)
+  : 60_000; // ms
+
   Logger.log(
-    `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown.`
+    `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown of ${RECONNECT_WINDOW}.`
   )
-  const RECONNECT_WINDOW = 60_000 // ms
   await Promise.allSettled(
     Object.values(activeClients.store).map(async (connectionContext) => {
       const disconnectIn = Math.floor(Math.random() * RECONNECT_WINDOW)

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -35,8 +35,8 @@ tracer.use('ioredis').use('http').use('pg')
 
 process.on('SIGTERM', async (signal) => {
   const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
-  ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10)
-  : 60_000; // ms
+    ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10)
+    : 60_000 // ms
 
   Logger.log(
     `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown of ${RECONNECT_WINDOW}.`


### PR DESCRIPTION
# Description

Allows setting a custom reconnect window for the web server, so it can gracefully stop in environments where 60s grace period isn't allowed.

## Demo
