### PR TITLE
fix: abs path for sourcemaps, add hc to blocklist for dd, disconnect query

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           yarn datadog-ci sourcemaps upload ./dist \
             --service=web \
             --release-version=${{env.ACTION_VERSION}} \
-            --minified-path-prefix="/parabol/dist/"
+            --minified-path-prefix="/home/node/parabol/dist/"
       - name: Report Status
         if: failure()
         uses: ravsamhq/notify-slack-action@v2

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -30,7 +30,12 @@ tracer.init({
   plugins: false,
   version: __APP_VERSION__
 })
-tracer.use('ioredis').use('http').use('pg')
+tracer
+  .use('ioredis')
+  .use('http', {
+    blocklist: ['/health', '/ready']
+  })
+  .use('pg')
 
 process.on('SIGTERM', async (signal) => {
   Logger.log(


### PR DESCRIPTION
# Description

- dd-trace-js http package should ignore logging all healthchecks
- dd-trace-js should use the absolute path for server sourcemaps
- disconnectSocket should take a variable socketId instead of context so future use will error

