### PR TITLE
chore: update copy that says only team leads can upgrade

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
@@ -104,7 +104,7 @@ const TeamSettings = (props: Props) => {
             <StyledRow>
               <div>
                 This team is currently on a <b className='capitalize'>{billingTier} plan</b>. Only
-                Team Leads can <b>Upgrade plans</b> and <b>Delete a team</b>.<br />
+                Team Leads can <b>delete a team</b>.<br />
                 The <b>Team Lead</b> for {teamName} is{' '}
                 <a href={`mailto:${contact.email}`} className='text-sky-500 underline'>
                   {contact.preferredName}


### PR DESCRIPTION
Copy says that only team leads can upgrade, but anyone can upgrade an org to the Team tier.

### To test

- [ ] In one terminal, run `stripe listen --forward-to localhost:3000/stripe`
- [ ] With a user that is not the team lead, upgrade to the team from Starter to Team

