### PR TITLE
fix: disconnectAllSockets accepts an input parameters for the disconnect window

### DIFF
--- a/packages/server/disconnectAllSockets.ts
+++ b/packages/server/disconnectAllSockets.ts
@@ -1,11 +1,11 @@
 import sleep from '../client/utils/sleep'
 import {activeClients} from './activeClients'
 
-export const disconnectAllSockets = async () => {
+export const disconnectAllSockets = async (disconnectWindow: number = 60_000) => {
   const ONDISCONNECT_LIMIT = 3000
   const connectionsToClose = Array.from(activeClients.values())
   if (connectionsToClose.length > 0) {
-    const msPerClose = (60_000 - ONDISCONNECT_LIMIT) / connectionsToClose.length
+    const msPerClose = (disconnectWindow - ONDISCONNECT_LIMIT) / connectionsToClose.length
     const closeEvery = Math.min(200, msPerClose)
     await Promise.allSettled(
       connectionsToClose.map(async (extra, idx) => {

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -43,7 +43,7 @@ process.on('SIGTERM', async (signal) => {
     `Server ID: ${process.env.SERVER_ID}. Kill signal received: ${signal}, starting graceful shutdown of ${RECONNECT_WINDOW}ms.`
   )
   setIsShuttingDown()
-  await disconnectAllSockets()
+  await disconnectAllSockets(RECONNECT_WINDOW)
   Logger.log(`Server ID: ${process.env.SERVER_ID}. Graceful shutdown complete, exiting.`)
   process.exit()
 })


### PR DESCRIPTION
# Description
Last changes in the PR [dump sockets before dumping heap](https://github.com/ParabolInc/parabol/pull/11213/files#diff-9e1fec50a8f6703395e589001a25d389729e6ef1e8a99fed70688afbd9bc2d38L51) removed the use of the app var `RECONNECT_WINDOW` that is used in our non-production environments. This PR adds that option back to the current code.