### PR TITLE
feat(Mattermost Plugin): TipTap link menu

### DIFF
--- a/packages/client/components/promptResponse/StandardBubbleMenu.tsx
+++ b/packages/client/components/promptResponse/StandardBubbleMenu.tsx
@@ -20,7 +20,11 @@ export const StandardBubbleMenu = (props: Props) => {
   // wrapping in div is necessary, https://github.com/ueberdosis/tiptap/issues/3784
   return (
     <div>
-      <BubbleMenu editor={editor} tippyOptions={{duration: 100}} shouldShow={shouldShowBubbleMenu}>
+      <BubbleMenu
+        editor={editor}
+        tippyOptions={{duration: 100, role: 'dialog'}}
+        shouldShow={shouldShowBubbleMenu}
+      >
         <div className='flex items-center rounded-sm border-[1px] border-solid border-slate-600 bg-white p-[3px]'>
           <BubbleMenuButton
             onClick={() => editor.chain().focus().toggleBold().run()}

--- a/packages/client/components/promptResponse/TipTapLinkMenu.tsx
+++ b/packages/client/components/promptResponse/TipTapLinkMenu.tsx
@@ -1,6 +1,12 @@
-import * as Popover from '@radix-ui/react-popover'
 import type {EditorEvents} from '@tiptap/core'
-import {Editor, getMarkRange, getMarkType, getTextBetween, useEditorState} from '@tiptap/react'
+import {
+  BubbleMenu,
+  Editor,
+  getMarkRange,
+  getMarkType,
+  getTextBetween,
+  useEditorState
+} from '@tiptap/react'
 import {useCallback, useEffect, useRef, useState} from 'react'
 import {TipTapLinkEditor} from './TipTapLinkEditor'
 import {TipTapLinkPreview} from './TipTapLinkPreview'
@@ -122,55 +128,28 @@ export const TipTapLinkMenu = (props: Props) => {
       .run()
     setLinkState(null)
   }, [editor])
-  const onOpenChange = (willOpen: boolean) => {
-    const isLinkActive = editor.isActive('link')
-    if (willOpen) {
-      setLinkState(isLinkActive ? 'preview' : 'edit')
-    } else {
-      // special case when switching from preview to edit radix-ui triggers onOpenChange(false)
-      if (!(oldLinkStateRef.current === 'preview' && linkState === 'edit')) {
-        setLinkState(null)
-      }
-      oldLinkStateRef.current = null
-    }
-  }
-  const transformRef = useRef<undefined | string>(undefined)
-  const getTransform = () => {
-    const coords = editor.view.coordsAtPos(editor.state.selection.from)
-    const {left, top} = coords
-    if (left !== 0 && top !== 0) {
-      transformRef.current = `translate(${coords.left}px,${coords.top + 20}px)`
-    }
-    return transformRef.current
-  }
+
   if (!linkState) return null
   return (
-    <Popover.Root open onOpenChange={onOpenChange}>
-      <Popover.Trigger asChild />
-      <Popover.Portal>
-        <Popover.Content
-          asChild
-          onOpenAutoFocus={(e) => {
-            // necessary for link preview to prevent focusing the first button
-            e.preventDefault()
-          }}
-        >
-          <div className='absolute top-0 left-0 z-10' style={{transform: getTransform()}}>
-            {linkState === 'edit' && (
-              <TipTapLinkEditor
-                initialUrl={link}
-                initialText={text}
-                onSetLink={onSetLink}
-                useLinkEditor={useLinkEditor}
-              />
-            )}
-            {linkState === 'preview' && (
-              <TipTapLinkPreview url={link} onClear={onUnsetLink} onEdit={handleEdit} />
-            )}
-          </div>
-        </Popover.Content>
-      </Popover.Portal>
-    </Popover.Root>
+    <BubbleMenu
+      editor={editor}
+      tippyOptions={{duration: 100, role: 'dialog'}}
+      shouldShow={() => true}
+    >
+      <div className='absolute top-0 left-0 z-10'>
+        {linkState === 'edit' && (
+          <TipTapLinkEditor
+            initialUrl={link}
+            initialText={text}
+            onSetLink={onSetLink}
+            useLinkEditor={useLinkEditor}
+          />
+        )}
+        {linkState === 'preview' && (
+          <TipTapLinkPreview url={link} onClear={onUnsetLink} onEdit={handleEdit} />
+        )}
+      </div>
+    </BubbleMenu>
   )
 }
 

