### PR TITLE
fix: joinPool early and wait for old servers to shut down

### DIFF
--- a/packages/server/listenHandler.ts
+++ b/packages/server/listenHandler.ts
@@ -1,5 +1,5 @@
-import ms from 'ms'
 import {us_listen_socket} from 'uWebSockets.js'
+import {RECONNECT_WINDOW} from './server'
 import getGraphQLExecutor from './utils/getGraphQLExecutor'
 import {Logger} from './utils/Logger'
 import sendToSentry from './utils/sendToSentry'
@@ -11,12 +11,9 @@ const listenHandler = (listenSocket: us_listen_socket) => {
   if (listenSocket) {
     Logger.log(`\n🔥🔥🔥 Server ID: ${SERVER_ID}. Ready for Sockets: Port ${PORT} 🔥🔥🔥`)
     getGraphQLExecutor().subscribe()
-    setTimeout(() => {
-      // if shutdowns are clean, this isn't necessary
-      // that's why we wait 3 minutes to let all the old servers shut down gracefully
-      serverHealthChecker.cleanUserPresence().catch(sendToSentry)
-      //
-    }, ms('3m'))
+    // if shutdowns are clean, this isn't necessary
+    // that's why we wait 3 minutes to let all the old servers shut down gracefully
+    serverHealthChecker.cleanUserPresence(RECONNECT_WINDOW + 120_000).catch(sendToSentry)
   } else {
     Logger.log(`❌❌❌    Port ${PORT} is in use!    ❌❌❌`)
   }

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -25,7 +25,7 @@ import {createStaticFileHandler} from './staticFileHandler'
 import {Logger} from './utils/Logger'
 import SAMLHandler from './utils/SAMLHandler'
 
-const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
+export const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
   ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000
   : 60_000 // ms
 

--- a/packages/server/utils/serverHealthChecker.ts
+++ b/packages/server/utils/serverHealthChecker.ts
@@ -36,7 +36,6 @@ class ServerHealthChecker {
   }
 
   async getLivingServers() {
-    await this.joinPool()
     this.remoteSocketServers = []
     await this.publisher.publish('socketServerPing', INSTANCE_ID)
     await sleep(500)
@@ -45,7 +44,11 @@ class ServerHealthChecker {
     return socketServers
   }
 
-  async cleanUserPresence() {
+  async cleanUserPresence(waitForStartup: number) {
+    await this.joinPool()
+    // how long should we wait for all the socket servers to come online?
+    //
+    await sleep(waitForStartup)
     const socketServers = await this.getLivingServers()
     const authToken = new ServerAuthToken()
 


### PR DESCRIPTION
# Description

After combing the logs, it's clear to see the serverHealthChecker was calling disconnect on users who were not disconnected, and then when they DID disconnect, we saw the errors in the logs. This should fix that (although it may take 2 deploys since some of those connections are already unjustly disconnected when this goes live) 