### PR TITLE
fix: Public Teams Modal Layout on Safari

### DIFF
--- a/packages/client/components/DashNavList/PublicTeamsModal.tsx
+++ b/packages/client/components/DashNavList/PublicTeamsModal.tsx
@@ -32,19 +32,20 @@ const PublicTeamsModal = (props: Props) => {
 
   return (
     <Dialog isOpen={isOpen} onClose={onClose}>
-      <DialogContent className='z-10 overflow-scroll'>
+      <DialogContent className='z-10 flex flex-col pr-0'>
         <DialogTitle>{`${publicTeamsCount} ${plural(publicTeamsCount, 'Public Team', 'Public Teams')}`}</DialogTitle>
-        <DialogDescription>
+        <DialogDescription className='pr-6'>
           Join as a Team Member on any public teams at{' '}
           <span className='font-semibold'>{orgName}</span>
         </DialogDescription>
-        <hr className='my-2 border-t border-slate-300' />
-        {publicTeams.map((team, index) => (
-          <Fragment key={team.id}>
-            <PublicTeamItem teamRef={team} />
-            {index < publicTeams.length - 1 && <hr className='my-2 border-t border-slate-300' />}
-          </Fragment>
-        ))}
+        <div className='overflow-auto pr-6'>
+          {publicTeams.map((team) => (
+            <Fragment key={team.id}>
+              <hr className='my-2 border-t border-slate-300' />
+              <PublicTeamItem teamRef={team} />
+            </Fragment>
+          ))}
+        </div>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
# Description

overflow-scroll will always reserve the space for horizontal and vertical scrollbars, looking quite odd.
While at it, I also changed the scrollbar to only scroll the content, not the Dialog header with the close button.

## Demo

<img width="713" alt="image" src="https://github.com/user-attachments/assets/cb49260f-35a9-4751-89f9-9ba488439dde" />

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
