### PR TITLE
feat: dump on sigusr2

### DIFF
--- a/packages/server/graphql/private/mutations/dumpHeap.ts
+++ b/packages/server/graphql/private/mutations/dumpHeap.ts
@@ -43,10 +43,14 @@ const dumpHeap: MutationResolvers['dumpHeap'] = async (
     session.post('HeapProfiler.takeHeapSnapshot', undefined, (err) => {
       session.disconnect()
       fs.closeSync(fd)
+      Logger.log('[Heap Dump]: Dump Complete')
       setIsBusy(false)
       resolve(err?.toString() || pathName)
     })
   })
 }
 
+process.on('SIGUSR2', () => {
+  dumpHeap({}, {isDangerous: true}, {} as any, {} as any)
+})
 export default dumpHeap


### PR DESCRIPTION
# Description

now we can do a heapdump by sending a SIGUSR2 to the container

e.g. `kill -SIGUSR2 1337`