### PR TITLE
chore: rename removeMultipleOrgUsers to removeOrgUsers

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -147,7 +147,7 @@
           "RemoveAgendaItemPayload": "./types/RemoveAgendaItemPayload#RemoveAgendaItemPayloadSource",
           "RemoveApprovedOrganizationDomainsSuccess": "./types/RemoveApprovedOrganizationDomainsSuccess#RemoveApprovedOrganizationDomainsSuccessSource",
           "RemoveIntegrationSearchQuerySuccess": "./types/RemoveIntegrationSearchQuerySuccess#RemoveIntegrationSearchQuerySuccessSource",
-          "RemoveMultipleOrgUsersSuccess": "./types/RemoveMultipleOrgUsersSuccess#RemoveMultipleOrgUsersSuccessSource",
+          "RemoveOrgUsersSuccess": "./types/RemoveOrgUsersSuccess#RemoveOrgUsersSuccessSource",
           "RemovePokerTemplatePayload": "./types/RemovePokerTemplatePayload#RemovePokerTemplatePayloadSource",
           "RemoveReflectTemplatePromptPayload": "./types/RemoveReflectTemplatePromptPayload#RemoveReflectTemplatePromptPayloadSource",
           "RemoveTeamMemberIntegrationAuthSuccess": "./types/RemoveTeamMemberIntegrationAuthPayload#RemoveTeamMemberIntegrationAuthSuccessSource",

--- a/packages/client/mutations/RemoveOrgUsersMutation.ts
+++ b/packages/client/mutations/RemoveOrgUsersMutation.ts
@@ -1,11 +1,11 @@
 import graphql from 'babel-plugin-relay/macro'
 import {commitLocalUpdate, commitMutation} from 'react-relay'
 import {RecordProxy} from 'relay-runtime'
