### PR TITLE
fix: client resub on server redeploy

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -70,7 +70,7 @@
     "@emotion/styled": "^10.0.27",
     "@mattkrick/graphql-trebuchet-client": "^2.2.1",
     "@mattkrick/sanitize-svg": "0.4.0",
-    "@mattkrick/trebuchet-client": "3.0.4",
+    "@mattkrick/trebuchet-client": "3.0.5",
     "@mui/base": "^5.0.0-beta.68",
     "@mui/icons-material": "^6.3.1",
     "@mui/material": "^6.3.1",

--- a/packages/server/graphql/subscribeGraphQL.ts
+++ b/packages/server/graphql/subscribeGraphQL.ts
@@ -124,6 +124,9 @@ const subscribeGraphQL = async (req: SubscribeRequest) => {
     const syn = !reliableSubscriptionPayloadBlackList.includes(fieldName)
     sendGQLMessage(connectionContext, opId, 'data', syn, {...restPayload, data: dehydratedData})
   }
+  // if the socket is disconnecting (client leaves, server shuts down, keepAlive fails) then don't resub or send complete
+  // sending a complete removes the subscription from the client & they won't resub
+  if (connectionContext.isDisconnecting) return
   const resubIdx = connectionContext.availableResubs.indexOf(opId)
   if (resubIdx !== -1) {
     // reinitialize the subscription

--- a/packages/server/socketHandlers/handleClose.ts
+++ b/packages/server/socketHandlers/handleClose.ts
@@ -1,18 +1,12 @@
-import {WebSocket} from 'uWebSockets.js'
-import sendToSentry from '../utils/sendToSentry'
+import {type WebSocketBehavior} from 'uWebSockets.js'
 import handleDisconnect from './handleDisconnect'
 import {SocketUserData} from './handleOpen'
 
-const handleClose = (ws: WebSocket<SocketUserData>) => {
+const handleClose: WebSocketBehavior<SocketUserData>['close'] = (ws) => {
   const userData = ws.getUserData()
   const {connectionContext} = userData
   if (!connectionContext) return
   userData.done = true
-  try {
-    handleDisconnect(connectionContext)
-  } catch (e) {
-    const error = e instanceof Error ? e : new Error('handleDisconnect failed')
-    sendToSentry(error)
-  }
+  handleDisconnect(connectionContext)
 }
 export default handleClose

--- a/yarn.lock
+++ b/yarn.lock
@@ -4523,10 +4523,10 @@
   resolved "https://registry.yarnpkg.com/@mattkrick/sanitize-svg/-/sanitize-svg-0.4.0.tgz#388c29614cf72aa0dd9803c77c9c9d070bd3cd2d"
   integrity sha512-TnPI97WVAxo8SQcPy8aV3OF9/2WjXB5/+pRNVudIWR7Bhi5ZjtR/ur162So08GkvsvB914AXCW2sxFh1x6KhHA==
 
-"@mattkrick/trebuchet-client@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@mattkrick/trebuchet-client/-/trebuchet-client-3.0.4.tgz#28e1e60dc86ef06d16ffebc3cd0287ac4e18cd34"
-  integrity sha512-h7kmdreiMiCDkJqHW2UjSPXkMnM4En42yxXGdymKFl2V3DMlowGn5WXIdSPf/eq11knw0VDonlXkr5GBmUA8tw==
+"@mattkrick/trebuchet-client@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@mattkrick/trebuchet-client/-/trebuchet-client-3.0.5.tgz#88da3f0cf1ebad933db16a5e7779de752dbe4f0e"
+  integrity sha512-txaEiJrV+GuTT05TbM4YRTDBoCT5YG7ZTDghXH5oXHTehzfL5sIcO2eDDxzuXvI45gQRwVwsC9CG3egdvtnn9g==
   dependencies:
     eventemitter3 "^5.0.1"
     tslib "^2.6.2"


### PR DESCRIPTION
# Description

This fixes 2 issues:
- when the server redeploys or crashes, or the client disconnects, the server no longer sends a "complete" message for each subscription. That way the client holds onto the subscription operation so when it reconnects it resubscribes
- bumps trebuchet-client to kill the keepAlive inside the CloseEvent so it doesn't fire after a new connection has already been established.