### PR TITLE
fix: use canonical image storage path helper func

### DIFF
--- a/packages/server/postgres/migrations/2025-01-08T15:10:42.442Z_addRetroTemplateLikeWishWonder.ts
+++ b/packages/server/postgres/migrations/2025-01-08T15:10:42.442Z_addRetroTemplateLikeWishWonder.ts
@@ -1,18 +1,5 @@
 import type {Kysely} from 'kysely'
-
-const getTemplateIllustrationUrl = (filename: string) => {
-  const cdnType = process.env.FILE_STORE_PROVIDER
-  const partialPath = `Organization/aGhostOrg/template/${filename}`
-  if (cdnType === 'local') {
-    return `/self-hosted/${partialPath}`
-  } else if (cdnType === 's3') {
-    const {CDN_BASE_URL} = process.env
-    if (!CDN_BASE_URL) throw new Error('Missng Env: CDN_BASE_URL')
-    const hostPath = CDN_BASE_URL.replace(/^\/+/, '')
-    return `https://${hostPath}/store/${partialPath}`
-  }
-  throw new Error('Mssing Env: FILE_STORE_PROVIDER')
-}
+import getTemplateIllustrationUrl from 'parabol-server/graphql/mutations/helpers/getTemplateIllustrationUrl'
 
 export async function up(db: Kysely<any>): Promise<void> {
   await db


### PR DESCRIPTION
# Description

Fixes #10828 

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [x] Can migrate down
- [x] Can migrate up

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
