### PR TITLE
feat(orgAdmin): org admin can rename a team in org teams view

### DIFF
--- a/packages/client/modules/teamDashboard/components/EditTeamName/EditableTeamName.tsx
+++ b/packages/client/modules/teamDashboard/components/EditTeamName/EditableTeamName.tsx
@@ -57,16 +57,15 @@ const EditableTeamName = (props: Props) => {
   }
 
   return (
-    <div className='font-sans text-lg leading-8'>
-      <EditableText
-        error={error as string}
-        handleSubmit={handleSubmit}
-        initialValue={teamName}
-        maxLength={50}
-        validate={validate}
-        placeholder={'Team Name'}
-      />
-    </div>
+    <EditableText
+      error={error as string}
+      handleSubmit={handleSubmit}
+      initialValue={teamName}
+      maxLength={50}
+      validate={validate}
+      placeholder={'Team Name'}
+      className='inline-flex items-center'
+    />
   )
 }
 

--- a/packages/client/modules/teamDashboard/components/EditTeamName/EditableTeamName.tsx
+++ b/packages/client/modules/teamDashboard/components/EditTeamName/EditableTeamName.tsx
@@ -1,23 +1,15 @@
-import styled from '@emotion/styled'
 import graphql from 'babel-plugin-relay/macro'
 import {useFragment} from 'react-relay'
 import useAtmosphere from '~/hooks/useAtmosphere'
 import {EditableTeamName_team$key} from '../../../../__generated__/EditableTeamName_team.graphql'
 import EditableText from '../../../../components/EditableText'
 import UpdateTeamNameMutation from '../../../../mutations/UpdateTeamNameMutation'
-import {FONT_FAMILY} from '../../../../styles/typographyV2'
 import withMutationProps, {WithMutationProps} from '../../../../utils/relay/withMutationProps'
 import teamNameValidation from '../../../../validation/teamNameValidation'
 
 interface Props extends WithMutationProps {
   team: EditableTeamName_team$key
 }
-
-const InheritedStyles = styled('div')({
-  fontFamily: FONT_FAMILY.SANS_SERIF,
-  fontSize: 24,
-  lineHeight: '32px'
-})
 
 const EditableTeamName = (props: Props) => {
   const atmosphere = useAtmosphere()
@@ -65,7 +57,7 @@ const EditableTeamName = (props: Props) => {
   }
 
   return (
-    <InheritedStyles>
+    <div className='font-sans text-lg leading-8'>
       <EditableText
         error={error as string}
         handleSubmit={handleSubmit}
@@ -74,7 +66,7 @@ const EditableTeamName = (props: Props) => {
         validate={validate}
         placeholder={'Team Name'}
       />
-    </InheritedStyles>
+    </div>
   )
 }
 

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -38,21 +38,19 @@ const OrgTeamsRow = (props: Props) => {
     <tr className='hover:bg-slate-50 border-b border-slate-300'>
       <td className='p-3'>
         <div className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'>
-          <div className='flex flex-1 items-center'>
+          <div className='flex items-center gap-2'>
             {isLead || isOrgAdmin ? <EditableTeamName team={team} /> : <span>{teamName}</span>}
             {isLead && (
-              <span className='ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
+              <span className='rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
                 Team Lead
               </span>
             )}
             {isMember && (
-              <span className='ml-2 rounded-full bg-sky-500 px-2 py-0.5 text-xs text-white'>
-                Member
-              </span>
+              <span className='rounded-full bg-sky-500 px-2 py-0.5 text-xs text-white'>Member</span>
             )}
           </div>
           <Link to={`teams/${teamId}`}>
-            <ChevronRight className='ml-2 text-slate-600' />
+            <ChevronRight className='ml-auto text-slate-600' />
           </Link>
         </div>
       </td>

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -4,6 +4,7 @@ import {format} from 'date-fns'
 import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
 import {OrgTeamsRow_team$key} from '../../../../__generated__/OrgTeamsRow_team.graphql'
+import EditableTeamName from '../../../teamDashboard/components/EditTeamName/EditableTeamName'
 
 type Props = {
   teamRef: OrgTeamsRow_team$key
@@ -21,11 +22,13 @@ const OrgTeamsRow = (props: Props) => {
           isLead
         }
         lastMetAt
+        isOrgAdmin
+        ...EditableTeamName_team
       }
     `,
     teamRef
   )
-  const {id: teamId, teamMembers, name, lastMetAt} = team
+  const {id: teamId, teamMembers, name: teamName, lastMetAt, isOrgAdmin} = team
   const teamMembersCount = teamMembers.length
   const viewerTeamMember = teamMembers.find((m) => m.isSelf)
   const isLead = viewerTeamMember?.isLead
@@ -34,12 +37,9 @@ const OrgTeamsRow = (props: Props) => {
   return (
     <tr className='hover:bg-slate-50 border-b border-slate-300'>
       <td className='p-3'>
-        <Link
-          to={`teams/${teamId}`}
-          className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'
-        >
+        <div className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'>
           <div className='flex flex-1 items-center'>
-            {name}
+            {isLead || isOrgAdmin ? <EditableTeamName team={team} /> : <span>{teamName}</span>}
             {isLead && (
               <span className='ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
                 Team Lead
@@ -51,8 +51,10 @@ const OrgTeamsRow = (props: Props) => {
               </span>
             )}
           </div>
-          <ChevronRight className='ml-2 text-slate-600' />
-        </Link>
+          <Link to={`teams/${teamId}`}>
+            <ChevronRight className='ml-2 text-slate-600' />
+          </Link>
+        </div>
       </td>
       <td className='text-gray-600 p-3'>{teamMembersCount}</td>
       <td className='text-gray-600 p-3'>


### PR DESCRIPTION
# Description

Fixes #10595

## Demo
![2025-05-14 16 28 16](https://github.com/user-attachments/assets/4fa19221-c12d-4ee2-8b81-ffac229fd2d7)

## Testing scenarios

- [ ] Change team name in org teams view
  - Go to `http://localhost:3000/me/organizations/xxxx/teams` as an org admin
  - See pencil icon next to the team name
  - Able to rename the team
  - See the changes populated to other team views

- [ ] Non org admin or team lead can't change team name
  - Go to `http://localhost:3000/me/organizations/xxxx/teams` as someone not on the team
  - See no pencil icon next to the team name
  - One cannot change the team name

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
