### PR TITLE
fix: issues when replying to comments

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -118,7 +118,7 @@ const DiscussionThreadInput = (props: Props) => {
     })
   })
   const [initialContent] = useState(() => {
-    return replyingTo?.createdByUser && !!replyingTo?.threadParentId
+    return replyingTo?.createdByUser
       ? JSON.stringify(makeReplyTo(replyingTo.createdByUser))
       : convertTipTapTaskContent('')
   })

--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -117,8 +117,9 @@ const DiscussionThreadInput = (props: Props) => {
         ?.setValue(null, 'replyingTo')
     })
   })
+  const {viewerId} = atmosphere
   const [initialContent] = useState(() => {
-    return replyingTo?.createdByUser
+    return replyingTo?.createdByUser && replyingTo.createdByUser.id !== viewerId
       ? JSON.stringify(makeReplyTo(replyingTo.createdByUser))
       : convertTipTapTaskContent('')
   })

--- a/packages/client/hooks/useTipTapCommentEditor.ts
+++ b/packages/client/hooks/useTipTapCommentEditor.ts
@@ -72,8 +72,7 @@ export const useTipTapCommentEditor = (
             }
           })
       ].filter(isValid),
-      editable: !readOnly,
-      autofocus: true
+      editable: !readOnly
     },
     [readOnly]
   )


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/10223

Demo: https://www.loom.com/share/971e6d96cdd947eb9629fdc7c9672914

This fixes three issues:

1. When replying to yourself, initially, it doesn't prefix the reply with the user's name. Only when replying to a reply does it do this.
2. When replying to yourself, it shouldn't add your name as the prefix.
3. When Bob replies to Susan, prefix Bob's comment with `@Susan` and ensure the cursor starts after `@Susan`. Currently, it's before.