### PR TITLE
fix: correct meeting link URL in the prompt for generating meeting summaries

### DIFF
--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -392,7 +392,7 @@ Return the analysis as a JSON object with this structure:
     You need to summarize the content of a meeting. Your summary must be one paragraph with no more than a two or three sentences.
     Below is a list of reflection topics and comments in YAML format from the meeting.
     Include quotes from the meeting, and mention the author.
-    Link directly to the discussion in the markdown format of [link](${meetingURL}[meetingId]/discuss/[discussionId]).
+    Link directly to the discussion in the markdown format of [link](${meetingURL}/[meetingId]/discuss/[discussionId]).
     Don't mention the name of the meeting.
     Prioritise the topics that got the most votes.
     Be sure that each author is only mentioned once.


### PR DESCRIPTION
# Description

To fix this issue:

![2025-03-25 10 52 04](https://github.com/user-attachments/assets/9b8ef5cf-f0ad-4f26-92d5-7a1c38361b0a)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
