### PR TITLE
fix: mark wrapped resolvers

### DIFF
--- a/packages/server/logging.ts
+++ b/packages/server/logging.ts
@@ -1,0 +1,27 @@
+import * as Sentry from '@sentry/node'
+import tracer from 'dd-trace'
+
+Sentry.init({
+  environment: 'server',
+  dsn: process.env.SENTRY_DSN,
+  release: __APP_VERSION__,
+  defaultIntegrations: false,
+  ignoreErrors: [
+    '429 Too Many Requests',
+    /language \S+ is not supported/,
+    'Not invited to the meeting. Cannot subscribe'
+  ]
+})
+
+tracer.init({
+  service: `web`,
+  appsec: process.env.DD_APPSEC_ENABLED === 'true',
+  plugins: false,
+  version: __APP_VERSION__
+})
+tracer
+  .use('ioredis')
+  .use('http', {
+    blocklist: ['/health', '/ready']
+  })
+  .use('pg')

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -1,4 +1,3 @@
-import tracer from 'dd-trace'
 import uws from 'uWebSockets.js'
 import ICSHandler from './ICSHandler'
 import PWAHandler from './PWAHandler'
@@ -8,7 +7,6 @@ import createSSR from './createSSR'
 import {disconnectAllSockets} from './disconnectAllSockets'
 import {setIsShuttingDown} from './getIsShuttingDown'
 import './hocusPocus'
-import './initSentry'
 import mattermostWebhookHandler from './integrations/mattermost/mattermostWebhookHandler'
 import jiraImagesHandler from './jiraImagesHandler'
 import listenHandler from './listenHandler'
@@ -24,19 +22,6 @@ import {yoga} from './yoga'
 export const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
   ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000
   : 60_000 // ms
-
-tracer.init({
-  service: `web`,
-  appsec: process.env.DD_APPSEC_ENABLED === 'true',
-  plugins: false,
-  version: __APP_VERSION__
-})
-tracer
-  .use('ioredis')
-  .use('http', {
-    blocklist: ['/health', '/ready']
-  })
-  .use('pg')
 
 process.on('SIGTERM', async (signal) => {
   Logger.log(

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -15,6 +15,7 @@ const EMBEDDER_ROOT = path.join(PROJECT_ROOT, 'packages', 'embedder')
 const DOTENV = path.join(PROJECT_ROOT, 'scripts/webpack/utils/dotenv.js')
 const distPath = path.join(PROJECT_ROOT, 'dist')
 const INIT_PUBLIC_PATH = path.join(SERVER_ROOT, 'initPublicPath.ts')
+const INIT_LOGGING = path.join(SERVER_ROOT, 'logging.ts')
 
 const COMMIT_HASH = cp.execSync('git rev-parse HEAD').toString().trim()
 const runtimePlatform = `${process.platform}-${process.arch}`
@@ -31,6 +32,7 @@ module.exports = (config) => {
       web: [
         DOTENV,
         INIT_PUBLIC_PATH,
+        INIT_LOGGING,
         // each instance of web needs to generate its own index.html to use on startup
         path.join(PROJECT_ROOT, 'scripts/toolboxSrc/applyEnvVarsToClientAssets.ts'),
         path.join(SERVER_ROOT, 'server.ts')


### PR DESCRIPTION
# Description

We know there is a circular reference somewhere in the resolver logic flow, but it isn't manifesting itself in dev or staging.
Here are my two best guesses on the culprit. It's most likely the one where the wrapping function is getting rewrapped, so I put a symbol on the function itself to mark it as wrapped.