### PR TITLE
README: add pnpm install argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ pnpm dev
 ```bash
 # There's a pesky bug in pnpm if you don't have an SSH key: https://github.com/pnpm/pnpm/issues/7243
 $ git config --global url."https://github.com/enahum/redux-offline.git".insteadOf git@github.com:enahum/redux-offline.git
-$ pnpm && pnpm pg:build && pnpm build && pnpm predeploy && pnpm start
+$ pnpm i && pnpm pg:build && pnpm build && pnpm predeploy && pnpm start
 ```
 
 - [How to Ship](./docs/deployment.md)


### PR DESCRIPTION
# Description

Update deployment step. In contrast to yarn, pnpm needs the `i(install)` argument to install dependencies.

## Demo

N/A

## Testing scenarios

Running `pnpm` just prints the help, `pnpm i` installs dependencies.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
