### PR TITLE
chore: Add loginMattermost private mutation

### DIFF
--- a/packages/server/graphql/private/mutations/loginMattermost.ts
+++ b/packages/server/graphql/private/mutations/loginMattermost.ts
@@ -1,18 +1,80 @@
+import crypto from 'crypto'
+import {createVerifier, httpbis} from 'http-message-signatures'
 import AuthToken from '../../../database/types/AuthToken'
 import getKysely from '../../../postgres/getKysely'
 import encodeAuthToken from '../../../utils/encodeAuthToken'
 import {MutationResolvers} from '../resolverTypes'
 
+const checkDigestError = (body: string, digest: string) => {
+  const [_, algorithm, receivedDigest] = digest.match(/(.*)=:(.*):/) ?? []
+  if (algorithm?.toLowerCase() !== 'sha-256') {
+    return 'Unsupported digest algorithm'
+  }
+
+  const hash = crypto.createHash('sha256')
+  hash.update(body)
+  const calculatedDigest = hash.digest('base64')
+
+  if (receivedDigest !== calculatedDigest) {
+    return 'Invalid digest'
+  }
+  return null
+}
+
 const loginMattermost: MutationResolvers['loginMattermost'] = async (
   _source,
-  {email}
+  {request: rawRequest, body},
+  {dataLoader}
 ) => {
+  const [mattermostProvider] = await dataLoader
+    .get('sharedIntegrationProviders')
+    .load({service: 'mattermost', orgIds: [], teamIds: []})
+  if (
+    !mattermostProvider ||
+    mattermostProvider.authStrategy !== 'sharedSecret' ||
+    !mattermostProvider.sharedSecret
+  ) {
+    return {error: {message: 'Mattermost integration not found'}}
+  }
+  const {sharedSecret} = mattermostProvider
+
+  const request = JSON.parse(rawRequest)
+  const verified = await httpbis.verifyMessage(
+    {
+      async keyLookup(_: any) {
+        // TODO When we support multiple Parabol - Mattermost connections, we should look up the key from IntegrationProvider
+        // const keyId = params.keyid;
+        return {
+          id: '',
+          algs: ['hmac-sha256'],
+          verify: createVerifier(sharedSecret, 'hmac-sha256')
+        }
+      }
+    },
+    request
+  )
+  if (!verified) {
+    return {error: {message: 'Invalid signature'}}
+  }
+
+  const digest = request['headers']?.['content-digest']
+  if (!digest) {
+    return {error: {message: 'Missing content-digest'}}
+  }
+
+  const digestError = checkDigestError(body, digest)
+  if (digestError) {
+    return {error: {message: digestError}}
+  }
+
+  const parsedBody = JSON.parse(body)
+  const {email} = parsedBody
+  if (!email) {
+    return {error: {message: 'Missing email'}}
+  }
+
   const pg = getKysely()
-  const user = await pg
-    .selectFrom('User')
-    .selectAll()
-    .where('email', '=', email)
-    .executeTakeFirst()
+  const user = await pg.selectFrom('User').selectAll().where('email', '=', email).executeTakeFirst()
   if (!user) {
     return {error: {message: 'Unknown user'}}
   }

--- a/packages/server/graphql/private/mutations/loginMattermost.ts
+++ b/packages/server/graphql/private/mutations/loginMattermost.ts
@@ -1,0 +1,29 @@
+import AuthToken from '../../../database/types/AuthToken'
+import getKysely from '../../../postgres/getKysely'
+import encodeAuthToken from '../../../utils/encodeAuthToken'
+import {MutationResolvers} from '../resolverTypes'
+
+const loginMattermost: MutationResolvers['loginMattermost'] = async (
+  _source,
+  {email}
+) => {
+  const pg = getKysely()
+  const user = await pg
+    .selectFrom('User')
+    .selectAll()
+    .where('email', '=', email)
+    .executeTakeFirst()
+  if (!user) {
+    return {error: {message: 'Unknown user'}}
+  }
+  const {id: userId, tms} = user
+  const authToken = new AuthToken({sub: userId, tms})
+
+  return {
+    userId,
+    authToken: encodeAuthToken(authToken),
+    isNewUser: false
+  }
+}
+
+export default loginMattermost

--- a/packages/server/graphql/private/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/private/typeDefs/Mutation.graphql
@@ -192,21 +192,6 @@ type Mutation {
   ): String
 
   """
-  add/remove a flag on an org asking them to pay
-  """
-  flagConversionModal(
-    """
-    true to turn the modal on, false to turn it off
-    """
-    active: Boolean!
-
-    """
-    the orgId to toggle the flag for
-    """
-    orgId: ID!
-  ): FlagConversionModalPayload
-
-  """
   hard deletes a user and all its associated objects
   """
   hardDeleteUser(
@@ -456,9 +441,27 @@ type Mutation {
   """
   loginMattermost(
     """
-    The email of the user
+    JSON stringified headers of the request
+    ```
+    {
+      "headers": {
+        "content-type": "application/json",
+        "content-digest": "digest",
+        "content-length": 123,
+        "signature": "signature",
+        "signature-input": "signatureInput"
+      },
+      "method": "POST",
+      "url": "https://action.parabol.co/mattermost",
+    }
+    ```
     """
-    email: Email!
+    request: String!
+
+    """
+    Original body from the request
+    """
+    body: String!
   ): UserLogInPayload!
 
   """

--- a/packages/server/graphql/private/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/private/typeDefs/Mutation.graphql
@@ -192,6 +192,21 @@ type Mutation {
   ): String
 
   """
+  add/remove a flag on an org asking them to pay
+  """
+  flagConversionModal(
+    """
+    true to turn the modal on, false to turn it off
+    """
+    active: Boolean!
+
+    """
+    the orgId to toggle the flag for
+    """
+    orgId: ID!
+  ): FlagConversionModalPayload
+
+  """
   hard deletes a user and all its associated objects
   """
   hardDeleteUser(
@@ -434,6 +449,16 @@ type Mutation {
     The name of the SAML identifier. The slug used in the redirect URL
     """
     samlName: ID!
+  ): UserLogInPayload!
+
+  """
+  Log in with email from a trusted Mattermost
+  """
+  loginMattermost(
+    """
+    The email of the user
+    """
+    email: Email!
   ): UserLogInPayload!
 
   """

--- a/packages/server/integrations/mattermost/mattermostWebhookHandler.ts
+++ b/packages/server/integrations/mattermost/mattermostWebhookHandler.ts
@@ -1,23 +1,36 @@
 import {createVerifier, httpbis} from 'http-message-signatures'
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
 import appOrigin from '../../appOrigin'
-import AuthToken from '../../database/types/AuthToken'
 import uWSAsyncHandler from '../../graphql/uWSAsyncHandler'
 import parseBody from '../../parseBody'
-import getKysely from '../../postgres/getKysely'
+import publishWebhookGQL from '../../utils/publishWebhookGQL'
+import ConnectionContext from '../../socketHelpers/ConnectionContext'
+import uwsGetIP from '../../utils/uwsGetIP'
+import checkBlacklistJWT from '../../utils/checkBlacklistJWT'
+import activeClients from '../../activeClients'
+import handleConnect from '../../socketHandlers/handleConnect'
+import getVerifiedAuthToken from '../../utils/getVerifiedAuthToken'
 import encodeAuthToken from '../../utils/encodeAuthToken'
+import {MMSocket} from '../../socketHelpers/transports/MMSocket'
 
 const MATTERMOST_SECRET = process.env.MATTERMOST_SECRET
 
+
 const login = async (email: string) => {
-  const pg = getKysely()
-  const user = await pg
-    .selectFrom('User')
-    .selectAll()
-    .where('email', '=', email)
-    .executeTakeFirstOrThrow()
-  const authToken = new AuthToken({sub: user.id, tms: user.tms})
-  return encodeAuthToken(authToken)
+  const query = `
+    mutation LoginMattermost($email: String!) {
+      loginMattermost(email: $email) {
+        error {
+          message
+        }
+        authToken
+      }
+    }
+  `
+
+  const loginResult = await publishWebhookGQL<any>(query, {email})
+  const {authToken} = loginResult?.data?.loginMattermost ?? {}
+  return authToken as string
 }
 
 const mattermostWebhookHandler = uWSAsyncHandler(async (res: HttpResponse, req: HttpRequest) => {
@@ -25,6 +38,10 @@ const mattermostWebhookHandler = uWSAsyncHandler(async (res: HttpResponse, req: 
     res.writeStatus('404').end()
     return
   }
+
+  const ip = uwsGetIP(res, req)
+  const connectionId = req.getHeader('x-correlation-id')
+
   const headers = {
     'content-type': req.getHeader('content-type'),
     'content-digest': req.getHeader('content-digest'),
@@ -66,11 +83,26 @@ const mattermostWebhookHandler = uWSAsyncHandler(async (res: HttpResponse, req: 
     return
   }
 
-  const authToken = await login(email)
+  const authToken = getVerifiedAuthToken(await login(email))
+
+  const connectionContext = new ConnectionContext(new MMSocket(connectionId), authToken, ip)
+  // TODO: Find a nicer solution to this. This is the easiest to multiplex the webhook in the MM-Plugin.
+  // If we don't use the client provided connectionId, the plugin would need to keep state to correlate userIDs with connectionIds.
+  // This might be superseeded once we establish the Parabol userId <-> Mattermost userId mapping on Parabol side.
+  connectionContext.id = connectionId
+  const {sub: userId, iat} = authToken
+  const isBlacklistedJWT = await checkBlacklistJWT(userId, iat)
+  if (isBlacklistedJWT) {
+    return
+  }
+
+  activeClients.set(connectionContext)
+  const nextAuthToken = await handleConnect(connectionContext)
+ 
   res
     .writeStatus('200')
     .writeHeader('Content-Type', 'application/json')
-    .end(JSON.stringify({authToken}))
+    .end(JSON.stringify({authToken: nextAuthToken ?? encodeAuthToken(authToken)}))
 })
 
 export default mattermostWebhookHandler

--- a/packages/server/postgres/queries/src/upsertIntegrationProviderQuery.sql
+++ b/packages/server/postgres/queries/src/upsertIntegrationProviderQuery.sql
@@ -13,6 +13,7 @@ INSERT INTO
     "consumerSecret",
     "serverBaseUrl",
     "webhookUrl",
+    "sharedSecret",
     "teamId",
     "orgId"
   )
@@ -28,6 +29,7 @@ VALUES
     :consumerSecret,
     :serverBaseUrl,
     :webhookUrl,
+    :sharedSecret,
     :teamId,
     :orgId
   )
@@ -42,6 +44,7 @@ ON CONFLICT ("orgId", "teamId", "service", "authStrategy") DO UPDATE SET
   "consumerSecret" = EXCLUDED."consumerSecret",
   "serverBaseUrl" = EXCLUDED."serverBaseUrl",
   "webhookUrl" = EXCLUDED."webhookUrl",
+  "sharedSecret" = EXCLUDED."sharedSecret",
   "updatedAt" = CURRENT_TIMESTAMP,
   "isActive" = TRUE
 

--- a/packages/server/postgres/queries/upsertIntegrationProvider.ts
+++ b/packages/server/postgres/queries/upsertIntegrationProvider.ts
@@ -14,6 +14,7 @@ interface IUpsertIntegrationProviderInput {
   tenantId?: string | null
   clientSecret?: string
   serverBaseUrl?: string
+  sharedSecret?: string
   webhookUrl?: string
   teamId: string | null
   orgId: string | null

--- a/scripts/toolboxSrc/primeIntegrations.ts
+++ b/scripts/toolboxSrc/primeIntegrations.ts
@@ -29,10 +29,21 @@ const upsertGlobalIntegrationProvidersFromEnv = async () => {
       serverBaseUrl: 'https://www.googleapis.com/calendar/v3',
       clientId: process.env.GOOGLE_OAUTH_CLIENT_ID,
       clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET
+    },
+    {
+      service: 'mattermost',
+      authStrategy: 'sharedSecret',
+      scope: 'global',
+      serverBaseUrl: process.env.MATTERMOST_URL,
+      sharedSecret: process.env.MATTERMOST_SECRET
     }
   ] as const
 
-  const validProviders = providers.filter(({clientId, clientSecret, serverBaseUrl}) => clientId && clientSecret && serverBaseUrl)
+  const validProviders = providers.filter(({authStrategy, clientId, clientSecret, serverBaseUrl, sharedSecret}) => 
+    (authStrategy === 'oauth2' && clientId && clientSecret && serverBaseUrl)
+    || (authStrategy === 'sharedSecret' && sharedSecret && serverBaseUrl)
+  )
+
   await Promise.all(
     validProviders.map((provider) => {
       return upsertIntegrationProvider(provider)


### PR DESCRIPTION
# Description

Add a Mattermost shared secret global provider and use it to verify the login request as well. The logic to verify the request was moved into a private mutation. It now also verifies the content-digest which was missed previously.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
