### PR TITLE
fix: Handle publish taking longer than 30s

### DIFF
--- a/packages/server/billing/helpers/removeTeamsLimitObjects.ts
+++ b/packages/server/billing/helpers/removeTeamsLimitObjects.ts
@@ -3,6 +3,9 @@ import updateNotification from '../../graphql/public/mutations/helpers/updateNot
 import getKysely from '../../postgres/getKysely'
 
 const removeTeamsLimitObjects = async (orgId: string, dataLoader: DataLoaderWorker) => {
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
+
   const removeJobTypes = ['LOCK_ORGANIZATION', 'WARN_ORGANIZATION'] as const
   const removeNotificationTypes = ['TEAMS_LIMIT_EXCEEDED', 'TEAMS_LIMIT_REMINDER'] as const
   const pg = getKysely()
@@ -18,9 +21,6 @@ const removeTeamsLimitObjects = async (orgId: string, dataLoader: DataLoaderWork
     .where('type', 'in', removeNotificationTypes)
     .returning(['id', 'userId'])
     .execute()
-
-  const operationId = dataLoader.share()
-  const subOptions = {operationId}
 
   updateNotificationsChanges?.forEach((change) => {
     updateNotification(change, subOptions)

--- a/packages/server/database/types/processTeamsLimitsJob.ts
+++ b/packages/server/database/types/processTeamsLimitsJob.ts
@@ -7,6 +7,8 @@ import getKysely from '../../postgres/getKysely'
 import ScheduledTeamLimitsJob from './ScheduledTeamLimitsJob'
 
 const processTeamsLimitsJob = async (job: ScheduledTeamLimitsJob, dataLoader: DataLoaderWorker) => {
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
   const {orgId, type} = job
   const [organization, orgUsers] = await Promise.all([
     dataLoader.get('organizations').loadNonNull(orgId),
@@ -45,8 +47,6 @@ const processTeamsLimitsJob = async (job: ScheduledTeamLimitsJob, dataLoader: Da
     }))
 
     await getKysely().insertInto('Notification').values(notificationsToInsert).execute()
-    const operationId = dataLoader.share()
-    const subOptions = {operationId}
     notificationsToInsert.forEach((notification) => {
       publishNotification(notification, subOptions)
     })

--- a/packages/server/graphql/mutations/helpers/generateAIGroupTitle.ts
+++ b/packages/server/graphql/mutations/helpers/generateAIGroupTitle.ts
@@ -16,6 +16,8 @@ const generateAIGroupTitle = async (
   meetingId: string,
   dataLoader: DataLoaderWorker
 ) => {
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
   const manager = new OpenAIServerManager()
   const aiTitle = await manager.generateGroupTitle(reflections)
   const newTitle = aiTitle ?? getSimpleGroupTitle(reflections)
@@ -31,7 +33,7 @@ const generateAIGroupTitle = async (
       reflectionGroupId,
       title: aiTitle
     },
-    {operationId: dataLoader.share()}
+    subOptions
   )
 }
 

--- a/packages/server/graphql/mutations/helpers/generateGroups.ts
+++ b/packages/server/graphql/mutations/helpers/generateGroups.ts
@@ -14,6 +14,8 @@ const generateGroups = async (
   dataLoader: DataLoaderWorker
 ) => {
   if (reflections.length === 0) return
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
   const {meetingId} = reflections[0]!
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   if (!(await canAccessAI(team, dataLoader))) return
@@ -58,8 +60,6 @@ const generateGroups = async (
   const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
   const {facilitatorUserId} = meeting
   const data = {meetingId}
-  const operationId = dataLoader.share()
-  const subOptions = {operationId}
   const user = await dataLoader.get('users').loadNonNull(facilitatorUserId!)
   analytics.suggestedGroupsGenerated(user, meetingId, teamId)
   publish(SubscriptionChannel.MEETING, meetingId, 'GenerateGroupsSuccess', data, subOptions)

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -33,6 +33,8 @@ const getTranscription = async (recallBotId?: string | null) => {
 
 const summarizeRetroMeeting = async (meeting: RetrospectiveMeeting, context: InternalContext) => {
   const {dataLoader} = context
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
   const {id: meetingId, phases, teamId, recallBotId} = meeting
   const pg = getKysely()
   const [reflectionGroups, reflections, sentimentScore, transcription] = await Promise.all([
@@ -75,8 +77,6 @@ const summarizeRetroMeeting = async (meeting: RetrospectiveMeeting, context: Int
   // wait for meeting stats to be generated before sending Slack notification
   IntegrationNotifier.endMeeting(dataLoader, meetingId, teamId)
   const data = {meetingId}
-  const operationId = dataLoader.share()
-  const subOptions = {operationId}
   publish(SubscriptionChannel.MEETING, meetingId, 'EndRetrospectiveSuccess', data, subOptions)
 }
 

--- a/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndTeamPrompt.ts
@@ -17,6 +17,8 @@ import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
 
 const summarizeTeamPrompt = async (meeting: TeamPromptMeeting, context: InternalContext) => {
   const {dataLoader} = context
+  const operationId = dataLoader.share()
+  const subOptions = {operationId}
   const pg = getKysely()
 
   const summary = await generateStandupMeetingSummary(meeting, dataLoader)
@@ -29,8 +31,6 @@ const summarizeTeamPrompt = async (meeting: TeamPromptMeeting, context: Internal
   // wait for meeting stats to be generated before sending Slack notification
   IntegrationNotifier.endMeeting(dataLoader, meeting.id, meeting.teamId)
   const data = {meetingId: meeting.id}
-  const operationId = dataLoader.share()
-  const subOptions = {operationId}
   publish(SubscriptionChannel.MEETING, meeting.id, 'EndTeamPromptSuccess', data, subOptions)
 }
 

--- a/packages/server/utils/publish.ts
+++ b/packages/server/utils/publish.ts
@@ -13,7 +13,11 @@ const REDIS_DATALOADER_TTL = 25_000
 class PublishedDataLoaders {
   private promiseLookup = {} as Record<string, Promise<void>>
   private async pushToRedis(id: string) {
-    const dataLoaderWorker = getInMemoryDataLoader(id)!.dataLoaderWorker
+    const dataLoaderWorker = getInMemoryDataLoader(id)?.dataLoaderWorker
+    if (!dataLoaderWorker) {
+      // publish did not happen within SHARED_DATALOADER_TTL
+      return
+    }
     const buffer = await serializeDataLoader(dataLoaderWorker)
     // keep the serialized dataloader in redis for long enough for each server to fetch it and make an in-memory copy
     await getRedis().set(`dataLoader:${id}`, buffer, 'PX', REDIS_DATALOADER_TTL)


### PR DESCRIPTION
# Description

If publish gets called after the mutation is finished, the dataloader might already be disposed. This can happen either by not sharing it early enough or the operation taking longer than the shared dataloader ttl of 30s.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

* Add a `await sleep(40000)` in `generateGroups`: https://github.com/ParabolInc/parabol/blob/057a60cb86d5b874b65189a9834a6f6e2ce1c82d/packages/server/graphql/mutations/helpers/generateGroups.ts#L19
* add reflections and finish the reflect phase with AI enabled
* wait for the group suggestions

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