--- a/packages/client/components/promptResponse/TiptapLinkExtension.ts
+++ b/packages/client/components/promptResponse/TiptapLinkExtension.ts
@@ -1,13 +1,31 @@
-import {mergeAttributes, type Editor} from '@tiptap/core'
+import {getMarkRange, getMarkType, mergeAttributes, type Editor} from '@tiptap/core'
 import BaseLink from '@tiptap/extension-link'
 import {Plugin} from '@tiptap/pm/state'
 import {EditorView} from '@tiptap/pm/view'
-import {LinkMenuState} from './TipTapLinkMenu'
+
+export type LinkMenuState = 'preview' | 'edit' | null
 
 declare module '@tiptap/core' {
   interface EditorEvents {
     linkStateChange: {editor: Editor; linkState: LinkMenuState}
   }
+
+  interface Commands<ReturnType> {
+    upsertLink: {
+      upsertLink: (link: {text: string; url: string}) => ReturnType
+    }
+    removeLink: {
+      removeLink: () => ReturnType
+    }
+  }
+}
+
+export const getRangeForType = (editor: Editor, typeOrName: string) => {
+  const {state} = editor
+  const {selection, schema} = state
+  const {$from} = selection
+  const type = getMarkType(typeOrName, schema)
+  return getMarkRange($from, type)
 }
 
 export const TiptapLinkExtension = BaseLink.extend({
@@ -19,6 +37,63 @@ export const TiptapLinkExtension = BaseLink.extend({
         this.editor.emit('linkStateChange', {editor: this.editor, linkState: 'edit'})
         return true
       }
+    }
+  },
+  addCommands() {
+    return {
+      upsertLink:
+        ({text, url}) =>
+        ({editor}) => {
+          const range = getRangeForType(editor, 'link')
+          if (!range) {
+            const {state} = editor
+            const {selection} = state
+            const {from} = selection
+            const nextTo = from + text.length
+            // adding a new link
+            return editor
+              .chain()
+              .focus()
+              .command(({tr}) => {
+                tr.insertText(text)
+                return true
+              })
+              .setTextSelection({
+                from,
+                to: nextTo
+              })
+              .setLink({href: url, target: '_blank'})
+              .setTextSelection({from: nextTo, to: nextTo})
+              .run()
+          }
+          const {from} = range
+          const to = from + text.length
+          return editor
+            .chain()
+            .focus()
+            .setTextSelection(range)
+            .insertContent(text)
+            .setTextSelection({
+              from,
+              to
+            })
+            .setLink({href: url, target: '_blank'})
+            .setTextSelection({from: to, to})
+            .run()
+        },
+      removeLink:
+        () =>
+        ({editor}) => {
+          const range = getRangeForType(editor, 'link')
+          if (!range) return false
+          return editor
+            .chain()
+            .focus()
+            .extendMarkRange('link')
+            .unsetLink()
+            .setTextSelection({from: range.to, to: range.to})
+            .run()
+        }
     }
   },
   parseHTML() {

--- a/packages/mattermost-plugin/components/PushReflection/PushReflectionModal.tsx
+++ b/packages/mattermost-plugin/components/PushReflection/PushReflectionModal.tsx
@@ -207,6 +207,14 @@ const PushReflectionModal = () => {
         }
       } as Partial<Post>)
     })
+    /*
+    TODO update to this call once https://github.com/mattermost/mattermost/pull/30117 was released
+    Client4.createPostEphemeral(mmUser.id, {
+      channel_id: post.channel_id,
+      root_id: post.root_id || post.id,
+      props
+    })
+     */
 
     handleClose()
   }

--- a/packages/mattermost-plugin/components/PushReflection/PushReflectionModal.tsx
+++ b/packages/mattermost-plugin/components/PushReflection/PushReflectionModal.tsx
@@ -11,7 +11,6 @@ import StarterKit from '@tiptap/starter-kit'
 import graphql from 'babel-plugin-relay/macro'
 
 import {Post} from 'mattermost-redux/types/posts'
-import {TipTapEditor} from 'parabol-client/components/promptResponse/TipTapEditor'
 import {PALETTE} from 'parabol-client/styles/paletteV3'
 import {PushReflectionModalMutation} from '../../__generated__/PushReflectionModalMutation.graphql'
 import {PushReflectionModalQuery} from '../../__generated__/PushReflectionModalQuery.graphql'
