### PR TITLE
fix: Switch to @whatwg/fetch throughout the server

### DIFF
--- a/packages/embedder/ai_models/helpers/fetchWithRetry.ts
+++ b/packages/embedder/ai_models/helpers/fetchWithRetry.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {Logger} from '../../../server/utils/Logger'
 
 interface FetchWithRetryOptions extends RequestInit {

--- a/packages/server/fileStorage/GCSManager.ts
+++ b/packages/server/fileStorage/GCSManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {sign} from 'jsonwebtoken'
 import mime from 'mime-types'
 import path from 'path'

--- a/packages/server/graphql/nestedSchema/nestGitLabEndpoint.ts
+++ b/packages/server/graphql/nestedSchema/nestGitLabEndpoint.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {GraphQLObjectType, GraphQLResolveInfo, OperationDefinitionNode, parse, print} from 'graphql'
 import nestGraphQLEndpoint from 'nest-graphql-endpoint/lib/nestGraphQLEndpoint'
 import {

--- a/packages/server/graphql/public/mutations/embedUserAsset.ts
+++ b/packages/server/graphql/public/mutations/embedUserAsset.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import base64url from 'base64url'
 import {createHash} from 'crypto'
 import mime from 'mime-types'

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import base64url from 'base64url'
 import {sql} from 'kysely'
 import ms from 'ms'

--- a/packages/server/hubSpot/backfillHubSpot.ts
+++ b/packages/server/hubSpot/backfillHubSpot.ts
@@ -1,4 +1,5 @@
 // call with yarn sucrase-node hubSpot/backfillHubSpot.ts
+import {fetch} from '@whatwg-node/fetch'
 import '../../../scripts/webpack/utils/dotenv'
 import {getUsersByEmails} from '../postgres/queries/getUsersByEmails'
 import {Logger} from '../utils/Logger'

--- a/packages/server/hubSpot/hubSpotApi.ts
+++ b/packages/server/hubSpot/hubSpotApi.ts
@@ -1,3 +1,5 @@
+import {fetch} from '@whatwg-node/fetch'
+
 const accessToken = process.env.HUBSPOT_API_KEY
 
 type Company = {

--- a/packages/server/integrations/helpers/authorizeOAuth2.ts
+++ b/packages/server/integrations/helpers/authorizeOAuth2.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {OAuth2Error, OAuth2Success} from '../../types/custom'
 
 type OAuth2Response = OAuth2Success | OAuth2Error

--- a/packages/server/integrations/jiraServer/JiraServerOAuth1Manager.ts
+++ b/packages/server/integrations/jiraServer/JiraServerOAuth1Manager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import crypto from 'crypto'
 import OAuth from 'oauth-1.0a'
 import appOrigin from '../../appOrigin'

--- a/packages/server/integrations/jiraServer/JiraServerRestManager.ts
+++ b/packages/server/integrations/jiraServer/JiraServerRestManager.ts
@@ -1,4 +1,5 @@
 import {generateText, JSONContent} from '@tiptap/core'
+import {fetch} from '@whatwg-node/fetch'
 import crypto from 'crypto'
 import OAuth from 'oauth-1.0a'
 import {serverTipTapExtensions} from 'parabol-client/shared/tiptap/serverTipTapExtensions'

--- a/packages/server/jiraImagesHandler.ts
+++ b/packages/server/jiraImagesHandler.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {HttpRequest, HttpResponse} from 'uWebSockets.js'
 import jiraPlaceholder from '../../static/images/illustrations/imageNotFound.png'
 import sleep from '../client/utils/sleep'

--- a/packages/server/utils/AtlassianServerManager.ts
+++ b/packages/server/utils/AtlassianServerManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import JiraIssueId from 'parabol-client/shared/gqlIds/JiraIssueId'
 import JiraProjectKeyId from 'parabol-client/shared/gqlIds/JiraProjectKeyId'
 import {SprintPokerDefaults} from 'parabol-client/types/constEnums'
@@ -276,7 +277,7 @@ interface JiraPageBean<T> {
 export type JiraScreensResponse = JiraPageBean<JiraScreen>
 
 class AtlassianServerManager extends AtlassianManager {
-  fetch = fetch as any
+  fetch = fetch
   static async init(code: string) {
     return AtlassianServerManager.fetchToken({
       grant_type: 'authorization_code',

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -1,4 +1,5 @@
 import {JSONContent} from '@tiptap/core'
+import {fetch} from '@whatwg-node/fetch'
 import tracer from 'dd-trace'
 import AzureDevOpsIssueId from 'parabol-client/shared/gqlIds/AzureDevOpsIssueId'
 import IntegrationHash from 'parabol-client/shared/gqlIds/IntegrationHash'

--- a/packages/server/utils/GoogleServerManager.ts
+++ b/packages/server/utils/GoogleServerManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {decode} from 'jsonwebtoken'
 import GoogleManager from 'parabol-client/utils/GoogleManager'
 import makeAppURL from 'parabol-client/utils/makeAppURL'

--- a/packages/server/utils/MSTeamsServerManager.ts
+++ b/packages/server/utils/MSTeamsServerManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 // MS Teams is a server-only integration for now, unlike the Slack integration
 
 // We're following a similar manager pattern here should we wish to refactor the

--- a/packages/server/utils/MattermostServerManager.ts
+++ b/packages/server/utils/MattermostServerManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {createSigner, httpbis} from 'http-message-signatures'
 // Mattermost is a server-only integration for now, unlike the Slack integration
 

--- a/packages/server/utils/MicrosoftServerManager.ts
+++ b/packages/server/utils/MicrosoftServerManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {decode} from 'jsonwebtoken'
 import MicrosoftManager from 'parabol-client/utils/MicrosoftManager'
 import makeAppURL from 'parabol-client/utils/makeAppURL'

--- a/packages/server/utils/SlackServerManager.ts
+++ b/packages/server/utils/SlackServerManager.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import SlackManager from 'parabol-client/utils/SlackManager'
 import {stringify} from 'querystring'
 import {makeOAuth2Redirect} from './makeOAuth2Redirect'

--- a/packages/server/utils/TenorManager.ts
+++ b/packages/server/utils/TenorManager.ts
@@ -1,3 +1,5 @@
+import {fetch} from '@whatwg-node/fetch'
+
 const MAX_REQUEST_TIME = 5000
 
 interface TenorResponse {

--- a/packages/server/utils/fetchGQL.ts
+++ b/packages/server/utils/fetchGQL.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import appOrigin from '../appOrigin'
 import ServerAuthToken from '../database/types/ServerAuthToken'
 import encodeAuthToken from './encodeAuthToken'

--- a/packages/server/utils/getSSOMetadataFromURL.ts
+++ b/packages/server/utils/getSSOMetadataFromURL.ts
@@ -1,3 +1,5 @@
+import {fetch} from '@whatwg-node/fetch'
+
 export const getSSOMetadataFromURL = async (metadataURL: string) => {
   const normalizedURL = metadataURL.trim()
   if (!normalizedURL.startsWith('https://'))


### PR DESCRIPTION
# Description

Relates to @11243
We don't know if this fixes anything, but we're using @whatwg/fetch in yoga, so there is no reason to use a different fetch in other parts of the server.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
