### PR TITLE
chore: Normalize User.tms

### DIFF
--- a/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
+++ b/packages/server/graphql/mutations/helpers/createTeamAndLeader.ts
@@ -1,4 +1,3 @@
-import {sql} from 'kysely'
 import TeamMemberId from '../../../../client/shared/gqlIds/TeamMemberId'
 import {MeetingSettingsThreshold} from '../../../../client/types/constEnums'
 import Team from '../../../database/types/Team'
@@ -53,12 +52,6 @@ export default async function createTeamAndLeader(
   await Promise.all([
     pg
       .with('TeamInsert', (qc) => qc.insertInto('Team').values(verifiedTeam))
-      .with('UserUpdate', (qc) =>
-        qc
-          .updateTable('User')
-          .set({tms: sql`arr_append_uniq("tms", ${teamId})`})
-          .where('id', '=', userId)
-      )
       .with('TeamMemberInsert', (qc) =>
         qc.insertInto('TeamMember').values({
           id: TeamMemberId.join(teamId, userId),

--- a/packages/server/graphql/mutations/helpers/removeTeamMember.ts
+++ b/packages/server/graphql/mutations/helpers/removeTeamMember.ts
@@ -80,12 +80,6 @@ const removeTeamMember = async (
     .where(sql<boolean>`'archived' != ALL(tags)`)
     .execute()
   const reassignedTasks = await pg
-    .with('UserUpdate', (qb) =>
-      qb
-        .updateTable('User')
-        .set(({fn, ref, val}) => ({tms: fn('ARRAY_REMOVE', [ref('tms'), val(teamId)])}))
-        .where('id', '=', userId)
-    )
     .updateTable('Task')
     .set({userId: nextTeamLead.userId})
     .where('userId', '=', userId)

--- a/packages/server/graphql/public/mutations/acceptRequestToJoinDomain.ts
+++ b/packages/server/graphql/public/mutations/acceptRequestToJoinDomain.ts
@@ -1,4 +1,3 @@
-import {sql} from 'kysely'
 import DomainJoinRequestId from 'parabol-client/shared/gqlIds/DomainJoinRequestId'
 import {InvoiceItemType, SubscriptionChannel} from 'parabol-client/types/constEnums'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
@@ -90,12 +89,6 @@ const acceptRequestToJoinDomain: MutationResolvers['acceptRequestToJoinDomain'] 
     const [organizationUser] = await Promise.all([
       dataLoader.get('organizationUsersByUserIdOrgId').load({orgId, userId}),
       pg
-        .with('UserUpdate', (qc) =>
-          qc
-            .updateTable('User')
-            .set({tms: sql`arr_append_uniq("tms", ${teamId})`})
-            .where('id', '=', userId)
-        )
         .insertInto('TeamMember')
         .values({
           id: TeamMemberId.join(teamId, userId),

--- a/packages/server/postgres/migrations/2025-06-24T13:42:32.158Z_addTMSTriggers.ts
+++ b/packages/server/postgres/migrations/2025-06-24T13:42:32.158Z_addTMSTriggers.ts
@@ -1,0 +1,67 @@
+import {sql, type Kysely} from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+CREATE OR REPLACE FUNCTION "updateUserTmsAfterTeam"()
+RETURNS TRIGGER AS $$
+DECLARE
+  "_teamId" VARCHAR := COALESCE(NEW.id, OLD.id);
+BEGIN
+  IF TG_OP = 'DELETE' OR NEW."isArchived" = true THEN
+    UPDATE "User"
+    SET tms = array_remove(tms, "_teamId")
+    WHERE id IN (
+      SELECT tm."userId"
+      FROM "TeamMember" tm
+      WHERE tm."teamId" = "_teamId"
+    );
+  ELSE
+    UPDATE "User"
+    SET tms = arr_append_uniq(tms, "_teamId")
+    WHERE id IN (
+      SELECT tm."userId"
+      FROM "TeamMember" tm
+      WHERE tm."teamId" = "_teamId"
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER trg_Team_update_User_tms
+AFTER INSERT OR UPDATE OF "isArchived" OR DELETE ON "Team"
+FOR EACH ROW EXECUTE FUNCTION "updateUserTmsAfterTeam"();
+
+CREATE OR REPLACE FUNCTION "updateUserTmsAfterTeamMember"()
+RETURNS TRIGGER AS $$
+DECLARE
+  "_teamId" VARCHAR := COALESCE(NEW."teamId", OLD."teamId");
+  "_userId" VARCHAR := COALESCE(NEW."userId", OLD."userId");
+BEGIN
+  IF TG_OP = 'DELETE' OR NEW."isNotRemoved" = false OR (SELECT "isArchived" FROM "Team" WHERE id = "_teamId") THEN
+    UPDATE "User"
+    SET tms = array_remove(tms, "_teamId")
+    WHERE id = "_userId";
+  ELSE
+    UPDATE "User"
+    SET tms = arr_append_uniq(tms, "_teamId")
+    WHERE id = "_userId";
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE OR REPLACE TRIGGER trg_TeamMember_update_User_tms
+AFTER INSERT OR UPDATE OF "isNotRemoved" OR DELETE ON "TeamMember"
+FOR EACH ROW EXECUTE FUNCTION "updateUserTmsAfterTeamMember"();
+  `.execute(db)
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    DROP TRIGGER IF EXISTS trg_Team_update_User_tms ON "Team";
+    DROP FUNCTION IF EXISTS "updateUserTmsAfterTeam" CASCADE;
+    DROP TRIGGER IF EXISTS trg_TeamMember_update_User_tms ON "TeamMember";
+    DROP FUNCTION IF EXISTS "updateUserTmsAfterTeamMember" CASCADE;
+  `.execute(db)
+}

--- a/packages/server/postgres/migrations/2025-06-26T13:51:02.635Z_cleanupUserTMS.ts
+++ b/packages/server/postgres/migrations/2025-06-26T13:51:02.635Z_cleanupUserTMS.ts
@@ -1,0 +1,50 @@
+import type {Kysely} from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+  // clean our own backyard first
+  const teamId = 'aGhostTeam'
+  const userId = 'aGhostUser'
+  await db
+    .insertInto('TeamMember')
+    .values({
+      id: `${userId}::${teamId}`,
+      teamId,
+      userId
+    })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+
+  //with truth as (select u.id, array_agg(tm."teamId") as truth, tms from "TeamMember" tm join "Team" t on tm."teamId" = t.id join "User" u on tm."userId" = u.id where t."isArchived" = false and tm."isNotRemoved" = true group by u.id having not (tms @> array_agg(tm."teamId") and tms <@ array_agg(tm."teamId")))
+  //select * from "User" where id in (select id from truth)
+  await db
+    .with('truth', (qc) =>
+      qc
+        .selectFrom('TeamMember as tm')
+        .innerJoin('Team as t', 'tm.teamId', 't.id')
+        .innerJoin('User as u', 'tm.userId', 'u.id')
+        .select((eb) => ['u.id', eb.fn.agg('array_agg', 'tm.teamId').as('truth'), 'u.tms'])
+        .where('t.isArchived', '=', false)
+        .where('tm.isNotRemoved', '=', true)
+        .groupBy('u.id')
+        .having(({eb, fn}) =>
+          eb.not(
+            eb.and(
+              eb('u.tms', '@>', fn.agg('array_agg', 'tm.teamId')),
+              eb('u.tms', '<@', fn.agg('array_agg', 'tm.teamId'))
+            )
+          )
+        )
+    )
+    .updateTable('User')
+    .set((eb) => ({
+      tms: eb.ref('truth.truth')
+    }))
+    .from('truth')
+    .where((eb) => eb('User.id', '=', eb.ref('truth.id')))
+    .where((eb) => eb('User.id', 'in', eb.selectFrom('truth').select('id')))
+    .execute()
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {}

--- a/packages/server/safeMutations/acceptTeamInvitation.ts
+++ b/packages/server/safeMutations/acceptTeamInvitation.ts
@@ -80,12 +80,6 @@ const acceptTeamInvitation = async (team: Team, userId: string, dataLoader: Data
         })
         .onConflict((oc) => oc.column('id').doUpdateSet({isNotRemoved: true, isLead: false}))
     )
-    .with('UserUpdate', (qc) =>
-      qc
-        .updateTable('User')
-        .set({tms: sql`arr_append_uniq("tms", ${teamId})`})
-        .where('id', '=', userId)
-    )
     .with('TeamInvitationUpdate', (qb) =>
       // redeem all invitations, otherwise if they have 2 someone could join after they've been kicked out
       qb

--- a/packages/server/safeMutations/safeArchiveTeam.ts
+++ b/packages/server/safeMutations/safeArchiveTeam.ts
@@ -21,16 +21,10 @@ const safeArchiveTeam = async (teamId: string, dataLoader: DataLoaderWorker) => 
       .returningAll()
       .executeTakeFirst(),
     pg
-      .with('TeamInvitationUpdate', (qb) =>
-        qb
-          .updateTable('TeamInvitation')
-          .set({expiresAt: sql`CURRENT_TIMESTAMP`})
-          .where('teamId', '=', teamId)
-          .where('acceptedAt', 'is', null)
-      )
-      .updateTable('User')
-      .set(({fn, ref, val}) => ({tms: fn('ARRAY_REMOVE', [ref('tms'), val(teamId)])}))
-      .where('id', 'in', userIds)
+      .updateTable('TeamInvitation')
+      .set({expiresAt: sql`CURRENT_TIMESTAMP`})
+      .where('teamId', '=', teamId)
+      .where('acceptedAt', 'is', null)
       .execute()
   ])
   dataLoader.clearAll(['teamMembers', 'users', 'teams'])


### PR DESCRIPTION
# Description

Fixes #9932 
We query User.tms quite often to check permissions, so it's useful to be denormalized. To avoid update errors, I added triggers for Team and TeamMember operations which update the array.
There is also some inconsistent data in the database, I've added a migration to clean that up as well.

## Demo

Nothing should change for the user.

## Testing scenarios

Joining, leaving and archiving teams

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
