### PR TITLE
fix: typo on public team setting help text

### DIFF
--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -76,12 +76,12 @@ const TeamPrivacyToggle = (props: Props) => {
           </div>
 
           {isStarterTier && (
-            <div className='mt-2 text-xs text-slate-600'>
+            <div className='mt-2 text-xs font-medium text-slate-600'>
               {isPublic ? (
                 <>
                   To make this team private, you need to{' '}
                   <a className='cursor-pointer text-sky-500 underline' onClick={handleUpgradeClick}>
-                    upgrade to {TierLabel.TEAM} or ${TierLabel.ENTERPRISE} Plan
+                    upgrade to {TierLabel.TEAM} or {TierLabel.ENTERPRISE} Plan
                   </a>
                   .
                 </>


### PR DESCRIPTION
Was peeping font weight 500, saw and yanked the extra `$` character in the help text.