### PR TITLE
fix: dont show person is typing if anonymous comment

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -140,7 +140,7 @@ const DiscussionThreadInput = (props: Props) => {
     onEscape: clearReplyingTo
   })
 
-  useTipTapTypingStatus(editor, discussionId)
+  useTipTapTypingStatus(editor, discussionId, isAnonymousComment)
   const {submitting, onError, onCompleted, submitMutation} = useMutationProps()
 
   useInitialLocalState(discussionId, 'isAnonymousComment', false)

--- a/packages/client/hooks/useTipTapTypingStatus.ts
+++ b/packages/client/hooks/useTipTapTypingStatus.ts
@@ -3,13 +3,17 @@ import {useEffect, useRef, useState} from 'react'
 import EditCommentingMutation from '../mutations/EditCommentingMutation'
 import useAtmosphere from './useAtmosphere'
 
-export const useTipTapTypingStatus = (editor: Editor | null, discussionId: string) => {
+export const useTipTapTypingStatus = (
+  editor: Editor | null,
+  discussionId: string,
+  isAnonymous: boolean
+) => {
   const [isTyping, setIsTyping] = useState<boolean | null>(null)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const atmosphere = useAtmosphere()
 
   useEffect(() => {
-    if (!editor) return
+    if (!editor || isAnonymous) return
     const handleUpdate = () => {
       if (editor.isEmpty) return
       setIsTyping(true)
@@ -32,7 +36,7 @@ export const useTipTapTypingStatus = (editor: Editor | null, discussionId: strin
       editor.off('blur', handleBlur)
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
     }
-  }, [editor])
+  }, [editor, isAnonymous])
 
   useEffect(() => {
     if (isTyping === null) return


### PR DESCRIPTION
Demo: https://www.loom.com/share/378205e8be8e461e9752337f0a53ff4f

Fix https://github.com/ParabolInc/parabol/issues/10953

### To test

- [ ] Click to add an anonymous comment, start typing, and see that it doesn't say that the user is typing 