@@ -22,6 +21,7 @@ import {closePushPostAsReflection, openLinkTeamModal, openStartActivityModal} fr
 import {getPluginServerRoute, getPostURL, pushPostAsReflection} from '../../selectors'
 import Modal from '../Modal'
 import Select from '../Select'
+import {TipTapEditor} from '../TipTap/Editor'
 
 const PostUtils = (window as any).PostUtils
 

--- a/packages/mattermost-plugin/components/TipTap/Editor.tsx
+++ b/packages/mattermost-plugin/components/TipTap/Editor.tsx
@@ -1,0 +1,25 @@
+import {Editor, EditorContent, type EditorContentProps} from '@tiptap/react'
+import {StandardBubbleMenu} from 'parabol-client/components/promptResponse/StandardBubbleMenu'
+import {cn} from 'parabol-client/ui/cn'
+import TipTapLinkMenu from './LinkMenu'
+
+interface Props extends EditorContentProps {
+  editor: Editor
+  showBubbleMenu?: boolean
+  useLinkEditor?: () => void
+}
+export const TipTapEditor = (props: Props) => {
+  const {className, editor, showBubbleMenu, useLinkEditor, ref, ...rest} = props
+  return (
+    <>
+      <StandardBubbleMenu editor={editor} />
+      <TipTapLinkMenu editor={editor} useLinkEditor={useLinkEditor} />
+      <EditorContent
+        ref={ref as any}
+        {...rest}
+        editor={editor}
+        className={cn('min-h-10 px-4 text-sm leading-none', className)}
+      />
+    </>
+  )
+}

