### PR TITLE
fix: gitlab & azure summaries show up

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryPokerStories.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryPokerStories.tsx
@@ -76,6 +76,10 @@ const SummaryPokerStories = (props: Props) => {
                       __typename
                       title
                     }
+                    ... on AzureDevOpsWorkItem {
+                      __typename
+                      title
+                    }
                   }
                 }
               }
@@ -110,6 +114,8 @@ const SummaryPokerStories = (props: Props) => {
                 } else if (integration?.__typename === '_xGitHubIssue') {
                   title = integration.title
                 } else if (integration?.__typename === '_xGitLabIssue') {
+                  title = integration.title
+                } else if (integration?.__typename === 'AzureDevOpsWorkItem') {
                   title = integration.title
                 }
                 const urlPath = `/meet/${meetingId}/estimate/${idx + 1}`

--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryPokerStories.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/SummaryPokerStories.tsx
@@ -72,6 +72,10 @@ const SummaryPokerStories = (props: Props) => {
                       number
                       title
                     }
+                    ... on _xGitLabIssue {
+                      __typename
+                      title
+                    }
                   }
                 }
               }
@@ -104,6 +108,8 @@ const SummaryPokerStories = (props: Props) => {
                 if (integration?.__typename === 'JiraIssue') {
                   title = integration.summary
                 } else if (integration?.__typename === '_xGitHubIssue') {
+                  title = integration.title
+                } else if (integration?.__typename === '_xGitLabIssue') {
                   title = integration.title
                 }
                 const urlPath = `/meet/${meetingId}/estimate/${idx + 1}`


### PR DESCRIPTION
Fix: https://github.com/ParabolInc/parabol/issues/11080

In prod, if you import GitLab or Azure issues into a Poker meeting, they don't show up in the summary. There's a generic message instead.

Now they do show up:
![Screenshot 2025-04-03 at 18 32 49](https://github.com/user-attachments/assets/1dc15450-2dae-4478-8bdf-34b758bc6b6b)

### AC

- [ ] Add Azure issues to a Poker meeting and see that the issues show up in the summary
- [ ] The same works for GitLab
- [ ] Clicking on the issue in the summary takes you to the issue in the Poker meeting