### PR TITLE
feat(templates): allow org admins to access team templates

### DIFF
--- a/packages/server/graphql/public/types/MeetingTemplate.ts
+++ b/packages/server/graphql/public/types/MeetingTemplate.ts
@@ -15,14 +15,24 @@ const MeetingTemplate: MeetingTemplateResolvers = {
   illustrationUrl: async ({illustrationUrl}, _args, {dataLoader}) => {
     return dataLoader.get('fileStoreAsset').load(illustrationUrl)
   },
-  viewerLowestScope: async ({teamId}, _args, {authToken, dataLoader}) => {
+  viewerLowestScope: async ({teamId, orgId}, _args, {authToken, dataLoader}) => {
     if (teamId === 'aGhostTeam') return 'PUBLIC'
     const viewerId = getUserId(authToken)
     const teamMemberId = TeamMemberId.join(teamId, viewerId)
-    const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
+    const [teamMember, orgUser] = await Promise.all([
+      dataLoader.get('teamMembers').load(teamMemberId),
+      dataLoader.get('organizationUsersByUserIdOrgId').load({
+        orgId,
+        userId: viewerId
+      })
+    ])
     const isViewerOnOwningTeam = teamMember && teamMember.isNotRemoved
+    const isViewerAdmin =
+      orgUser &&
+      orgUser.removedAt === null &&
+      (orgUser.role === 'ORG_ADMIN' || orgUser.role === 'BILLING_LEADER')
     // public user-defined templates are not visible outside their org
-    return isViewerOnOwningTeam ? 'TEAM' : 'ORGANIZATION'
+    return isViewerOnOwningTeam || isViewerAdmin ? 'TEAM' : 'ORGANIZATION'
   }
 }
 


### PR DESCRIPTION
# Description

[Previously](https://github.com/ParabolInc/parabol/pull/10902) we enable billing leaders and org admins to delete their templates. However on front end they are not able to see that. This PR addresses that issue.

## Testing scenarios

  - User A should be billing leader or org admin for Org 1
  - User B is in Org 1
  - User B has their own team B, in Org 1 but User A is not on the team
  - User B create a template for team B
  - User A should be able to edit/delete the template from team B

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
