### PR TITLE
chore: add extra logging to gql executor timeouts

### DIFF
--- a/packages/server/graphql/ResponseStream.ts
+++ b/packages/server/graphql/ResponseStream.ts
@@ -44,7 +44,17 @@ export default class ResponseStream implements AsyncIterableIterator<ExecutionRe
     } catch (e) {
       const error =
         e instanceof Error ? e : new Error(`GQL executor failed to publish. docId: ${docId}`)
-      sendToSentry(error, {userId: getUserId(authToken)})
+      sendToSentry(error, {
+        userId: getUserId(authToken),
+        tags: {
+          authToken: JSON.stringify(authToken),
+          docId: docId || '',
+          query: query || '',
+          variables: JSON.stringify(variables),
+          socketServerId: socketId,
+          executorServerId
+        }
+      })
       return this.next()
     }
   }

--- a/packages/server/graphql/handleGraphQLTrebuchetRequest.ts
+++ b/packages/server/graphql/handleGraphQLTrebuchetRequest.ts
@@ -62,7 +62,8 @@ const handleGraphQLTrebuchetRequest = async (
             authToken: JSON.stringify(authToken),
             docId: docId || '',
             query: query || '',
-            variables: JSON.stringify(variables)
+            variables: JSON.stringify(variables),
+            socketServerId: socketId
           }
         })
         return {


### PR DESCRIPTION
# Description

this adds extra logging to triage the TIMEOUT error.
Since none of the datadog logs had tags, I'm assuming all those TIMEOUTs came from subscriptions, which means the UX wasn't impacted since the client will refresh those when it connects to a new webserver. These new logs should support that assumption.