### PR TITLE
chore: check down migrations are valid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        sparse-checkout: 
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -132,7 +133,8 @@ jobs:
 
       - name: Run new down migrations
         run: |
-          LAST_BASE_MIGRATION=$(git ls-tree --name-only ${{ github.base_ref }} packages/server/postgres/migrations/ | tail -n1)
+          git fetch --depth=1 origin master
+          LAST_BASE_MIGRATION=$(git ls-tree --name-only origin/master -- packages/server/postgres/migrations/ | tail -n1)
           yarn kysely migrate:down $LAST_BASE_MIGRATION
 
       - name: Report Status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Run new down migrations
         run: |
           git fetch --depth=1 origin master
-          LAST_BASE_MIGRATION=$(git ls-tree --name-only origin/master -- packages/server/postgres/migrations/ | tail -n1)
+          LAST_BASE_MIGRATION=$(git ls-tree --name-only origin/master -- packages/server/postgres/migrations/ | tail -n1 | xargs basename -s .ts)
           yarn kysely migrate:down $LAST_BASE_MIGRATION
 
       - name: Report Status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        sparse-checkout: 
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,11 @@ jobs:
           path: packages/integration-tests/test-results/
           retention-days: 7
 
+      - name: Run new down migrations
+        run: |
+          LAST_BASE_MIGRATION=$(git ls-tree --name-only ${{ github.base_ref }} packages/server/postgres/migrations/ | tail -n1)
+          yarn kysely migrate:down $LAST_BASE_MIGRATION
+
       - name: Report Status
         if: ${{ failure() && github.ref_name == 'master' }}
         uses: ravsamhq/notify-slack-action@v2

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -4,10 +4,8 @@
 yarn postcheckout
 
 DELETED_POSTGRES_MIGRATIONS=$(git diff $1 $2 --name-only --diff-filter=D -- packages/server/postgres/migrations/)
-LAST_COMMON_MIGRATION=$(git ls-tree --name-only $2 -- packages/server/postgres/migrations/ | tail -n1)
+LAST_COMMON_MIGRATION=$(git ls-tree --name-only $2 -- packages/server/postgres/migrations/ | tail -n1 | xargs basename -s .ts)
 if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
-    LAST_COMMON_MIGRATION_FILE=${LAST_COMMON_MIGRATION##*/}
-    LAST_COMMON_MIGRATION_NAME=${LAST_COMMON_MIGRATION_FILE%.ts}
     CURRENT_BRANCH=$(git branch --show-current)
     NUM_POSTGRES_MIGRATIONS=$(echo $DELETED_POSTGRES_MIGRATIONS | wc -w)
     echo "WARNING: You're leaving behind the following migrations not present on the current branch:"
@@ -20,7 +18,7 @@ if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
     echo
     echo "  git checkout ${1} &&"
     if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
-        echo "  yarn kysely migrate:down ${LAST_COMMON_MIGRATION_NAME} &&"
+        echo "  yarn kysely migrate:down ${LAST_COMMON_MIGRATION} &&"
     fi
     echo "  git checkout ${CURRENT_BRANCH:-$2}"
     echo

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -4,7 +4,10 @@
 yarn postcheckout
 
 DELETED_POSTGRES_MIGRATIONS=$(git diff $1 $2 --name-only --diff-filter=D -- packages/server/postgres/migrations/)
+LAST_COMMON_MIGRATION=$(git ls-tree --name-only $2 -- packages/server/postgres/migrations/ | tail -n1)
 if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
+    LAST_COMMON_MIGRATION_FILE=${LAST_COMMON_MIGRATION##*/}
+    LAST_COMMON_MIGRATION_NAME=${LAST_COMMON_MIGRATION_FILE%.ts}
     CURRENT_BRANCH=$(git branch --show-current)
     NUM_POSTGRES_MIGRATIONS=$(echo $DELETED_POSTGRES_MIGRATIONS | wc -w)
     echo "WARNING: You're leaving behind the following migrations not present on the current branch:"
@@ -17,7 +20,7 @@ if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
     echo
     echo "  git checkout ${1} &&"
     if [ ! -z "$DELETED_POSTGRES_MIGRATIONS" ]; then
-        echo "  yarn kysely migrate:down ${NUM_POSTGRES_MIGRATIONS} &&"
+        echo "  yarn kysely migrate:down ${LAST_COMMON_MIGRATION_NAME} &&"
     fi
     echo "  git checkout ${CURRENT_BRANCH:-$2}"
     echo


### PR DESCRIPTION
# Description

Down migrations should be valid code at least.
I think if we want to explicitly throw in the down migration to prevent accidental runs of it, then we can still bypass the test, but syntax errors like https://github.com/ParabolInc/parabol/pull/11013 should be caught.

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
