### PR TITLE
fix: ensure process recurrence runs sequentially

### DIFF
--- a/packages/server/graphql/private/mutations/helpers/checkSequential.ts
+++ b/packages/server/graphql/private/mutations/helpers/checkSequential.ts
@@ -1,13 +1,16 @@
-import {GraphQLResolveInfo} from "graphql";
-import {ErrorPayload, ResolverFn} from "../../resolverTypes";
-import getRedis from "../../../../utils/getRedis";
-import Redlock from "redlock";
-import standardError from "../../../../utils/standardError";
+import {GraphQLResolveInfo} from 'graphql'
+import Redlock from 'redlock'
+import getRedis from '../../../../utils/getRedis'
+import standardError from '../../../../utils/standardError'
+import {ErrorPayload, ResolverFn} from '../../resolverTypes'
 
 /**
  * Check if a resolver is already running for this mutation and if so, return an error.
  */
-export const checkSequential = <TSuccessPayload, TResult extends ErrorPayload | TSuccessPayload, TParent, TContext, TArgs>(resolver: ResolverFn<TResult, TParent, TContext, TArgs>) => (
+export const checkSequential =
+  <TSuccessPayload, TResult extends ErrorPayload | TSuccessPayload, TParent, TContext, TArgs>(
+    resolver: ResolverFn<TResult, TParent, TContext, TArgs>
+  ) =>
   async (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => {
     const {fieldName} = info
     const redis = getRedis()
@@ -17,11 +20,9 @@ export const checkSequential = <TSuccessPayload, TResult extends ErrorPayload | 
       console.log(`Attempting to acquire lock for ${fieldName}`)
       return await redlock.using([`checkSequential_${fieldName}`], 10_000, async () => {
         console.log(`Lock acquired for ${fieldName}`)
-        return resolver(parent, args, context, info);
+        return resolver(parent, args, context, info)
       })
     } catch (error) {
       return standardError(new Error(`Mutation ${fieldName} is already running`))
     }
   }
-)
-

--- a/packages/server/graphql/private/mutations/helpers/checkSequential.ts
+++ b/packages/server/graphql/private/mutations/helpers/checkSequential.ts
@@ -1,0 +1,27 @@
+import {GraphQLResolveInfo} from "graphql";
+import {ErrorPayload, ResolverFn} from "../../resolverTypes";
+import getRedis from "../../../../utils/getRedis";
+import Redlock from "redlock";
+import standardError from "../../../../utils/standardError";
+
+/**
+ * Check if a resolver is already running for this mutation and if so, return an error.
+ */
+export const checkSequential = <TSuccessPayload, TResult extends ErrorPayload | TSuccessPayload, TParent, TContext, TArgs>(resolver: ResolverFn<TResult, TParent, TContext, TArgs>) => (
+  async (parent: TParent, args: TArgs, context: TContext, info: GraphQLResolveInfo) => {
+    const {fieldName} = info
+    const redis = getRedis()
+    const redlock = new Redlock([redis], {retryCount: 0})
+
+    try {
+      console.log(`Attempting to acquire lock for ${fieldName}`)
+      return await redlock.using([`checkSequential_${fieldName}`], 10_000, async () => {
+        console.log(`Lock acquired for ${fieldName}`)
+        return resolver(parent, args, context, info);
+      })
+    } catch (error) {
+      return standardError(new Error(`Mutation ${fieldName} is already running`))
+    }
+  }
+)
+

