### PR TITLE
fix: Show error message when failing to integrate with Azure DevOps

### DIFF
--- a/packages/client/modules/teamDashboard/components/ProviderRow/AzureDevOpsProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/AzureDevOpsProviderRow.tsx
@@ -52,7 +52,7 @@ const AzureDevOpsProviderRow = (props: Props) => {
     viewerRef
   )
   const atmosphere = useAtmosphere()
-  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
+  const {submitting, submitMutation, error, onError, onCompleted} = useMutationProps()
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
   const {teamMember} = viewer
   const {integrations} = teamMember!
@@ -78,6 +78,7 @@ const AzureDevOpsProviderRow = (props: Props) => {
         providerName={Providers.AZUREDEVOPS_NAME}
         providerDescription={Providers.AZUREDEVOPS_DESC}
         providerLogo={<AzureDevOpsProviderLogo />}
+        error={error?.message}
       />
       {menuPortal(
         <AzureDevOpsConfigMenu

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GcalProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GcalProviderRow.tsx
@@ -36,7 +36,7 @@ const GcalProviderRow = (props: Props) => {
   const {viewerRef, teamId} = props
   const atmosphere = useAtmosphere()
   const mutationProps = useMutationProps()
-  const {submitting} = mutationProps
+  const {submitting, error} = mutationProps
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
 
   const viewer = useFragment(
@@ -74,6 +74,7 @@ const GcalProviderRow = (props: Props) => {
         providerName={Providers.GCAL_NAME}
         providerDescription={Providers.GCAL_DESC}
         providerLogo={<GcalProviderLogo />}
+        error={error?.message}
       />
       {menuPortal(
         <GcalConfigMenu menuProps={menuProps} mutationProps={mutationProps} teamId={teamId} />

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitHubProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitHubProviderRow.tsx
@@ -32,7 +32,7 @@ const GitHubProviderRow = (props: Props) => {
     `,
     viewerRef
   )
-  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
+  const {submitting, submitMutation, error, onError, onCompleted} = useMutationProps()
   const atmosphere = useAtmosphere()
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
   const {teamMember} = viewer
@@ -57,6 +57,7 @@ const GitHubProviderRow = (props: Props) => {
         providerName={Providers.GITHUB_NAME}
         providerDescription={Providers.GITHUB_DESC}
         providerLogo={<GitHubProviderLogo />}
+        error={error?.message}
       />
       {menuPortal(
         <GitHubConfigMenu menuProps={menuProps} mutationProps={mutationProps} teamId={teamId} />

--- a/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/GitLabProviderRow.tsx
@@ -51,7 +51,7 @@ const GitLabProviderRow = (props: Props) => {
   const {teamId, viewerRef} = props
   const atmosphere = useAtmosphere()
   const mutationProps = useMutationProps()
-  const {submitting} = mutationProps
+  const {submitting, error} = mutationProps
   const openOAuth = (providerId: string, clientId: string, serverBaseUrl: string) => {
     GitLabClientManager.openOAuth(
       atmosphere,
@@ -111,6 +111,11 @@ const GitLabProviderRow = (props: Props) => {
                         ? 'Use GitLab Issues from within Parabol.'
                         : 'Connect to your own GitLab server.'}
                     </RowInfoCopy>
+                    {!!error?.message && (
+                      <div className='text-sm text-tomato-500 [&_a]:font-semibold [&_a]:text-tomato-500 [&_a]:underline'>
+                        {error.message}
+                      </div>
+                    )}
                   </RowInfo>
                   <ProviderActions>
                     {!connected && (

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MSTeamsProviderRow.tsx
@@ -46,7 +46,7 @@ const MSTeamsProviderRow = (props: Props) => {
   )
   const [isConnectClicked, setConnectClicked] = useState(false)
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
-  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
+  const {submitting, submitMutation, error, onError, onCompleted} = useMutationProps()
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
   const {teamMember} = viewer
   const {integrations} = teamMember!
@@ -68,6 +68,7 @@ const MSTeamsProviderRow = (props: Props) => {
         providerLogo={<MSTeamsProviderLogo />}
         connectButtonText={!isConnectClicked ? 'Connect' : 'Cancel'}
         connectButtonIcon={!isConnectClicked ? <AddIcon /> : <CloseIcon />}
+        error={error?.message}
       >
         {(auth || isConnectClicked) && <MSTeamsPanel teamId={teamId} viewerRef={viewer} />}
       </ProviderRow>

--- a/packages/client/modules/teamDashboard/components/ProviderRow/MattermostProviderRow.tsx
+++ b/packages/client/modules/teamDashboard/components/ProviderRow/MattermostProviderRow.tsx
@@ -46,7 +46,7 @@ const MattermostProviderRow = (props: Props) => {
   )
   const [isConnectClicked, setConnectClicked] = useState(false)
   const {togglePortal, originRef, menuPortal, menuProps} = useMenu(MenuPosition.UPPER_RIGHT)
-  const {submitting, submitMutation, onError, onCompleted} = useMutationProps()
+  const {submitting, submitMutation, error, onError, onCompleted} = useMutationProps()
   const mutationProps = {submitting, submitMutation, onError, onCompleted} as MenuMutationProps
   const {teamMember} = viewer
   const {integrations} = teamMember!
@@ -68,6 +68,7 @@ const MattermostProviderRow = (props: Props) => {
         providerLogo={<MattermostProviderLogo />}
         connectButtonText={!isConnectClicked ? 'Connect' : 'Cancel'}
         connectButtonIcon={!isConnectClicked ? <AddIcon /> : <CloseIcon />}
+        error={error?.message}
       >
         {(auth || isConnectClicked) && <MattermostPanel teamId={teamId} viewerRef={viewer} />}
       </ProviderRow>


### PR DESCRIPTION
# Description

Handling for showing the error message was missing.

## Demo

<img width="740" alt="image" src="https://github.com/user-attachments/assets/2da68303-cf04-4d85-b54f-f69ab74b5d75" />

## Testing scenarios

Add an early return to https://github.com/ParabolInc/parabol/blob/e1d0c7248bce22e39800c91af9e1eab061155ff5/packages/server/graphql/public/mutations/addTeamMemberIntegrationAuth.ts#L39
```ts
  return standardError(new Error('GEORG was here'), {userId: viewerId})
```
and try integrating.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
