### PR TITLE
chore: Cork serving static files

### DIFF
--- a/packages/server/selfHostedHandler.ts
+++ b/packages/server/selfHostedHandler.ts
@@ -28,7 +28,7 @@ const selfHostedHandler = async (res: HttpResponse, req: HttpRequest) => {
   const ext = path.extname(url).slice(1)
   const contentType = mime.types[ext] ?? 'application/octet-stream'
 
-  res.writeHeader('content-type', contentType)
+  res.cork(() => res.writeHeader('content-type', contentType))
   const readStream = fs.createReadStream(url)
   pipeStreamOverResponse(res, readStream, size)
 }


### PR DESCRIPTION
I got a lot of warnings locally about writing without proper corking. It is safe to cork/uncork synchronously.
The gist of it is: [always cork](https://github.com/uNetworking/uWebSockets/blob/master/misc/READMORE.md#corking)

See also #9261 for how we handle corking in the other routes.

## Testing scenarios

- with files served locally (`FILE_STORE_PROVIDER='local'
`) run `yarn dev` and open the activity library
- see no warnings

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
