### PR TITLE
feat: User provisioning to different Organization via SAML claim

### DIFF
--- a/packages/server/graphql/private/mutations/assignSAMLIdToOrg.ts
+++ b/packages/server/graphql/private/mutations/assignSAMLIdToOrg.ts
@@ -17,7 +17,7 @@ const assignSAMLIdToOrg: MutationResolvers['assignSAMLIdToOrg'] = async (
   const organization = await pg
     .updateTable('Organization')
     .set({
-      samlId: normalizedSamlId
+      samlId: normalizedSamlId ?? null
     })
     .where('id', '=', orgId)
     .returningAll()

--- a/packages/server/graphql/private/mutations/assignSAMLIdToOrg.ts
+++ b/packages/server/graphql/private/mutations/assignSAMLIdToOrg.ts
@@ -1,0 +1,32 @@
+import getKysely from '../../../postgres/getKysely'
+import {CreditCard} from '../../../postgres/select'
+import {MutationResolvers} from '../resolverTypes'
+
+const assignSAMLIdToOrg: MutationResolvers['assignSAMLIdToOrg'] = async (
+  _source,
+  {orgId, samlId}
+) => {
+  const pg = getKysely()
+
+  // VALIDATION
+  const normalizedSamlId = samlId?.trim()
+  if (normalizedSamlId === '') {
+    return {error: {message: 'The SAML ID cannot be an empty string'}}
+  }
+
+  const organization = await pg
+    .updateTable('Organization')
+    .set({
+      samlId: normalizedSamlId
+    })
+    .where('id', '=', orgId)
+    .returningAll()
+    .returning(({fn}) => [fn<CreditCard | null>('to_json', ['creditCard']).as('creditCard')])
+    .executeTakeFirst()
+  if (!organization) {
+    return {error: {message: `Organization not found`}}
+  }
+  return {organization}
+}
+
+export default assignSAMLIdToOrg

--- a/packages/server/graphql/private/mutations/updateSAML.ts
+++ b/packages/server/graphql/private/mutations/updateSAML.ts
@@ -1,0 +1,35 @@
+import getKysely from '../../../postgres/getKysely'
+import {MutationResolvers} from '../resolverTypes'
+import normalizeSlugName from './helpers/normalizeSlugName'
+
+const updateSAML: MutationResolvers['updateSAML'] = async (_source, {slug, samlOrgAttribute}) => {
+  const pg = getKysely()
+
+  // VALIDATION
+  const slugName = normalizeSlugName(slug)
+  if (slugName instanceof Error) return {error: {message: slugName.message}}
+
+  const normalizedSamlOrgAttribute = samlOrgAttribute?.trim()
+  if (normalizedSamlOrgAttribute === '') {
+    return {error: {message: 'The attribute name cannot be an empty string'}}
+  }
+
+  const saml = await pg
+    .updateTable('SAML')
+    .set({
+      samlOrgAttribute: normalizedSamlOrgAttribute
+    })
+    .where('id', '=', slugName)
+    .returningAll()
+    .executeTakeFirst()
+  if (!saml) {
+    return {
+      error: {
+        message: `No SAML found for ${slugName}`
+      }
+    }
+  }
+  return {saml}
+}
+
+export default updateSAML

--- a/packages/server/graphql/private/mutations/updateSAML.ts
+++ b/packages/server/graphql/private/mutations/updateSAML.ts
@@ -17,7 +17,7 @@ const updateSAML: MutationResolvers['updateSAML'] = async (_source, {slug, samlO
   const saml = await pg
     .updateTable('SAML')
     .set({
-      samlOrgAttribute: normalizedSamlOrgAttribute
+      samlOrgAttribute: normalizedSamlOrgAttribute ?? null
     })
     .where('id', '=', slugName)
     .returningAll()

--- a/packages/server/graphql/private/typeDefs/AssignSAMLIdToOrgPayload.graphql
+++ b/packages/server/graphql/private/typeDefs/AssignSAMLIdToOrgPayload.graphql
@@ -1,0 +1,4 @@
+"""
+Return value for assignSAMLIdToOrg, which could be an error
+"""
+union AssignSAMLIdToOrgPayload = ErrorPayload | AssignSAMLIdToOrgSuccess

--- a/packages/server/graphql/private/typeDefs/AssignSAMLIdToOrgSuccess.graphql
+++ b/packages/server/graphql/private/typeDefs/AssignSAMLIdToOrgSuccess.graphql
@@ -1,0 +1,6 @@
+type AssignSAMLIdToOrgSuccess {
+  """
+  Updated organization
+  """
+  organization: Organization!
+}

--- a/packages/server/graphql/private/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/private/typeDefs/Mutation.graphql
@@ -567,4 +567,27 @@ type Mutation {
     """
     removeDomains: [ID!]
   ): VerifyDomainPayload!
+
+  """
+  update the SAML Org attribute
+  """
+  updateSAML(
+    """
+    The name of the company, used as a slug in signon URLs. Usually the domain without the tld
+    """
+    slug: ID!
+    """
+    The full attribute name used to provision users to specific orgs. Will be removed if null.
+    """
+    samlOrgAttribute: ID
+  ): UpdateSAMLPayload!
+
+  assignSAMLIdToOrg(
+    orgId: ID!
+
+    """
+    The new SAML Org Attribute value which should map to this org. Null will unset it.
+    """
+    samlId: ID
+  ): AssignSAMLIdToOrgPayload!
 }

--- a/packages/server/graphql/private/typeDefs/UpdateSAMLPayload.graphql
+++ b/packages/server/graphql/private/typeDefs/UpdateSAMLPayload.graphql
@@ -1,0 +1,4 @@
+"""
+Return value for updateSAML, which could be an error
+"""
+union UpdateSAMLPayload = ErrorPayload | UpdateSAMLSuccess

--- a/packages/server/graphql/private/typeDefs/UpdateSAMLSuccess.graphql
+++ b/packages/server/graphql/private/typeDefs/UpdateSAMLSuccess.graphql
@@ -1,4 +1,4 @@
-type VerifyDomainSuccess {
+type UpdateSAMLSuccess {
   """
   Updated SAML record
   """

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -187,6 +187,11 @@ type Organization {
   saml: SAML
 
   """
+  The SAML id for the organization if it is provisioned via SAML attribute
+  """
+  samlId: ID
+
+  """
   A list of domains approved by the organization to join.
   Empty if all domains are allowed
   """

--- a/packages/server/graphql/public/typeDefs/SAML.graphql
+++ b/packages/server/graphql/public/typeDefs/SAML.graphql
@@ -48,4 +48,9 @@ type SAML {
   The organization that owns this SAML record and corresponding domain. Null if SAML record is a legacy orphan
   """
   organization: Organization
+
+  """
+  The full attribute name used to provision users to specific orgs, see also Organization.samlId
+  """
+  samlOrgAttribute: ID
 }

--- a/packages/server/postgres/migrations/2025-03-25T13:33:26.204Z_addSAMLOrganizationAttributes.ts
+++ b/packages/server/postgres/migrations/2025-03-25T13:33:26.204Z_addSAMLOrganizationAttributes.ts
@@ -1,0 +1,11 @@
+import type {Kysely} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  db.schema.alterTable('Organization').addColumn('samlId', 'varchar(100)').execute()
+  db.schema.alterTable('SAML').addColumn('samlOrgAttribute', 'varchar(100)').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  db.schema.alterTable('Organization').dropColumn('samlId').execute()
+  db.schema.alterTable('SAML').dropColumn('samlOrgAttribute').execute()
+}


### PR DESCRIPTION
# Description

Fixes #10921 
This is a special use case where multiple organizations share an IdP and users are provisioned to different orgs based on a SAML claim.Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

- configure SAML
- configure the SAML app to add additional attributes to the login response. I found it easiest to map groups to a user defined attribute
- run the following mutations
  ```graphql
  mutation AssignSAMLAttribute {
    updateSAML(slug: "parabol", samlOrgAttribute: "https://action.parabol.co/organization") {
      ...on ErrorPayload {
        error {
          message
        }
      }
      ...on UpdateSAMLSuccess {
        saml {
          id
          samlOrgAttribute
        }
      }
    }
  }
  ```
  ```graphql
  mutation AssignSAMLIdToOrg {
    assignSAMLIdToOrg(
      orgId: "FlGUVTj0dy",
      samlId: "d24b589e-f759-4688-813e-f5ebd576b581"
    ) {
      ...on ErrorPayload {
        error {
          message
        }
      }
      ...on AssignSAMLIdToOrgSuccess {
        organization {
          id
          name
          samlId
        }
      }
    }
  }
  ```
  with the correct values
- join with a new user

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
