### PR TITLE
fix: improve error handling for websocket connections in safari 

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -129,13 +129,6 @@ export default class Atmosphere extends Environment {
     // wait until the first and only upgrade has completed
     if (!this.connectWebsocketPromise) {
       this.connectWebsocketPromise = createWSClient(this)
-      this.connectWebsocketPromise
-        .then((client) => {
-          this.subscriptionClient = client
-        })
-        .catch(() => {
-          /* noop */
-        })
     }
     return this.connectWebsocketPromise
   }

--- a/packages/client/utils/createWSClient.ts
+++ b/packages/client/utils/createWSClient.ts
@@ -106,6 +106,7 @@ export function createWSClient(atmosphere: Atmosphere) {
           }
           if (!hasConnected) {
             hasConnected = true
+            atmosphere.subscriptionClient = subscriptionClient
             resolve(subscriptionClient)
           }
           setConnectedStatus(atmosphere, true)

--- a/packages/client/utils/createWSClient.ts
+++ b/packages/client/utils/createWSClient.ts
@@ -112,7 +112,7 @@ export function createWSClient(atmosphere: Atmosphere) {
         },
         closed: (event) => {
           if (!hasConnected) {
-            console.error('Could not connect via WebSocket')
+            console.error('Could not connect via WebSocket', event)
             reject(event)
           }
           const {code, reason} = event as CloseEvent


### PR DESCRIPTION
# Description

fix #11250

this should improve the websocket connectivity problems. if we do have a case where folks can't connect, it now includes the error event