### PR TITLE
fix: Increase integration OAuth2 access token size

### DIFF
--- a/packages/server/postgres/migrations/2025-02-18T17:07:41.668Z_increaseTeamMemberIntegrationAuthAccessTokenSize.ts
+++ b/packages/server/postgres/migrations/2025-02-18T17:07:41.668Z_increaseTeamMemberIntegrationAuthAccessTokenSize.ts
@@ -1,0 +1,15 @@
+import type {Kysely} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('TeamMemberIntegrationAuth')
+    .alterColumn('accessToken', (ac) => ac.setDataType('varchar(8192)'))
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('TeamMemberIntegrationAuth')
+    .alterColumn('accessToken', (ac) => ac.setDataType('varchar(2056)'))
+    .execute()
+}


### PR DESCRIPTION
# Description

Azure DevOps was running into our size limit.
I only found some [answer](https://learn.microsoft.com/en-us/answers/questions/1657854/oauth-2-0-refresh-token-and-access-token-max-lengt) that there is no max size because it's a JWT and depends on the claims. I'm only increasing the token size because there is no reason the refresh token should grow in the same manner.

Fixes #10891 

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
