### PR TITLE
fix: multiple retro meeting fixes

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -317,7 +317,7 @@ const MeetingCard = (props: Props) => {
           <MeetingInfo>
             <TopLine>
               <Link to={meetingLink}>
-                <Name>{isRecurring ? meetingSeries.title : name}</Name>
+                <Name>{name}</Name>
               </Link>
               <Options ref={originRef} onClick={togglePortal}>
                 <IconLabel ref={tooltipRef} icon='more_vert' />

--- a/packages/client/components/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/Recurrence/RecurrenceSettings.tsx
@@ -213,19 +213,19 @@ export const RecurrenceSettings = (props: Props) => {
     }
   }
 
-  const getNextMeetingDate = (selectedDays: Day[]) => {
+  const getNextMeetingDate = (selectedDays: Day[], selectedTime: Dayjs) => {
     const today = dayjs();
 
     const nextMeetingDates = selectedDays.map((day) => {
-      const nextDay = today.day(day.intVal+1);
+      let nextDay = today.day(day.intVal + 1);
       if (nextDay.isBefore(today, 'day')) {
-        return nextDay.add(1, 'week');
+        nextDay = nextDay.add(1, 'week');
       }
-      return nextDay;
+      return nextDay.set('hour', selectedTime.hour()).set('minute', selectedTime.minute());
     });
 
     if (nextMeetingDates.length === 0) {
-      return today;
+      return today.set('hour', selectedTime.hour()).set('minute', selectedTime.minute());
     }
 
     let nextMeetingDate = nextMeetingDates[0];
@@ -235,10 +235,17 @@ export const RecurrenceSettings = (props: Props) => {
       }
     });
 
-    return nextMeetingDate;
+    return nextMeetingDate!.set('hour', selectedTime.hour()).set('minute', selectedTime.minute());
   }
 
-  const nextMeetingDate = getNextMeetingDate(recurrenceDays);
+  const nextMeetingDate = getNextMeetingDate(recurrenceDays, recurrenceStartTime);
+
+  useEffect(() => {
+    if (recurrenceDays.length > 0) {
+      const nextDate = getNextMeetingDate(recurrenceDays, recurrenceStartTime);
+      setRecurrenceStartTime(nextDate);
+    }
+  }, [recurrenceDays]);
 
   useEffect(() => {
     const rrule =

--- a/packages/client/components/Recurrence/RecurrenceSettings.tsx
+++ b/packages/client/components/Recurrence/RecurrenceSettings.tsx
@@ -213,6 +213,33 @@ export const RecurrenceSettings = (props: Props) => {
     }
   }
 
+  const getNextMeetingDate = (selectedDays: Day[]) => {
+    const today = dayjs();
+
+    const nextMeetingDates = selectedDays.map((day) => {
+      const nextDay = today.day(day.intVal+1);
+      if (nextDay.isBefore(today, 'day')) {
+        return nextDay.add(1, 'week');
+      }
+      return nextDay;
+    });
+
+    if (nextMeetingDates.length === 0) {
+      return today;
+    }
+
+    let nextMeetingDate = nextMeetingDates[0];
+    nextMeetingDates.forEach((date) => {
+      if (date.isBefore(nextMeetingDate)) {
+        nextMeetingDate = date;
+      }
+    });
+
+    return nextMeetingDate;
+  }
+
+  const nextMeetingDate = getNextMeetingDate(recurrenceDays);
+
   useEffect(() => {
     const rrule =
       recurrenceDays.length > 0 && !intervalError
@@ -252,7 +279,7 @@ export const RecurrenceSettings = (props: Props) => {
           <Description>
             The next meeting in this series will be called{' '}
             <span className='font-semibold'>
-              "{title} - {dayjs(new Date()).format('MMM DD')}"
+              "{title} - {nextMeetingDate!.format('MMM DD')}"
             </span>
           </Description>
         )}

--- a/packages/server/graphql/public/mutations/startRetrospective.ts
+++ b/packages/server/graphql/public/mutations/startRetrospective.ts
@@ -47,10 +47,18 @@ const startRetrospective: MutationResolvers['startRetrospective'] = async (
     videoMeetingURL
   } = meetingSettings as typeof meetingSettings & {meetingType: 'retrospective'}
   const selectedTemplateId = meetingSettings.selectedTemplateId || 'workingStuckTemplate'
+  const startTime=new Date(
+    rrule!.dtstart.year,
+    rrule!.dtstart.month - 1,
+    rrule!.dtstart.day,
+    rrule!.dtstart.hour,
+    rrule!.dtstart.minute,
+    rrule!.dtstart.second
+  );
   const meetingName = !name
     ? `Retro #${meetingCount + 1}`
     : rrule
-      ? createMeetingSeriesTitle(name, new Date(), 'UTC')
+      ? createMeetingSeriesTitle(name, startTime, rrule.tzid)
       : name
   const meetingSeriesName = name || meetingName
 


### PR DESCRIPTION
# Description

Fixes #9748 #10111 #10113 

The Retro series card now shows the upcoming meeting name instead of the retro series name.
Also, the creation of recurrent meeting where the date was not being taken as per the selected day of the week is fixed and this also flows to the meetings which are recurrent/series as the name of the card. Updated the code to save the same in backend.

## Demo

Adding screenshots.
<img width="611" alt="Screenshot 2025-02-22 at 21 53 21" src="https://github.com/user-attachments/assets/ba06a184-ab00-46a9-91b9-49bf72ada68e" />
<img width="383" alt="Screenshot 2025-02-22 at 21 53 35" src="https://github.com/user-attachments/assets/f8efa62e-dc26-491b-a44e-c5c3086099ab" />

Please let me know if things are not clear, will add a loom video.


## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
