### PR TITLE
feat(orgAdmin): UI for mass org user removal

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
@@ -46,6 +46,7 @@ const BillingLeader = (props: Props) => {
     graphql`
       fragment BillingLeader_orgUser on OrganizationUser {
         ...OrgAdminActionMenu_organizationUser
+        ...RemoveFromOrgModal_organizationUsers
         role
         user {
           id
@@ -110,7 +111,12 @@ const BillingLeader = (props: Props) => {
       </RowActions>
       {leaveModal(<LeaveOrgModal orgId={orgId} closePortal={closeLeaveModal} />)}
       {removeModal(
-        <RemoveFromOrgModal orgId={orgId} userIds={[userId]} closePortal={closeRemoveModal} />
+        <RemoveFromOrgModal
+          orgId={orgId}
+          userIds={[userId]}
+          organizationUsers={[billingLeader]}
+          closePortal={closeRemoveModal}
+        />
       )}
     </StyledRow>
   )

--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
@@ -112,7 +112,7 @@ const BillingLeader = (props: Props) => {
       {removeModal(
         <RemoveFromOrgModal
           orgId={orgId}
-          userId={userId}
+          userIds={[userId]}
           preferredName={preferredName}
           closePortal={closeRemoveModal}
         />

--- a/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/BillingLeader.tsx
@@ -110,12 +110,7 @@ const BillingLeader = (props: Props) => {
       </RowActions>
       {leaveModal(<LeaveOrgModal orgId={orgId} closePortal={closeLeaveModal} />)}
       {removeModal(
-        <RemoveFromOrgModal
-          orgId={orgId}
-          userIds={[userId]}
-          preferredName={preferredName}
-          closePortal={closeRemoveModal}
-        />
+        <RemoveFromOrgModal orgId={orgId} userIds={[userId]} closePortal={closeRemoveModal} />
       )}
     </StyledRow>
   )

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -13,6 +13,7 @@ import ExportToCSVButton from '../../../../components/ExportToCSVButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useModal from '../../../../hooks/useModal'
 import {APP_CORS_OPTIONS} from '../../../../types/cors'
+import {BATCH_ORG_USER_REMOVAL_LIMIT} from '../../../../utils/constants'
 import OrgMemberRow from '../OrgUserRow/OrgMemberRow'
 import RemoveFromOrgModal from '../RemoveFromOrgModal/RemoveFromOrgModal'
 
@@ -240,26 +241,34 @@ const OrgMembers = (props: Props) => {
             <div className='flex items-center font-bold'>
               {organizationUsers.edges.length} total
               {selectedUserIds.length > 0 && (
-                <span className='text-blue-600 ml-2'>({selectedUserIds.length} selected)</span>
+                <span className='ml-2 text-sky-600'>({selectedUserIds.length} selected)</span>
               )}
             </div>
             <div className='flex space-x-2'>
-              {selectedUserIds.length > 0 && isOrgAdmin && (
-                <>
-                  <button
-                    onClick={exportToCSV}
-                    className='flex h-6 items-center rounded border border-slate-300 bg-slate-100 px-3 text-xs font-medium text-slate-700 hover:bg-slate-200'
-                  >
-                    Export Selected to CSV
-                  </button>
-                  <button
-                    onClick={toggleBulkRemove}
-                    className='flex h-6 items-center rounded border border-slate-300 bg-slate-100 px-3 text-xs font-medium text-slate-700 hover:bg-slate-200'
-                  >
-                    Remove Selected
-                  </button>
-                </>
-              )}
+              {selectedUserIds.length > 0 &&
+                selectedUserIds.length > BATCH_ORG_USER_REMOVAL_LIMIT && (
+                  <span className='text-xs font-bold text-tomato-600'>
+                    Oops! You can select up to {BATCH_ORG_USER_REMOVAL_LIMIT} users at a time.
+                  </span>
+                )}
+              {selectedUserIds.length > 0 &&
+                selectedUserIds.length <= BATCH_ORG_USER_REMOVAL_LIMIT &&
+                isOrgAdmin && (
+                  <>
+                    <button
+                      onClick={exportToCSV}
+                      className='flex h-6 items-center rounded border border-slate-300 bg-slate-100 px-3 text-xs font-medium text-slate-700 hover:bg-slate-200'
+                    >
+                      Export Selected to CSV
+                    </button>
+                    <button
+                      onClick={toggleBulkRemove}
+                      className='flex h-6 items-center rounded border border-slate-300 bg-slate-100 px-3 text-xs font-medium text-slate-700 hover:bg-slate-200'
+                    >
+                      Remove Selected
+                    </button>
+                  </>
+                )}
             </div>
           </div>
         </div>
@@ -274,7 +283,7 @@ const OrgMembers = (props: Props) => {
                         type='checkbox'
                         checked={isAllSelected}
                         onChange={handleSelectAll}
-                        className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
+                        className='h-4 w-4 rounded border-slate-300 text-grape-700 focus:ring-grape-500'
                       />
                     )}
                   </div>

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -190,13 +190,15 @@ const OrgMembers = (props: Props) => {
     const parser = new Parser({withBOM: true, eol: '\n'}) as JSON2CSVParser<any>
     const csv = parser.parse(rows)
     const date = new Date()
+    // copied from https://stackoverflow.com/questions/18848860/javascript-array-to-csv/18849208#18849208
+    // note: using encodeUri does NOT work on the # symbol & breaks
     const numDate = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
     const blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'})
     const encodedUri = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.setAttribute('href', encodedUri)
     link.setAttribute('download', `Parabol_${orgName}_${numDate}.csv`)
-    document.body.appendChild(link)
+    document.body.appendChild(link) // Required for FF
     link.click()
     document.body.removeChild(link)
   }

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -38,6 +38,7 @@ const OrgMembers = (props: Props) => {
             id
             name
             isBillingLeader
+            isOrgAdmin
             organizationUsers(first: $first, after: $after)
               @connection(key: "OrgMembers_organizationUsers") {
               edges {
@@ -69,7 +70,7 @@ const OrgMembers = (props: Props) => {
   const {data} = paginationRes
   const {viewer} = data
   const organization = viewer.organization!
-  const {organizationUsers, name: orgName, isBillingLeader} = organization
+  const {organizationUsers, name: orgName, isBillingLeader, isOrgAdmin} = organization
   const billingLeaderCount = organizationUsers.edges.reduce(
     (count, {node}) =>
       ['BILLING_LEADER', 'ORG_ADMIN'].includes(node.role ?? '') ? count + 1 : count,
@@ -219,7 +220,7 @@ const OrgMembers = (props: Props) => {
               )}
             </div>
             <div className='flex space-x-2'>
-              {selectedUserIds.length > 0 && isBillingLeader && (
+              {selectedUserIds.length > 0 && isOrgAdmin && (
                 <>
                   <button
                     onClick={exportToCSV}
@@ -244,12 +245,14 @@ const OrgMembers = (props: Props) => {
               <tr className='border-b border-slate-300'>
                 <th className='w-[5%] p-3 text-left'>
                   <div className='flex items-center justify-center'>
-                    <input
-                      type='checkbox'
-                      checked={isAllSelected}
-                      onChange={handleSelectAll}
-                      className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
-                    />
+                    {isOrgAdmin && (
+                      <input
+                        type='checkbox'
+                        checked={isAllSelected}
+                        onChange={handleSelectAll}
+                        className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
+                      />
+                    )}
                   </div>
                 </th>
                 <th

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -9,11 +9,11 @@ import {OrgMembersPaginationQuery} from '~/__generated__/OrgMembersPaginationQue
 import {OrgMembersQuery} from '~/__generated__/OrgMembersQuery.graphql'
 import {OrgMembers_viewer$key} from '~/__generated__/OrgMembers_viewer.graphql'
 import User from '../../../../../server/database/types/User'
+import {BATCH_ORG_USER_REMOVAL_LIMIT} from '../../../../../server/postgres/constants'
 import ExportToCSVButton from '../../../../components/ExportToCSVButton'
 import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useModal from '../../../../hooks/useModal'
 import {APP_CORS_OPTIONS} from '../../../../types/cors'
-import {BATCH_ORG_USER_REMOVAL_LIMIT} from '../../../../utils/constants'
 import OrgMemberRow from '../OrgUserRow/OrgMemberRow'
 import RemoveFromOrgModal from '../RemoveFromOrgModal/RemoveFromOrgModal'
 

--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -58,7 +58,7 @@ interface UserAvatarProps {
   picture?: string
 }
 
-const UserAvatar: React.FC<UserAvatarProps> = ({picture}) => (
+const UserAvatar = ({picture}: UserAvatarProps) => (
   <div className='mr-4 hidden md:block'>
     {picture ? (
       <Avatar picture={picture} className='h-11 w-11' />
@@ -76,13 +76,7 @@ interface UserInfoProps {
   inactive: boolean | null | undefined
 }
 
-const UserInfo: React.FC<UserInfoProps> = ({
-  preferredName,
-  email,
-  isBillingLeader,
-  isOrgAdmin,
-  inactive
-}) => (
+const UserInfo = ({preferredName, email, isBillingLeader, isOrgAdmin, inactive}: UserInfoProps) => (
   <RowInfo className='pl-0'>
     <RowInfoHeader>
       <RowInfoHeading>{preferredName}</RowInfoHeading>
@@ -99,14 +93,9 @@ const UserInfo: React.FC<UserInfoProps> = ({
 interface UserActionsProps {
   organization: OrgMemberRow_organization$data
   organizationUser: OrgMemberRow_organizationUser$data
-  preferredName: string
 }
 
-const UserActions: React.FC<UserActionsProps> = ({
-  organizationUser,
-  organization,
-  preferredName
-}) => {
+const UserActions = ({organizationUser, organization}: UserActionsProps) => {
   const {id: orgId} = organization
   const {
     user: {id: userId}
@@ -121,6 +110,7 @@ const UserActions: React.FC<UserActionsProps> = ({
     modalPortal: removeModal,
     closePortal: closeRemoveModal
   } = useModal()
+
   return (
     <RowActions>
       <ActionsBlock>
@@ -132,12 +122,7 @@ const UserActions: React.FC<UserActionsProps> = ({
         />
         {leaveModal(<LeaveOrgModal orgId={orgId} closePortal={closeLeaveModal} />)}
         {removeModal(
-          <RemoveFromOrgModal
-            orgId={orgId}
-            userIds={[userId]}
-            preferredName={preferredName}
-            closePortal={closeRemoveModal}
-          />
+          <RemoveFromOrgModal orgId={orgId} userIds={[userId]} closePortal={closeRemoveModal} />
         )}
       </ActionsBlock>
     </RowActions>
@@ -232,11 +217,7 @@ const OrgMemberRow = (props: Props) => {
         <RowInfo className='pl-0'>{formattedLastSeenAt}</RowInfo>
       </td>
       <td className='w-1/5 px-2 py-3 align-middle'>
-        <UserActions
-          organizationUser={organizationUser}
-          organization={organization}
-          preferredName={preferredName}
-        />
+        <UserActions organizationUser={organizationUser} organization={organization} />
       </td>
     </tr>
   )

--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -155,6 +155,7 @@ const OrgMemberRow = (props: Props) => {
     graphql`
       fragment OrgMemberRow_organization on Organization {
         id
+        isOrgAdmin
         ...OrgAdminActionMenu_organization
       }
     `,
@@ -187,6 +188,7 @@ const OrgMemberRow = (props: Props) => {
 
   const isBillingLeader = role === 'BILLING_LEADER'
   const isOrgAdmin = role === 'ORG_ADMIN'
+  const {isOrgAdmin: isViewerOrgAdmin} = organization
   const formattedLastSeenAt = lastSeenAt ? format(new Date(lastSeenAt), 'yyyy-MM-dd') : 'Never'
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -197,12 +199,14 @@ const OrgMemberRow = (props: Props) => {
     <tr className='border-b border-slate-300 last:border-b-0'>
       <td className='px-2 py-3 align-middle'>
         <div className='flex items-center justify-center'>
-          <input
-            type='checkbox'
-            checked={isSelected}
-            onChange={handleCheckboxChange}
-            className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
-          />
+          {isViewerOrgAdmin && (
+            <input
+              type='checkbox'
+              checked={isSelected}
+              onChange={handleCheckboxChange}
+              className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
+            />
+          )}
         </div>
       </td>
       <td className='w-1/2 px-2 py-3 align-middle'>

--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -194,7 +194,7 @@ const OrgMemberRow = (props: Props) => {
               type='checkbox'
               checked={isSelected}
               onChange={handleCheckboxChange}
-              className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
+              className='h-4 w-4 rounded border-slate-300 text-grape-700 focus:ring-grape-500'
             />
           )}
         </div>

--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -20,6 +20,7 @@ import RowInfoLink from '../../../../components/Row/RowInfoLink'
 import BaseTag from '../../../../components/Tag/BaseTag'
 import InactiveTag from '../../../../components/Tag/InactiveTag'
 import RoleTag from '../../../../components/Tag/RoleTag'
+import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useModal from '../../../../hooks/useModal'
 import defaultUserAvatar from '../../../../styles/theme/images/avatar-user.svg'
 import lazyPreload from '../../../../utils/lazyPreload'
@@ -150,6 +151,8 @@ const OrgMemberRow = (props: Props) => {
     isSelected = false,
     onSelectUser
   } = props
+  const atmosphere = useAtmosphere()
+  const {viewerId} = atmosphere
 
   const organization = useFragment(
     graphql`
@@ -182,7 +185,7 @@ const OrgMemberRow = (props: Props) => {
   )
 
   const {
-    user: {email, inactive, picture, preferredName, lastSeenAt},
+    user: {email, inactive, picture, preferredName, lastSeenAt, id: userId},
     role
   } = organizationUser
 
@@ -190,6 +193,8 @@ const OrgMemberRow = (props: Props) => {
   const isOrgAdmin = role === 'ORG_ADMIN'
   const {isOrgAdmin: isViewerOrgAdmin} = organization
   const formattedLastSeenAt = lastSeenAt ? format(new Date(lastSeenAt), 'yyyy-MM-dd') : 'Never'
+  const isSelf = viewerId === userId
+  const canBeSelected = isViewerOrgAdmin && !isSelf && !isBillingLeader && !isOrgAdmin
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     onSelectUser?.(organizationUser.user.id, e.target.checked)
@@ -199,7 +204,7 @@ const OrgMemberRow = (props: Props) => {
     <tr className='border-b border-slate-300 last:border-b-0'>
       <td className='px-2 py-3 align-middle'>
         <div className='flex items-center justify-center'>
-          {isViewerOrgAdmin && (
+          {canBeSelected && (
             <input
               type='checkbox'
               checked={isSelected}

--- a/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgUserRow/OrgMemberRow.tsx
@@ -35,6 +35,8 @@ interface Props {
   orgAdminCount: number
   organizationUser: OrgMemberRow_organizationUser$key
   organization: OrgMemberRow_organization$key
+  isSelected?: boolean
+  onSelectUser?: (userId: string, isSelected: boolean) => void
 }
 
 const LeaveOrgModal = lazyPreload(
@@ -131,7 +133,7 @@ const UserActions: React.FC<UserActionsProps> = ({
         {removeModal(
           <RemoveFromOrgModal
             orgId={orgId}
-            userId={userId}
+            userIds={[userId]}
             preferredName={preferredName}
             closePortal={closeRemoveModal}
           />
@@ -142,7 +144,12 @@ const UserActions: React.FC<UserActionsProps> = ({
 }
 
 const OrgMemberRow = (props: Props) => {
-  const {organizationUser: organizationUserRef, organization: organizationRef} = props
+  const {
+    organizationUser: organizationUserRef,
+    organization: organizationRef,
+    isSelected = false,
+    onSelectUser
+  } = props
 
   const organization = useFragment(
     graphql`
@@ -157,6 +164,7 @@ const OrgMemberRow = (props: Props) => {
   const organizationUser = useFragment(
     graphql`
       fragment OrgMemberRow_organizationUser on OrganizationUser {
+        id
         user {
           id
           email
@@ -181,8 +189,22 @@ const OrgMemberRow = (props: Props) => {
   const isOrgAdmin = role === 'ORG_ADMIN'
   const formattedLastSeenAt = lastSeenAt ? format(new Date(lastSeenAt), 'yyyy-MM-dd') : 'Never'
 
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onSelectUser?.(organizationUser.user.id, e.target.checked)
+  }
+
   return (
     <tr className='border-b border-slate-300 last:border-b-0'>
+      <td className='px-2 py-3 align-middle'>
+        <div className='flex items-center justify-center'>
+          <input
+            type='checkbox'
+            checked={isSelected}
+            onChange={handleCheckboxChange}
+            className='text-blue-600 focus:ring-blue-500 h-4 w-4 rounded border-slate-300'
+          />
+        </div>
+      </td>
       <td className='w-1/2 px-2 py-3 align-middle'>
         <div className='flex w-full items-center overflow-hidden'>
           <UserAvatar picture={picture} />

--- a/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
+++ b/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
@@ -1,4 +1,7 @@
 import styled from '@emotion/styled'
+import graphql from 'babel-plugin-relay/macro'
+import {useFragment} from 'react-relay'
+import {RemoveFromOrgModal_organizationUsers$key} from '../../../../__generated__/RemoveFromOrgModal_organizationUsers.graphql'
 import DialogContainer from '../../../../components/DialogContainer'
 import DialogContent from '../../../../components/DialogContent'
 import DialogTitle from '../../../../components/DialogTitle'
@@ -17,6 +20,7 @@ const StyledButton = styled(PrimaryButton)({
 interface Props {
   orgId: string
   userIds: string[]
+  organizationUsers: RemoveFromOrgModal_organizationUsers$key
   closePortal: () => void
   onSuccess?: () => void
 }
@@ -25,19 +29,48 @@ const StyledDialogContainer = styled(DialogContainer)({
   width: '400px'
 })
 
+// Fragment for organization users that can be potentially removed
+const organizationUsersFragment = graphql`
+  fragment RemoveFromOrgModal_organizationUsers on OrganizationUser @relay(plural: true) {
+    role
+    user {
+      id
+      preferredName
+    }
+  }
+`
+
 const RemoveFromOrgModal = (props: Props) => {
-  const {orgId, userIds, closePortal, onSuccess} = props
+  const {orgId, userIds, organizationUsers, closePortal, onSuccess} = props
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
+  const {viewerId} = atmosphere
 
-  const count = userIds.length
+  const users = useFragment(organizationUsersFragment, organizationUsers)
+
+  // Filter out non-removable users
+  const removableUserIds = users
+    .filter((organizationUser) => {
+      const isSelf = organizationUser.user.id === viewerId
+      const isBillingLeader = organizationUser.role === 'BILLING_LEADER'
+      const isOrgAdmin = organizationUser.role === 'ORG_ADMIN'
+      return !isSelf && !isBillingLeader && !isOrgAdmin
+    })
+    .map((organizationUser) => organizationUser.user.id)
+
+  const skippedCount = userIds.length - removableUserIds.length
+  const removableCount = removableUserIds.length
 
   const handleClick = () => {
+    if (removableUserIds.length === 0) {
+      closePortal()
+      return
+    }
     submitMutation()
     RemoveOrgUsersMutation(
       atmosphere,
-      {orgId, userIds},
+      {orgId, userIds: removableUserIds},
       {
         history,
         onError,
@@ -54,14 +87,36 @@ const RemoveFromOrgModal = (props: Props) => {
     <StyledDialogContainer>
       <DialogTitle>{'Are you sure?'}</DialogTitle>
       <DialogContent>
-        {`This will remove ${count} ${plural(count, 'member')} from all teams within the organization. Any outstanding tasks will be given to the respective team leads.`}
-        <StyledButton size='medium' onClick={handleClick} waiting={submitting}>
-          <IconLabel
-            icon='arrow_forward'
-            iconAfter
-            label={`Remove ${count} ${plural(count, 'member')}`}
-          />
-        </StyledButton>
+        {removableCount > 0 && (
+          <div>
+            {`This will remove ${removableCount} ${plural(removableCount, 'member')} from all teams within the organization. Any outstanding tasks will be given to the respective team leads.`}
+          </div>
+        )}
+        {skippedCount > 0 && (
+          <div className='mt-2 text-sm text-slate-600'>
+            {`Note: ${skippedCount} ${plural(skippedCount, 'user')} ${skippedCount === 1 ? 'has' : 'have'} been skipped because ${skippedCount === 1 ? 'they are' : 'they are either'} yourself, an organization admin, or a billing leader.`}
+          </div>
+        )}
+        {removableCount > 0 && (
+          <StyledButton size='medium' onClick={handleClick} waiting={submitting}>
+            <IconLabel
+              icon='arrow_forward'
+              iconAfter
+              label={`Remove ${removableCount} ${plural(removableCount, 'member')}`}
+            />
+          </StyledButton>
+        )}
+        {removableCount === 0 && (
+          <div>
+            <div className='mt-2 text-sm text-slate-600'>
+              None of the selected users can be removed as they are either yourself, organization
+              admins, or billing leaders.
+            </div>
+            <StyledButton size='medium' onClick={closePortal}>
+              <IconLabel icon='close' label='Close' />
+            </StyledButton>
+          </div>
+        )}
       </DialogContent>
     </StyledDialogContainer>
   )

--- a/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
+++ b/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
@@ -8,6 +8,7 @@ import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
 import useRouter from '../../../../hooks/useRouter'
 import RemoveOrgUsersMutation from '../../../../mutations/RemoveOrgUsersMutation'
+import plural from '../../../../utils/plural'
 
 const StyledButton = styled(PrimaryButton)({
   margin: '1.5rem auto 0'
@@ -15,9 +16,7 @@ const StyledButton = styled(PrimaryButton)({
 
 interface Props {
   orgId: string
-  userId?: string
-  userIds?: string[]
-  preferredName?: string
+  userIds: string[]
   closePortal: () => void
   onSuccess?: () => void
 }
@@ -27,21 +26,18 @@ const StyledDialogContainer = styled(DialogContainer)({
 })
 
 const RemoveFromOrgModal = (props: Props) => {
-  const {orgId, preferredName, userId, userIds, closePortal, onSuccess} = props
+  const {orgId, userIds, closePortal, onSuccess} = props
   const atmosphere = useAtmosphere()
   const {history} = useRouter()
   const {onCompleted, onError, submitMutation, submitting} = useMutationProps()
 
-  // Determine if we're in single or bulk mode
-  const isSingleUser = !!userId && !!preferredName
-  const actualUserIds = isSingleUser ? [userId!] : userIds || []
-  const count = actualUserIds.length
+  const count = userIds.length
 
   const handleClick = () => {
     submitMutation()
     RemoveOrgUsersMutation(
       atmosphere,
-      {orgId, userIds: actualUserIds},
+      {orgId, userIds},
       {
         history,
         onError,
@@ -58,18 +54,12 @@ const RemoveFromOrgModal = (props: Props) => {
     <StyledDialogContainer>
       <DialogTitle>{'Are you sure?'}</DialogTitle>
       <DialogContent>
-        {isSingleUser
-          ? `This will remove ${preferredName} from all teams within the organization. Any outstanding tasks will be given to the respective team leads.`
-          : `This will remove ${count} member${count === 1 ? '' : 's'} from all teams within the organization. Any outstanding tasks will be given to the respective team leads.`}
+        {`This will remove ${count} ${plural(count, 'member')} from all teams within the organization. Any outstanding tasks will be given to the respective team leads.`}
         <StyledButton size='medium' onClick={handleClick} waiting={submitting}>
           <IconLabel
             icon='arrow_forward'
             iconAfter
-            label={
-              isSingleUser
-                ? `Remove ${preferredName}`
-                : `Remove ${count} member${count === 1 ? '' : 's'}`
-            }
+            label={`Remove ${count} ${plural(count, 'member')}`}
           />
         </StyledButton>
       </DialogContent>

--- a/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
+++ b/packages/client/modules/userDashboard/components/RemoveFromOrgModal/RemoveFromOrgModal.tsx
@@ -49,39 +49,31 @@ const RemoveFromOrgModal = (props: Props) => {
 
   const users = useFragment(organizationUsersFragment, organizationUsers)
 
-  // Track non-removable users and their reasons
-  const nonRemovableUsers = users
-    .filter((organizationUser) => {
-      const isSelf = organizationUser.user.id === viewerId
-      const isBillingLeader = organizationUser.role === 'BILLING_LEADER'
-      const isOrgAdmin = organizationUser.role === 'ORG_ADMIN'
-      return isSelf || isBillingLeader || isOrgAdmin
-    })
-    .map((organizationUser) => {
-      const isSelf = organizationUser.user.id === viewerId
-      const isBillingLeader = organizationUser.role === 'BILLING_LEADER'
-      const isOrgAdmin = organizationUser.role === 'ORG_ADMIN'
+  // Map users with their removal status and reason
+  const usersWithRemovalStatus = users.map((organizationUser) => {
+    const isSelf = organizationUser.user.id === viewerId
+    const isBillingLeader = organizationUser.role === 'BILLING_LEADER'
+    const isOrgAdmin = organizationUser.role === 'ORG_ADMIN'
 
-      let reason = ''
-      if (isSelf) reason = 'Yourself'
-      else if (isOrgAdmin) reason = 'Organization Admin'
-      else if (isBillingLeader) reason = 'Billing Leader'
+    let reason = ''
+    if (isSelf) reason = 'Yourself'
+    else if (isOrgAdmin) reason = 'Organization Admin'
+    else if (isBillingLeader) reason = 'Billing Leader'
 
-      return {
-        user: organizationUser.user,
-        reason
-      }
-    })
+    return {
+      user: organizationUser.user,
+      reason,
+      isRemovable: !reason
+    }
+  })
 
   // Filter out non-removable users
-  const removableUserIds = users
-    .filter((organizationUser) => {
-      const isSelf = organizationUser.user.id === viewerId
-      const isBillingLeader = organizationUser.role === 'BILLING_LEADER'
-      const isOrgAdmin = organizationUser.role === 'ORG_ADMIN'
-      return !isSelf && !isBillingLeader && !isOrgAdmin
-    })
-    .map((organizationUser) => organizationUser.user.id)
+  const nonRemovableUsers = usersWithRemovalStatus.filter((user) => !user.isRemovable)
+
+  // Get removable user IDs
+  const removableUserIds = usersWithRemovalStatus
+    .filter((user) => user.isRemovable)
+    .map((user) => user.user.id)
 
   const skippedCount = userIds.length - removableUserIds.length
   const removableCount = removableUserIds.length

--- a/packages/client/mutations/RemoveOrgUsersMutation.ts
+++ b/packages/client/mutations/RemoveOrgUsersMutation.ts
@@ -17,6 +17,7 @@ import findStageById from '../utils/meetings/findStageById'
 import onExOrgRoute from '../utils/onExOrgRoute'
 import onMeetingRoute from '../utils/onMeetingRoute'
 import onTeamRoute from '../utils/onTeamRoute'
+import plural from '../utils/plural'
 import safeRemoveNodeFromConn from '../utils/relay/safeRemoveNodeFromConn'
 import {setLocalStageAndPhase} from '../utils/relay/updateLocalStage'
 import handleAddNotifications from './handlers/handleAddNotifications'
@@ -25,6 +26,7 @@ import handleRemoveOrgMembers from './handlers/handleRemoveOrgMembers'
 import handleRemoveTeamMembers from './handlers/handleRemoveTeamMembers'
 import handleRemoveTeams from './handlers/handleRemoveTeams'
 import handleTasksForRemovedUsers from './handlers/handleTasksForRemovedUsers'
+
 graphql`
   fragment RemoveOrgUsersMutation_organization on RemoveOrgUsersSuccess {
     affectedOrganizationId
@@ -220,6 +222,13 @@ export const removeOrgUsersNotificationOnNext: OnNextHandler<
       history.push('/meetings')
       return
     }
+  } else {
+    const removedUserCount = removedUserIds.length
+    atmosphere.eventEmitter.emit('addSnackbar', {
+      key: `removedFromOrg:${affectedOrganizationId}`,
+      autoDismiss: 10,
+      message: `${removedUserCount} ${plural(removedUserCount, 'member')} have been removed from ${affectedOrganizationName}`
+    })
   }
 }
 

--- a/packages/client/mutations/RemoveOrgUsersMutation.ts
+++ b/packages/client/mutations/RemoveOrgUsersMutation.ts
@@ -227,7 +227,7 @@ export const removeOrgUsersNotificationOnNext: OnNextHandler<
     atmosphere.eventEmitter.emit('addSnackbar', {
       key: `removedFromOrg:${affectedOrganizationId}`,
       autoDismiss: 10,
-      message: `${removedUserCount} ${plural(removedUserCount, 'member')} have been removed from ${affectedOrganizationName}`
+      message: `${removedUserCount} ${plural(removedUserCount, 'member')} ${removedUserCount === 1 ? 'has' : 'have'} been removed from ${affectedOrganizationName}`
     })
   }
 }

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -108,6 +108,8 @@ export const FAILED = 'FAILED'
 /* character limits */
 export const TASK_MAX_CHARS = 51200
 
+export const BATCH_ORG_USER_REMOVAL_LIMIT = 100
+
 /* Task tags */
 export const tags = [
   {

--- a/packages/client/utils/constants.ts
+++ b/packages/client/utils/constants.ts
@@ -108,8 +108,6 @@ export const FAILED = 'FAILED'
 /* character limits */
 export const TASK_MAX_CHARS = 51200
 
-export const BATCH_ORG_USER_REMOVAL_LIMIT = 100
-
 /* Task tags */
 export const tags = [
   {


### PR DESCRIPTION
# Description
1. This is a limited feature for org admins only
2. To simplify the first iteration, other billing leaders or org admins are not selectable.
3. They can not select more than 100 org users

## Demo
![2025-03-12 15 44 05](https://github.com/user-attachments/assets/a17bae4f-0eca-4a2c-aa3f-391653f80d38)



## Testing scenarios

- [ ] Regression
  - [ ] Individual can still be removed from the three-dot menu
  - [ ] One can still remove themselves

- [ ] Org-Admin only
  - [ ] The mass selection checkbox is only present for org admin
  - [ ] If there are no removable org users, the "select all" checkbox won't be present
  - [ ] Cannot select other org admin or billing leaders

- [ ] Mass select & removal
  - [ ] Select 1 user and remove
  - [ ] Select > 1 users and remove
  - [ ] Select > `BATCH_ORG_USER_REMOVAL_LIMIT` (manually change it to a small number) and see the warning message
  - [ ] Removed users get individual toast messages. Org admin gets a summary toast.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