-import {RemoveMultipleOrgUsersMutation as TRemoveMultipleOrgUsersMutation} from '~/__generated__/RemoveMultipleOrgUsersMutation.graphql'
-import {RemoveMultipleOrgUsersMutation_organization$data} from '~/__generated__/RemoveMultipleOrgUsersMutation_organization.graphql'
-import {RemoveMultipleOrgUsersMutation_notification$data} from '../__generated__/RemoveMultipleOrgUsersMutation_notification.graphql'
-import {RemoveMultipleOrgUsersMutation_task$data} from '../__generated__/RemoveMultipleOrgUsersMutation_task.graphql'
-import {RemoveMultipleOrgUsersMutation_team$data} from '../__generated__/RemoveMultipleOrgUsersMutation_team.graphql'
+import {RemoveOrgUsersMutation as TRemoveOrgUsersMutation} from '~/__generated__/RemoveOrgUsersMutation.graphql'
+import {RemoveOrgUsersMutation_organization$data} from '~/__generated__/RemoveOrgUsersMutation_organization.graphql'
+import {RemoveOrgUsersMutation_notification$data} from '../__generated__/RemoveOrgUsersMutation_notification.graphql'
+import {RemoveOrgUsersMutation_task$data} from '../__generated__/RemoveOrgUsersMutation_task.graphql'
+import {RemoveOrgUsersMutation_team$data} from '../__generated__/RemoveOrgUsersMutation_team.graphql'
 import {
   HistoryLocalHandler,
   OnNextHandler,
@@ -25,7 +25,7 @@ import handleRemoveTeamMembers from './handlers/handleRemoveTeamMembers'
 import handleRemoveTeams from './handlers/handleRemoveTeams'
 import handleTasksForRemovedUsers from './handlers/handleTasksForRemovedUsers'
 graphql`
-  fragment RemoveMultipleOrgUsersMutation_organization on RemoveMultipleOrgUsersSuccess {
+  fragment RemoveOrgUsersMutation_organization on RemoveOrgUsersSuccess {
     affectedOrganizationId
     affectedOrganizationName
     removedOrgMemberIds
@@ -34,7 +34,7 @@ graphql`
 `
 
 graphql`
-  fragment RemoveMultipleOrgUsersMutation_notification on RemoveMultipleOrgUsersSuccess {
+  fragment RemoveOrgUsersMutation_notification on RemoveOrgUsersSuccess {
     affectedOrganizationId
     affectedOrganizationName
     kickOutNotifications {
@@ -48,7 +48,7 @@ graphql`
 `
 
 graphql`
-  fragment RemoveMultipleOrgUsersMutation_team on RemoveMultipleOrgUsersSuccess {
+  fragment RemoveOrgUsersMutation_team on RemoveOrgUsersSuccess {
     removedTeamMemberIds
     removedUserIds
     affectedTeamIds
@@ -66,7 +66,7 @@ graphql`
 `
 
 graphql`
-  fragment RemoveMultipleOrgUsersMutation_task on RemoveMultipleOrgUsersSuccess {
+  fragment RemoveOrgUsersMutation_task on RemoveOrgUsersSuccess {
     affectedTasks {
       ...CompleteTaskFrag @relay(mask: false)
     }
@@ -75,25 +75,25 @@ graphql`
 `
 
 const mutation = graphql`
-  mutation RemoveMultipleOrgUsersMutation($userIds: [ID!]!, $orgId: ID!) {
-    removeMultipleOrgUsers(userIds: $userIds, orgId: $orgId) {
+  mutation RemoveOrgUsersMutation($userIds: [ID!]!, $orgId: ID!) {
+    removeOrgUsers(userIds: $userIds, orgId: $orgId) {
       ... on ErrorPayload {
         error {
           message
         }
       }
-      ... on RemoveMultipleOrgUsersSuccess {
-        ...RemoveMultipleOrgUsersMutation_organization @relay(mask: false)
-        ...RemoveMultipleOrgUsersMutation_team @relay(mask: false)
-        ...RemoveMultipleOrgUsersMutation_task @relay(mask: false)
-        ...RemoveMultipleOrgUsersMutation_notification @relay(mask: false)
+      ... on RemoveOrgUsersSuccess {
+        ...RemoveOrgUsersMutation_organization @relay(mask: false)
+        ...RemoveOrgUsersMutation_team @relay(mask: false)
+        ...RemoveOrgUsersMutation_task @relay(mask: false)
+        ...RemoveOrgUsersMutation_notification @relay(mask: false)
       }
     }
   }
 `
 
-export const removeMultipleOrgUsersOrganizationUpdater: SharedUpdater<
-  RemoveMultipleOrgUsersMutation_organization$data
+export const removeOrgUsersOrganizationUpdater: SharedUpdater<
+  RemoveOrgUsersMutation_organization$data
 > = (payload, {atmosphere, store}) => {
   const removedOrgMemberIds = payload.getValue('removedOrgMemberIds')
   const affectedOrganizationId = payload.getValue('affectedOrganizationId')
@@ -109,16 +109,17 @@ export const removeMultipleOrgUsersOrganizationUpdater: SharedUpdater<
   }
 }
 
-export const removeMultipleOrgUsersNotificationUpdater: SharedUpdater<
-  RemoveMultipleOrgUsersMutation_notification$data
+export const removeOrgUsersNotificationUpdater: SharedUpdater<
+  RemoveOrgUsersMutation_notification$data
 > = (payload, {store}) => {
   const kickOutNotifications = payload.getLinkedRecords('kickOutNotifications')
   handleAddNotifications(kickOutNotifications, store)
 }
 
-export const removeMultipleOrgUsersTeamUpdater: SharedUpdater<
-  RemoveMultipleOrgUsersMutation_team$data
-> = (payload, {atmosphere, store}) => {
+export const removeOrgUsersTeamUpdater: SharedUpdater<RemoveOrgUsersMutation_team$data> = (
+  payload,
+  {atmosphere, store}
+) => {
   const removedUserIds = payload.getValue('removedUserIds')
   const {viewerId} = atmosphere
 
@@ -131,18 +132,20 @@ export const removeMultipleOrgUsersTeamUpdater: SharedUpdater<
   }
 }
 
-export const removeMultipleOrgUsersTaskUpdater: SharedUpdater<
-  RemoveMultipleOrgUsersMutation_task$data
-> = (payload, {atmosphere, store}) => {
+export const removeOrgUsersTaskUpdater: SharedUpdater<RemoveOrgUsersMutation_task$data> = (
+  payload,
+  {atmosphere, store}
+) => {
   const tasks = payload.getLinkedRecords('affectedTasks')
   const removedUserIds = payload.getValue('removedUserIds') as string[]
   const {viewerId} = atmosphere
   handleTasksForRemovedUsers(tasks, removedUserIds, viewerId, store)
 }
 
-export const removeMultipleOrgUsersTeamOnNext: OnNextHandler<
-  RemoveMultipleOrgUsersMutation_team$data
-> = (payload, context) => {
+export const removeOrgUsersTeamOnNext: OnNextHandler<RemoveOrgUsersMutation_team$data> = (
+  payload,
+  context
+) => {
   const {atmosphere} = context
   const {affectedMeetings} = payload
   affectedMeetings.forEach((newMeeting) => {
@@ -161,8 +164,8 @@ export const removeMultipleOrgUsersTeamOnNext: OnNextHandler<
   })
 }
 
-export const removeMultipleOrgUsersOrganizationOnNext: OnNextHandler<
-  RemoveMultipleOrgUsersMutation_organization$data,
+export const removeOrgUsersOrganizationOnNext: OnNextHandler<
+  RemoveOrgUsersMutation_organization$data,
   OnNextHistoryContext
 > = (payload, context) => {
   const {
@@ -179,8 +182,8 @@ export const removeMultipleOrgUsersOrganizationOnNext: OnNextHandler<
   }
 }
 
-export const removeMultipleOrgUsersNotificationOnNext: OnNextHandler<
-  RemoveMultipleOrgUsersMutation_notification$data,
+export const removeOrgUsersNotificationOnNext: OnNextHandler<
+  RemoveOrgUsersMutation_notification$data,
   OnNextHistoryContext
 > = (payload, {atmosphere, history}) => {
   if (!payload) return
@@ -203,54 +206,53 @@ export const removeMultipleOrgUsersNotificationOnNext: OnNextHandler<
   }
 }
 
-const RemoveMultipleOrgUsersMutation: StandardMutation<
-  TRemoveMultipleOrgUsersMutation,
-  HistoryLocalHandler
-> = (atmosphere, variables, {history, onError, onCompleted}) => {
-  return commitMutation<TRemoveMultipleOrgUsersMutation>(atmosphere, {
+const RemoveOrgUsersMutation: StandardMutation<TRemoveOrgUsersMutation, HistoryLocalHandler> = (
+  atmosphere,
+  variables,
+  {history, onError, onCompleted}
+) => {
+  return commitMutation<TRemoveOrgUsersMutation>(atmosphere, {
     mutation,
     variables,
     updater: (store) => {
-      const payload = store.getRootField('removeMultipleOrgUsers')
+      const payload = store.getRootField('removeOrgUsers')
       if (!payload) return
       if (payload.getValue('error')) return
-      const success = payload.getLinkedRecord('RemoveMultipleOrgUsersSuccess')
+      const success = payload.getLinkedRecord('RemoveOrgUsersSuccess')
       if (!success) return
 
-      const organizationSuccess =
-        success as RecordProxy<RemoveMultipleOrgUsersMutation_organization$data>
-      const teamSuccess = success as RecordProxy<RemoveMultipleOrgUsersMutation_team$data>
-      const taskSuccess = success as RecordProxy<RemoveMultipleOrgUsersMutation_task$data>
-      const notificationSuccess =
-        success as RecordProxy<RemoveMultipleOrgUsersMutation_notification$data>
+      const organizationSuccess = success as RecordProxy<RemoveOrgUsersMutation_organization$data>
+      const teamSuccess = success as RecordProxy<RemoveOrgUsersMutation_team$data>
+      const taskSuccess = success as RecordProxy<RemoveOrgUsersMutation_task$data>
+      const notificationSuccess = success as RecordProxy<RemoveOrgUsersMutation_notification$data>
 
-      removeMultipleOrgUsersOrganizationUpdater(organizationSuccess, {atmosphere, store})
-      removeMultipleOrgUsersTeamUpdater(teamSuccess, {atmosphere, store})
-      removeMultipleOrgUsersTaskUpdater(taskSuccess, {atmosphere, store})
-      removeMultipleOrgUsersNotificationUpdater(notificationSuccess, {atmosphere, store})
+      removeOrgUsersOrganizationUpdater(organizationSuccess, {atmosphere, store})
+      removeOrgUsersTeamUpdater(teamSuccess, {atmosphere, store})
+      removeOrgUsersTaskUpdater(taskSuccess, {atmosphere, store})
+      removeOrgUsersNotificationUpdater(notificationSuccess, {atmosphere, store})
     },
     onCompleted: (res, errors) => {
       if (onCompleted) {
         onCompleted(res, errors)
       }
-      const payload = res.removeMultipleOrgUsers
+      const payload = res.removeOrgUsers
       if (!payload || !('success' in payload)) return
       const {success} = payload
       if (!success) return
 
-      const organizationSuccess = success as RemoveMultipleOrgUsersMutation_organization$data
-      const teamSuccess = success as RemoveMultipleOrgUsersMutation_team$data
-      const notificationSuccess = success as RemoveMultipleOrgUsersMutation_notification$data
+      const organizationSuccess = success as RemoveOrgUsersMutation_organization$data
+      const teamSuccess = success as RemoveOrgUsersMutation_team$data
+      const notificationSuccess = success as RemoveOrgUsersMutation_notification$data
 
-      removeMultipleOrgUsersOrganizationOnNext(organizationSuccess, {
+      removeOrgUsersOrganizationOnNext(organizationSuccess, {
         history,
         atmosphere
       })
-      removeMultipleOrgUsersTeamOnNext(teamSuccess, {atmosphere})
-      removeMultipleOrgUsersNotificationOnNext(notificationSuccess, {atmosphere, history})
+      removeOrgUsersTeamOnNext(teamSuccess, {atmosphere})
+      removeOrgUsersNotificationOnNext(notificationSuccess, {atmosphere, history})
     },
     onError
   })
 }
 
-export default RemoveMultipleOrgUsersMutation
+export default RemoveOrgUsersMutation

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -21,13 +21,13 @@ import {
   inviteToTeamNotificationUpdater
 } from '../mutations/InviteToTeamMutation'
 import {
-  removeMultipleOrgUsersNotificationOnNext,
-  removeMultipleOrgUsersNotificationUpdater
-} from '../mutations/RemoveMultipleOrgUsersMutation'
-import {
   removeOrgUserNotificationOnNext,
   removeOrgUserNotificationUpdater
 } from '../mutations/RemoveOrgUserMutation'
+import {
+  removeOrgUsersNotificationOnNext,
+  removeOrgUsersNotificationUpdater
+} from '../mutations/RemoveOrgUsersMutation'
 import handleAddNotifications from '../mutations/handlers/handleAddNotifications'
 import {popNotificationToastOnNext} from '../mutations/toasts/popNotificationToast'
 import {updateNotificationToastOnNext} from '../mutations/toasts/updateNotificationToast'
@@ -119,8 +119,8 @@ const subscription = graphql`
       RemoveOrgUserPayload {
         ...RemoveOrgUserMutation_notification @relay(mask: false)
       }
-      RemoveMultipleOrgUsersSuccess {
-        ...RemoveMultipleOrgUsersMutation_notification @relay(mask: false)
+      RemoveOrgUsersSuccess {
+        ...RemoveOrgUsersMutation_notification @relay(mask: false)
       }
       InvalidateSessionsPayload {
         ...InvalidateSessionsMutation_notification @relay(mask: false)
@@ -291,7 +291,7 @@ const updateHandlers = {
   InviteToTeamPayload: inviteToTeamNotificationUpdater,
   MeetingStageTimeLimitPayload: meetingStageTimeLimitUpdater,
   RemoveOrgUserPayload: removeOrgUserNotificationUpdater,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersNotificationUpdater,
+  RemoveOrgUsersSuccess: removeOrgUsersNotificationUpdater,
   StripeFailPaymentPayload: stripeFailPaymentNotificationUpdater,
   ArchiveTimelineEventSuccess: archiveTimelineEventNotificationUpdater
 } as const
@@ -301,7 +301,7 @@ const onNextHandlers = {
   CreateTaskPayload: createTaskNotificationOnNext,
   InviteToTeamPayload: inviteToTeamNotificationOnNext,
   RemoveOrgUserPayload: removeOrgUserNotificationOnNext,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersNotificationOnNext,
+  RemoveOrgUsersSuccess: removeOrgUsersNotificationOnNext,
   StripeFailPaymentPayload: stripeFailPaymentNotificationOnNext,
   MeetingStageTimeLimitPayload: meetingStageTimeLimitOnNext,
   InvalidateSessionsPayload: invalidateSessionsNotificationOnNext,

--- a/packages/client/subscriptions/OrganizationSubscription.ts
+++ b/packages/client/subscriptions/OrganizationSubscription.ts
@@ -12,13 +12,13 @@ import {
 import Atmosphere from '../Atmosphere'
 import {addOrgMutationOrganizationUpdater} from '../mutations/AddOrgMutation'
 import {
-  removeMultipleOrgUsersOrganizationOnNext,
-  removeMultipleOrgUsersOrganizationUpdater
-} from '../mutations/RemoveMultipleOrgUsersMutation'
-import {
   removeOrgUserOrganizationOnNext,
   removeOrgUserOrganizationUpdater
 } from '../mutations/RemoveOrgUserMutation'
+import {
+  removeOrgUsersOrganizationOnNext,
+  removeOrgUsersOrganizationUpdater
+} from '../mutations/RemoveOrgUsersMutation'
 import {
   setOrgUserRoleAddedOrganizationOnNext,
   setOrgUserRoleAddedOrganizationUpdater
@@ -52,8 +52,8 @@ const subscription = graphql`
       RemoveOrgUserPayload {
         ...RemoveOrgUserMutation_organization @relay(mask: false)
       }
-      RemoveMultipleOrgUsersSuccess {
-        ...RemoveMultipleOrgUsersMutation_organization @relay(mask: false)
+      RemoveOrgUsersSuccess {
+        ...RemoveOrgUsersMutation_organization @relay(mask: false)
       }
       SetOrgUserRoleSuccess {
         ...SetOrgUserRoleMutation_organization @relay(mask: false)
@@ -71,7 +71,7 @@ const subscription = graphql`
 const onNextHandlers = {
   ArchiveOrganizationPayload: archiveOrganizationOrganizationOnNext,
   RemoveOrgUserPayload: removeOrgUserOrganizationOnNext,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersOrganizationOnNext,
+  RemoveOrgUsersSuccess: removeOrgUsersOrganizationOnNext,
   SetOrgUserRoleSuccess: setOrgUserRoleAddedOrganizationOnNext
 } as const
 
@@ -79,7 +79,7 @@ const updateHandlers = {
   AddOrgPayload: addOrgMutationOrganizationUpdater,
   ArchiveOrganizationPayload: archiveOrganizationOrganizationUpdater,
   RemoveOrgUserPayload: removeOrgUserOrganizationUpdater,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersOrganizationUpdater,
+  RemoveOrgUsersSuccess: removeOrgUsersOrganizationUpdater,
   SetOrgUserRoleSuccess: setOrgUserRoleAddedOrganizationUpdater,
   UpdateTemplateScopeSuccess: updateTemplateScopeOrganizationUpdater
 } as const

--- a/packages/client/subscriptions/TaskSubscription.ts
+++ b/packages/client/subscriptions/TaskSubscription.ts
@@ -10,8 +10,8 @@ import {changeTaskTeamTaskUpdater} from '../mutations/ChangeTaskTeamMutation'
 import {createTaskTaskUpdater} from '../mutations/CreateTaskMutation'
 import {deleteTaskTaskUpdater} from '../mutations/DeleteTaskMutation'
 import {editTaskTaskUpdater} from '../mutations/EditTaskMutation'
-import {removeMultipleOrgUsersTaskUpdater} from '../mutations/RemoveMultipleOrgUsersMutation'
 import {removeOrgUserTaskUpdater} from '../mutations/RemoveOrgUserMutation'
+import {removeOrgUsersTaskUpdater} from '../mutations/RemoveOrgUsersMutation'
 import {updateTaskTaskOnNext, updateTaskTaskUpdater} from '../mutations/UpdateTaskMutation'
 import subscriptionOnNext from './subscriptionOnNext'
 import subscriptionUpdater from './subscriptionUpdater'
@@ -41,8 +41,8 @@ const subscription = graphql`
       RemoveOrgUserPayload {
         ...RemoveOrgUserMutation_task @relay(mask: false)
       }
-      RemoveMultipleOrgUsersSuccess {
-        ...RemoveMultipleOrgUsersMutation_task @relay(mask: false)
+      RemoveOrgUsersSuccess {
+        ...RemoveOrgUsersMutation_task @relay(mask: false)
       }
       UpdateTaskPayload {
         ...UpdateTaskMutation_task @relay(mask: false)
@@ -64,7 +64,7 @@ const updateHandlers = {
   DeleteTaskPayload: deleteTaskTaskUpdater,
   EditTaskPayload: editTaskTaskUpdater,
   RemoveOrgUserPayload: removeOrgUserTaskUpdater,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersTaskUpdater,
+  RemoveOrgUsersSuccess: removeOrgUsersTaskUpdater,
   UpdateTaskPayload: updateTaskTaskUpdater
 } as const
 

--- a/packages/client/subscriptions/TeamSubscription.ts
+++ b/packages/client/subscriptions/TeamSubscription.ts
@@ -32,11 +32,11 @@ import {endTeamPromptTeamUpdater} from '../mutations/EndTeamPromptMutation'
 import {moveReflectTemplatePromptTeamUpdater} from '../mutations/MoveReflectTemplatePromptMutation'
 import {pushInvitationTeamOnNext} from '../mutations/PushInvitationMutation'
 import {removeAgendaItemUpdater} from '../mutations/RemoveAgendaItemMutation'
-import {
-  removeMultipleOrgUsersTeamOnNext,
-  removeMultipleOrgUsersTeamUpdater
-} from '../mutations/RemoveMultipleOrgUsersMutation'
 import {removeOrgUserTeamOnNext, removeOrgUserTeamUpdater} from '../mutations/RemoveOrgUserMutation'
+import {
+  removeOrgUsersTeamOnNext,
+  removeOrgUsersTeamUpdater
+} from '../mutations/RemoveOrgUsersMutation'
 import {removeReflectTemplateTeamUpdater} from '../mutations/RemoveReflectTemplateMutation'
 import {removeReflectTemplatePromptTeamUpdater} from '../mutations/RemoveReflectTemplatePromptMutation'
 import {
@@ -129,8 +129,8 @@ const subscription = graphql`
       RemoveOrgUserPayload {
         ...RemoveOrgUserMutation_team @relay(mask: false)
       }
-      RemoveMultipleOrgUsersSuccess {
-        ...RemoveMultipleOrgUsersMutation_team @relay(mask: false)
+      RemoveOrgUsersSuccess {
+        ...RemoveOrgUsersMutation_team @relay(mask: false)
       }
       RemoveReflectTemplatePayload {
         ...RemoveReflectTemplateMutation_team @relay(mask: false)
@@ -201,7 +201,7 @@ const onNextHandlers = {
   EndRetrospectiveSuccess: endRetrospectiveTeamOnNext,
   EndSprintPokerSuccess: endSprintPokerTeamOnNext,
   RemoveOrgUserPayload: removeOrgUserTeamOnNext,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersTeamOnNext,
+  RemoveOrgUsersSuccess: removeOrgUsersTeamOnNext,
   RemoveTeamMemberPayload: removeTeamMemberTeamOnNext,
   PushInvitationPayload: pushInvitationTeamOnNext
 } as const
@@ -224,7 +224,7 @@ const updateHandlers = {
   MoveReflectTemplatePromptPayload: moveReflectTemplatePromptTeamUpdater,
   NavigateMeetingPayload: navigateMeetingTeamUpdater,
   RemoveOrgUserPayload: removeOrgUserTeamUpdater,
-  RemoveMultipleOrgUsersSuccess: removeMultipleOrgUsersTeamUpdater,
+  RemoveOrgUsersSuccess: removeOrgUsersTeamUpdater,
   RemoveReflectTemplatePayload: removeReflectTemplateTeamUpdater,
   RemoveReflectTemplatePromptPayload: removeReflectTemplatePromptTeamUpdater,
   RemoveTeamMemberPayload: removeTeamMemberTeamUpdater

--- a/packages/server/graphql/public/mutations/removeOrgUsers.ts
+++ b/packages/server/graphql/public/mutations/removeOrgUsers.ts
@@ -10,7 +10,7 @@ import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
 import removeFromOrg from '../../mutations/helpers/removeFromOrg'
 import {MutationResolvers} from '../resolverTypes'
-const removeMultipleOrgUsers: MutationResolvers['removeMultipleOrgUsers'] = async (
+const removeOrgUsers: MutationResolvers['removeOrgUsers'] = async (
   _source,
   {userIds, orgId},
   {authToken, dataLoader, socketId: mutatorId}
@@ -100,23 +100,17 @@ const removeMultipleOrgUsers: MutationResolvers['removeMultipleOrgUsers'] = asyn
     })
   })
 
-  publish(
-    SubscriptionChannel.ORGANIZATION,
-    orgId,
-    'RemoveMultipleOrgUsersSuccess',
-    data,
-    subOptions
-  )
+  publish(SubscriptionChannel.ORGANIZATION, orgId, 'RemoveOrgUsersSuccess', data, subOptions)
 
   data.affectedTeamIds.forEach((teamId) => {
-    publish(SubscriptionChannel.TEAM, teamId, 'RemoveMultipleOrgUsersSuccess', data, subOptions)
+    publish(SubscriptionChannel.TEAM, teamId, 'RemoveOrgUsersSuccess', data, subOptions)
   })
 
   removedUserResults.map(async ({removedUserId}) => {
     publish(
       SubscriptionChannel.NOTIFICATION,
       removedUserId,
-      'RemoveMultipleOrgUsersSuccess',
+      'RemoveOrgUsersSuccess',
       data,
       subOptions
     )
@@ -125,16 +119,10 @@ const removeMultipleOrgUsers: MutationResolvers['removeMultipleOrgUsers'] = asyn
   data.removedTeamMemberIds.map(async (removedTeamMemberId) => {
     const teamMember = await dataLoader.get('teamMembers').load(removedTeamMemberId)
     if (!teamMember) return
-    publish(
-      SubscriptionChannel.TASK,
-      teamMember.userId,
-      'RemoveMultipleOrgUsersSuccess',
-      data,
-      subOptions
-    )
+    publish(SubscriptionChannel.TASK, teamMember.userId, 'RemoveOrgUsersSuccess', data, subOptions)
   })
 
   return data
 }
 
-export default removeMultipleOrgUsers
+export default removeOrgUsers

--- a/packages/server/graphql/public/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/public/typeDefs/Mutation.graphql
@@ -618,7 +618,7 @@ type Mutation {
   """
   Remove multiple users from an org
   """
-  removeMultipleOrgUsers(
+  removeOrgUsers(
     """
     The list of user IDs to remove
     """
@@ -628,7 +628,7 @@ type Mutation {
     The org that does not want them anymore
     """
     orgId: ID!
-  ): RemoveMultipleOrgUsersPayload!
+  ): RemoveOrgUsersPayload!
 
   """
   Remove a poker meeting template

--- a/packages/server/graphql/public/typeDefs/NotificationSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/NotificationSubscriptionPayload.graphql
@@ -15,7 +15,7 @@ type NotificationSubscriptionPayload {
   InviteToTeamPayload: InviteToTeamPayload
   MeetingStageTimeLimitPayload: MeetingStageTimeLimitPayload
   RemoveOrgUserPayload: RemoveOrgUserPayload
-  RemoveMultipleOrgUsersSuccess: RemoveMultipleOrgUsersSuccess
+  RemoveOrgUsersSuccess: RemoveOrgUsersSuccess
   StripeFailPaymentPayload: StripeFailPaymentPayload
   PersistJiraSearchQuerySuccess: PersistJiraSearchQuerySuccess
   User: User

--- a/packages/server/graphql/public/typeDefs/OrganizationSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/OrganizationSubscriptionPayload.graphql
@@ -6,7 +6,7 @@ type OrganizationSubscriptionPayload {
   DowngradeToStarterPayload: DowngradeToStarterPayload
   RemoveIntegrationProviderSuccess: RemoveIntegrationProviderSuccess
   RemoveOrgUserPayload: RemoveOrgUserPayload
-  RemoveMultipleOrgUsersSuccess: RemoveMultipleOrgUsersSuccess
+  RemoveOrgUsersSuccess: RemoveOrgUsersSuccess
   ToggleAIFeaturesSuccess: ToggleAIFeaturesSuccess
   SetOrgUserRoleSuccess: SetOrgUserRoleSuccess
   UpdateCreditCardPayload: UpdateCreditCardPayload

--- a/packages/server/graphql/public/typeDefs/RemoveMultipleOrgUsersPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/RemoveMultipleOrgUsersPayload.graphql
@@ -1,4 +1,0 @@
-"""
-Return value for removeMultipleOrgUsers, which could be an error
-"""
-union RemoveMultipleOrgUsersPayload = ErrorPayload | RemoveMultipleOrgUsersSuccess

--- a/packages/server/graphql/public/typeDefs/RemoveOrgUsersPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/RemoveOrgUsersPayload.graphql
@@ -1,0 +1,4 @@
+"""
+Return value for removeOrgUsers, which could be an error
+"""
+union RemoveOrgUsersPayload = ErrorPayload | RemoveOrgUsersSuccess

--- a/packages/server/graphql/public/typeDefs/RemoveOrgUsersSuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/RemoveOrgUsersSuccess.graphql
@@ -1,4 +1,4 @@
-type RemoveMultipleOrgUsersSuccess {
+type RemoveOrgUsersSuccess {
   """
   The ids of the users removed from the organization
   """

--- a/packages/server/graphql/public/typeDefs/TaskSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/TaskSubscriptionPayload.graphql
@@ -6,7 +6,7 @@ type TaskSubscriptionPayload {
   DeleteTaskPayload: DeleteTaskPayload
   EditTaskPayload: EditTaskPayload
   RemoveOrgUserPayload: RemoveOrgUserPayload
-  RemoveMultipleOrgUsersSuccess: RemoveMultipleOrgUsersSuccess
+  RemoveOrgUsersSuccess: RemoveOrgUsersSuccess
   RemoveTeamMemberPayload: RemoveTeamMemberPayload
   UpdateTaskPayload: UpdateTaskPayload
   UpdateTaskDueDatePayload: UpdateTaskDueDatePayload

--- a/packages/server/graphql/public/typeDefs/TeamSubscriptionPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamSubscriptionPayload.graphql
@@ -19,7 +19,7 @@ type TeamSubscriptionPayload {
   PromoteToTeamLeadPayload: PromoteToTeamLeadPayload
   RemoveAgendaItemPayload: RemoveAgendaItemPayload
   RemoveOrgUserPayload: RemoveOrgUserPayload
-  RemoveMultipleOrgUsersSuccess: RemoveMultipleOrgUsersSuccess
+  RemoveOrgUsersSuccess: RemoveOrgUsersSuccess
   RemoveTeamMemberPayload: RemoveTeamMemberPayload
   RenameMeetingSuccess: RenameMeetingSuccess
   SelectTemplatePayload: SelectTemplatePayload

--- a/packages/server/graphql/public/types/RemoveOrgUsersSuccess.ts
+++ b/packages/server/graphql/public/types/RemoveOrgUsersSuccess.ts
@@ -1,9 +1,9 @@
 import {KickedOutNotification} from '../../../postgres/types/Notification'
 import {getUserId} from '../../../utils/authorization'
 import isValid from '../../isValid'
-import {RemoveMultipleOrgUsersSuccessResolvers} from '../resolverTypes'
+import {RemoveOrgUsersSuccessResolvers} from '../resolverTypes'
 
-export type RemoveMultipleOrgUsersSuccessSource = {
+export type RemoveOrgUsersSuccessSource = {
   removedUserIds: string[]
   removedOrgMemberIds: string[]
   removedTeamMemberIds: string[]
@@ -15,7 +15,7 @@ export type RemoveMultipleOrgUsersSuccessSource = {
   kickOutNotificationIds: string[]
 }
 
-const RemoveMultipleOrgUsersSuccess: RemoveMultipleOrgUsersSuccessResolvers = {
+const RemoveOrgUsersSuccess: RemoveOrgUsersSuccessResolvers = {
   affectedTasks: async ({affectedTaskIds}, _args, {dataLoader}) => {
     return (await dataLoader.get('tasks').loadMany(affectedTaskIds)).filter(isValid)
   },
@@ -30,4 +30,4 @@ const RemoveMultipleOrgUsersSuccess: RemoveMultipleOrgUsersSuccessResolvers = {
   }
 }
 
-export default RemoveMultipleOrgUsersSuccess
+export default RemoveOrgUsersSuccess


### PR DESCRIPTION
# Description

Rename the mutation `removeMultipleOrgUsers` to `removeOrgUsers`. Next step is to deprecate `removeOrgUser`.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
