### PR TITLE
fix: do not bump parabol-client dependency in package.json

### DIFF
--- a/packages/mattermost-plugin/package.json
+++ b/packages/mattermost-plugin/package.json
@@ -37,7 +37,7 @@
     "webpack": "^5.99.6"
   },
   "dependencies": {
-    "parabol-client": "10.3.0",
+    "parabol-client": "workspace:*",
     "@mui/icons-material": "^6.3.1",
     "@mui/material": "^6.3.1",
     "@radix-ui/react-popover": "^1.1.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -115,7 +115,7 @@
     "oauth-1.0a": "^2.2.6",
     "object-hash": "^3.0.0",
     "oy-vey": "^0.12.1",
-    "parabol-client": "10.3.0",
+    "parabol-client": "workspace:*",
     "pg": "^8.5.1",
     "prosemirror-model": "^1.25.1",
     "prosemirror-state": "^1.4.3",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -47,18 +47,8 @@
     },
     {
       "type": "json",
-      "path": "packages/server/package.json",
-      "jsonpath": "$.dependencies['parabol-client']"
-    },
-    {
-      "type": "json",
       "path": "packages/mattermost-plugin/package.json",
       "jsonpath": "$.version"
-    },
-    {
-      "type": "json",
-      "path": "packages/mattermost-plugin/package.json",
-      "jsonpath": "$.dependencies['parabol-client']"
     }
   ]
 }


### PR DESCRIPTION
# Description

release-please no longer needs to bump package versions in the dependency. pnpm likes the value of `workspace:*`.