### PR TITLE
fix: bump trebuchet-client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -70,7 +70,7 @@
     "@emotion/styled": "^10.0.27",
     "@mattkrick/graphql-trebuchet-client": "^2.2.1",
     "@mattkrick/sanitize-svg": "0.4.0",
-    "@mattkrick/trebuchet-client": "3.0.3",
+    "@mattkrick/trebuchet-client": "3.0.4",
     "@mui/base": "^5.0.0-beta.68",
     "@mui/icons-material": "^6.3.1",
     "@mui/material": "^6.3.1",


### PR DESCRIPTION
# Description

When the server disconnects (e.g. during a new version release) the client would reconnect to the new server. Then, SOMETIMES it would disconnect and reconnect to a new server again. I believe this was initiated client-side due to a keepAlive that was not cancelled when the first connection was closed. Should be fixed now.

