### PR TITLE
fix(MSTeamsIntegration.ts): Updates incorrect service name from `mattermost` to `msTeams`

### DIFF
--- a/packages/server/dataloader/integrationAuthLoaders.ts
+++ b/packages/server/dataloader/integrationAuthLoaders.ts
@@ -183,6 +183,7 @@ export const teamMemberIntegrationAuthsByTeamIdAndService = (parent: RootDataLoa
             keys.map(({teamId, service}) => tuple(teamId, service))
           )
         )
+        .where('isActive', '=', true)
         .execute()) as unknown as TeamMemberIntegrationAuth[]
 
       return keys.map((key) =>

--- a/packages/server/graphql/public/types/MSTeamsIntegration.ts
+++ b/packages/server/graphql/public/types/MSTeamsIntegration.ts
@@ -9,7 +9,7 @@ export type MSTeamsIntegrationSource = {
 const loadActiveProvider = async (teamId: string, dataLoader: DataLoaderWorker) => {
   const auths = await dataLoader
     .get('teamMemberIntegrationAuthsByTeamIdAndService')
-    .load({teamId, service: 'mattermost'})
+    .load({teamId, service: 'msTeams'})
   if (!auths || auths.length !== 1) return null
   const {providerId} = auths[0]!
   return await dataLoader.get('integrationProviders').loadNonNull(providerId)
@@ -33,7 +33,7 @@ const MSTeamsIntegration: MsTeamsIntegrationResolvers = {
   isActive: async ({teamId}, _args, {dataLoader}) => {
     const auths = await dataLoader
       .get('teamMemberIntegrationAuthsByTeamIdAndService')
-      .load({teamId, service: 'mattermost'})
+      .load({teamId, service: 'msTeams'})
     return auths && auths.length > 1
   },
 

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -785,7 +785,8 @@ const User: ReqResolvers<'User'> = {
     const similarEmbeddings = await pg
       .with('Model', (qc) =>
         qc
-          .selectFrom(MODEL)
+          .selectFrom(MODEL as any)
+          // @ts-ignore
           .innerJoin('EmbeddingsMetadata', 'EmbeddingsMetadata.id', `${MODEL}.embeddingsMetadataId`)
           .select([`${MODEL}.id`, 'embeddingsMetadataId', 'embedding', 'refId'])
           .where('objectType', '=', 'meetingTemplate')


### PR DESCRIPTION
# Description

Fixes https://github.com/ParabolInc/parabol/issues/11258

The issue in #11258 occurs in the `loadActiveProvider` function in `MSTeamsIntegration.ts`, it contains an incorrect service name in the query. The same error also exists in the `isActive` method. Updates the service name from `mattermost` to `msTeams`. 

## Demo

I'm not sure how to reproduce the bug to test. @Dschoordsch kindly suggested I open a PR anyway and he'll look into testing it. 

## Testing scenarios

Owner: @Dschoordsch 

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

### FYI Precommit hook fails

(for visibility) It looks like the precommit hook is failing in `package/server`:

To reproduce run:

```sh
cd package/server
pnpm run typecheck
# or
pnpm run precommit

# ...
> parabol-server@10.3.3 precommit /Users/arthur/Documents/arthurgousset/parabol/packages/server
> lint-staged

✔ Preparing...
⚠ Running tasks...
  ✔ Running tasks for *.{ts,tsx}
  ↓ No staged files match *.graphql [SKIPPED]
  ❯ Running tasks for **/*.{ts,tsx}
    ✖ tsc --noEmit -p tsconfig.json [FAILED]
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up...

✖ tsc --noEmit -p tsconfig.json:
graphql/public/types/User.ts:788:23 - error TS2345: Argument of type '"Embeddings_ember_1"' is not assignable to parameter of type 'TableExpressionOrList<DB, never>'.

# ...
Found 2 errors in the same file, starting at: graphql/public/types/User.ts:788
```

This is failing on my commit and on the latest commit on `master`.

I bypassed the precommit hook (with `git commit --no-verify`), but thought I'd leave a note for future reference that this is failing. The type error doesn't seem related to my code changes.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
