### PR TITLE
fix(Mattermost): use x-application-authorization header

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "stylecheck": "pnpm -r prettier:check",
     "codecheck": "concurrently --names \"lintcheck,stylecheck\" \"pnpm lintcheck\" \"pnpm stylecheck\" ",
     "ultrahook": "export $(grep ^ULTRAHOOK_API_KEY .env | tr -d \"'\") && ultrahook -k $ULTRAHOOK_API_KEY dev 3000",
-    "precommit": "pnpm -r precommit",
+    "precommit": "pnpm -r --workspace-concurrency=1 precommit",
     "postcheckout": "node scripts/generateGraphQLArtifacts.js &>/dev/null &",
     "prepare": "husky install",
     "relay:build": "node scripts/generateGraphQLArtifacts.js",

--- a/packages/mattermost-plugin/Atmosphere.ts
+++ b/packages/mattermost-plugin/Atmosphere.ts
@@ -33,7 +33,7 @@ const fetchGraphQL = (state: State) => (params: RequestParameters, variables: Va
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          authorization: authToken ? `Bearer ${authToken}` : ''
+          'x-application-authorization': authToken ? `Bearer ${authToken}` : ''
         },
         body: JSON.stringify({
           docId: params.id,

--- a/packages/server/utils/getReqAuth.ts
+++ b/packages/server/utils/getReqAuth.ts
@@ -2,7 +2,8 @@ import {HttpRequest} from 'uWebSockets.js'
 import getVerifiedAuthToken from './getVerifiedAuthToken'
 
 const getReqAuth = (req: HttpRequest) => {
-  const authHeader = req.getHeader('authorization')
+  // mattermost plugin cannot use the `authorization` header directly
+  const authHeader = req.getHeader('x-application-authorization') || req.getHeader('authorization')
   const token = authHeader.slice(7)
   return getVerifiedAuthToken(token)
 }


### PR DESCRIPTION
While the plugin would work with the bearer token in the authorization header, Mattermost interprets it as its own and spams its logs with warnings.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
