### PR TITLE
chore: set oauth2redirect defaults, document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,14 +60,20 @@ FILE_STORE_PROVIDER='local'
 # WEB_SERVER_RECONNECT_WINDOW='60'
 
 # CHRONOS
+# Optional. Used to broadcast signups/logins to slack.
 CHRONOS_PULSE_EMAIL=''
 CHRONOS_PULSE_CHANNEL=''
 CHRONOS_PULSE_DAILY='0 0 4 * * *'
 CHRONOS_PULSE_WEEKLY='0 0 4 * * 1'
+# Required. See sendBatchNotificationEmails
 CHRONOS_BATCH_EMAILS='0 0 10 * * *'
+# Required. See runScheduledJobs
 CHRONOS_SCHEDULE_JOBS='0 */10 * * * *'
+# Required if using Jira. See updateOAuthRefreshTokens
 CHRONOS_UPDATE_TOKENS='0 0 0 1,15 * *'
+# Required if using standups. See processRecurrence
 CHRONOS_PROCESS_RECURRENCE='0 */5 * * * *'
+# Required. See autopauseUsers
 CHRONOS_AUTOPAUSE='0 0 5 * * *'
 
 # DATABASES

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ AI_EMBEDDER_WORKERS='1'
 # AUTH_SSO_DISABLED='false'
 # GOOGLE_OAUTH_CLIENT_ID=''
 # GOOGLE_OAUTH_CLIENT_SECRET=''
+# URL to a microservice that links 1 oauth2 integration to multiple parabol instances on different hosts. If missing, uses the app route /auth/service
 # OAUTH2_REDIRECT=''
 # could be a specific tenant for on premise installs
 # MICROSOFT_TENANT_ID='common'

--- a/packages/server/graphql/private/mutations/updateEmail.ts
+++ b/packages/server/graphql/private/mutations/updateEmail.ts
@@ -1,6 +1,6 @@
 import getKysely from '../../../postgres/getKysely'
-import {MutationResolvers} from '../resolverTypes'
 import {JsonObject} from '../../../postgres/types/pg'
+import {MutationResolvers} from '../resolverTypes'
 
 const updateEmail: MutationResolvers['updateEmail'] = async (_source, {oldEmail, newEmail}) => {
   const pg = getKysely()
@@ -23,7 +23,7 @@ const updateEmail: MutationResolvers['updateEmail'] = async (_source, {oldEmail,
   const {id: userId, identities} = user
 
   if (identities && identities.length > 0) {
-    const localIdentity = (identities as JsonObject[]).find(identity => identity.type === 'LOCAL')
+    const localIdentity = (identities as JsonObject[]).find((identity) => identity.type === 'LOCAL')
     if (localIdentity) {
       localIdentity.isEmailVerified = false
     }

--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -12,6 +12,7 @@ import {
 } from '../integrations/OAuth2Manager'
 import {authorizeOAuth2} from '../integrations/helpers/authorizeOAuth2'
 import {Logger} from './Logger'
+import {makeOAuth2Redirect} from './makeOAuth2Redirect'
 
 export interface JiraUser {
   self: string
@@ -280,7 +281,7 @@ class AtlassianServerManager extends AtlassianManager {
     return AtlassianServerManager.fetchToken({
       grant_type: 'authorization_code',
       code,
-      redirect_uri: process.env.OAUTH2_REDIRECT!
+      redirect_uri: makeOAuth2Redirect()
     })
   }
 

--- a/packages/server/utils/SlackServerManager.ts
+++ b/packages/server/utils/SlackServerManager.ts
@@ -1,5 +1,6 @@
 import SlackManager from 'parabol-client/utils/SlackManager'
 import {stringify} from 'querystring'
+import {makeOAuth2Redirect} from './makeOAuth2Redirect'
 
 interface IncomingWebhook {
   url: string
@@ -36,7 +37,7 @@ class SlackServerManager extends SlackManager {
       client_id: process.env.SLACK_CLIENT_ID,
       client_secret: process.env.SLACK_CLIENT_SECRET,
       code,
-      redirect_uri: process.env.OAUTH2_REDIRECT!
+      redirect_uri: makeOAuth2Redirect()
     }
 
     const uri = `https://slack.com/api/oauth.v2.access?${stringify(queryParams)}`

--- a/packages/server/utils/makeOAuth2Redirect.ts
+++ b/packages/server/utils/makeOAuth2Redirect.ts
@@ -1,0 +1,7 @@
+import makeAppURL from '../../client/utils/makeAppURL'
+import appOrigin from '../appOrigin'
+export const makeOAuth2Redirect = () => {
+  // we do this as a convenience for PPMI setup.
+  // If they don't include the env variable, we use the app instead
+  return process.env.OAUTH2_REDIRECT || makeAppURL(appOrigin, 'auth/service')
+}

--- a/scripts/toolboxSrc/applyEnvVarsToClientAssets.ts
+++ b/scripts/toolboxSrc/applyEnvVarsToClientAssets.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import {minify} from 'html-minifier-terser'
 import path from 'path'
+import {makeOAuth2Redirect} from '../../packages/server/utils/makeOAuth2Redirect'
 import logo192 from '../../static/images/brand/mark-cropped-192.png'
 import logo512 from '../../static/images/brand/mark-cropped-512.png'
 import getProjectRoot from '../webpack/utils/getProjectRoot'
@@ -62,7 +63,7 @@ const rewriteIndexHTML = () => {
     slack: process.env.SLACK_CLIENT_ID,
     stripe: process.env.STRIPE_PUBLISHABLE_KEY,
     publicPath: __webpack_public_path__,
-    oauth2Redirect: process.env.OAUTH2_REDIRECT,
+    oauth2Redirect: makeOAuth2Redirect(),
     hasOpenAI: !!process.env.OPEN_AI_API_KEY,
     prblIn: process.env.INVITATION_SHORTLINK,
     AUTH_INTERNAL_ENABLED: process.env.AUTH_INTERNAL_DISABLED !== 'true',

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const vendors = require('../../dev/dll/vendors')
 const clientTransformRules = require('./utils/clientTransformRules')
 const getProjectRoot = require('./utils/getProjectRoot')
+const {makeOAuth2Redirect} = require('../../packages/server/utils/makeOAuth2Redirect')
 
 const PROJECT_ROOT = getProjectRoot()
 const CLIENT_ROOT = path.join(PROJECT_ROOT, 'packages', 'client')
@@ -136,7 +137,7 @@ module.exports = {
         sentry: process.env.SENTRY_DSN,
         slack: process.env.SLACK_CLIENT_ID,
         stripe: process.env.STRIPE_PUBLISHABLE_KEY,
-        oauth2Redirect: process.env.OAUTH2_REDIRECT,
+        oauth2Redirect: makeOAuth2Redirect(),
         hasOpenAI: !!process.env.OPEN_AI_API_KEY,
         prblIn: process.env.INVITATION_SHORTLINK,
         AUTH_INTERNAL_ENABLED: process.env.AUTH_INTERNAL_DISABLED !== 'true',


### PR DESCRIPTION
# Description

fix #10438 fix #10452 fix #10409

Makes oauth2_redirect env var optional for PPMIs.
When they create an integration, instruct them to use `https://<HOST>/auth/service` as a redirect_url