### PR TITLE
chore: Refactor tiptap events 

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -130,7 +130,7 @@ const DiscussionThreadInput = (props: Props) => {
     if (submitting || !editor || editor.isEmpty) return
     addComment(JSON.stringify(editor.getJSON()))
   })
-  const {editor, setLinkState, linkState} = useTipTapCommentEditor(initialContent, {
+  const {editor} = useTipTapCommentEditor(initialContent, {
     readOnly: !allowComments,
     atmosphere,
     teamId,
@@ -216,8 +216,6 @@ const DiscussionThreadInput = (props: Props) => {
         <TipTapEditor
           className='flex max-h-80 min-h-0 grow overflow-auto px-0 leading-4'
           editor={editor}
-          linkState={linkState}
-          setLinkState={setLinkState}
         />
         <SendCommentButton commentSubmitState={commentSubmitState} onSubmit={onSubmit} />
       </div>

--- a/packages/client/components/NullableTask/NullableTask.tsx
+++ b/packages/client/components/NullableTask/NullableTask.tsx
@@ -57,7 +57,7 @@ const NullableTask = (props: Props) => {
   const atmosphere = useAtmosphere()
   const isArchived = isTaskArchived(tags)
   const readOnly = isTempId(taskId) || isArchived || !!isDraggingOver || isIntegration
-  const {editor, linkState, setLinkState} = useTipTapTaskEditor(content, {
+  const {editor} = useTipTapTaskEditor(content, {
     atmosphere,
     teamId,
     readOnly
@@ -70,8 +70,6 @@ const NullableTask = (props: Props) => {
       area={area}
       className={className}
       editor={editor}
-      linkState={linkState}
-      setLinkState={setLinkState}
       isDraggingOver={isDraggingOver}
       isAgenda={isAgenda}
       task={task}

--- a/packages/client/components/ParabolScopingSearchResultItem.tsx
+++ b/packages/client/components/ParabolScopingSearchResultItem.tsx
@@ -70,7 +70,7 @@ const ParabolScopingSearchResultItem = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
   const isEditingThisItem = !plaintextContent
-  const {editor, linkState, setLinkState} = useTipTapTaskEditor(content, {
+  const {editor} = useTipTapTaskEditor(content, {
     atmosphere,
     teamId,
     readOnly: !isEditingThisItem
@@ -140,12 +140,7 @@ const ParabolScopingSearchResultItem = (props: Props) => {
           addTaskChild('root')
         }}
       >
-        <TipTapEditor
-          editor={editor}
-          linkState={linkState}
-          setLinkState={setLinkState}
-          useLinkEditor={() => useTaskChild('editor-link-changer')}
-        />
+        <TipTapEditor editor={editor} useLinkEditor={() => useTaskChild('editor-link-changer')} />
       </Task>
     </Item>
   )

--- a/packages/client/components/PokerEstimateHeaderCardParabol.tsx
+++ b/packages/client/components/PokerEstimateHeaderCardParabol.tsx
@@ -90,7 +90,7 @@ const PokerEstimateHeaderCardParabol = (props: Props) => {
     }
     UpdateTaskMutation(atmosphere, {updatedTask}, {})
   })
-  const {editor, linkState, setLinkState} = useTipTapTaskEditor(content, {
+  const {editor} = useTipTapTaskEditor(content, {
     atmosphere,
     teamId,
     onBlur
@@ -108,8 +108,6 @@ const PokerEstimateHeaderCardParabol = (props: Props) => {
           <EditorWrapper isExpanded={isExpanded}>
             <TipTapEditor
               editor={editor}
-              linkState={linkState}
-              setLinkState={setLinkState}
               useLinkEditor={() => useTaskChild('editor-link-changer')}
             />
           </EditorWrapper>

--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -186,7 +186,7 @@ const ReflectionCard = (props: Props) => {
     phases,
     isSpotlightSource
   )
-  const {editor, linkState, setLinkState} = useTipTapReflectionEditor(content, {
+  const {editor} = useTipTapReflectionEditor(content, {
     atmosphere,
     teamId,
     readOnly: !!readOnly
@@ -332,8 +332,6 @@ const ReflectionCard = (props: Props) => {
             readOnly ? (phaseType === 'discuss' ? 'select-text' : 'select-none') : undefined
           )}
           editor={editor}
-          linkState={linkState}
-          setLinkState={setLinkState}
           onFocus={handleEditorFocus}
           onBlur={handleEditorBlur}
         />

--- a/packages/client/components/ResponseReplied.tsx
+++ b/packages/client/components/ResponseReplied.tsx
@@ -46,7 +46,7 @@ const ResponseReplied = (props: Props) => {
     history.push(`/meet/${meetingId}/responses?responseId=${encodeURIComponent(response.id)}`)
   }
 
-  const {editor, setLinkState, linkState} = useTipTapCommentEditor(comment.content, {
+  const {editor} = useTipTapCommentEditor(comment.content, {
     readOnly: true
   })
   if (!editor) return null
@@ -59,7 +59,7 @@ const ResponseReplied = (props: Props) => {
       action={<NotificationAction label={'See the discussion'} onClick={goThere} />}
     >
       <div className='my-1 rounded-sm bg-white p-2 text-sm leading-5 shadow-card'>
-        <TipTapEditor editor={editor} setLinkState={setLinkState} linkState={linkState} />
+        <TipTapEditor editor={editor} />
       </div>
     </NotificationTemplate>
   )

--- a/packages/client/components/RetroReflectPhase/HTMLReflection.tsx
+++ b/packages/client/components/RetroReflectPhase/HTMLReflection.tsx
@@ -1,0 +1,23 @@
+import {cn} from '../../ui/cn'
+
+interface Props {
+  html: string
+  disableAnonymity: boolean
+}
+
+export const HTMLReflection = (props: Props) => {
+  const {html, disableAnonymity} = props
+  return (
+    <div className={cn('relative w-full overflow-auto text-sm leading-4 text-slate-700')}>
+      <div
+        className={cn(
+          'ProseMirror flex max-h-28 min-h-4 w-full flex-col items-start justify-center px-4 pt-3 leading-none',
+          disableAnonymity ? 'pb-0' : 'pb-3'
+        )}
+        dangerouslySetInnerHTML={{__html: html}}
+      ></div>
+    </div>
+  )
+}
+
+export default HTMLReflection

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -17,6 +17,7 @@ import {cn} from '../../ui/cn'
 import ReflectionCardAuthor from '../ReflectionCard/ReflectionCardAuthor'
 import ReflectionCardRoot from '../ReflectionCard/ReflectionCardRoot'
 import {TipTapEditor} from '../promptResponse/TipTapEditor'
+import HTMLReflection from './HTMLReflection'
 import {ReflectColumnCardInFlight} from './PhaseItemColumn'
 import getBBox from './getBBox'
 
@@ -219,17 +220,7 @@ const PhaseItemEditor = (props: Props) => {
                 isStart={card.isStart}
                 onTransitionEnd={removeCardInFlight(card.key)}
               >
-                <div
-                  className={cn('relative w-full overflow-auto text-sm leading-4 text-slate-700')}
-                >
-                  <div
-                    className={cn(
-                      'ProseMirror flex max-h-28 min-h-4 w-full flex-col items-start justify-center px-4 pt-3 leading-none',
-                      disableAnonymity ? 'pb-0' : 'pb-3'
-                    )}
-                    dangerouslySetInnerHTML={{__html: card.html}}
-                  ></div>
-                </div>
+                <HTMLReflection html={card.html} disableAnonymity={disableAnonymity} />
                 {disableAnonymity && (
                   <ReflectionCardAuthor>
                     {viewerMeetingMember?.user.preferredName}

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -125,7 +125,7 @@ const PhaseItemEditor = (props: Props) => {
       setTimeout(removeCardInFlight(content), FLIGHT_TIME)
     })
   })
-  const {editor, linkState, setLinkState} = useTipTapReflectionEditor(
+  const {editor} = useTipTapReflectionEditor(
     JSON.stringify({type: 'doc', content: [{type: 'paragraph'}]}),
     {
       atmosphere,
@@ -201,8 +201,6 @@ const PhaseItemEditor = (props: Props) => {
             disableAnonymity ? 'pb-0' : 'pb-3'
           )}
           editor={editor}
-          linkState={linkState}
-          setLinkState={setLinkState}
           onBlur={onBlur}
           onFocus={onFocus}
         />

--- a/packages/client/components/ThreadedCommentBase.tsx
+++ b/packages/client/components/ThreadedCommentBase.tsx
@@ -110,7 +110,7 @@ const ThreadedCommentBase = (props: Props) => {
     editor?.setEditable(false)
   })
 
-  const {editor, setLinkState, linkState} = useTipTapCommentEditor(content, {
+  const {editor} = useTipTapCommentEditor(content, {
     readOnly: true,
     atmosphere,
     teamId,
@@ -179,12 +179,7 @@ const ThreadedCommentBase = (props: Props) => {
         />
         {isActive && (
           <div className='pr-4'>
-            <TipTapEditor
-              editor={editor}
-              setLinkState={setLinkState}
-              linkState={linkState}
-              onBlur={onSubmit}
-            />
+            <TipTapEditor editor={editor} onBlur={onSubmit} />
           </div>
         )}
         {isActive && (

--- a/packages/client/components/promptResponse/BubbleMenuButton.tsx
+++ b/packages/client/components/promptResponse/BubbleMenuButton.tsx
@@ -11,7 +11,7 @@ export const BubbleMenuButton = (props: Props) => {
     <Button
       variant='flat'
       data-highlighted={isActive}
-      className='h-5 w-5 rounded-xs py-1 hover:bg-slate-300 data-highlighted:bg-slate-300'
+      className='h-7 w-7 rounded-xs hover:bg-slate-300 data-highlighted:bg-slate-300'
       {...rest}
     >
       {children}

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -15,7 +15,6 @@ import BaseButton from '../BaseButton'
 import {LoomExtension, unfurlLoomLinks} from './loomExtension'
 import {TipTapEditor} from './TipTapEditor'
 import {TiptapLinkExtension} from './TiptapLinkExtension'
-import {LinkMenuState} from './TipTapLinkMenu'
 
 const SubmitButton = styled(BaseButton)<{disabled?: boolean}>(({disabled}) => ({
   backgroundColor: disabled ? PALETTE.SLATE_200 : PALETTE.SKY_500,
@@ -104,8 +103,6 @@ const PromptResponseEditor = (props: Props) => {
     }
   }
 
-  const [linkState, setLinkState] = useState<LinkMenuState>(null)
-
   const editor = useEditor(
     {
       content,
@@ -119,10 +116,7 @@ const PromptResponseEditor = (props: Props) => {
         Mention.configure(tiptapMentionConfig(atmosphere, teamId)),
         Mention.extend({name: 'emojiMention'}).configure(tiptapEmojiConfig),
         TiptapLinkExtension.configure({
-          openOnClick: false,
-          popover: {
-            setLinkState
-          }
+          openOnClick: false
         })
       ],
       autofocus: autoFocus,
@@ -153,12 +147,7 @@ const PromptResponseEditor = (props: Props) => {
   if (!editor) return null
   return (
     <>
-      <TipTapEditor
-        linkState={linkState}
-        setLinkState={setLinkState}
-        editor={editor}
-        showBubbleMenu={!readOnly}
-      />
+      <TipTapEditor editor={editor} showBubbleMenu={!readOnly} />
       {!readOnly && (
         // The render conditions for these buttons *should* only be true when 'readOnly' is false, but let's be explicit
         // about it.

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import {Editor} from '@tiptap/core'
 import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
+import Underline from '@tiptap/extension-underline'
 import {JSONContent, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import {useCallback, useEffect, useMemo, useState} from 'react'
@@ -108,6 +109,7 @@ const PromptResponseEditor = (props: Props) => {
       content,
       extensions: [
         StarterKit,
+        Underline,
         LoomExtension,
         Placeholder.configure({
           showOnlyWhenEditable: false,

--- a/packages/client/components/promptResponse/StandardBubbleMenu.tsx
+++ b/packages/client/components/promptResponse/StandardBubbleMenu.tsx
@@ -19,7 +19,7 @@ export const StandardBubbleMenu = (props: Props) => {
 
   return (
     <BubbleMenu editor={editor} tippyOptions={{duration: 100}} shouldShow={shouldShowBubbleMenu}>
-      <div className='flex items-center rounded-sm border-[1px] border-solid border-slate-600 bg-white p-1'>
+      <div className='flex items-center rounded-sm border-[1px] border-solid border-slate-600 bg-white p-[3px]'>
         <BubbleMenuButton
           onClick={() => editor.chain().focus().toggleBold().run()}
           isActive={editor.isActive('bold')}
@@ -31,6 +31,12 @@ export const StandardBubbleMenu = (props: Props) => {
           isActive={editor.isActive('italic')}
         >
           <i>I</i>
+        </BubbleMenuButton>
+        <BubbleMenuButton
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          isActive={editor.isActive('underline')}
+        >
+          <u>U</u>
         </BubbleMenuButton>
         <BubbleMenuButton
           onClick={() => editor.chain().focus().toggleStrike().run()}

--- a/packages/client/components/promptResponse/StandardBubbleMenu.tsx
+++ b/packages/client/components/promptResponse/StandardBubbleMenu.tsx
@@ -2,22 +2,19 @@ import {Link} from '@mui/icons-material'
 import {BubbleMenu, Editor} from '@tiptap/react'
 import {BubbleMenuButton} from './BubbleMenuButton'
 import isTextSelected from './isTextSelected'
-import {LinkMenuState} from './TipTapLinkMenu'
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   editor: Editor
-  setLinkState: (linkState: LinkMenuState) => void
 }
 export const StandardBubbleMenu = (props: Props) => {
-  const {editor, setLinkState} = props
-
+  const {editor} = props
   const shouldShowBubbleMenu = () => {
     if (!editor || editor.isActive('link')) return false
     return isTextSelected(editor)
   }
 
   const openLinkEditor = () => {
-    setLinkState('edit')
+    editor.emit('linkStateChange', {editor, linkState: 'edit'})
   }
 
   return (

--- a/packages/client/components/promptResponse/TipTapEditor.tsx
+++ b/packages/client/components/promptResponse/TipTapEditor.tsx
@@ -1,34 +1,19 @@
 import {Editor, EditorContent, type EditorContentProps} from '@tiptap/react'
 import {cn} from '../../ui/cn'
 import {StandardBubbleMenu} from './StandardBubbleMenu'
-import TipTapLinkMenu, {LinkMenuState} from './TipTapLinkMenu'
+import TipTapLinkMenu from './TipTapLinkMenu'
 
 interface Props extends EditorContentProps {
   editor: Editor
-  linkState?: LinkMenuState
-  setLinkState?: (linkState: LinkMenuState) => void
   showBubbleMenu?: boolean
   useLinkEditor?: () => void
 }
 export const TipTapEditor = (props: Props) => {
-  const {className, editor, linkState, setLinkState, showBubbleMenu, useLinkEditor, ref, ...rest} =
-    props
+  const {className, editor, showBubbleMenu, useLinkEditor, ref, ...rest} = props
   return (
     <>
-      {showBubbleMenu && setLinkState && (
-        <StandardBubbleMenu editor={editor} setLinkState={setLinkState} />
-      )}
-      {setLinkState && linkState && (
-        <TipTapLinkMenu
-          editor={editor}
-          setLinkState={(linkState: LinkMenuState) => {
-            editor.commands.focus()
-            setLinkState(linkState)
-          }}
-          linkState={linkState}
-          useLinkEditor={useLinkEditor}
-        />
-      )}
+      <StandardBubbleMenu editor={editor} />
+      <TipTapLinkMenu editor={editor} useLinkEditor={useLinkEditor} />
       <EditorContent
         ref={ref as any}
         {...rest}

--- a/packages/client/components/promptResponse/TipTapLinkMenu.tsx
+++ b/packages/client/components/promptResponse/TipTapLinkMenu.tsx
@@ -29,7 +29,10 @@ export const TipTapLinkMenu = (props: Props) => {
   const [linkState, _setLinkState] = useState<LinkMenuState>(null)
 
   const setLinkState: typeof _setLinkState = (linkState) => {
-    editor.commands.focus()
+    if (!linkState) {
+      // closing the menu by hitting Esc should refocus on the editor
+      editor.commands.focus()
+    }
     _setLinkState(linkState)
   }
 

--- a/packages/client/components/promptResponse/TipTapLinkMenu.tsx
+++ b/packages/client/components/promptResponse/TipTapLinkMenu.tsx
@@ -1,6 +1,7 @@
 import * as Popover from '@radix-ui/react-popover'
+import type {EditorEvents} from '@tiptap/core'
 import {Editor, getMarkRange, getMarkType, getTextBetween, useEditorState} from '@tiptap/react'
-import {useCallback, useRef} from 'react'
+import {useCallback, useEffect, useRef, useState} from 'react'
 import {TipTapLinkEditor} from './TipTapLinkEditor'
 import {TipTapLinkPreview} from './TipTapLinkPreview'
 
@@ -21,12 +22,26 @@ const getRangeForType = (editor: Editor, typeOrName: string) => {
 export type LinkMenuState = 'preview' | 'edit' | null
 interface Props {
   editor: Editor
-  linkState: LinkMenuState
-  setLinkState: (linkState: LinkMenuState) => void
   useLinkEditor?: () => void
 }
 export const TipTapLinkMenu = (props: Props) => {
-  const {editor, linkState, setLinkState, useLinkEditor} = props
+  const {editor, useLinkEditor} = props
+  const [linkState, _setLinkState] = useState<LinkMenuState>(null)
+
+  const setLinkState: typeof _setLinkState = (linkState) => {
+    editor.commands.focus()
+    _setLinkState(linkState)
+  }
+
+  useEffect(() => {
+    const updateState = (change: EditorEvents['linkStateChange']) => {
+      setLinkState(change.linkState)
+    }
+    editor.on('linkStateChange', updateState)
+    return () => {
+      editor.off('linkStateChange', updateState)
+    }
+  }, [])
 
   const {link, text} = useEditorState({
     editor,

--- a/packages/client/components/promptResponse/TiptapLinkExtension.ts
+++ b/packages/client/components/promptResponse/TiptapLinkExtension.ts
@@ -1,21 +1,22 @@
-import {mergeAttributes} from '@tiptap/core'
-import BaseLink, {LinkOptions} from '@tiptap/extension-link'
+import {mergeAttributes, type Editor} from '@tiptap/core'
+import BaseLink from '@tiptap/extension-link'
 import {Plugin} from '@tiptap/pm/state'
 import {EditorView} from '@tiptap/pm/view'
 import {LinkMenuState} from './TipTapLinkMenu'
 
-interface ExtendedOptions extends LinkOptions {
-  popover: {
-    setLinkState: (linkState: LinkMenuState) => void
+declare module '@tiptap/core' {
+  interface EditorEvents {
+    linkStateChange: {editor: Editor; linkState: LinkMenuState}
   }
 }
-export const TiptapLinkExtension = BaseLink.extend<ExtendedOptions>({
+
+export const TiptapLinkExtension = BaseLink.extend({
   // if the caret is at the end of the link, it is not part of the link
   inclusive: false,
   addKeyboardShortcuts(this) {
     return {
       'Mod-k': () => {
-        this.options.popover.setLinkState('edit')
+        this.editor.emit('linkStateChange', {editor: this.editor, linkState: 'edit'})
         return true
       }
     }
@@ -29,7 +30,8 @@ export const TiptapLinkExtension = BaseLink.extend<ExtendedOptions>({
   },
   onSelectionUpdate() {
     const href = this.editor.getAttributes('link').href
-    this.options.popover.setLinkState(href ? 'preview' : null)
+    const linkState = href ? 'preview' : null
+    this.editor.emit('linkStateChange', {editor: this.editor, linkState})
   },
   addProseMirrorPlugins() {
     const {editor} = this

--- a/packages/client/hooks/useTipTapCommentEditor.ts
+++ b/packages/client/hooks/useTipTapCommentEditor.ts
@@ -1,5 +1,6 @@
 import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
+import Underline from '@tiptap/extension-underline'
 import {Extension, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import {useRef} from 'react'
@@ -37,6 +38,7 @@ export const useTipTapCommentEditor = (
       content: contentJSON,
       extensions: [
         StarterKit,
+        Underline,
         LoomExtension,
         Placeholder.configure({
           showOnlyWhenEditable: false,

--- a/packages/client/hooks/useTipTapCommentEditor.ts
+++ b/packages/client/hooks/useTipTapCommentEditor.ts
@@ -2,11 +2,10 @@ import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
 import {Extension, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import {useRef, useState} from 'react'
+import {useRef} from 'react'
 import Atmosphere from '../Atmosphere'
 import {LoomExtension} from '../components/promptResponse/loomExtension'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
-import {LinkMenuState} from '../components/promptResponse/TipTapLinkMenu'
 import {mentionConfig} from '../shared/tiptap/serverTipTapExtensions'
 import {tiptapEmojiConfig} from '../utils/tiptapEmojiConfig'
 import {tiptapMentionConfig} from '../utils/tiptapMentionConfig'
@@ -30,7 +29,6 @@ export const useTipTapCommentEditor = (
 ) => {
   const {atmosphere, teamId, readOnly, placeholder, onEnter, onEscape} = options
   const [contentJSON, editorRef] = useTipTapEditorContent(content)
-  const [linkState, setLinkState] = useState<LinkMenuState>(null)
   const placeholderRef = useRef(placeholder)
   // Keeping it in a ref means we don't have to re-initialize the editor, so content is preserved
   placeholderRef.current = placeholder
@@ -52,10 +50,7 @@ export const useTipTapCommentEditor = (
         ),
         Mention.extend({name: 'emojiMention'}).configure(tiptapEmojiConfig),
         TiptapLinkExtension.configure({
-          openOnClick: false,
-          popover: {
-            setLinkState
-          }
+          openOnClick: false
         }),
         onEnter &&
           onEscape &&
@@ -80,5 +75,5 @@ export const useTipTapCommentEditor = (
     },
     [readOnly]
   )
-  return {editor: editorRef.current, linkState, setLinkState}
+  return {editor: editorRef.current}
 }

--- a/packages/client/hooks/useTipTapIcebreakerEditor.ts
+++ b/packages/client/hooks/useTipTapIcebreakerEditor.ts
@@ -1,5 +1,6 @@
 import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
+import Underline from '@tiptap/extension-underline'
 import {generateText, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import {serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
@@ -15,6 +16,7 @@ export const useTipTapIcebreakerEditor = (content: string, options: {readOnly?: 
       content: contentJSON,
       extensions: [
         StarterKit,
+        Underline,
         Placeholder.configure({
           showOnlyWhenEditable: false,
           placeholder: 'e.g. How are you?'

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -11,7 +11,6 @@ import {useEffect, useRef, useState} from 'react'
 import Atmosphere from '../Atmosphere'
 import {LoomExtension} from '../components/promptResponse/loomExtension'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
-import {LinkMenuState} from '../components/promptResponse/TipTapLinkMenu'
 import {isEqualWhenSerialized} from '../shared/isEqualWhenSerialized'
 import {mentionConfig, serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
 import ImageBlock from '../tiptap/extensions/imageBlock/ImageBlock'
@@ -51,7 +50,6 @@ export const useTipTapReflectionEditor = (
   }
 ) => {
   const {atmosphere, teamId, readOnly, placeholder, onEnter} = options
-  const [linkState, setLinkState] = useState<LinkMenuState>(null)
   const [contentJSON] = useState(() => JSON.parse(content))
   const placeholderRef = useRef(placeholder)
   placeholderRef.current = placeholder
@@ -87,10 +85,7 @@ export const useTipTapReflectionEditor = (
         ),
         Mention.extend({name: 'emojiMention'}).configure(tiptapEmojiConfig),
         TiptapLinkExtension.configure({
-          openOnClick: false,
-          popover: {
-            setLinkState
-          }
+          openOnClick: false
         }),
         SearchAndReplace.configure(),
         CharacterCount.configure({
@@ -147,5 +142,5 @@ export const useTipTapReflectionEditor = (
     editor.setEditable(!readOnly)
   }, [readOnly])
 
-  return {editor, linkState, setLinkState}
+  return {editor}
 }

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -5,6 +5,7 @@ import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
 import {TaskItem} from '@tiptap/extension-task-item'
 import {TaskList} from '@tiptap/extension-task-list'
+import Underline from '@tiptap/extension-underline'
 import {Extension, generateText, useEditor, type Editor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import {useEffect, useRef, useState} from 'react'
@@ -58,6 +59,7 @@ export const useTipTapReflectionEditor = (
       content: contentJSON,
       extensions: [
         StarterKit,
+        Underline,
         TaskList,
         TaskItem.configure({
           nested: true

--- a/packages/client/hooks/useTipTapTaskEditor.ts
+++ b/packages/client/hooks/useTipTapTaskEditor.ts
@@ -2,11 +2,9 @@ import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
 import {generateText, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import {useState} from 'react'
 import Atmosphere from '../Atmosphere'
 import {LoomExtension} from '../components/promptResponse/loomExtension'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
-import {LinkMenuState} from '../components/promptResponse/TipTapLinkMenu'
 import {mentionConfig, serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
 import {tiptapEmojiConfig} from '../utils/tiptapEmojiConfig'
 import {tiptapMentionConfig} from '../utils/tiptapMentionConfig'
@@ -26,7 +24,6 @@ export const useTipTapTaskEditor = (
 ) => {
   const {atmosphere, teamId, readOnly, onBlur} = options
   const [contentJSON, editorRef] = useTipTapEditorContent(content)
-  const [linkState, setLinkState] = useState<LinkMenuState>(null)
   editorRef.current = useEditor(
     {
       content: contentJSON,
@@ -43,10 +40,7 @@ export const useTipTapTaskEditor = (
         ),
         Mention.extend({name: 'emojiMention'}).configure(tiptapEmojiConfig),
         TiptapLinkExtension.configure({
-          openOnClick: false,
-          popover: {
-            setLinkState
-          }
+          openOnClick: false
         })
       ],
       editable: !readOnly,
@@ -55,5 +49,5 @@ export const useTipTapTaskEditor = (
     },
     [contentJSON, readOnly, onBlur]
   )
-  return {editor: editorRef.current, linkState, setLinkState}
+  return {editor: editorRef.current}
 }

--- a/packages/client/hooks/useTipTapTaskEditor.ts
+++ b/packages/client/hooks/useTipTapTaskEditor.ts
@@ -1,5 +1,6 @@
 import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
+import Underline from '@tiptap/extension-underline'
 import {generateText, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Atmosphere from '../Atmosphere'
@@ -29,6 +30,7 @@ export const useTipTapTaskEditor = (
       content: contentJSON,
       extensions: [
         StarterKit,
+        Underline,
         LoomExtension,
         Placeholder.configure({
           showOnlyWhenEditable: false,

--- a/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
+++ b/packages/client/modules/outcomeCard/components/OutcomeCard/OutcomeCard.tsx
@@ -9,7 +9,6 @@ import EditingStatus from '~/components/EditingStatus/EditingStatus'
 import {PALETTE} from '~/styles/paletteV3'
 import IntegratedTaskContent from '../../../../components/IntegratedTaskContent'
 import {TipTapEditor} from '../../../../components/promptResponse/TipTapEditor'
-import {LinkMenuState} from '../../../../components/promptResponse/TipTapLinkMenu'
 import TaskIntegrationLink from '../../../../components/TaskIntegrationLink'
 import TaskWatermark from '../../../../components/TaskWatermark'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
@@ -60,8 +59,6 @@ interface Props {
   isTaskFocused: boolean
   isTaskHovered: boolean
   editor: Editor
-  linkState: LinkMenuState
-  setLinkState: (linkState: LinkMenuState) => void
   handleCardUpdate: () => void
   isAgenda: boolean
   isDraggingOver: TaskStatusEnum | undefined
@@ -79,8 +76,6 @@ const OutcomeCard = memo((props: Props) => {
     isTaskFocused,
     isTaskHovered,
     editor,
-    linkState,
-    setLinkState,
     handleCardUpdate,
     isAgenda,
     isDraggingOver,
@@ -187,8 +182,6 @@ const OutcomeCard = memo((props: Props) => {
           >
             <TipTapEditor
               editor={editor}
-              linkState={linkState}
-              setLinkState={setLinkState}
               useLinkEditor={() => useTaskChild('editor-link-changer')}
               onBlur={onFocusChange(false)}
               onFocus={onFocusChange(true)}

--- a/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
+++ b/packages/client/modules/outcomeCard/containers/OutcomeCard/OutcomeCardContainer.tsx
@@ -8,7 +8,6 @@ import {AreaEnum, TaskStatusEnum} from '~/__generated__/UpdateTaskMutation.graph
 import useClickAway from '~/hooks/useClickAway'
 import useScrollIntoView from '~/hooks/useScrollIntoVIew'
 import SetTaskHighlightMutation from '~/mutations/SetTaskHighlightMutation'
-import {LinkMenuState} from '../../../../components/promptResponse/TipTapLinkMenu'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useTaskChildFocus from '../../../../hooks/useTaskChildFocus'
 import DeleteTaskMutation from '../../../../mutations/DeleteTaskMutation'
@@ -23,8 +22,6 @@ const Wrapper = styled('div')({
 interface Props {
   area: AreaEnum
   editor: Editor
-  linkState: LinkMenuState
-  setLinkState: (linkState: LinkMenuState) => void
   className?: string
   isAgenda: boolean | undefined
   isDraggingOver: TaskStatusEnum | undefined
@@ -37,8 +34,6 @@ interface Props {
 const OutcomeCardContainer = memo((props: Props) => {
   const {
     editor,
-    linkState,
-    setLinkState,
     className,
     isDraggingOver,
     task: taskRef,
@@ -108,8 +103,6 @@ const OutcomeCardContainer = memo((props: Props) => {
       <OutcomeCard
         area={area}
         editor={editor}
-        linkState={linkState}
-        setLinkState={setLinkState}
         handleCardUpdate={handleCardUpdate}
         isTaskFocused={isTaskFocused()}
         isTaskHovered={isTaskHovered}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -99,6 +99,7 @@
     "@tiptap/extension-placeholder": "^2.9.1",
     "@tiptap/extension-task-item": "^2.11.0",
     "@tiptap/extension-task-list": "^2.11.0",
+    "@tiptap/extension-underline": "^2.11.5",
     "@tiptap/html": "^2.9.1",
     "@tiptap/pm": "^2.9.1",
     "@tiptap/react": "^2.9.1",

--- a/packages/client/shared/tiptap/serverTipTapExtensions.ts
+++ b/packages/client/shared/tiptap/serverTipTapExtensions.ts
@@ -3,6 +3,7 @@ import BaseLink from '@tiptap/extension-link'
 import Mention, {MentionNodeAttrs, MentionOptions} from '@tiptap/extension-mention'
 import {TaskItem} from '@tiptap/extension-task-item'
 import {TaskList} from '@tiptap/extension-task-list'
+import Underline from '@tiptap/extension-underline'
 import StarterKit from '@tiptap/starter-kit'
 import {LoomExtension} from '../../components/promptResponse/loomExtension'
 import {ImageBlockBase} from '../../tiptap/extensions/imageBlock/ImageBlockBase'
@@ -19,6 +20,7 @@ export const mentionConfig: Partial<MentionOptions<any, MentionNodeAttrs>> = {
 }
 export const serverTipTapExtensions = [
   StarterKit,
+  Underline,
   TaskList,
   TaskItem.configure({
     nested: true

--- a/packages/client/tiptap/extensions/imageUpload/ImageUpload.ts
+++ b/packages/client/tiptap/extensions/imageUpload/ImageUpload.ts
@@ -1,7 +1,12 @@
-import {ReactNodeViewRenderer} from '@tiptap/react'
-import {EventEmitter} from 'eventemitter3'
+import {ReactNodeViewRenderer, type Editor} from '@tiptap/react'
 import {ImageUploadBase} from '../../../shared/tiptap/extensions/ImageUploadBase'
 import {ImageUploadView} from './ImageUploadView'
+
+declare module '@tiptap/core' {
+  interface EditorEvents {
+    enter: {editor: Editor}
+  }
+}
 
 export const ImageUpload = ImageUploadBase.extend<{editorWidth: number; editorHeight: number}>({
   addOptions() {
@@ -12,7 +17,6 @@ export const ImageUpload = ImageUploadBase.extend<{editorWidth: number; editorHe
   },
   addStorage(this) {
     return {
-      emitter: new EventEmitter(),
       editorWidth: this.options.editorWidth,
       editorHeight: this.options.editorHeight
     }
@@ -25,7 +29,7 @@ export const ImageUpload = ImageUploadBase.extend<{editorWidth: number; editorHe
         // and we can't communicate with that component via props or state
         // so we attach an event emitter on the editor, since that's shared
         if (editor.isActive('imageUpload')) {
-          this.storage.emitter.emit('enter')
+          editor.emit('enter', {editor})
           return true
         }
         return false

--- a/packages/client/tiptap/extensions/imageUpload/ImageUploadView.tsx
+++ b/packages/client/tiptap/extensions/imageUpload/ImageUploadView.tsx
@@ -52,9 +52,9 @@ export const ImageUploadView = (props: NodeViewProps) => {
   })
 
   useEffect(() => {
-    editor.storage.imageUpload.emitter.on('enter', openPopover)
+    editor.on('enter', openPopover)
     return () => {
-      editor.storage.imageUpload.emitter.off('enter', openPopover)
+      editor.off('enter', openPopover)
     }
   }, [])
   const triggerRef = useHideWhenTriggerHidden(setOpen)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7727,6 +7727,11 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-text/-/extension-text-2.9.1.tgz#e4cda144b0af916ee0dafb700f833cd40eeae6d9"
   integrity sha512-3wo9uCrkLVLQFgbw2eFU37QAa1jq1/7oExa+FF/DVxdtHRS9E2rnUZ8s2hat/IWzvPUHXMwo3Zg2XfhoamQpCA==
 
+"@tiptap/extension-underline@^2.11.5":
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/@tiptap/extension-underline/-/extension-underline-2.11.5.tgz#eacf453fec192e517fdadecb7a81c976a08a9e05"
+  integrity sha512-YpWHXNIkSoRSuzT2cvgKpyJ2tTz3LzqkTM64uC+uTJ8cUkvXIWUWejJR42q8ma/mTlQe4lHff4IQ0Sf58Digtw==
+
 "@tiptap/html@^2.9.1":
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/@tiptap/html/-/html-2.9.1.tgz#0bc75c9eeb3abe6a9ed8d6285aabfdb96162519a"
@@ -10321,9 +10326,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669, caniuse-lite@~1.0.0:
-  version "1.0.30001692"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz#4585729d95e6b95be5b439da6ab55250cd125bf9"
-  integrity sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==
+  version "1.0.30001697"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz#040bbbb54463c4b4b3377c716b34a322d16e6fc7"
+  integrity sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Description

I really didn't like the leaky abstraction I originally built where linkState was created by the parent Component & passed to useEditor and then TipTapEditor. 

This fixes it by using the event emitter built into the editor. Keeps everything modular and cleeeean.

Also adds underlines to the bubble menu