### PR TITLE
fix: db:start command created the dev folder with the current user

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pg:build": "pgtyped -c ./packages/server/postgres/pgtypedConfig.js",
     "pg:generate": "bash -c 'set -a; source .env; set +a; ./node_modules/.bin/kysely-codegen --exclude-pattern \"(StripeQuantityMismatchLogging)\" --out-file ./packages/server/postgres/types/pg.d.ts --dialect postgres --url \"postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB\" && prettier --write ./packages/server/postgres/types/pg.d.ts'",
     "pg:restore": "node ./scripts/toolbox/pgRestore.js",
-    "db:start": "docker compose -f docker/stacks/development/docker-compose.yml up -d",
+    "db:start": "mkdir -p dev && docker compose -f docker/stacks/development/docker-compose.yml up -d",
     "db:stop": "docker compose -f docker/stacks/development/docker-compose.yml down",
     "predeploy": "node dist/preDeploy.js",
     "dev": "bash -c 'set -a; source .env; set +a; PM2_SILENT=true pm2 start pm2.dev.config.js --no-daemon'",


### PR DESCRIPTION
# Description

I couldn't run `yarn dev` locally after running `yarn && yarn db:start` for multiple reasons:
- `dev` folder was created by Docker and owned by root. Then, yarn dev couldn't access to it.
- `yarn dev` wouldn't work until I ran `yarn pg:build && yarn relay:build`

This PR fixes the first