### PR TITLE
chore: remove S3 from Iron Bank action

### DIFF
--- a/.github/workflows/ironbank.yml
+++ b/.github/workflows/ironbank.yml
@@ -55,17 +55,6 @@ jobs:
       - name: Zip the files
         run: zip -r ${{ github.event.inputs.version_number }}.zip dist build ip-to-server_id
 
-      - name: Set up AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.IRONBANK_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.IRONBANK_AWS_SECRET_ACCESS_KEY }}
-          aws-region: "us-east-1"
-
-      - name: Upload to S3
-        run: |
-          aws s3 cp ${{ github.event.inputs.version_number }}.zip s3://ironbank-proving-ground-action-files.parabol.co/${{ github.event.inputs.version_number }}.zip
-
       - name: Upload to GCS
         uses: actions-hub/gcloud@master
         env:


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #[issue number]
Removes uploading to S3 for the Iron Bank GH action since we are deprecating.

## Demo

N/A

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
