### PR TITLE
fix: reduce jira issue TTL from 2 days to 1 day

### DIFF
--- a/packages/server/utils/atlassian/jiraIssues.ts
+++ b/packages/server/utils/atlassian/jiraIssues.ts
@@ -6,7 +6,7 @@ import sleep from 'parabol-client/utils/sleep'
 import AtlassianServerManager, {JiraGetIssueRes} from '../AtlassianServerManager'
 import getRedis from '../getRedis'
 
-const ISSUE_TTL_MS = ms('2d')
+const ISSUE_TTL_MS = ms('1d')
 const MAX_ATTEMPT_DURATION = ms('9s')
 
 type StoreAndNetworkRequests = CacheHit | CacheMiss | CacheError


### PR DESCRIPTION
`jira:*` keys in redis are taking up 1.6GB. let's reduce the TTL to 1 day so we don't have to grow our redis instance.