### PR TITLE
feat: implement team public/private settings

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -202,6 +202,7 @@
           "ToggleFavoriteTemplateSuccess": "./types/ToggleFavoriteTemplateSuccess#ToggleFavoriteTemplateSuccessSource",
           "ToggleFeatureFlagSuccess": "./types/ToggleFeatureFlagSuccess#ToggleFeatureFlagSuccessSource",
           "ToggleSummaryEmailSuccess": "./types/ToggleSummaryEmailSuccess#ToggleSummaryEmailSuccessSource",
+          "ToggleTeamPrivacySuccess": "./types/ToggleTeamPrivacySuccess#ToggleTeamPrivacySuccessSource",
           "UpdateAgendaItemPayload": "./types/UpdateAgendaItemPayload#UpdateAgendaItemPayloadSource",
           "UpdateAutoJoinSuccess": "./types/UpdateAutoJoinSuccess#UpdateAutoJoinSuccessSource",
           "UpdateCommentContentSuccess": "./types/UpdateCommentContentSuccess#UpdateCommentContentSuccessSource",

--- a/packages/client/components/DashNavList/DashNavListTeams.tsx
+++ b/packages/client/components/DashNavList/DashNavListTeams.tsx
@@ -29,7 +29,6 @@ const DashNavListTeams = (props: Props) => {
         id
         name
         tier
-        hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
         viewerTeams {
           ...DashNavListTeam @relay(mask: false)
         }
@@ -41,8 +40,8 @@ const DashNavListTeams = (props: Props) => {
     organizationRef
   )
   const [showModal, setShowModal] = useState(false)
-  const {publicTeams, viewerTeams, hasPublicTeamsFlag} = organization
-  const publicTeamsCount = hasPublicTeamsFlag ? publicTeams.length : 0
+  const {publicTeams, viewerTeams} = organization
+  const publicTeamsCount = publicTeams.length
 
   const handleClose = () => {
     setShowModal(false)

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyConfirmModal.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyConfirmModal.tsx
@@ -1,0 +1,47 @@
+import PrimaryButton from '../../../../components/PrimaryButton'
+import SecondaryButton from '../../../../components/SecondaryButton'
+import {TierLabel} from '../../../../types/constEnums'
+import {Dialog} from '../../../../ui/Dialog/Dialog'
+import {DialogActions} from '../../../../ui/Dialog/DialogActions'
+import {DialogContent} from '../../../../ui/Dialog/DialogContent'
+import {DialogTitle} from '../../../../ui/Dialog/DialogTitle'
+
+interface Props {
+  isOpen: boolean
+  teamName: string
+  onClose: () => void
+  onConfirm: () => void
+}
+
+const TeamPrivacyConfirmModal = (props: Props) => {
+  const {isOpen, teamName, onClose, onConfirm} = props
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose}>
+      <DialogContent className='w-[400px] p-4'>
+        <DialogTitle>Make team public?</DialogTitle>
+        <div className='my-4 text-slate-700'>
+          <p>
+            You're about to make <b>{teamName}</b> public. This means:
+          </p>
+          <ul className='mt-2 list-disc pl-5'>
+            <li>Anyone in your organization can find and join this team</li>
+            <li>
+              This action <b>cannot be undone</b> on the Starter Plan
+            </li>
+            <li>You would need to upgrade to the {TierLabel.TEAM} Plan to make it private again</li>
+          </ul>
+          <p className='mt-2'>Are you sure you want to continue?</p>
+        </div>
+        <DialogActions>
+          <SecondaryButton onClick={onClose}>Cancel</SecondaryButton>
+          <PrimaryButton className='ml-4' onClick={onConfirm}>
+            Make Team Public
+          </PrimaryButton>
+        </DialogActions>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default TeamPrivacyConfirmModal

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyConfirmModal.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyConfirmModal.tsx
@@ -29,7 +29,10 @@ const TeamPrivacyConfirmModal = (props: Props) => {
             <li>
               This action <b>cannot be undone</b> on the Starter Plan
             </li>
-            <li>You would need to upgrade to the {TierLabel.TEAM} Plan to make it private again</li>
+            <li>
+              You would need to upgrade to the {TierLabel.TEAM} or {TierLabel.ENTERPRISE} Plan to
+              make it private again
+            </li>
           </ul>
           <p className='mt-2'>Are you sure you want to continue?</p>
         </div>

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -81,7 +81,7 @@ const TeamPrivacyToggle = (props: Props) => {
                 <>
                   To make this team private, you need to{' '}
                   <a className='cursor-pointer text-sky-500 underline' onClick={handleUpgradeClick}>
-                    upgrade to {TierLabel.TEAM} Plan
+                    upgrade to {TierLabel.TEAM} or ${TierLabel.ENTERPRISE} Plan
                   </a>
                   .
                 </>

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -1,4 +1,3 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import {TeamPrivacyToggle_team$key} from '~/__generated__/TeamPrivacyToggle_team.graphql'
@@ -7,52 +6,7 @@ import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
 import useRouter from '../../../../hooks/useRouter'
 import ToggleTeamPrivacyMutation from '../../../../mutations/ToggleTeamPrivacyMutation'
-import {PALETTE} from '../../../../styles/paletteV3'
 import {TierLabel} from '../../../../types/constEnums'
-
-const StyledRow = styled('div')({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'flex-start',
-  width: '100%'
-})
-
-const ToggleBlock = styled('div')({
-  display: 'flex',
-  alignItems: 'center',
-  marginLeft: 24,
-  flexShrink: 0
-})
-
-const PrivacyLabel = styled('div')({
-  fontWeight: 600,
-  fontSize: 14,
-  color: PALETTE.SLATE_700,
-  marginRight: 8
-})
-
-const TextBlock = styled('div')({
-  fontSize: 14,
-  color: PALETTE.SLATE_700,
-  maxWidth: '80%'
-})
-
-const Description = styled('div')({
-  fontSize: 14,
-  color: PALETTE.SLATE_700
-})
-
-const WarningText = styled('div')({
-  fontSize: 13,
-  color: PALETTE.SLATE_600,
-  marginTop: 8
-})
-
-const UpgradeLink = styled('a')({
-  color: PALETTE.SKY_500,
-  textDecoration: 'underline',
-  cursor: 'pointer'
-})
 
 interface Props {
   teamRef: TeamPrivacyToggle_team$key
@@ -67,7 +21,6 @@ const TeamPrivacyToggle = (props: Props) => {
         isPublic
         name
         tier
-        billingTier
         orgId
       }
     `,
@@ -75,10 +28,10 @@ const TeamPrivacyToggle = (props: Props) => {
   )
 
   const {history} = useRouter()
-  const {id: teamId, isPublic, name: teamName, billingTier, orgId} = team
+  const {id: teamId, isPublic, name: teamName, tier, orgId} = team
   const atmosphere = useAtmosphere()
   const {onCompleted, onError, submitting, submitMutation} = useMutationProps()
-  const isStarterTier = billingTier === 'starter'
+  const isStarterTier = tier === 'starter'
 
   const toggleTeamPrivacy = () => {
     // If team is public and on starter tier, they can't make it private
@@ -94,22 +47,22 @@ const TeamPrivacyToggle = (props: Props) => {
   }
 
   return (
-    <StyledRow>
-      <TextBlock>
-        <Description>
+    <div className='flex w-full items-start justify-between'>
+      <div className='max-w-[80%] text-sm text-slate-700'>
+        <div className='text-sm text-slate-700'>
           {isPublic
             ? `${teamName} is currently public. Anyone in your organization can find and join this team.`
             : `${teamName} is currently private. Only invited members can join this team.`}
-        </Description>
+        </div>
 
         {isStarterTier && (
-          <WarningText>
+          <div className='mt-2 text-xs text-slate-600'>
             {isPublic ? (
               <>
                 To make this team private, you need to{' '}
-                <UpgradeLink onClick={handleUpgradeClick}>
+                <a className='cursor-pointer text-sky-500 underline' onClick={handleUpgradeClick}>
                   upgrade to {TierLabel.TEAM} Plan
-                </UpgradeLink>
+                </a>
                 .
               </>
             ) : (
@@ -117,18 +70,18 @@ const TeamPrivacyToggle = (props: Props) => {
                 <b>Note</b>: Making this team public cannot be undone on the starter plan.
               </>
             )}
-          </WarningText>
+          </div>
         )}
-      </TextBlock>
-      <ToggleBlock>
-        <PrivacyLabel>Public</PrivacyLabel>
+      </div>
+      <div className='ml-6 flex flex-shrink-0 items-center'>
+        <div className='mr-2 text-sm font-semibold text-slate-700'>Public</div>
         <Toggle
           active={isPublic}
           disabled={submitting || (isPublic && isStarterTier)}
           onClick={toggleTeamPrivacy}
         />
-      </ToggleBlock>
-    </StyledRow>
+      </div>
+    </div>
   )
 }
 

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -1,0 +1,85 @@
+import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
+import {useFragment} from 'react-relay'
+import {TeamPrivacyToggle_team$key} from '~/__generated__/TeamPrivacyToggle_team.graphql'
+import Toggle from '../../../../components/Toggle/Toggle'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
+import useMutationProps from '../../../../hooks/useMutationProps'
+import {PALETTE} from '../../../../styles/paletteV3'
+
+const StyledRow = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%'
+})
+
+const ToggleBlock = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  marginLeft: 16
+})
+
+const PrivacyLabel = styled('div')({
+  fontWeight: 600,
+  fontSize: 14,
+  color: PALETTE.SLATE_700,
+  marginRight: 8
+})
+
+const Description = styled('div')({
+  fontSize: 14,
+  color: PALETTE.SLATE_700,
+  maxWidth: '70%'
+})
+
+interface Props {
+  teamRef: TeamPrivacyToggle_team$key
+}
+
+const TeamPrivacyToggle = (props: Props) => {
+  const {teamRef} = props
+  const team = useFragment(
+    graphql`
+      fragment TeamPrivacyToggle_team on Team {
+        id
+        isPublic
+        name
+        organization {
+          hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
+        }
+      }
+    `,
+    teamRef
+  )
+
+  const {id: teamId, isPublic, name: teamName, organization} = team
+  const {hasPublicTeamsFlag} = organization
+  const atmosphere = useAtmosphere()
+  const {onCompleted, onError, submitting, submitMutation} = useMutationProps()
+
+  // This would be implemented with a real mutation
+  const toggleTeamPrivacy = () => {
+    if (submitting) return
+    submitMutation()
+    // ToggleTeamPrivacyMutation(atmosphere, {teamId, isPublic: !isPublic}, {onError, onCompleted})
+  }
+
+  if (!hasPublicTeamsFlag) return null
+
+  return (
+    <StyledRow>
+      <Description>
+        {isPublic
+          ? `${teamName} is currently public. Anyone in your organization can find and join this team.`
+          : `${teamName} is currently private. Only invited members can join this team.`}
+      </Description>
+      <ToggleBlock>
+        <PrivacyLabel>Public</PrivacyLabel>
+        <Toggle active={isPublic} disabled={submitting} onClick={toggleTeamPrivacy} />
+      </ToggleBlock>
+    </StyledRow>
+  )
+}
+
+export default TeamPrivacyToggle

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -5,6 +5,7 @@ import {TeamPrivacyToggle_team$key} from '~/__generated__/TeamPrivacyToggle_team
 import Toggle from '../../../../components/Toggle/Toggle'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
+import ToggleTeamPrivacyMutation from '../../../../mutations/ToggleTeamPrivacyMutation'
 import {PALETTE} from '../../../../styles/paletteV3'
 
 const StyledRow = styled('div')({
@@ -45,6 +46,7 @@ const TeamPrivacyToggle = (props: Props) => {
         id
         isPublic
         name
+        tier
         organization {
           hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
         }
@@ -62,7 +64,7 @@ const TeamPrivacyToggle = (props: Props) => {
   const toggleTeamPrivacy = () => {
     if (submitting) return
     submitMutation()
-    // ToggleTeamPrivacyMutation(atmosphere, {teamId, isPublic: !isPublic}, {onError, onCompleted})
+    ToggleTeamPrivacyMutation(atmosphere, {teamId, isPublic: !isPublic}, {onError, onCompleted})
   }
 
   if (!hasPublicTeamsFlag) return null

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -1,6 +1,6 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
-import {TeamPrivacyToggle_team$key} from '~/__generated__/TeamPrivacyToggle_team.graphql'
+import {TeamPrivacyToggle_team$key} from '../../../../__generated__/TeamPrivacyToggle_team.graphql'
 import Toggle from '../../../../components/Toggle/Toggle'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
@@ -10,7 +10,7 @@ import useRouter from '../../../../hooks/useRouter'
 import {PALETTE} from '../../../../styles/paletteV3'
 import {Layout, TierLabel} from '../../../../types/constEnums'
 import ArchiveTeam from '../ArchiveTeam/ArchiveTeam'
-import TeamPrivacyToggle from './TeamPrivacy'
+import TeamPrivacyToggle from './TeamPrivacyToggle'
 
 const TeamSettingsLayout = styled('div')({
   display: 'flex',

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
@@ -99,7 +99,7 @@ const TeamSettings = (props: Props) => {
           <>
             <Panel label='Team Privacy'>
               <PanelRow>
-                <TeamPrivacyToggle teamRef={team} />
+                <TeamPrivacyToggle teamRef={team!} />
               </PanelRow>
             </Panel>
             <Panel label='Danger Zone'>

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamSettings.tsx
@@ -10,6 +10,7 @@ import useRouter from '../../../../hooks/useRouter'
 import {PALETTE} from '../../../../styles/paletteV3'
 import {Layout, TierLabel} from '../../../../types/constEnums'
 import ArchiveTeam from '../ArchiveTeam/ArchiveTeam'
+import TeamPrivacyToggle from './TeamPrivacy'
 
 const TeamSettingsLayout = styled('div')({
   display: 'flex',
@@ -42,6 +43,7 @@ const query = graphql`
     viewer {
       team(teamId: $teamId) {
         ...ArchiveTeam_team
+        ...TeamPrivacyToggle_team
         isViewerLead
         id
         name
@@ -94,11 +96,18 @@ const TeamSettings = (props: Props) => {
           </Panel>
         )}
         {viewerIsLead || viewerIsOrgAdmin ? (
-          <Panel label='Danger Zone'>
-            <PanelRow>
-              <ArchiveTeam team={team!} />
-            </PanelRow>
-          </Panel>
+          <>
+            <Panel label='Team Privacy'>
+              <PanelRow>
+                <TeamPrivacyToggle teamRef={team} />
+              </PanelRow>
+            </Panel>
+            <Panel label='Danger Zone'>
+              <PanelRow>
+                <ArchiveTeam team={team!} />
+              </PanelRow>
+            </Panel>
+          </>
         ) : (
           <Panel className='mt-8'>
             <StyledRow>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
@@ -39,12 +39,8 @@ const FeatureNameGroup = styled('div')({
   }
 })
 
-// TODO: create a migration that updates featureName to be a readable string
-// then update the references throughout the app and remove this
 const FEATURE_NAME_LOOKUP: Record<string, string> = {
-  insights: 'Team Insights',
-  publicTeams: 'Public Teams',
-  relatedDiscussions: 'Related Discussions'
+  insights: 'Insights'
 }
 
 interface Props {
@@ -82,7 +78,7 @@ const OrgFeatureFlags = (props: Props) => {
     })
   }
 
-  if (!isOrgAdmin) return null
+  if (!isOrgAdmin || organization.orgFeatureFlags.length === 0) return null
   return (
     <StyledPanel isWide label='Organization Feature Flags'>
       <PanelRow>

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -22,7 +22,6 @@ const OrgTeams = (props: Props) => {
       fragment OrgTeams_organization on Organization {
         id
         tier
-        hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
         allTeams {
           id
           name
@@ -50,8 +49,8 @@ const OrgTeams = (props: Props) => {
   const [sortBy, setSortBy] = useState<SortField>('lastMetAt')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 
-  const {allTeams, tier, viewerTeams, allTeamsCount, hasPublicTeamsFlag} = organization
-  const showAllTeams = allTeams.length === allTeamsCount || hasPublicTeamsFlag
+  const {allTeams, tier, viewerTeams, allTeamsCount} = organization
+  const showingAllTeams = allTeams.length === allTeamsCount
   const viewerTeamCount = viewerTeams.length
 
   const handleSort = (field: SortField) => {
@@ -103,7 +102,7 @@ const OrgTeams = (props: Props) => {
           <div className='flex w-full justify-between'>
             <div className='flex items-center font-bold'>
               {allTeamsCount} {' total '}
-              {!showAllTeams ? `(${allTeamsCount - viewerTeamCount} hidden)` : null}
+              {!showingAllTeams ? `(${allTeamsCount - viewerTeamCount} hidden)` : null}
             </div>
           </div>
         </div>
@@ -142,7 +141,7 @@ const OrgTeams = (props: Props) => {
           </table>
         </div>
 
-        {tier !== 'enterprise' && allTeamsCount > viewerTeamCount && !showAllTeams && (
+        {tier !== 'enterprise' && allTeamsCount > viewerTeamCount && !showingAllTeams && (
           <TeaserOrgTeamsRow
             hiddenTeamCount={allTeamsCount - viewerTeamCount}
             orgId={organization.id}

--- a/packages/client/mutations/DowngradeToStarterMutation.ts
+++ b/packages/client/mutations/DowngradeToStarterMutation.ts
@@ -8,6 +8,10 @@ graphql`
     organization {
       tier
       billingTier
+      viewerTeams {
+        isPaid
+        tier
+      }
     }
   }
 `

--- a/packages/client/mutations/ToggleTeamPrivacyMutation.ts
+++ b/packages/client/mutations/ToggleTeamPrivacyMutation.ts
@@ -1,0 +1,40 @@
+import graphql from 'babel-plugin-relay/macro'
+import {commitMutation} from 'react-relay'
+import {ToggleTeamPrivacyMutation as TToggleTeamPrivacyMutation} from '../__generated__/ToggleTeamPrivacyMutation.graphql'
+import {StandardMutation} from '../types/relayMutations'
+
+graphql`
+  fragment ToggleTeamPrivacyMutation_team on ToggleTeamPrivacySuccess {
+    team {
+      isPublic
+    }
+  }
+`
+
+const mutation = graphql`
+  mutation ToggleTeamPrivacyMutation($teamId: ID!) {
+    toggleTeamPrivacy(teamId: $teamId) {
+      ... on ErrorPayload {
+        error {
+          message
+        }
+      }
+      ...ToggleTeamPrivacyMutation_team @relay(mask: false)
+    }
+  }
+`
+
+const ToggleTeamPrivacyMutation: StandardMutation<TToggleTeamPrivacyMutation> = (
+  atmosphere,
+  variables,
+  {onError, onCompleted}
+) => {
+  return commitMutation<TToggleTeamPrivacyMutation>(atmosphere, {
+    mutation,
+    variables,
+    onCompleted,
+    onError
+  })
+}
+
+export default ToggleTeamPrivacyMutation

--- a/packages/client/mutations/fragments/PublicTeamsFrag.ts
+++ b/packages/client/mutations/fragments/PublicTeamsFrag.ts
@@ -7,7 +7,6 @@ graphql`
       id
     }
     organization {
-      hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
       allTeams {
         id
       }

--- a/packages/server/graphql/public/mutations/toggleTeamPrivacy.ts
+++ b/packages/server/graphql/public/mutations/toggleTeamPrivacy.ts
@@ -1,0 +1,47 @@
+import toTeamMemberId from '../../../../client/utils/relay/toTeamMemberId'
+import getKysely from '../../../postgres/getKysely'
+import {getUserId, isUserOrgAdmin} from '../../../utils/authorization'
+import standardError from '../../../utils/standardError'
+import {MutationResolvers} from '../resolverTypes'
+
+const toggleTeamPrivacy: MutationResolvers['toggleTeamPrivacy'] = async (
+  _source,
+  {teamId},
+  {authToken, dataLoader}
+) => {
+  const viewerId = getUserId(authToken)
+  const pg = getKysely()
+
+  const teamMemberId = toTeamMemberId(teamId, viewerId)
+  const teamMember = await dataLoader.get('teamMembers').load(teamMemberId)
+  if (!teamMember) {
+    return standardError(new Error('Not a member of the team'))
+  }
+
+  const team = await dataLoader.get('teams').load(teamId)
+  if (!team) {
+    return standardError(new Error('Team not found'))
+  }
+  const isOrgAdmin = await isUserOrgAdmin(viewerId, team.orgId, dataLoader)
+  if (!teamMember.isLead && !isOrgAdmin) {
+    return standardError(new Error('Not team lead or org admin'))
+  }
+
+  if (team.isPublic && team.tier === 'starter') {
+    return standardError(new Error('Cannot make a public team private on the starter tier'))
+  }
+
+  await pg
+    .updateTable('Team')
+    .set({
+      isPublic: !team.isPublic
+    })
+    .where('id', '=', teamId)
+    .execute()
+
+  const data = {teamId}
+
+  return data
+}
+
+export default toggleTeamPrivacy

--- a/packages/server/graphql/public/mutations/toggleTeamPrivacy.ts
+++ b/packages/server/graphql/public/mutations/toggleTeamPrivacy.ts
@@ -39,6 +39,8 @@ const toggleTeamPrivacy: MutationResolvers['toggleTeamPrivacy'] = async (
     .where('id', '=', teamId)
     .execute()
 
+  team.isPublic = !team.isPublic
+
   const data = {teamId}
 
   return data

--- a/packages/server/graphql/public/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/public/typeDefs/Mutation.graphql
@@ -1187,6 +1187,16 @@ type Mutation {
   ): ToggleAIFeaturesPayload!
 
   """
+  Toggle whether the team privacy settings
+  """
+  toggleTeamPrivacy(
+    """
+    The id of the team being toggled
+    """
+    teamId: ID!
+  ): ToggleTeamPrivacyPayload!
+
+  """
   Update how a parabol dimension maps to a GitHub label
   """
   updateGitHubDimensionField(

--- a/packages/server/graphql/public/typeDefs/ToggleTeamPrivacyPayload.graphql
+++ b/packages/server/graphql/public/typeDefs/ToggleTeamPrivacyPayload.graphql
@@ -1,0 +1,4 @@
+"""
+Return value for toggleTeamPrivacy, which could be an error
+"""
+union ToggleTeamPrivacyPayload = ErrorPayload | ToggleTeamPrivacySuccess

--- a/packages/server/graphql/public/typeDefs/ToggleTeamPrivacySuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/ToggleTeamPrivacySuccess.graphql
@@ -1,0 +1,6 @@
+type ToggleTeamPrivacySuccess {
+  """
+  The team with the updated privacy setting
+  """
+  team: Team!
+}

--- a/packages/server/graphql/public/types/Organization.ts
+++ b/packages/server/graphql/public/types/Organization.ts
@@ -55,16 +55,13 @@ const Organization: OrganizationResolvers = {
 
   allTeams: async ({id: orgId}, _args, {dataLoader, authToken}) => {
     const viewerId = getUserId(authToken)
-    const [allTeamsOnOrg, organization, isOrgAdmin] = await Promise.all([
+    const [allTeamsOnOrg, isOrgAdmin] = await Promise.all([
       dataLoader.get('teamsByOrgIds').load(orgId),
       dataLoader.get('organizations').loadNonNull(orgId),
       isUserOrgAdmin(viewerId, orgId, dataLoader)
     ])
     const sortedTeamsOnOrg = allTeamsOnOrg.sort((a, b) => a.name.localeCompare(b.name))
-    const hasPublicTeamsFlag = await dataLoader
-      .get('featureFlagByOwnerId')
-      .load({ownerId: organization.id, featureName: 'publicTeams'})
-    if (isOrgAdmin || isSuperUser(authToken) || hasPublicTeamsFlag) {
+    if (isOrgAdmin || isSuperUser(authToken)) {
       const viewerTeams = sortedTeamsOnOrg.filter((team) => authToken.tms.includes(team.id))
       const otherTeams = sortedTeamsOnOrg.filter((team) => !authToken.tms.includes(team.id))
       return [...viewerTeams, ...otherTeams]
@@ -90,7 +87,38 @@ const Organization: OrganizationResolvers = {
     const publicTeams = allTeamsOnOrg.filter(
       (team) => (team.isPublic || isSuperUser(authToken)) && !isTeamMember(authToken, team.id)
     )
-    return publicTeams
+
+    const teamsWithMeetingData = await Promise.all(
+      publicTeams.map(async (team) => {
+        const [completedMeetings, activeMeetings] = await Promise.all([
+          dataLoader.get('completedMeetingsByTeamId').load(team.id),
+          dataLoader.get('activeMeetingsByTeamId').load(team.id)
+        ])
+
+        const allMeetingDates = [
+          ...completedMeetings.map((meeting) => new Date(meeting.endedAt || meeting.createdAt)),
+          ...activeMeetings.map((meeting) => new Date(meeting.createdAt))
+        ]
+
+        const lastMetAt =
+          allMeetingDates.length > 0
+            ? new Date(Math.max(...allMeetingDates.map((date) => date.getTime())))
+            : null
+
+        return {
+          ...team,
+          lastMetAt
+        }
+      })
+    )
+
+    // Show teams who met most recently first
+    return teamsWithMeetingData.sort((a, b) => {
+      if (!a.lastMetAt && !b.lastMetAt) return 0
+      if (!a.lastMetAt) return 1
+      if (!b.lastMetAt) return -1
+      return b.lastMetAt.getTime() - a.lastMetAt.getTime()
+    })
   },
 
   viewerOrganizationUser: async ({id: orgId}, _args, {dataLoader, authToken}) => {

--- a/packages/server/graphql/public/types/ToggleTeamPrivacySuccess.ts
+++ b/packages/server/graphql/public/types/ToggleTeamPrivacySuccess.ts
@@ -1,0 +1,13 @@
+import {ToggleTeamPrivacySuccessResolvers} from '../resolverTypes'
+
+export type ToggleTeamPrivacySuccessSource = {
+  teamId: string
+}
+
+const ToggleTeamPrivacySuccess: ToggleTeamPrivacySuccessResolvers = {
+  team: async ({teamId}, _args, {dataLoader}) => {
+    return dataLoader.get('teams').loadNonNull(teamId)
+  }
+}
+
+export default ToggleTeamPrivacySuccess

--- a/packages/server/postgres/migrations/2025-03-12T15:20:56.255Z_remove-publicTeams.ts
+++ b/packages/server/postgres/migrations/2025-03-12T15:20:56.255Z_remove-publicTeams.ts
@@ -1,0 +1,15 @@
+import type {Kysely} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.deleteFrom('FeatureFlag').where('featureName', '=', 'publicTeams').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .insertInto('FeatureFlag')
+    .values({
+      featureName: 'publicTeams',
+      expiresAt: '2025-03-31T00:00:00.000Z'
+    })
+    .execute()
+}


### PR DESCRIPTION
Fixes https://github.com/ParabolInc/parabol/issues/10925 & https://github.com/ParabolInc/parabol/issues/10926

Demo: https://www.loom.com/share/1a66922d8bac411c81ec352947e6af13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new team privacy toggle on the Team Settings page, empowering team leads and organisation admins to easily switch a team's privacy between public and private.
  - Added contextual guidance and visual feedback to indicate when a team's current tier restricts privacy changes, with prompts to upgrade if necessary.
  - Enhanced the overall experience with immediate, clear responses following privacy adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->