### PR TITLE
fix: gitlab name in summary

### DIFF
--- a/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
+++ b/packages/client/modules/email/components/SummaryEmail/MeetingSummaryEmail/ExportAllTasks.tsx
@@ -33,7 +33,7 @@ const integrationToServiceName: Record<TaskServiceEnum, string> = {
   jira: 'Jira',
   jiraServer: Providers.JIRA_SERVER_NAME,
   azureDevOps: Providers.AZUREDEVOPS_NAME,
-  gitlab: Providers.GITHUB_NAME
+  gitlab: Providers.GITLAB_NAME
 }
 
 interface Props {

--- a/packages/client/types/constEnums.ts
+++ b/packages/client/types/constEnums.ts
@@ -302,6 +302,7 @@ export const enum Providers {
   GCAL_DESC = 'Create Google Calendar events from within Parabol.',
   GITHUB_DESC = 'Use GitHub Issues from within Parabol.',
   GITHUB_SCOPE = 'read:org,repo',
+  GITLAB_NAME = 'GitLab',
   GITLAB_SCOPE = 'api',
   MATTERMOST_NAME = 'Mattermost',
   MATTERMOST_DESC = 'Push notifications to Mattermost.',


### PR DESCRIPTION
# Description

Fixes a typo our friends at GitLab caught where we mislabelled "GitLab" as "GitHub" in the meeting summary.
