### PR TITLE
fix: update icebreaker styles

### DIFF
--- a/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
+++ b/packages/client/modules/meeting/components/MeetingCheckInPrompt/NewCheckInQuestion.tsx
@@ -164,7 +164,11 @@ const NewCheckInQuestion = (props: Props) => {
   return (
     <>
       <div className='flex flex-col items-center py-4'>
-        <EditorContent className='text-2xl' editor={editor} onBlur={updateQuestion} />
+        <EditorContent
+          className='text-2xl [&_.ProseMirror_p]:leading-normal'
+          editor={editor}
+          onBlur={updateQuestion}
+        />
         {isFacilitating && (
           <div className='flex gap-x-2'>
             <Tooltip open={isFacilitating ? undefined : false}>


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/10683

![Screenshot 2025-02-10 at 10 29 27](https://github.com/user-attachments/assets/a9fc6df3-5507-49ec-84cd-bfe72fa52937)

Ideally, we'd update global styles, but in a previous PR, this caused issues elsewhere. For now, I'd like to make this quick change as the Icebreaker looks bad and everyone sees it as soon as they start a meeting.