### PR TITLE
fix: end xreadgroup gracefully on shutdown

### DIFF
--- a/packages/gql-executor/gqlExecutor.ts
+++ b/packages/gql-executor/gqlExecutor.ts
@@ -40,7 +40,7 @@ const run = async () => {
     Logger.log(
       `Server ID: ${SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown.`
     )
-
+    await incomingStream.return()
     await publisher.xgroup(
       'DELCONSUMER',
       ServerChannel.GQL_EXECUTOR_STREAM,

--- a/packages/server/graphql/private/mutations/disconnectSocket.ts
+++ b/packages/server/graphql/private/mutations/disconnectSocket.ts
@@ -31,7 +31,7 @@ const disconnectSocket: MutationResolvers['disconnectSocket'] = async (
   if (!disconnectingSocket) {
     // this happens a lot on server restart in dev mode
     if (!__PRODUCTION__) return {user}
-    throw new Error('Called disconnect without a valid socket')
+    throw new Error(`Called disconnect without a valid socket: ${socketId}`)
   }
   await redis.lrem(`presence:${userId}`, 0, disconnectingSocket)
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -110,7 +110,7 @@
     "html-minifier-terser": "^5.0.2",
     "http-message-signatures": "^1.0.4",
     "immutable": "3.8.2",
-    "ioredis": "^5.2.3",
+    "ioredis": "^5.5.0",
     "jsdom": "^20.0.0",
     "jsonwebtoken": "^9.0.0",
     "lodash.pick": "^4.4.0",

--- a/packages/server/socketHandlers/handleDisconnect.ts
+++ b/packages/server/socketHandlers/handleDisconnect.ts
@@ -1,6 +1,7 @@
 import activeClients from '../activeClients'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 import closeTransport from '../socketHelpers/closeTransport'
+import {Logger} from '../utils/Logger'
 import {getUserId} from '../utils/authorization'
 import publishInternalGQL from '../utils/publishInternalGQL'
 import relayUnsubscribeAll from '../utils/relayUnsubscribeAll'
@@ -28,6 +29,7 @@ const handleDisconnect = async (connectionContext: ConnectionContext, options: O
   relayUnsubscribeAll(connectionContext)
   if (authToken.rol !== 'impersonate') {
     const userId = getUserId(authToken)
+    Logger.log(`handleDisconnect: ${socketId}`)
     await publishInternalGQL({authToken, ip, query: disconnectQuery, socketId, variables: {userId}})
   }
   activeClients.delete(connectionContext.id)

--- a/packages/server/utils/serverHealthChecker.ts
+++ b/packages/server/utils/serverHealthChecker.ts
@@ -69,6 +69,7 @@ class ServerHealthChecker {
             const {socketInstanceId, socketId} = presence
             if (socketServers.includes(socketInstanceId)) return
             // let GQL handle the disconnect logic so it can do special handling like notify team memers
+            Logger.log(`serverHealthChecker: ${socketId}`)
             return publishInternalGQL({
               authToken,
               query: disconnectQuery,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10414,9 +10414,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669, caniuse-lite@~1.0.0:
-  version "1.0.30001697"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz#040bbbb54463c4b4b3377c716b34a322d16e6fc7"
-  integrity sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==
+  version "1.0.30001699"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz#a102cf330d153bf8c92bfb5be3cd44c0a89c8c12"
+  integrity sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -14915,10 +14915,10 @@ io-ts@^2.2.20:
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.21.tgz#4ef754176f7082a1099d04c7d5c4ea53267c530a"
   integrity sha512-zz2Z69v9ZIC3mMLYWIeoUcwWD6f+O7yP92FMVVaXEOSZH1jnVBmET/urd/uoarD1WGBY4rCj8TAyMPzsGNzMFQ==
 
-ioredis@^5.2.3:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.4.1.tgz#1c56b70b759f01465913887375ed809134296f40"
-  integrity sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==
+ioredis@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.5.0.tgz#ff2332e125ca2ac8e15472ddd14ecdffa6484a2a"
+  integrity sha512-7CutT89g23FfSa8MDoIFs2GYYa0PaNiW/OrT+nRyjRXHDZd17HmIgy+reOQ/yhh72NznNjGuS8kbCAcA4Ro4mw==
   dependencies:
     "@ioredis/commands" "^1.1.1"
     cluster-key-slot "^1.1.0"


### PR DESCRIPTION
# Description

Still trying to hunt down all the logs when we deploy...
Current working theory is that when we SIGTERM the executor that we shut down the consumer, but we still left xreadgroup open. Per redis docs:

> Note, however, that any pending messages that the consumer had will become unclaimable after it was deleted. It is strongly recommended, therefore, that any pending messages are claimed or acknowledged prior to deleting the consumer from the group.

To test, I'm now killing the xreadgroup connection & logging any pending messages-- there should be 0!
Next theory is that the GQL Executors are not available when they say they are, so I increased shutdown length to a minimum of 10 seconds so new ones have to wait 8 more seconds.

FInally, the seemingly separate issue of disconnectSocket getting called twice on the same socket, I log every socket disconnect. This will be ugly, but the only way to get more info.
