### PR TITLE
chore: track upgrade clicks from public teams

### DIFF
--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -221,9 +221,9 @@ const NewTeamForm = (props: Props) => {
     }
   }
 
-  const goToBilling = (isPublicTrigger: boolean = false) => {
+  const goToBilling = (ctaLocation: 'publicTeams' | 'createTeam') => {
     SendClientSideEvent(atmosphere, 'Upgrade CTA Clicked', {
-      upgradeCTALocation: isPublicTrigger ? 'publicTeams' : 'createTeam',
+      upgradeCTALocation: ctaLocation,
       orgId,
       upgradeTier: 'team'
     })
@@ -329,7 +329,7 @@ const NewTeamForm = (props: Props) => {
               <BoldText>{lockedSelectedOrg.name}</BoldText>
               {` has reached the limit of `}
               <BoldText>{`${Threshold.MAX_STARTER_TIER_TEAMS} free teams.`} </BoldText>
-              <StyledLink onClick={() => goToBilling()}>Upgrade</StyledLink>
+              <StyledLink onClick={() => goToBilling('publicTeams')}>Upgrade</StyledLink>
               {' to create more teams.'}
             </WarningMsg>
           )}
@@ -355,8 +355,10 @@ const NewTeamForm = (props: Props) => {
                             </>
                           ) : (
                             <>
-                              <StyledLink onClick={() => goToBilling(true)}>Upgrade</StyledLink> to
-                              make it private.
+                              <StyledLink onClick={() => goToBilling('createTeam')}>
+                                Upgrade
+                              </StyledLink>{' '}
+                              to make it private.
                             </>
                           )}
                         </div>

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -221,9 +221,9 @@ const NewTeamForm = (props: Props) => {
     }
   }
 
-  const goToBilling = () => {
+  const goToBilling = (isPublicTrigger: boolean = false) => {
     SendClientSideEvent(atmosphere, 'Upgrade CTA Clicked', {
-      upgradeCTALocation: 'createTeam',
+      upgradeCTALocation: isPublicTrigger ? 'publicTeams' : 'createTeam',
       orgId,
       upgradeTier: 'team'
     })

--- a/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
+++ b/packages/client/modules/newTeam/components/NewTeamForm/NewTeamForm.tsx
@@ -329,7 +329,7 @@ const NewTeamForm = (props: Props) => {
               <BoldText>{lockedSelectedOrg.name}</BoldText>
               {` has reached the limit of `}
               <BoldText>{`${Threshold.MAX_STARTER_TIER_TEAMS} free teams.`} </BoldText>
-              <StyledLink onClick={goToBilling}>Upgrade</StyledLink>
+              <StyledLink onClick={() => goToBilling()}>Upgrade</StyledLink>
               {' to create more teams.'}
             </WarningMsg>
           )}
@@ -355,8 +355,8 @@ const NewTeamForm = (props: Props) => {
                             </>
                           ) : (
                             <>
-                              <StyledLink onClick={goToBilling}>Upgrade</StyledLink> to make it
-                              private.
+                              <StyledLink onClick={() => goToBilling(true)}>Upgrade</StyledLink> to
+                              make it private.
                             </>
                           )}
                         </div>

--- a/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
+++ b/packages/client/modules/teamDashboard/components/TeamSettings/TeamPrivacyToggle.tsx
@@ -10,6 +10,7 @@ import ToggleTeamPrivacyMutation from '../../../../mutations/ToggleTeamPrivacyMu
 import {Tooltip} from '../../../../ui/Tooltip/Tooltip'
 import {TooltipContent} from '../../../../ui/Tooltip/TooltipContent'
 import {TooltipTrigger} from '../../../../ui/Tooltip/TooltipTrigger'
+import SendClientSideEvent from '../../../../utils/SendClientSideEvent'
 import TeamPrivacyConfirmModal from './TeamPrivacyConfirmModal'
 
 interface Props {
@@ -65,6 +66,10 @@ const TeamPrivacyToggle = (props: Props) => {
 
   const handleUpgradeClick = () => {
     history.push(`/me/organizations/${orgId}`)
+    SendClientSideEvent(atmosphere, 'Upgrade CTA Clicked', {
+      upgradeCTALocation: 'publicTeams',
+      orgId
+    })
   }
 
   return (

--- a/packages/client/shared/UpgradeCTALocationEnumType.d.ts
+++ b/packages/client/shared/UpgradeCTALocationEnumType.d.ts
@@ -16,3 +16,4 @@ export type UpgradeCTALocationEnumType =
   | 'createNewTemplateAL'
   | 'cloneTemplateAL'
   | 'meetingSettingsTeamHealth'
+  | 'publicTeams'


### PR DESCRIPTION
This PR helps us track when users click to upgrade after discovering Private teams is a premium feature.