### PR TITLE
fix: bugs found under production load with graphql-yoga

### DIFF
--- a/packages/embedder/custom.d.ts
+++ b/packages/embedder/custom.d.ts
@@ -1,4 +1,4 @@
-import type {DataLoaderInstance} from '../server/dataloader/RootDataLoader'
+import type {DataLoaderWorker} from '../server/graphql/graphql'
 import type {DB} from '../server/postgres/types/pg'
 import {JobQueueError} from './JobQueueError'
 
@@ -8,7 +8,7 @@ type GetInputData<T> = T extends JobQueueStepRun<infer U> ? U : never
 export type ParentJob<T> = GetInputData<T> | GetInputData<T>[]
 
 interface StepContext<TData> {
-  dataLoader: DataLoaderInstance
+  dataLoader: DataLoaderWorker
   data: TData
 }
 

--- a/packages/server/hocusPocus.ts
+++ b/packages/server/hocusPocus.ts
@@ -18,6 +18,7 @@ if (isNaN(port) || port < 0 || port > 65536) {
   throw new Error('Invalid Env Var: HOCUS_POCUS_PORT must be >= 0 and < 65536')
 }
 const server = Server.configure({
+  stopOnSignals: false,
   port,
   quiet: true,
   async onListen(data) {
@@ -92,3 +93,15 @@ const server = Server.configure({
 })
 
 server.listen()
+
+const signalHandler = async () => {
+  await server.destroy()
+  process.exit(0)
+}
+
+process.on('SIGINT', signalHandler)
+process.on('SIGQUIT', signalHandler)
+process.on('SIGTERM', async () => {
+  // DO NOT CALL process.exit(0), let the handler in server.js handle that
+  await server.destroy()
+})


### PR DESCRIPTION
# Description

fix #11117 
fix #11115 
fix #11114 
fix #11112

SIGTERM handler was exiting almost immediately because the hocusPocus server, which runs on the same process, was called `process.exit(0)` on SIGTERM when it was finished, which meant that the webserver was exiting before it was able to handle its graceful shutdown. 