### PR TITLE
fix: ungrouped reflection layout issue on kanban

### DIFF
--- a/packages/client/components/promptResponse/StandardBubbleMenu.tsx
+++ b/packages/client/components/promptResponse/StandardBubbleMenu.tsx
@@ -1,6 +1,6 @@
 import {Link} from '@mui/icons-material'
 import {BubbleMenu, Editor} from '@tiptap/react'
-import clsx from 'clsx'
+import {cn} from '../../ui/cn'
 import {BubbleMenuButton} from './BubbleMenuButton'
 import isTextSelected from './isTextSelected'
 
@@ -29,7 +29,7 @@ export const StandardBubbleMenu = (props: Props) => {
         shouldShow={shouldShowBubbleMenu}
       >
         <div
-          className={clsx(
+          className={cn(
             'items-center rounded-sm border-[1px] border-solid border-slate-600 bg-white p-[3px]',
             shouldShow ? 'flex' : 'hidden' // hide this if not active or dnd height gets screwed up
           )}

--- a/packages/client/components/promptResponse/StandardBubbleMenu.tsx
+++ b/packages/client/components/promptResponse/StandardBubbleMenu.tsx
@@ -1,5 +1,6 @@
 import {Link} from '@mui/icons-material'
 import {BubbleMenu, Editor} from '@tiptap/react'
+import clsx from 'clsx'
 import {BubbleMenuButton} from './BubbleMenuButton'
 import isTextSelected from './isTextSelected'
 
@@ -17,6 +18,8 @@ export const StandardBubbleMenu = (props: Props) => {
     editor.emit('linkStateChange', {editor, linkState: 'edit'})
   }
 
+  const shouldShow = shouldShowBubbleMenu()
+
   // wrapping in div is necessary, https://github.com/ueberdosis/tiptap/issues/3784
   return (
     <div>
@@ -25,7 +28,12 @@ export const StandardBubbleMenu = (props: Props) => {
         tippyOptions={{duration: 100, role: 'dialog'}}
         shouldShow={shouldShowBubbleMenu}
       >
-        <div className='flex items-center rounded-sm border-[1px] border-solid border-slate-600 bg-white p-[3px]'>
+        <div
+          className={clsx(
+            'items-center rounded-sm border-[1px] border-solid border-slate-600 bg-white p-[3px]',
+            shouldShow ? 'flex' : 'hidden' // hide this if not active or dnd height gets screwed up
+          )}
+        >
           <BubbleMenuButton
             onClick={() => editor.chain().focus().toggleBold().run()}
             isActive={editor.isActive('bold')}


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/10868

Demo: https://www.loom.com/share/5a73efb06aeb4cb69bf1cc17b9b47aba

The `TipTapEditor` was updated here https://github.com/ParabolInc/parabol/pull/10800/files#diff-4f071a6ead07a33aa3809ea02b3d9de303aa1e432a9f866869953b9a915d8e77 to always include `StandardBubbleMenu`. This affects the height calculation in `useDraggableReflectionCard` which makes the reflection have the extra spacing below it as it returns to the kanban. 

Returning early in the `StandardBubbleMenu` causes a `removeChild` error, as indicated by GitHub issue linked in line 23, so using the className to hide the component seems like the cleanest solution to me. 

### To test

- [ ] Ungroup a reflection and see that it returns to the expected position in the kanban