--- a/packages/mattermost-plugin/components/TipTap/LinkEditor.tsx
+++ b/packages/mattermost-plugin/components/TipTap/LinkEditor.tsx
@@ -1,0 +1,74 @@
+import {Link, Title} from '@mui/icons-material'
+import linkify from 'parabol-client/utils/linkify'
+import {useCallback, useMemo, useState} from 'react'
+
+export type props = {
+  initialUrl: string
+  initialText: string
+  onSetLink: (link: {text: string; url: string}) => void
+  useLinkEditor?: () => void
+}
+
+export const TipTapLinkEditor = (props: props) => {
+  const {useLinkEditor, onSetLink, initialUrl, initialText} = props
+
+  const [url, setUrl] = useState(initialUrl)
+  const [text, setText] = useState(initialText)
+  const onChangeURL = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setUrl(event.target.value)
+  }, [])
+  const onChangeText = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setText(event.target.value)
+  }, [])
+  const isValidUrl = useMemo(() => (!url ? false : linkify.match(url)), [url])
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      if (!isValidUrl) return
+      onSetLink({text, url})
+    },
+    [url, text, isValidUrl, onSetLink]
+  )
+  useLinkEditor?.()
+  return (
+    <form onSubmit={handleSubmit} className='flex flex-col items-center pt-2 text-slate-600'>
+      <div className='form-group flex items-center'>
+        <Link
+          style={{
+            width: 18,
+            height: 18
+          }}
+          className='mr-2 flex-none'
+        />
+        <input
+          autoFocus
+          type='url'
+          className='min-w-52 flex-1 border-none bg-transparent'
+          placeholder='Enter URL'
+          value={url}
+          onChange={onChangeURL}
+        />
+      </div>
+      <div className='form-group flex items-center'>
+        <Title
+          style={{
+            width: 18,
+            height: 18
+          }}
+          className='mr-2 flex-none'
+        />
+        <input
+          className='min-w-52 flex-1 border-none bg-transparent'
+          placeholder='Link Title'
+          value={text}
+          onChange={onChangeText}
+        />
+      </div>
+      <div className='flex w-full items-end justify-end'>
+        <button type='submit' disabled={!isValidUrl} className='btn btn-tertiary'>
+          Save
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/packages/mattermost-plugin/components/TipTap/LinkPreview.tsx
+++ b/packages/mattermost-plugin/components/TipTap/LinkPreview.tsx
@@ -1,0 +1,63 @@
+import {Delete, Edit, Link} from '@mui/icons-material'
+import {Tooltip} from 'parabol-client/ui/Tooltip/Tooltip'
+import {TooltipContent} from 'parabol-client/ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from 'parabol-client/ui/Tooltip/TooltipTrigger'
+
+export type Props = {
+  url: string
+  onEdit: () => void
+  onClear: () => void
+}
+
+export const TipTapLinkPreview = (props: Props) => {
+  const {onClear, onEdit, url} = props
+  return (
+    <div className={'flex items-center justify-center truncate p-1'}>
+      <Link
+        style={{
+          width: 18,
+          height: 18
+        }}
+        className='flex-none pr-1 text-slate-700'
+      />
+      <a
+        href={url}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='text-md max-w-64 truncate break-all underline'
+      >
+        {url}
+      </a>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className={
+              'flex items-center justify-center rounded border-none bg-transparent p-2 font-semibold text-black outline-none hover:bg-slate-300'
+            }
+            aria-label='Edit'
+          >
+            <Edit onClick={onEdit} className='text-base' />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side='top' align='center'>
+          {'Edit link'}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className={
+              'flex items-center justify-center rounded border-none bg-transparent p-2 font-semibold text-black outline-none hover:bg-slate-300'
+            }
+            aria-label='Remove link'
+          >
+            <Delete onClick={onClear} className='text-base' />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side='top' align='center'>
+          {'Remove link'}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/packages/mattermost-plugin/hooks/useTipTapTaskEditor.tsx
+++ b/packages/mattermost-plugin/hooks/useTipTapTaskEditor.tsx
@@ -1,5 +1,6 @@
 import Mention from '@tiptap/extension-mention'
 import Placeholder from '@tiptap/extension-placeholder'
+import Underline from '@tiptap/extension-underline'
 import {useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import {TiptapLinkExtension} from 'parabol-client/components/promptResponse/TiptapLinkExtension'
@@ -13,6 +14,7 @@ export const useTipTapTaskEditor = (content: string) => {
     content: contentJSON,
     extensions: [
       StarterKit,
+      Underline,
       Placeholder.configure({
         showOnlyWhenEditable: false,
         placeholder: 'Describe what “Done” looks like'

--- a/packages/mattermost-plugin/index.css
+++ b/packages/mattermost-plugin/index.css
@@ -3,13 +3,26 @@
 @import "tailwindcss/utilities.css" layer(utilities);
 @source "../client";
 
-.form-control.h-auto {
-  @apply h-auto;
-}
-
+/* make popper work together with bootstrap modals and existing z-indexes */
 div[data-radix-popper-content-wrapper] {
   @apply z-1500;
   > div {
     @apply z-1500;
   }
 }
+
+/* hacks to overwrite some of Mattermosts styles for specific use cases of ours */
+.form-control.h-auto {
+  @apply h-auto;
+}
+.truncate.flex {
+  @apply flex;
+}
+
+.tippy-box[role="dialog"] {
+  @apply bg-white shadow-lg rounded-lg;
+  button {
+    @apply m-1 w-16 items-center px-4 border-none rounded font-semibold outline-none hover:bg-slate-500 data-[highlighted=true]:bg-slate-500 bg-slate-300;
+  }
+}
+

--- a/packages/mattermost-plugin/index.css
+++ b/packages/mattermost-plugin/index.css
@@ -18,11 +18,18 @@ div[data-radix-popper-content-wrapper] {
 .truncate.flex {
   @apply flex;
 }
+.popover.fixed {
+  @apply fixed;
+}
 
+/* styling of the tiptap bubble menu */
 .tippy-box[role="dialog"] {
   @apply bg-white shadow-lg rounded-lg;
   button {
-    @apply m-1 w-16 items-center px-4 border-none rounded font-semibold outline-none hover:bg-slate-500 data-[highlighted=true]:bg-slate-500 bg-slate-300;
+    @apply w-12 items-center px-4 border-none rounded font-semibold outline-none hover:bg-slate-300 data-[highlighted=true]:bg-slate-300 bg-transparent text-black;
+  }
+  .tippy-content {
+    @apply p-0;
   }
 }
 


### PR DESCRIPTION
# Description

Fixes #10797 
Mattermost uses react-bootstrap for modals. To play nicely with their components, that's what we're using as well in the plugin. The bubble menu used for formatting works nicely once the z-index is set accordingly.
The radix-ui/react-popover used by the link menu does not work because we portal it to the document.body. The modal does not detect that the popover is a child and thus steal its focus. Not portaling it would solve it (after fixing the offset) but using a portal might be necessary in the app at some point, so this might be broken by unrelated code changes.
I would have liked to use a mechanism similar to the BubbleMenu. This would work in theory, but BubbleMenu does not follow the React update cycle. It only re-evaluates `shouldShow` on document changes. This makes it impossible to programmatically trigger the link menu. Even editor state changes are not enough.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
