### PR TITLE
fix(graphql): Fixes a bug whereby org admins are unable to edit templates

### DIFF
--- a/packages/server/utils/authorization.ts
+++ b/packages/server/utils/authorization.ts
@@ -62,3 +62,18 @@ export const isUserInOrg = async (userId: string, orgId: string, dataLoader: Dat
     .load({userId, orgId})
   return !!organizationUser
 }
+
+export const isTeamMemberOrOrgAdmin = async (
+  authToken: AuthToken,
+  teamId: string,
+  dataLoader: DataLoaderWorker
+) => {
+  const viewerId = getUserId(authToken)
+  // First check if they're a team member (faster check)
+  if (isTeamMember(authToken, teamId)) return true
+
+  // If not, check if they're an org admin
+  const team = await dataLoader.get('teams').load(teamId)
+  if (!team) return false
+  return isUserOrgAdmin(viewerId, team.orgId, dataLoader)
+}


### PR DESCRIPTION
# Description

Fixes/Partially Fixes #10966

Organization admins are unable to save changes when editing templates because the server-side authorization logic only checks if a user is a team member and doesn't consider org admin privileges. Both `updateMeetingTemplate.ts` and `renameMeetingTemplate.ts` mutations only check if the user is a team member using the `isTeamMember()` function, without checking if the user is an organization admin.

@priyankc and I looked into this bug, but coincidentally @tianrunhe just opened a PR 20min ago for the same issue: https://github.com/ParabolInc/parabol/pull/11326

We used our tool (called "WorkBack") to perform a [root cause analysis](https://hyperdrive.engineering/#report-3b373615-5bf9-46ce-bd94-7384d7ccfbee) and create the patch, but we struggled to reproduce the bug and verify the fix on our machines.

## Demo

N/A

## Testing scenarios

We struggled to set up an Enterprise Org on our local Parabol instance to reproduce the bug and verify the fix.

We gave ourselves super user permissions to play around in `http://localhost:3000/admin/graphql` with this script:

```sh
pnpm node ./scripts/toolbox/assignSURole.js --add you@example.com
```

We also looked into the Postgres tables, but couldn't find any relevant tables. 

Would love to know how to reproduce this bug locally to verify the fix in general.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog