### PR TITLE
chore: change settings tooltip copy

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamDashHeader/TeamDashHeader.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamDashHeader/TeamDashHeader.tsx
@@ -179,7 +179,7 @@ const TeamDashHeader = (props: Props) => {
               {({css}) => (
                 <NavLink
                   className={css(secondLink)}
-                  title={'Settings & Integrations'}
+                  title={'Team Settings'}
                   to={`/team/${teamId}/settings/`}
                 >
                   {'Settings'}


### PR DESCRIPTION
Integrations have been moved out of the team settings section. This updates the tooltip to reflect that.