### PR TITLE
fix: remove handleDisconnect logs

### DIFF
--- a/packages/server/socketHandlers/handleDisconnect.ts
+++ b/packages/server/socketHandlers/handleDisconnect.ts
@@ -1,7 +1,6 @@
 import activeClients from '../activeClients'
 import ConnectionContext from '../socketHelpers/ConnectionContext'
 import closeTransport from '../socketHelpers/closeTransport'
-import {Logger} from '../utils/Logger'
 import {getUserId} from '../utils/authorization'
 import publishInternalGQL from '../utils/publishInternalGQL'
 import relayUnsubscribeAll from '../utils/relayUnsubscribeAll'
@@ -29,7 +28,6 @@ const handleDisconnect = async (connectionContext: ConnectionContext, options: O
   relayUnsubscribeAll(connectionContext)
   if (authToken.rol !== 'impersonate') {
     const userId = getUserId(authToken)
-    Logger.log(`handleDisconnect: ${socketId}`)
     await publishInternalGQL({authToken, ip, query: disconnectQuery, socketId, variables: {userId}})
   }
   activeClients.delete(connectionContext.id)

--- a/packages/server/utils/serverHealthChecker.ts
+++ b/packages/server/utils/serverHealthChecker.ts
@@ -72,7 +72,7 @@ class ServerHealthChecker {
             const {socketInstanceId, socketId} = presence
             if (socketServers.includes(socketInstanceId)) return
             // let GQL handle the disconnect logic so it can do special handling like notify team memers
-            Logger.log(`serverHealthChecker: ${socketId}`)
+            Logger.log(`serverHealthChecker: ${socketId} is on dead instace ${socketInstanceId}`)
             return publishInternalGQL({
               authToken,
               query: disconnectQuery,


### PR DESCRIPTION
# Description

Looks like we fixed it. I still saw 2 instances where the server health checker removed invalid sockets. Leaving logs in there in case that happens again.