### PR TITLE
fix: Handle duplicate SAML attributes

### DIFF
--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -86,6 +86,10 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
   const normalizedAttributes = Object.fromEntries(
     Object.entries(attributes).map(([key, value]) => {
       const normalizedKey = CLAIM_SPEC[key as keyof typeof CLAIM_SPEC] ?? key.toLowerCase()
+      // This happens if the IdP sends duplicate claims
+      if (Array.isArray(value)) {
+        return [normalizedKey, Array.from(new Set(value.map(String))).toString()]
+      }
       return [normalizedKey, String(value)]
     })
   )

--- a/packages/server/graphql/private/mutations/loginSAML.ts
+++ b/packages/server/graphql/private/mutations/loginSAML.ts
@@ -101,7 +101,7 @@ const loginSAML: MutationResolvers['loginSAML'] = async (
       new Error(
         `Email attribute is missing from the SAML response. The following attributes were included: ${Object.keys(attributes).join(', ')}`
       ),
-      {extras: {body}}
+      {extras: {attributes}}
     )
   }
   if (email.length > USER_PREFERRED_NAME_LIMIT) {


### PR DESCRIPTION
If the customer has email multiple times in their message, we could get an array with multiple of the same email. To work around this, create a set of array attributes.
If they claim multiple emails, then we should still fail, as we don't know which one to choose.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
