### PR TITLE
fix: show resource names in webpack dev build

### DIFF
--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -93,7 +93,8 @@ module.exports = {
     path: path.join(PROJECT_ROOT, 'build'),
     filename: '[name].js',
     chunkFilename: '[name].chunk.js',
-    publicPath: '/'
+    publicPath: '/',
+    assetModuleFilename: '[name][ext][query]-[hash]'
   },
   resolve: {
     alias: {
@@ -220,7 +221,7 @@ module.exports = {
       },
       {
         test: /\.(eot|ttf|wav|mp3|woff|woff2|otf)$/,
-        use: ['file-loader']
+        type: 'asset/resource'
       },
       // https://github.com/graphql/graphiql/issues/1055#issuecomment-561353578
       {


### PR DESCRIPTION
# Description

fonts weren't showing up for some reason on the frontend, so i needed to see which ones.  this should make dev debugging easier all around