### PR TITLE
fix: Dragging reflections would crash if subscription did not work

### DIFF
--- a/packages/client/mutations/UpdateDragLocationMutation.ts
+++ b/packages/client/mutations/UpdateDragLocationMutation.ts
@@ -30,7 +30,7 @@ const UpdateDragLocationMutation = (
   atmosphere: Atmosphere,
   variables: TUpdateDragLocationMutation['variables']
 ) => {
-  atmosphere.subscriptionClient.subscribe(
+  atmosphere.subscriptionClient?.subscribe(
     {operationName: name, docId: id, query: '', variables} as any,
     noopSink
   )


### PR DESCRIPTION

# Description

Fixes #11228
This just fixes the symptom, we should get subscriptions working for these few users again.


## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

- [ ] Connect to the app through ngrok
- [ ] drag a reflection card in grouping

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
