### PR TITLE
feat: team privacy UI updates

### DIFF
--- a/packages/client/components/AddTeamDialog.tsx
+++ b/packages/client/components/AddTeamDialog.tsx
@@ -15,6 +15,9 @@ import {DialogActions} from '../ui/Dialog/DialogActions'
 import {DialogContent} from '../ui/Dialog/DialogContent'
 import {DialogTitle} from '../ui/Dialog/DialogTitle'
 import {Input} from '../ui/Input/Input'
+import {Tooltip} from '../ui/Tooltip/Tooltip'
+import {TooltipContent} from '../ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '../ui/Tooltip/TooltipTrigger'
 import FlatPrimaryButton from './FlatPrimaryButton'
 import Toggle from './Toggle/Toggle'
 
@@ -152,39 +155,45 @@ const AddTeamDialog = (props: Props) => {
           <div className='flex items-center justify-between'>
             <div className='flex-1'>
               <label className={labelStyles}>Team Privacy</label>
-              <div className='text-xs text-slate-600'>
+              <div className='mt-1 text-xs text-slate-600'>
                 {isPublic ? (
-                  disablePrivacyToggle ? (
-                    <>
-                      Anyone in the organization can join this team. You can make this team private
-                      if you{' '}
-                      <span
-                        onClick={goToBilling}
-                        className='cursor-pointer font-semibold text-sky-500 outline-none hover:text-sky-600'
-                      >
-                        upgrade
-                      </span>
-                      .
-                    </>
-                  ) : (
-                    <span className='whitespace-nowrap'>
-                      Anyone in the organization can join this team
-                    </span>
-                  )
+                  <>
+                    <div>
+                      This team is <b>Public</b>. Anybody in the organization can find and join the
+                      team.
+                    </div>
+                    {disablePrivacyToggle && (
+                      <div className='mt-1'>
+                        <span
+                          onClick={goToBilling}
+                          className='cursor-pointer font-semibold text-sky-500 outline-none hover:text-sky-600'
+                        >
+                          Upgrade
+                        </span>{' '}
+                        to make private.
+                      </div>
+                    )}
+                  </>
                 ) : (
-                  <span className='whitespace-nowrap'>
-                    Only invited members can access this team
-                  </span>
+                  <div>
+                    This team is <b>Private</b>. New team members may join by invite only.
+                  </div>
                 )}
               </div>
             </div>
             <div className='flex items-center'>
-              <div className='mr-2 text-sm font-medium text-slate-700'>Public</div>
-              <Toggle
-                active={isPublic}
-                disabled={disablePrivacyToggle}
-                onClick={() => setIsPublic(!isPublic)}
-              />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <Toggle
+                      active={!isPublic}
+                      disabled={disablePrivacyToggle}
+                      onClick={() => setIsPublic(!isPublic)}
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{isPublic ? 'Set to private' : 'Set to public'}</TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </fieldset>

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -346,9 +346,19 @@ const NewTeamForm = (props: Props) => {
                         This team is <b>Public</b>. Anybody in the organization can find and join
                         the team.
                       </div>
-                      {disablePrivacyToggle && !isNewOrg && (
+                      {disablePrivacyToggle && (
                         <div className='mt-1'>
-                          <StyledLink onClick={goToBilling}>Upgrade</StyledLink> to make private.
+                          {isNewOrg ? (
+                            <>
+                              After creating your organization you can upgrade to make teams
+                              private.
+                            </>
+                          ) : (
+                            <>
+                              <StyledLink onClick={goToBilling}>Upgrade</StyledLink> to make it
+                              private.
+                            </>
+                          )}
                         </div>
                       )}
                     </>

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -134,7 +134,7 @@ const NewTeamForm = (props: Props) => {
     `,
     organizationsRef
   )
-  const [isPublic, setIsPublic] = useState(true)
+  const [isPublic, setIsPublic] = useState(false)
   const [isNewOrg, setIsNewOrg] = useState(isInitiallyNewOrg)
   const [orgId, setOrgId] = useState('')
   const [rawInvitees, setRawInvitees] = useState('')
@@ -346,14 +346,11 @@ const NewTeamForm = (props: Props) => {
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <div className='space-y-2'>
-                        <div>
-                          <b>Public teams:</b> Anyone in the organization can find and join the team
-                        </div>
-                        <div>
-                          <b>Private teams:</b> The team is hidden from other organization members
-                          and only invited members can access it
-                        </div>
+                      <div>
+                        <b>Public:</b> Visible to all organization members
+                      </div>
+                      <div>
+                        <b>Private:</b> Only visible to invited members
                       </div>
                     </TooltipContent>
                   </Tooltip>
@@ -383,9 +380,8 @@ const NewTeamForm = (props: Props) => {
               </div>
             </div>
             <div className='flex items-center'>
-              <div className='mr-2 text-sm font-medium text-slate-700'>Public</div>
               <Toggle
-                active={isPublic}
+                active={!isPublic}
                 disabled={disablePrivacyToggle}
                 onClick={() => setIsPublic(!isPublic)}
               />

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled'
-import {Info as InfoIcon} from '@mui/icons-material'
 import graphql from 'babel-plugin-relay/macro'
 import * as React from 'react'
 import {ChangeEvent, FormEvent, useState} from 'react'
@@ -339,21 +338,6 @@ const NewTeamForm = (props: Props) => {
               <div>
                 <div className='flex items-center'>
                   <div className='text-sm font-medium text-slate-700'>Team Privacy</div>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className='ml-2 flex cursor-pointer items-center text-slate-600'>
-                        <InfoIcon fontSize='small' />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <div>
-                        <b>Public</b>: Anybody in the organization can find and join the team.
-                      </div>
-                      <div>
-                        <b>Private</b>: New team members may join by invite only.
-                      </div>
-                    </TooltipContent>
-                  </Tooltip>
                 </div>
                 <div className='mt-1 w-full text-xs text-slate-600'>
                   {isPublic ? (
@@ -369,26 +353,26 @@ const NewTeamForm = (props: Props) => {
                       )}
                     </>
                   ) : (
-                    <>
-                      <div>
-                        This team is <b>Private</b>. New team members may join by invite only.
-                      </div>
-                      {disablePrivacyToggle && !isNewOrg && (
-                        <div className='mt-1'>
-                          <StyledLink onClick={goToBilling}>Upgrade</StyledLink> to make private.
-                        </div>
-                      )}
-                    </>
+                    <div>
+                      This team is <b>Private</b>. New team members may join by invite only.
+                    </div>
                   )}
                 </div>
               </div>
             </div>
             <div className='flex items-center'>
-              <Toggle
-                active={!isPublic}
-                disabled={disablePrivacyToggle}
-                onClick={() => setIsPublic(!isPublic)}
-              />
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <Toggle
+                      active={!isPublic}
+                      disabled={disablePrivacyToggle}
+                      onClick={() => setIsPublic(!isPublic)}
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{isPublic ? 'Set to private' : 'Set to public'}</TooltipContent>
+              </Tooltip>
             </div>
           </div>
           <p className='mt-8 mb-3 text-xs leading-4'>

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -134,7 +134,7 @@ const NewTeamForm = (props: Props) => {
     `,
     organizationsRef
   )
-  const [isPublic, setIsPublic] = useState(false)
+  const [isPublic, setIsPublic] = useState(true)
   const [isNewOrg, setIsNewOrg] = useState(isInitiallyNewOrg)
   const [orgId, setOrgId] = useState('')
   const [rawInvitees, setRawInvitees] = useState('')
@@ -347,34 +347,38 @@ const NewTeamForm = (props: Props) => {
                     </TooltipTrigger>
                     <TooltipContent>
                       <div>
-                        <b>Public:</b> Visible to all organization members
+                        <b>Public</b>: Anybody in the organization can find and join the team.
                       </div>
                       <div>
-                        <b>Private:</b> Only visible to invited members
+                        <b>Private</b>: New team members may join by invite only.
                       </div>
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <div className='mt-1 w-full max-w-[90%] text-xs text-slate-600'>
+                <div className='mt-1 w-full text-xs text-slate-600'>
                   {isPublic ? (
-                    disablePrivacyToggle ? (
-                      isNewOrg ? (
-                        <>After creating your organization you can upgrade to make teams private</>
-                      ) : (
-                        <>
-                          Anyone in the organization can join this team. You can make this team
-                          private if you <StyledLink onClick={goToBilling}>upgrade</StyledLink>.
-                        </>
-                      )
-                    ) : (
-                      <span className='whitespace-nowrap'>
-                        Anyone in the organization can join this team
-                      </span>
-                    )
+                    <>
+                      <div>
+                        This team is <b>Public</b>. Anybody in the organization can find and join
+                        the team.
+                      </div>
+                      {disablePrivacyToggle && !isNewOrg && (
+                        <div className='mt-1'>
+                          <StyledLink onClick={goToBilling}>Upgrade</StyledLink> to make private.
+                        </div>
+                      )}
+                    </>
                   ) : (
-                    <span className='whitespace-nowrap'>
-                      Only invited members can access this team
-                    </span>
+                    <>
+                      <div>
+                        This team is <b>Private</b>. New team members may join by invite only.
+                      </div>
+                      {disablePrivacyToggle && !isNewOrg && (
+                        <div className='mt-1'>
+                          <StyledLink onClick={goToBilling}>Upgrade</StyledLink> to make private.
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
               </div>

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -7,7 +7,9 @@ import useAtmosphere from '../../../../hooks/useAtmosphere'
 import useMutationProps from '../../../../hooks/useMutationProps'
 import useRouter from '../../../../hooks/useRouter'
 import ToggleTeamPrivacyMutation from '../../../../mutations/ToggleTeamPrivacyMutation'
-import {TierLabel} from '../../../../types/constEnums'
+import {Tooltip} from '../../../../ui/Tooltip/Tooltip'
+import {TooltipContent} from '../../../../ui/Tooltip/TooltipContent'
+import {TooltipTrigger} from '../../../../ui/Tooltip/TooltipTrigger'
 import TeamPrivacyConfirmModal from './TeamPrivacyConfirmModal'
 
 interface Props {
@@ -68,38 +70,43 @@ const TeamPrivacyToggle = (props: Props) => {
   return (
     <>
       <div className='flex w-full items-start justify-between'>
-        <div className='max-w-[80%] text-sm text-slate-700'>
+        <div className='text-sm text-slate-700'>
           <div className='text-sm text-slate-700'>
-            {isPublic
-              ? `${teamName} is currently public. Anyone in your organization can find and join this team.`
-              : `${teamName} is currently private. Only invited members can join this team.`}
+            {isPublic ? (
+              <>
+                <div>
+                  This team is <b>Public</b>. Anybody in the organization can find and join this
+                  team.
+                </div>
+                {isStarterTier && (
+                  <div className='mt-1 text-xs font-medium text-slate-600'>
+                    <a className='cursor-pointer text-sky-500' onClick={handleUpgradeClick}>
+                      Upgrade
+                    </a>{' '}
+                    to make it private.
+                  </div>
+                )}
+              </>
+            ) : (
+              <div>
+                This team is <b>Private</b>. New team members may join by invite only.
+              </div>
+            )}
           </div>
-
-          {isStarterTier && (
-            <div className='mt-2 text-xs font-medium text-slate-600'>
-              {isPublic ? (
-                <>
-                  To make this team private, you need to{' '}
-                  <a className='cursor-pointer text-sky-500 underline' onClick={handleUpgradeClick}>
-                    upgrade to {TierLabel.TEAM} or {TierLabel.ENTERPRISE} Plan
-                  </a>
-                  .
-                </>
-              ) : (
-                <>
-                  <b>Note</b>: Making this team public cannot be undone on the starter plan.
-                </>
-              )}
-            </div>
-          )}
         </div>
         <div className='ml-6 flex flex-shrink-0 items-center'>
-          <div className='mr-2 text-sm font-semibold text-slate-700'>Public</div>
-          <Toggle
-            active={isPublic}
-            disabled={submitting || (isPublic && isStarterTier)}
-            onClick={toggleTeamPrivacy}
-          />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <Toggle
+                  active={!isPublic}
+                  disabled={submitting || (isPublic && isStarterTier)}
+                  onClick={toggleTeamPrivacy}
+                />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>{isPublic ? 'Set to private' : 'Set to public'}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/11073

See figma feedback [here](https://www.figma.com/board/0M06dFpkcXjKq3aYeQIYbp/Team-Privacy?node-id=1-298&t=ykeYKDhCnYTh5KkY-0). 

![Screenshot 2025-03-27 at 16 55 54](https://github.com/user-attachments/assets/e8fc8134-8425-45e7-ab19-06ccc85c10a0)

![Screenshot 2025-03-27 at 16 29 11](https://github.com/user-attachments/assets/efe71edd-eefc-4742-820b-8eea7debd738)

![Screenshot 2025-03-27 at 17 01 00](https://github.com/user-attachments/assets/7c630228-c0a8-4af9-a937-783bb75b4cde)
![Screenshot 2025-03-27 at 17 04 46](https://github.com/user-attachments/assets/2cceef3e-52c3-4ef7-a56c-6479fced6702)
![Screenshot 2025-03-27 at 17 04 30](https://github.com/user-attachments/assets/2ad0748f-6489-4ca6-a82a-fee525ab5240)
![Screenshot 2025-03-27 at 17 04 49](https://github.com/user-attachments/assets/6bca63d9-8df9-4143-8e97-b39a4c77537e)


### To test

- [ ] Tooltip is now concise: Set to public/private
- [ ] Label removed from toggle
- [ ] Turning on the toggle now makes the team private rather than public
- [ ] Upgrade hyperlink is in the second line
- [ ] Handle use case where the user creates a new org 
- [ ] Info icon removed