### PR TITLE
chore: remove public teams feature flag

### DIFF
--- a/packages/client/components/DashNavList/DashNavListTeams.tsx
+++ b/packages/client/components/DashNavList/DashNavListTeams.tsx
@@ -29,7 +29,6 @@ const DashNavListTeams = (props: Props) => {
         id
         name
         tier
-        hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
         viewerTeams {
           ...DashNavListTeam @relay(mask: false)
         }
@@ -41,8 +40,8 @@ const DashNavListTeams = (props: Props) => {
     organizationRef
   )
   const [showModal, setShowModal] = useState(false)
-  const {publicTeams, viewerTeams, hasPublicTeamsFlag} = organization
-  const publicTeamsCount = hasPublicTeamsFlag ? publicTeams.length : 0
+  const {publicTeams, viewerTeams} = organization
+  const publicTeamsCount = publicTeams.length
 
   const handleClose = () => {
     setShowModal(false)

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
@@ -39,13 +39,8 @@ const FeatureNameGroup = styled('div')({
   }
 })
 
-// TODO: create a migration that updates featureName to be a readable string
-// then update the references throughout the app and remove this
-const FEATURE_NAME_LOOKUP: Record<string, string> = {
-  insights: 'Team Insights',
-  publicTeams: 'Public Teams',
-  relatedDiscussions: 'Related Discussions'
-}
+// add feature flag name here
+const FEATURE_NAME_LOOKUP: Record<string, string> = {}
 
 interface Props {
   organizationRef: OrgFeatureFlags_organization$key
@@ -82,7 +77,7 @@ const OrgFeatureFlags = (props: Props) => {
     })
   }
 
-  if (!isOrgAdmin) return null
+  if (!isOrgAdmin || organization.orgFeatureFlags.length === 0) return null
   return (
     <StyledPanel isWide label='Organization Feature Flags'>
       <PanelRow>

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
@@ -39,9 +39,6 @@ const FeatureNameGroup = styled('div')({
   }
 })
 
-// add feature flag name here
-const FEATURE_NAME_LOOKUP: Record<string, string> = {}
-
 interface Props {
   organizationRef: OrgFeatureFlags_organization$key
 }
@@ -84,7 +81,7 @@ const OrgFeatureFlags = (props: Props) => {
         {organization.orgFeatureFlags.map((feature) => (
           <FeatureRow key={feature.featureName}>
             <FeatureNameGroup>
-              <span>{FEATURE_NAME_LOOKUP[feature.featureName] || feature.featureName}</span>
+              <span>{feature.featureName}</span>
               <Tooltip>
                 <TooltipTrigger className='bg-transparent hover:cursor-pointer'>
                   <InfoIcon className='h-4 w-4 text-slate-600' />

--- a/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/OrgFeatureFlags.tsx
@@ -39,6 +39,10 @@ const FeatureNameGroup = styled('div')({
   }
 })
 
+const FEATURE_NAME_LOOKUP: Record<string, string> = {
+  insights: 'Insights'
+}
+
 interface Props {
   organizationRef: OrgFeatureFlags_organization$key
 }
@@ -81,7 +85,7 @@ const OrgFeatureFlags = (props: Props) => {
         {organization.orgFeatureFlags.map((feature) => (
           <FeatureRow key={feature.featureName}>
             <FeatureNameGroup>
-              <span>{feature.featureName}</span>
+              <span>{FEATURE_NAME_LOOKUP[feature.featureName] || feature.featureName}</span>
               <Tooltip>
                 <TooltipTrigger className='bg-transparent hover:cursor-pointer'>
                   <InfoIcon className='h-4 w-4 text-slate-600' />

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -50,7 +50,7 @@ const OrgTeams = (props: Props) => {
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 
   const {allTeams, tier, viewerTeams, allTeamsCount} = organization
-  const showAllTeams = allTeams.length === allTeamsCount
+  const showingAllTeams = allTeams.length === allTeamsCount
   const viewerTeamCount = viewerTeams.length
 
   const handleSort = (field: SortField) => {
@@ -102,7 +102,7 @@ const OrgTeams = (props: Props) => {
           <div className='flex w-full justify-between'>
             <div className='flex items-center font-bold'>
               {allTeamsCount} {' total '}
-              {!showAllTeams ? `(${allTeamsCount - viewerTeamCount} hidden)` : null}
+              {!showingAllTeams ? `(${allTeamsCount - viewerTeamCount} hidden)` : null}
             </div>
           </div>
         </div>
@@ -141,7 +141,7 @@ const OrgTeams = (props: Props) => {
           </table>
         </div>
 
-        {tier !== 'enterprise' && allTeamsCount > viewerTeamCount && !showAllTeams && (
+        {tier !== 'enterprise' && allTeamsCount > viewerTeamCount && !showingAllTeams && (
           <TeaserOrgTeamsRow
             hiddenTeamCount={allTeamsCount - viewerTeamCount}
             orgId={organization.id}

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeams.tsx
@@ -22,7 +22,6 @@ const OrgTeams = (props: Props) => {
       fragment OrgTeams_organization on Organization {
         id
         tier
-        hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
         allTeams {
           id
           name
@@ -50,8 +49,8 @@ const OrgTeams = (props: Props) => {
   const [sortBy, setSortBy] = useState<SortField>('lastMetAt')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
 
-  const {allTeams, tier, viewerTeams, allTeamsCount, hasPublicTeamsFlag} = organization
-  const showAllTeams = allTeams.length === allTeamsCount || hasPublicTeamsFlag
+  const {allTeams, tier, viewerTeams, allTeamsCount} = organization
+  const showAllTeams = allTeams.length === allTeamsCount
   const viewerTeamCount = viewerTeams.length
 
   const handleSort = (field: SortField) => {

--- a/packages/client/mutations/fragments/PublicTeamsFrag.ts
+++ b/packages/client/mutations/fragments/PublicTeamsFrag.ts
@@ -7,7 +7,6 @@ graphql`
       id
     }
     organization {
-      hasPublicTeamsFlag: featureFlag(featureName: "publicTeams")
       allTeams {
         id
       }

--- a/packages/server/postgres/migrations/2025-03-12T15:20:56.255Z_remove-publicTeams.ts
+++ b/packages/server/postgres/migrations/2025-03-12T15:20:56.255Z_remove-publicTeams.ts
@@ -1,0 +1,15 @@
+import type {Kysely} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.deleteFrom('FeatureFlag').where('featureName', '=', 'publicTeams').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db
+    .insertInto('FeatureFlag')
+    .values({
+      featureName: 'publicTeams',
+      expiresAt: '2025-03-31T00:00:00.000Z'
+    })
+    .execute()
+}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/10927

### To test

- [ ] Make your user the org admin of an org using the `setOrgUserRole` mutation
- [ ] Go to org settings and see that the feature flag section doesn't show up if there are no feature flags