### PR TITLE
fix: schedule time inaccuracy

### DIFF
--- a/packages/client/components/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/Recurrence/RecurrenceSettings.tsx
@@ -178,13 +178,13 @@ export const RecurrenceSettings = (props: Props) => {
       ? rrule.options.byweekday.map((weekday) => ALL_DAYS.find((day) => day.intVal === weekday)!)
       : []
   )
+  const {timeZone} = Intl.DateTimeFormat().resolvedOptions()
   const [recurrenceStartTime, setRecurrenceStartTime] = React.useState<Dayjs>(
     rrule
       ? fromRRuleDateTime(rrule)
-      : dayjs().add(1, 'day').set('hour', 6).set('minute', 0).set('second', 0).set('millisecond', 0) // suggest 6:00 AM tomorrow
+      : dayjs.tz(dayjs().add(1, 'day').startOf('day').add(6, 'hour'), timeZone) // suggest 6:00 AM tomorrow
   )
 
-  const {timeZone} = Intl.DateTimeFormat().resolvedOptions()
   const {menuPortal, togglePortal, menuProps, originRef} = useMenu<HTMLDivElement>(
     MenuPosition.LOWER_LEFT,
     {
@@ -289,7 +289,7 @@ export const RecurrenceSettings = (props: Props) => {
         <Label>Each instance starts at</Label>
         <DropdownMenuToggle
           className='w-full text-sm'
-          defaultText={`${recurrenceStartTime.local().format('h:mm A')} (${timeZone})`}
+          defaultText={`${recurrenceStartTime.format('h:mm A')} (${timeZone})`}
           onClick={togglePortal}
           ref={originRef}
           size='small'

--- a/packages/client/components/Recurrence/RecurrenceTimePicker.tsx
+++ b/packages/client/components/Recurrence/RecurrenceTimePicker.tsx
@@ -15,6 +15,8 @@ const DEFAULT_MEETING_START_TIME_IDX = OPTIONS.findIndex((n) => n === ms('6h'))
 
 export const RecurrenceTimePicker = (props: Props) => {
   const {menuProps, onClick} = props
+  const {timeZone} = Intl.DateTimeFormat().resolvedOptions()
+
   return (
     <Menu
       {...menuProps}
@@ -22,7 +24,8 @@ export const RecurrenceTimePicker = (props: Props) => {
       defaultActiveIdx={DEFAULT_MEETING_START_TIME_IDX}
     >
       {OPTIONS.map((n, idx) => {
-        const proposedTime = dayjs().add(1, 'day').startOf('day').add(n, 'ms')
+        const proposedTime = dayjs.tz(dayjs().add(1, 'day').startOf('day').add(n, 'ms'), timeZone)
+
         return (
           <MenuItem
             key={idx}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/10854

Loom demo: https://www.loom.com/share/ef36d41cac7447b684ae0dba724f2582

### To test

- [ ] I wasn't able to reproduce this using my default timezone, but after changing the timezone on my computer to New York, I could reproduce the bug in the issue. It's probably a GMT issue, but you may need to do this
- [ ] Select different times in the schedule meeting timer dropdown and see that it works as expected