### PR TITLE
fix: remove referece to dispose fn

### DIFF
--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -180,7 +180,10 @@ export const wsHandler = makeBehavior<{token?: string}>({
         wsHandler?.message?.(ctx.extra.socket, arrayBuffer, false)
       }
     } else {
-      dispose[id] = () => dataLoader!.dispose()
+      dispose[id] = () => {
+        delete dispose[id]
+        dataLoader!.dispose()
+      }
     }
     const args: EnvelopedExecutionArgs = {
       schema: authToken.rol === 'su' ? privateSchema : schema,
@@ -196,6 +199,9 @@ export const wsHandler = makeBehavior<{token?: string}>({
     return args
   },
   onComplete: (ctx, id) => {
+    ctx.extra.dispose[id]?.()
+  },
+  onError: (ctx, id) => {
     ctx.extra.dispose[id]?.()
   },
   onDisconnect: async (ctx) => {


### PR DESCRIPTION
# Description

fixes a memory leak where after disposing, we still hung on to the dispose function, which held on to the dataloader, so it didn't really do much disposing.
also calling dipose in `onError` for future proofing because if the query fails validation then onComplete never gets called

