### PR TITLE
feat(orgAdmin): add sortable `memberCount` and `lastMetAt` columns in OrgTeams view

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -1,13 +1,11 @@
-import {ChevronRight} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
-import {format} from 'date-fns'
 import {useState} from 'react'
 import {useFragment} from 'react-relay'
-import {Link} from 'react-router-dom'
 import {OrgTeams_organization$key} from '../../../../__generated__/OrgTeams_organization.graphql'
 import AddTeamDialogRoot from '../../../../components/AddTeamDialogRoot'
 import {Button} from '../../../../ui/Button/Button'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
+import OrgTeamsRow from './OrgTeamsRow'
 import TeaserOrgTeamsRow from './TeaserOrgTeamsRow'
 
 type Props = {
@@ -28,16 +26,14 @@ const OrgTeams = (props: Props) => {
         allTeams {
           id
           name
-          teamMembers {
-            id
-            isSelf
-            isLead
-            preferredName
-          }
           activeMeetings {
             id
             createdAt
           }
+          teamMembers {
+            id
+          }
+          ...OrgTeamsRow_team
         }
         viewerTeams {
           id
@@ -142,42 +138,9 @@ const OrgTeams = (props: Props) => {
               </tr>
             </thead>
             <tbody>
-              {sortedTeams.map((team) => {
-                const viewerTeamMember = team.teamMembers.find((m) => m.isSelf)
-                const isLead = viewerTeamMember?.isLead
-                const isMember = !!viewerTeamMember && !isLead
-                return (
-                  <tr key={team.id} className='hover:bg-slate-50 border-b border-slate-300'>
-                    <td className='p-3'>
-                      <Link
-                        to={`teams/${team.id}`}
-                        className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'
-                      >
-                        <div className='flex flex-1 items-center'>
-                          {team.name}
-                          {isLead && (
-                            <span className='ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
-                              Team Lead
-                            </span>
-                          )}
-                          {isMember && (
-                            <span className='ml-2 rounded-full bg-sky-500 px-2 py-0.5 text-xs text-white'>
-                              Member
-                            </span>
-                          )}
-                        </div>
-                        <ChevronRight className='ml-2 text-slate-600' />
-                      </Link>
-                    </td>
-                    <td className='text-gray-600 p-3'>{team.teamMembers.length}</td>
-                    <td className='text-gray-600 p-3'>
-                      {team.activeMeetings[0]?.createdAt
-                        ? format(new Date(team.activeMeetings[0].createdAt), 'yyyy-MM-dd')
-                        : 'Never'}
-                    </td>
-                  </tr>
-                )
-              })}
+              {sortedTeams.map((team) => (
+                <OrgTeamsRow key={team.id} teamRef={team} />
+              ))}
             </tbody>
           </table>
         </div>

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -1,16 +1,21 @@
+import {ChevronRight} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
+import {format} from 'date-fns'
+import {useState} from 'react'
 import {useFragment} from 'react-relay'
+import {Link} from 'react-router-dom'
 import {OrgTeams_organization$key} from '../../../../__generated__/OrgTeams_organization.graphql'
 import AddTeamDialogRoot from '../../../../components/AddTeamDialogRoot'
 import {Button} from '../../../../ui/Button/Button'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
-import plural from '../../../../utils/plural'
-import OrgTeamsRow from './OrgTeamsRow'
 import TeaserOrgTeamsRow from './TeaserOrgTeamsRow'
 
 type Props = {
   organizationRef: OrgTeams_organization$key
 }
+
+type SortField = 'name' | 'memberCount' | 'lastMetAt'
+type SortDirection = 'asc' | 'desc'
 
 const OrgTeams = (props: Props) => {
   const {organizationRef} = props
@@ -22,7 +27,17 @@ const OrgTeams = (props: Props) => {
         hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
         allTeams {
           id
-          ...OrgTeamsRow_team
+          name
+          teamMembers {
+            id
+            isSelf
+            isLead
+            preferredName
+          }
+          activeMeetings {
+            id
+            createdAt
+          }
         }
         viewerTeams {
           id
@@ -39,9 +54,38 @@ const OrgTeams = (props: Props) => {
     isOpen: isAddTeamDialogOpened
   } = useDialogState()
 
+  const [sortBy, setSortBy] = useState<SortField>('lastMetAt')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+
   const {allTeams, tier, viewerTeams, allTeamsCount, hasPublicTeamsFlag} = organization
   const showAllTeams = allTeams.length === allTeamsCount || hasPublicTeamsFlag
   const viewerTeamCount = viewerTeams.length
+
+  const handleSort = (field: SortField) => {
+    if (sortBy === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortBy(field)
+      setSortDirection('desc')
+    }
+  }
+
+  const sortedTeams = [...allTeams].sort((a, b) => {
+    const direction = sortDirection === 'asc' ? 1 : -1
+    if (sortBy === 'name') {
+      return direction * a.name.localeCompare(b.name)
+    } else if (sortBy === 'memberCount') {
+      return direction * (a.teamMembers.length - b.teamMembers.length)
+    } else {
+      // lastMetAt
+      const aLastMeeting = a.activeMeetings[0]?.createdAt
+      const bLastMeeting = b.activeMeetings[0]?.createdAt
+      if (!aLastMeeting && !bLastMeeting) return 0
+      if (!aLastMeeting) return -direction
+      if (!bLastMeeting) return direction
+      return direction * (new Date(aLastMeeting).getTime() - new Date(bLastMeeting).getTime())
+    }
+  })
 
   return (
     <div className='max-w-4xl pb-4'>
@@ -65,15 +109,77 @@ const OrgTeams = (props: Props) => {
         <div className='bg-slate-100 px-4 py-2'>
           <div className='flex w-full justify-between'>
             <div className='flex items-center font-bold'>
-              {allTeamsCount} {plural(allTeamsCount, 'Team')}{' '}
+              {allTeamsCount} {' total '}
               {!showAllTeams ? `(${allTeamsCount - viewerTeamCount} hidden)` : null}
             </div>
           </div>
         </div>
-        <div className='divide-y divide-slate-300 border-y border-slate-300'>
-          {allTeams.map((team) => (
-            <OrgTeamsRow key={team.id} teamRef={team} />
-          ))}
+        <div className='w-full overflow-x-auto px-4'>
+          <table className='w-full table-fixed border-collapse md:table-auto'>
+            <thead>
+              <tr className='border-b border-slate-300'>
+                <th
+                  className='w-[60%] cursor-pointer p-3 text-left font-semibold'
+                  onClick={() => handleSort('name')}
+                >
+                  Team
+                  {sortBy === 'name' && (sortDirection === 'asc' ? ' ▲' : ' ▼')}
+                </th>
+                <th
+                  className='w-[20%] cursor-pointer p-3 text-left font-semibold'
+                  onClick={() => handleSort('memberCount')}
+                >
+                  Member Count
+                  {sortBy === 'memberCount' && (sortDirection === 'asc' ? ' ▲' : ' ▼')}
+                </th>
+                <th
+                  className='w-[20%] cursor-pointer p-3 text-left font-semibold'
+                  onClick={() => handleSort('lastMetAt')}
+                >
+                  Last Met At
+                  {sortBy === 'lastMetAt' && (sortDirection === 'asc' ? ' ▲' : ' ▼')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedTeams.map((team) => {
+                const viewerTeamMember = team.teamMembers.find((m) => m.isSelf)
+                const isLead = viewerTeamMember?.isLead
+                const isMember = !!viewerTeamMember && !isLead
+                return (
+                  <tr key={team.id} className='hover:bg-slate-50 border-b border-slate-300'>
+                    <td className='p-3'>
+                      <Link
+                        to={`teams/${team.id}`}
+                        className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'
+                      >
+                        <div className='flex flex-1 items-center'>
+                          {team.name}
+                          {isLead && (
+                            <span className='ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
+                              Team Lead
+                            </span>
+                          )}
+                          {isMember && (
+                            <span className='ml-2 rounded-full bg-sky-500 px-2 py-0.5 text-xs text-white'>
+                              Member
+                            </span>
+                          )}
+                        </div>
+                        <ChevronRight className='ml-2 text-slate-600' />
+                      </Link>
+                    </td>
+                    <td className='text-gray-600 p-3'>{team.teamMembers.length}</td>
+                    <td className='text-gray-600 p-3'>
+                      {team.activeMeetings[0]?.createdAt
+                        ? format(new Date(team.activeMeetings[0].createdAt), 'yyyy-MM-dd')
+                        : 'Never'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
         </div>
 
         {tier !== 'enterprise' && allTeamsCount > viewerTeamCount && !showAllTeams && (

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -26,10 +26,7 @@ const OrgTeams = (props: Props) => {
         allTeams {
           id
           name
-          activeMeetings {
-            id
-            createdAt
-          }
+          lastMetAt
           teamMembers {
             id
           }
@@ -74,12 +71,12 @@ const OrgTeams = (props: Props) => {
       return direction * (a.teamMembers.length - b.teamMembers.length)
     } else {
       // lastMetAt
-      const aLastMeeting = a.activeMeetings[0]?.createdAt
-      const bLastMeeting = b.activeMeetings[0]?.createdAt
-      if (!aLastMeeting && !bLastMeeting) return 0
-      if (!aLastMeeting) return -direction
-      if (!bLastMeeting) return direction
-      return direction * (new Date(aLastMeeting).getTime() - new Date(bLastMeeting).getTime())
+      const aLastMet = a.lastMetAt
+      const bLastMet = b.lastMetAt
+      if (!aLastMet && !bLastMet) return 0
+      if (!aLastMet) return -direction
+      if (!bLastMet) return direction
+      return direction * (new Date(aLastMet).getTime() - new Date(bLastMet).getTime())
     }
   })
 

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -21,15 +21,12 @@ const OrgTeamsRow = (props: Props) => {
           isLead
           preferredName
         }
-        activeMeetings {
-          id
-          createdAt
-        }
+        lastMetAt
       }
     `,
     teamRef
   )
-  const {id: teamId, teamMembers, name, activeMeetings} = team
+  const {id: teamId, teamMembers, name, lastMetAt} = team
   const teamMembersCount = teamMembers.length
   const viewerTeamMember = teamMembers.find((m) => m.isSelf)
   const isLead = viewerTeamMember?.isLead
@@ -60,9 +57,7 @@ const OrgTeamsRow = (props: Props) => {
       </td>
       <td className='text-gray-600 p-3'>{teamMembersCount}</td>
       <td className='text-gray-600 p-3'>
-        {activeMeetings[0]?.createdAt
-          ? format(new Date(activeMeetings[0].createdAt), 'yyyy-MM-dd')
-          : 'Never'}
+        {lastMetAt ? format(new Date(lastMetAt), 'yyyy-MM-dd') : 'Never'}
       </td>
     </tr>
   )

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -1,10 +1,9 @@
 import {ChevronRight} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
+import {format} from 'date-fns'
 import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
-
 import {OrgTeamsRow_team$key} from '../../../../__generated__/OrgTeamsRow_team.graphql'
-import plural from '../../../../utils/plural'
 
 type Props = {
   teamRef: OrgTeamsRow_team$key
@@ -22,24 +21,28 @@ const OrgTeamsRow = (props: Props) => {
           isLead
           preferredName
         }
+        activeMeetings {
+          id
+          createdAt
+        }
       }
     `,
     teamRef
   )
-  const {id: teamId, teamMembers, name} = team
+  const {id: teamId, teamMembers, name, activeMeetings} = team
   const teamMembersCount = teamMembers.length
   const viewerTeamMember = teamMembers.find((m) => m.isSelf)
   const isLead = viewerTeamMember?.isLead
   const isMember = !!viewerTeamMember && !isLead
 
   return (
-    <Link
-      className='block hover:bg-slate-100 focus-visible:ring-1 focus-visible:outline-hidden focus-visible:ring-inset'
-      to={`teams/${teamId}`}
-    >
-      <div className='flex items-center p-4'>
-        <div className='flex flex-1 flex-col py-1'>
-          <div className='text-gray-700 flex items-center text-lg font-bold'>
+    <tr className='hover:bg-slate-50 border-b border-slate-300'>
+      <td className='p-3'>
+        <Link
+          to={`teams/${teamId}`}
+          className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'
+        >
+          <div className='flex flex-1 items-center'>
             {name}
             {isLead && (
               <span className='ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
@@ -52,17 +55,16 @@ const OrgTeamsRow = (props: Props) => {
               </span>
             )}
           </div>
-          <div className='flex items-center justify-between'>
-            <div className='text-gray-600'>
-              {`${teamMembersCount} ${plural(teamMembersCount, 'member')}`}
-            </div>
-          </div>
-        </div>
-        <div className='flex items-center justify-center'>
-          <ChevronRight />
-        </div>
-      </div>
-    </Link>
+          <ChevronRight className='ml-2 text-slate-600' />
+        </Link>
+      </td>
+      <td className='text-gray-600 p-3'>{teamMembersCount}</td>
+      <td className='text-gray-600 p-3'>
+        {activeMeetings[0]?.createdAt
+          ? format(new Date(activeMeetings[0].createdAt), 'yyyy-MM-dd')
+          : 'Never'}
+      </td>
+    </tr>
   )
 }
 

--- a/packages/server/graphql/public/typeDefs/Team.graphql
+++ b/packages/server/graphql/public/typeDefs/Team.graphql
@@ -32,6 +32,11 @@ type Team implements Node {
   lastMeetingType: MeetingTypeEnum!
 
   """
+  The datetime of the team's most recent meeting (from either active or completed meetings)
+  """
+  lastMetAt: DateTime
+
+  """
   The HTML message to show if isPaid is false
   """
   lockMessageHTML: String


### PR DESCRIPTION
# Description

Closes #10845 

## Demo

![2025-02-11 15 11 06](https://github.com/user-attachments/assets/e1bbeee1-a08b-48a6-8e44-1c8967ccde20)


## Testing scenarios

- [ ] Default sorting
  - Go to `http://localhost:3000/me/organizations/E3wNXGxEZy/teams`
  - See teams are sorted by `Last Met At` date by default, descending

- [ ] Sortable columns
  - Go to `http://localhost:3000/me/organizations/E3wNXGxEZy/teams`
  - Click `Member Count` or `Last Met At` to sort the teams by the column

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