--- a/packages/server/graphql/private/mutations/helpers/checkSequential.ts
+++ b/packages/server/graphql/private/mutations/helpers/checkSequential.ts
@@ -17,9 +17,7 @@ export const checkSequential =
     const redlock = new Redlock([redis], {retryCount: 0})
 
     try {
-      console.log(`Attempting to acquire lock for ${fieldName}`)
       return await redlock.using([`checkSequential_${fieldName}`], 10_000, async () => {
-        console.log(`Lock acquired for ${fieldName}`)
         return resolver(parent, args, context, info)
       })
     } catch (error) {

--- a/packages/server/graphql/private/mutations/processRecurrence.ts
+++ b/packages/server/graphql/private/mutations/processRecurrence.ts
@@ -24,6 +24,7 @@ import safeEndRetrospective from '../../mutations/helpers/safeEndRetrospective'
 import safeEndTeamPrompt from '../../mutations/helpers/safeEndTeamPrompt'
 import {stopMeetingSeries} from '../../public/mutations/updateRecurrenceSettings'
 import {MutationResolvers} from '../resolverTypes'
+import {checkSequential} from './helpers/checkSequential'
 
 const startRecurringMeeting = async (
   meetingSeries: MeetingSeries,
@@ -105,7 +106,7 @@ const startRecurringMeeting = async (
   return undefined
 }
 
-const processRecurrence: MutationResolvers['processRecurrence'] = async (
+const processRecurrence: MutationResolvers['processRecurrence'] = checkSequential(async (
   _source,
   _args,
   context
@@ -207,6 +208,6 @@ const processRecurrence: MutationResolvers['processRecurrence'] = async (
 
   const data = {meetingsStarted, meetingsEnded}
   return data
-}
+})
 
 export default processRecurrence


### PR DESCRIPTION
# Description

Fixes #11261 
Wrap the resolver in a lock function which returns an error if it's already running somewhere.

## Demo

```
3:21:00 2|Socket Server                  | {"time":"2025-04-30T11:21:00.014Z","level":"info","message":"🌱 Chronos Job processRecurrence: TICK []"}
13:21:00 4|Socket Server                  | {"time":"2025-04-30T11:21:00.016Z","level":"info","message":"🌱 Chronos Job processRecurrence: TICK []"}
13:21:00 1|Socket Server                  | {"time":"2025-04-30T11:21:00.017Z","level":"info","message":"🌱 Chronos Job processRecurrence: TICK []"}
13:21:00 1|Socket Server                  | Attempting to acquire lock for processRecurrence
13:21:00 8|Socket Server                  | {"time":"2025-04-30T11:21:00.021Z","level":"info","message":"🌱 Chronos Job processRecurrence: TICK []"}
13:21:00 1|Socket Server                  | Lock acquired for processRecurrence
13:21:00 2|Socket Server                  | Attempting to acquire lock for processRecurrence
13:21:00 4|Socket Server                  | Attempting to acquire lock for processRecurrence
13:21:00 8|Socket Server                  | Attempting to acquire lock for processRecurrence
13:21:00 8|Socket Server                  | {"time":"2025-04-30T11:21:00.063Z","level":"info","message":"SEND TO SENTRY [\n  Error: Mutation processRecurrence is already running\n      at /Volumes/User/parabol/dev/web.js:19999:49\n      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n      at async Object.processRecurrence (/Volumes/User/parabol/dev/web.js:75:14)\n      at async callGQL (/Volumes/User/parabol/dev/web.js:71603:18),\n  { tags: undefined }\n]"}
13:21:00 2|Socket Server                  | {"time":"2025-04-30T11:21:00.063Z","level":"info","message":"SEND TO SENTRY [\n  Error: Mutation processRecurrence is already running\n      at /Volumes/User/parabol/dev/web.js:19999:49\n      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n      at async Object.processRecurrence (/Volumes/User/parabol/dev/web.js:75:14)\n      at async callGQL (/Volumes/User/parabol/dev/web.js:71603:18),\n  { tags: undefined }\n]"}
13:21:00 4|Socket Server                  | {"time":"2025-04-30T11:21:00.067Z","level":"info","message":"SEND TO SENTRY [\n  Error: Mutation processRecurrence is already running\n      at /Volumes/User/parabol/dev/web.js:19999:49\n      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n      at async Object.processRecurrence (/Volumes/User/parabol/dev/web.js:75:14)\n      at async callGQL (/Volumes/User/parabol/dev/web.js:71603:18),\n  { tags: undefined }\n]"}
```

## Testing scenarios

* same preparations as #11272 
* comment out the lock in https://github.com/ParabolInc/parabol/blob/2dcdb0f0dfbc2e88d26eec53f85d6c8f337d058a/packages/server/LeaderRunner.ts#L22
* see multiple simultaneous ticks of `processRecurrence` with n-1 reporting a standard error

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
