### PR TITLE
chore(Mattermost Plugin): improve not logged in experience

### DIFF
--- a/packages/mattermost-plugin/Atmosphere.ts
+++ b/packages/mattermost-plugin/Atmosphere.ts
@@ -69,6 +69,7 @@ const login = (state: State) => async () => {
   )
   const body = await response.json()
   store.dispatch(onLogin(body.authToken))
+  return !!body.authToken
 }
 
 const relayFieldLogger: RelayFieldLogger = (event) => {
@@ -85,7 +86,7 @@ export type ResolverContext = {
 
 export class Atmosphere extends Environment {
   state: State
-  login: () => Promise<void>
+  login: () => Promise<boolean>
 
   constructor(serverUrl: string, reduxStore: Store<GlobalState, AnyAction>) {
     const state = {

--- a/packages/mattermost-plugin/components/Sidepanel/index.tsx
+++ b/packages/mattermost-plugin/components/Sidepanel/index.tsx
@@ -19,8 +19,15 @@ const SidePanelRoot = () => {
           <p className='py-4'>
             You are not logged in to Parabol.
             <br />
-            Please <a href={`${parabolUrl}/signin`}>sign in</a> or{' '}
-            <a href={`${parabolUrl}/create-account`}>create an account</a> and retry.
+            Please{' '}
+            <a href={`${parabolUrl}/signin`} target='_blank' rel='noopener noreferrer'>
+              sign in
+            </a>{' '}
+            or{' '}
+            <a href={`${parabolUrl}/create-account`} target='_blank' rel='noopener noreferrer'>
+              create an account
+            </a>{' '}
+            and retry.
           </p>
           <button className='btn btn-primary' onClick={atmosphere.login}>
             Retry


### PR DESCRIPTION
# Description

Fixes #11227 
When a user tries to execute a slash command, we now showing a more helpful error message if they're not logged in. The sidepanel links in this case now also open in a new window.


## Demo

https://www.loom.com/share/2cc5dca5c67b43b8b29dfadad13fd9c8?sid=307fe9f5-e72b-40b1-9079-8cced13030d4

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
