### PR TITLE
chore(Mattermost Plugin): Push command list from the client

### DIFF
--- a/packages/mattermost-plugin/index.tsx
+++ b/packages/mattermost-plugin/index.tsx
@@ -5,6 +5,7 @@ import SidePanelRoot from './components/Sidepanel'
 import PanelTitle from './components/Sidepanel/PanelTitle'
 import manifest from './manifest'
 import rootReducer, {
+  connect,
   openCreateTaskModal,
   openInviteToMeetingModal,
   openInviteToTeamModal,
@@ -19,6 +20,7 @@ import AtmosphereProvider from './AtmosphereProvider'
 import AutoLogin from './components/AutoLogin'
 import ModalRoot from './components/ModalRoot'
 import './index.css'
+import commands from './public/mattermost-plugin-commands.json'
 
 export const init = async (registry: PluginRegistry, store: Store<GlobalState, AnyAction>) => {
   const serverUrl = getPluginServerRoute(store.getState())
@@ -72,6 +74,8 @@ export const init = async (registry: PluginRegistry, store: Store<GlobalState, A
   registry.registerWebSocketEventHandler(`custom_${manifest.id}_share`, () => {
     store.dispatch(openInviteToMeetingModal())
   })
+
+  store.dispatch(connect({commands}) as any)
 
   registry.registerPostDropdownMenuAction(
     <div>

--- a/packages/mattermost-plugin/index.tsx
+++ b/packages/mattermost-plugin/index.tsx
@@ -13,7 +13,7 @@ import rootReducer, {
   openStartActivityModal
 } from './reducers'
 import {getAssetsUrl, getPluginServerRoute} from './selectors'
-import {PluginRegistry} from './types/mattermost-webapp'
+import {ContextArgs, PluginRegistry} from './types/mattermost-webapp'
 
 import {createEnvironment} from './Atmosphere'
 import AtmosphereProvider from './AtmosphereProvider'
@@ -25,10 +25,17 @@ import commands from './public/mattermost-plugin-commands.json'
 export const init = async (registry: PluginRegistry, store: Store<GlobalState, AnyAction>) => {
   const serverUrl = getPluginServerRoute(store.getState())
   const environment = createEnvironment(serverUrl, store)
-  /*registry.registerSlashCommandWillBePostedHook((message: string) => {
-    return message
+  registry.registerSlashCommandWillBePostedHook(async (message: string, args: ContextArgs) => {
+    const [command, subcommand] = message.split(/\s+/)
+    if (command === '/parabol') {
+      if (subcommand === 'connect') {
+        store.dispatch(connect({commands}) as any)
+        console.log(`${manifest.id} Updating commands`)
+        return {}
+      }
+    }
+    return {message, args}
   })
-   */
 
   registry.registerReducer(rootReducer)
   registry.registerRootComponent(() => (
@@ -87,5 +94,5 @@ export const init = async (registry: PluginRegistry, store: Store<GlobalState, A
     (postId: string) => store.dispatch(openPushPostAsReflection(postId))
   )
 
-  console.log(`Initialized plugin ${manifest.id}`)
+  console.log(`${manifest.id} Initialized plugin`)
 }

--- a/packages/mattermost-plugin/reducers.ts
+++ b/packages/mattermost-plugin/reducers.ts
@@ -48,6 +48,30 @@ export const removeTeamFromChannel = createAsyncThunk(
   }
 )
 
+export type Command = {
+  trigger: string
+  description: string
+}
+
+export type ClientConfig = {
+  commands: Command[]
+}
+
+export const connect = createAsyncThunk('connect', async (config: ClientConfig, thunkApi) => {
+  const serverUrl = getPluginServerRoute(thunkApi.getState() as any)
+  const res = await fetch(
+    `${serverUrl}/connect`,
+    Client4.getOptions({
+      method: 'POST',
+      body: JSON.stringify(config)
+    })
+  )
+  if (!res.ok) {
+    throw new Error(`Failed to initialize commands: ${res.statusText}`)
+  }
+  return
+})
+
 const localSlice = createSlice({
   name: 'local',
   initialState: {


### PR DESCRIPTION
This way the client does not need to expose additional files and if the client is refreshed, it can push the updated command help list.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
