### PR TITLE
feat: update OrgMembers component to display matched users in search results

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -234,7 +234,7 @@ const OrgMembers = (props: Props) => {
                 ? `${filteredOrgUsers.length} matched`
                 : `${organizationUsers.edges.length} total`}
               {selectedUserIds.length > 0 && (
-                <span className='ml-2 text-sky-600'>{selectedUserIds.length} selected</span>
+                <span className='ml-2 text-sky-600'>({selectedUserIds.length} selected)</span>
               )}
             </div>
             <div className='flex space-x-2'>

--- a/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgMembers/OrgMembers.tsx
@@ -230,9 +230,11 @@ const OrgMembers = (props: Props) => {
         <div className='flex h-10 items-center bg-slate-100 px-4'>
           <div className='flex w-full items-center justify-between'>
             <div className='flex items-center font-bold'>
-              {organizationUsers.edges.length} total
+              {searchInput
+                ? `${filteredOrgUsers.length} matched`
+                : `${organizationUsers.edges.length} total`}
               {selectedUserIds.length > 0 && (
-                <span className='ml-2 text-sky-600'>({selectedUserIds.length} selected)</span>
+                <span className='ml-2 text-sky-600'>{selectedUserIds.length} selected</span>
               )}
             </div>
             <div className='flex space-x-2'>
@@ -269,7 +271,7 @@ const OrgMembers = (props: Props) => {
               <tr className='border-b border-slate-300'>
                 <th className='w-[5%] p-3 text-left'>
                   <div className='flex items-center justify-center'>
-                    {isOrgAdmin && (
+                    {isOrgAdmin && filteredOrgUsers.length > 0 && (
                       <input
                         type='checkbox'
                         checked={isAllSelected}


### PR DESCRIPTION
# Description
Small UI changes:
1. After searching, display matched user count instead of always showing the total user count
2. Hide the select all checkbox if there are no matched users

## Demo
![2025-04-01 10 21 54](https://github.com/user-attachments/assets/5deb968f-1f0b-46a6-9b0c-0b4a616b2783)

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
