### PR TITLE
fix: ensure public teams are public for org admins

### DIFF
--- a/packages/client/components/DashNavList/DashNavListTeams.tsx
+++ b/packages/client/components/DashNavList/DashNavListTeams.tsx
@@ -33,6 +33,7 @@ const DashNavListTeams = (props: Props) => {
           ...DashNavListTeam @relay(mask: false)
           ...PublicTeamsModal_team
           isViewerOnTeam
+          isPublic
         }
       }
     `,
@@ -41,7 +42,7 @@ const DashNavListTeams = (props: Props) => {
   const [showModal, setShowModal] = useState(false)
   const allTeams = organization.teams
   const viewerTeams = allTeams.filter((team) => team.isViewerOnTeam)
-  const publicTeams = allTeams.filter((team) => !team.isViewerOnTeam)
+  const publicTeams = allTeams.filter((team) => !team.isViewerOnTeam && team.isPublic)
   const publicTeamsCount = publicTeams.length
 
   const handleClose = () => {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/11157

### To test

- [ ] Org admins do not see private teams they're not a member of in the public teams modal