### PR TITLE
fix: multipart header vuln

### DIFF
--- a/packages/server/yoga.ts
+++ b/packages/server/yoga.ts
@@ -57,6 +57,29 @@ export const getPersistedOperation = async (docId: string) => {
 export const yoga = createYoga<ServerContext, UserContext>({
   graphqlEndpoint: '/graphql',
   landingPage: false,
+  fetchAPI: {
+    fetch,
+    Headers,
+    Request,
+    Response,
+    FormData,
+    ReadableStream,
+    WritableStream,
+    TransformStream,
+    CompressionStream,
+    DecompressionStream,
+    TextDecoderStream,
+    TextEncoderStream,
+    Blob,
+    File,
+    crypto,
+    btoa,
+    TextEncoder,
+    TextDecoder,
+    URL,
+    URLSearchParams
+  },
+  graphiql: false,
   plugins: [
     useDatadogTracing({
       excludeArgs: {


### PR DESCRIPTION
# Description

fixes a vuln where `@whatwg-node/fetch` did not catch errors from busboy, which meant the error would propagate to the top level and crash the server.
Using native undici the error is still reported, but now it gets caught.
 