### PR TITLE
fix: can see public teams when there are no viewer teams

### DIFF
--- a/packages/client/components/DashNavList/DashNavListTeams.tsx
+++ b/packages/client/components/DashNavList/DashNavListTeams.tsx
@@ -55,7 +55,7 @@ const DashNavListTeams = (props: Props) => {
   const getIcon = (lockedAt: string | null | undefined, isPaid: boolean | null | undefined) =>
     lockedAt || !isPaid ? 'warning' : 'group'
 
-  if (!viewerTeams.length) return null
+  if (!viewerTeams.length && !publicTeamsCount) return null
   return (
     <div>
       {viewerTeams.map((team) => {


### PR DESCRIPTION
See conversation in Slack [here](https://parabol.slack.com/archives/C836NA350/p1742833245017449) 🔒 

If a user doesn't belong to any teams within an org, they should still be able to view the public teams

![Screenshot 2025-03-25 at 12 03 45](https://github.com/user-attachments/assets/802a8703-a336-4d9a-ae7d-abf6b6203089)
