### PR TITLE
fix: limit the Azure DevOps work items fetched

### DIFF
--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -323,7 +323,6 @@ export const allAzureDevOpsProjects = (parent: RootDataLoader) => {
     async (keys) => {
       const results = await Promise.allSettled(
         keys.map(async ({userId, teamId}) => {
-          const resultReferences = [] as TeamProjectReference[]
           const auth = await parent.get('freshAzureDevOpsAuth').load({teamId, userId})
           if (!auth) {
             return []
@@ -341,6 +340,7 @@ export const allAzureDevOpsProjects = (parent: RootDataLoader) => {
             Logger.log(error)
             return []
           }
+          const resultReferences = [] as TeamProjectReference[]
           if (projects !== null) resultReferences.push(...projects)
           return resultReferences.map((project) => {
             const instanceId = getInstanceId(project.url)

--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -131,9 +131,7 @@ export interface AzureProject extends ProjectRes {
   service: 'azureDevOps'
 }
 
-export const freshAzureDevOpsAuth = (
-  parent: RootDataLoader
-): DataLoader<TeamUserKey, TeamMemberIntegrationAuth | null, string> => {
+export const freshAzureDevOpsAuth = (parent: RootDataLoader) => {
   return new DataLoader<TeamUserKey, TeamMemberIntegrationAuth | null, string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -195,16 +193,14 @@ export const freshAzureDevOpsAuth = (
   )
 }
 
-export const azureDevOpsAllWorkItems = (
-  parent: RootDataLoader
-): DataLoader<AzureDevOpsAllUserWorkItemsKey, AzureDevOpsWorkItem[] | undefined, string> => {
-  return new DataLoader<AzureDevOpsAllUserWorkItemsKey, AzureDevOpsWorkItem[] | undefined, string>(
+export const azureDevOpsAllWorkItems = (parent: RootDataLoader) => {
+  return new DataLoader<AzureDevOpsAllUserWorkItemsKey, AzureDevOpsWorkItem[] | Error, string>(
     async (keys) => {
       const results = await Promise.allSettled(
         keys.map(async ({userId, teamId, queryString, projectKeyFilters, isWIQL}) => {
           const auth = await parent.get('freshAzureDevOpsAuth').load({teamId, userId})
           if (!auth) {
-            return undefined
+            return new Error('Failed to fetch a new access token, try re-authenticating')
           }
           const provider = await parent.get('integrationProviders').loadNonNull(auth.providerId)
           const manager = new AzureDevOpsServerManager(
@@ -220,8 +216,7 @@ export const azureDevOpsAllWorkItems = (
 
           const {error, workItems} = restResult
           if (error !== undefined || workItems === undefined) {
-            Logger.log(error)
-            return [] as AzureDevOpsWorkItem[]
+            return error ?? new Error('Failed to fetch work items')
           }
 
           const mappedWorkItems: AzureDevOpsWorkItem[] = await Promise.all(
@@ -241,7 +236,9 @@ export const azureDevOpsAllWorkItems = (
           return mappedWorkItems
         })
       )
-      return results.map((result) => (result.status === 'fulfilled' ? result.value : undefined))
+      return results.map((result) =>
+        result.status === 'fulfilled' ? result.value : new Error('Failed to fetch work items')
+      )
     },
     {
       ...parent.dataLoaderOptions,
@@ -250,9 +247,7 @@ export const azureDevOpsAllWorkItems = (
   )
 }
 
-export const azureDevUserInfo = (
-  parent: RootDataLoader
-): DataLoader<TeamUserKey, AzureUserInfo | undefined, string> => {
+export const azureDevUserInfo = (parent: RootDataLoader) => {
   return new DataLoader<TeamUserKey, AzureUserInfo | undefined, string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -286,9 +281,7 @@ export const azureDevUserInfo = (
   )
 }
 
-export const allAzureDevOpsAccessibleOrgs = (
-  parent: RootDataLoader
-): DataLoader<TeamUserKey, Resource[], string> => {
+export const allAzureDevOpsAccessibleOrgs = (parent: RootDataLoader) => {
   return new DataLoader<TeamUserKey, Resource[], string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -323,9 +316,7 @@ export const allAzureDevOpsAccessibleOrgs = (
   )
 }
 
-export const allAzureDevOpsProjects = (
-  parent: RootDataLoader
-): DataLoader<TeamUserKey, AzureAccountProject[], string> => {
+export const allAzureDevOpsProjects = (parent: RootDataLoader) => {
   return new DataLoader<TeamUserKey, AzureAccountProject[], string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -371,9 +362,7 @@ export const allAzureDevOpsProjects = (
   )
 }
 
-export const azureDevOpsProject = (
-  parent: RootDataLoader
-): DataLoader<AzureDevOpsRemoteProjectKey, AzureProject | null, string> => {
+export const azureDevOpsProject = (parent: RootDataLoader) => {
   return new DataLoader<AzureDevOpsRemoteProjectKey, AzureProject | null, string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -410,13 +399,7 @@ export const azureDevOpsProject = (
   )
 }
 
-export const azureDevOpsDimensionFieldMap = (
-  parent: RootDataLoader
-): DataLoader<
-  AzureDevOpsDimensionFieldMapKey,
-  AzureDevOpsDimensionFieldMapEntry | null,
-  string
-> => {
+export const azureDevOpsDimensionFieldMap = (parent: RootDataLoader) => {
   return new DataLoader<
     AzureDevOpsDimensionFieldMapKey,
     AzureDevOpsDimensionFieldMapEntry | null,
@@ -456,9 +439,7 @@ const getProjectId = (url: URL) => {
   return url.pathname.substring(firstIndex + 1, seconedIndex)
 }
 
-export const azureDevOpsUserStory = (
-  parent: RootDataLoader
-): DataLoader<AzureDevOpsWorkItemKey, AzureDevOpsWorkItem | null, string> => {
+export const azureDevOpsUserStory = (parent: RootDataLoader) => {
   return new DataLoader<AzureDevOpsWorkItemKey, AzureDevOpsWorkItem | null, string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -504,9 +485,7 @@ export const azureDevOpsUserStory = (
   )
 }
 
-export const azureDevOpsWorkItem = (
-  parent: RootDataLoader
-): DataLoader<AzureDevOpsWorkItemKey, AzureDevOpsWorkItem | null, string> => {
+export const azureDevOpsWorkItem = (parent: RootDataLoader) => {
   return new DataLoader<AzureDevOpsWorkItemKey, AzureDevOpsWorkItem | null, string>(
     async (keys) => {
       const results = await Promise.allSettled(
@@ -664,56 +643,4 @@ const getMappedAzureDevOpsWorkItem = async (
     azureDevOpsWorkItem.type = `${projectTemplate}:${returnedWorkItem.fields['System.WorkItemType']}`
   }
   return azureDevOpsWorkItem
-}
-
-export const azureDevOpsWorkItems = (
-  parent: RootDataLoader
-): DataLoader<AzureDevOpsWorkItemsKey, AzureDevOpsWorkItem[], string> => {
-  return new DataLoader<AzureDevOpsWorkItemsKey, AzureDevOpsWorkItem[], string>(
-    async (keys) => {
-      const results = await Promise.allSettled(
-        keys.map(async ({userId, teamId, instanceId}) => {
-          const auth = await parent.get('freshAzureDevOpsAuth').load({teamId, userId})
-          if (!auth) {
-            return []
-          }
-          const provider = await parent.get('integrationProviders').loadNonNull(auth.providerId)
-          const manager = new AzureDevOpsServerManager(
-            auth,
-            provider as IntegrationProviderAzureDevOps
-          )
-
-          const result = await manager.getWorkItems(instanceId, null, null, false)
-          const {error, workItems} = result
-          const workItemIds = workItems.map((workItem) => workItem.id)
-          const workItemData = await manager.getWorkItemData(instanceId, workItemIds)
-          const {error: workItemDataError, workItems: returnedWorkItems} = workItemData
-          if (workItemDataError !== undefined) {
-            Logger.log(error)
-            return []
-          }
-
-          const mappedWorkItems: AzureDevOpsWorkItem[] = await Promise.all(
-            returnedWorkItems.map(async (returnedWorkItem): Promise<AzureDevOpsWorkItem> => {
-              const mappedWorkItem = await getMappedAzureDevOpsWorkItem(
-                userId,
-                teamId,
-                instanceId,
-                returnedWorkItem,
-                parent
-              )
-              return mappedWorkItem
-            })
-          )
-
-          return mappedWorkItems
-        })
-      )
-      return results.map((result) => (result.status === 'fulfilled' ? result.value : []))
-    },
-    {
-      ...parent.dataLoaderOptions,
-      cacheKeyFn: (key) => `${key.projectId}:${key.teamId}:${key.instanceId}`
-    }
-  )
 }

--- a/packages/server/dataloader/azureDevOpsLoaders.ts
+++ b/packages/server/dataloader/azureDevOpsLoaders.ts
@@ -28,6 +28,7 @@ export interface AzureDevOpsAllUserWorkItemsKey {
   queryString: string | null
   projectKeyFilters: string[] | null
   isWIQL: boolean
+  limit?: number
 }
 
 export interface AzureDevOpsAccessibleOrgsKey {
@@ -197,7 +198,7 @@ export const azureDevOpsAllWorkItems = (parent: RootDataLoader) => {
   return new DataLoader<AzureDevOpsAllUserWorkItemsKey, AzureDevOpsWorkItem[] | Error, string>(
     async (keys) => {
       const results = await Promise.allSettled(
-        keys.map(async ({userId, teamId, queryString, projectKeyFilters, isWIQL}) => {
+        keys.map(async ({userId, teamId, queryString, projectKeyFilters, isWIQL, limit}) => {
           const auth = await parent.get('freshAzureDevOpsAuth').load({teamId, userId})
           if (!auth) {
             return new Error('Failed to fetch a new access token, try re-authenticating')
@@ -211,7 +212,8 @@ export const azureDevOpsAllWorkItems = (parent: RootDataLoader) => {
           const restResult = await manager.getAllUserWorkItems(
             queryString,
             projectKeyFilters,
-            isWIQL
+            isWIQL,
+            limit
           )
 
           const {error, workItems} = restResult

--- a/packages/server/graphql/public/types/AzureDevOpsIntegration.ts
+++ b/packages/server/graphql/public/types/AzureDevOpsIntegration.ts
@@ -32,21 +32,26 @@ const AzureDevOpsIntegration: AzureDevOpsIntegrationResolvers = {
       standardError(err, {tags: {teamId, userId}, userId: viewerId})
       return connectionFromTasks([], 0, err)
     }
-    const allUserWorkItems = await dataLoader
-      .get('azureDevOpsAllWorkItems')
-      .load({teamId, userId, queryString, projectKeyFilters, isWIQL})
-    if (!allUserWorkItems) {
-      return connectionFromTasks([], 0, undefined)
-    } else {
-      const workItems = Array.from(
-        allUserWorkItems.map((userWorkItem) => {
-          return {
-            ...userWorkItem,
-            updatedAt: new Date()
-          }
-        })
-      )
-      return connectionFromTasks(workItems, first, undefined)
+    try {
+      const allUserWorkItems = await dataLoader
+        .get('azureDevOpsAllWorkItems')
+        .load({teamId, userId, queryString, projectKeyFilters, isWIQL})
+      if (allUserWorkItems instanceof Error) {
+        return connectionFromTasks([], 0, allUserWorkItems)
+      } else {
+        const workItems = Array.from(
+          allUserWorkItems.map((userWorkItem) => {
+            return {
+              ...userWorkItem,
+              updatedAt: new Date()
+            }
+          })
+        )
+        return connectionFromTasks(workItems, first, undefined)
+      }
+    } catch (err) {
+      const error = new Error('GEORG really here in the catch Error fetching work items')
+      return connectionFromTasks([], 0, error)
     }
   },
 

--- a/packages/server/graphql/public/types/AzureDevOpsIntegration.ts
+++ b/packages/server/graphql/public/types/AzureDevOpsIntegration.ts
@@ -29,16 +29,14 @@ const AzureDevOpsIntegration: AzureDevOpsIntegrationResolvers = {
       return connectionFromTasks([], 0, err)
     }
     try {
-      const allUserWorkItems = await dataLoader
-        .get('azureDevOpsAllWorkItems')
-        .load({
-          teamId,
-          userId,
-          queryString: queryString ?? null,
-          projectKeyFilters,
-          isWIQL,
-          limit: first
-        })
+      const allUserWorkItems = await dataLoader.get('azureDevOpsAllWorkItems').load({
+        teamId,
+        userId,
+        queryString: queryString ?? null,
+        projectKeyFilters,
+        isWIQL,
+        limit: first
+      })
       if (allUserWorkItems instanceof Error) {
         return connectionFromTasks([], 0, allUserWorkItems)
       } else {

--- a/packages/server/graphql/queries/helpers/connectionFromTasks.ts
+++ b/packages/server/graphql/queries/helpers/connectionFromTasks.ts
@@ -12,8 +12,10 @@ const connectionFromTasks = <T extends {updatedAt: Date} = Task>(
     node
   }))
   const firstEdge = edges[0]
+  // If we return a real error, yoga will thow and mask it
+  const sanitizedError = error instanceof Error ? {message: error.message} : error
   return {
-    error,
+    error: sanitizedError,
     edges,
     pageInfo: {
       startCursor: firstEdge && firstEdge.cursor,

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -459,7 +459,6 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
   async executeWiqlQuery(instanceId: string, query: string) {
     return tracer.trace('AzureDevOpsServerManager.executeWiqlQuery', async () => {
       const workItemReferences = [] as WorkItemReference[]
-      let firstError: Error | undefined
       const payload = {
         query: query
       }
@@ -468,9 +467,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
         payload
       )
       if (res instanceof Error) {
-        if (!firstError) {
-          firstError = res
-        }
+        return {error: res, workItems: null}
       } else {
         const workItems = res.workItems.map((workItem) => {
           const {id, url} = workItem
@@ -481,11 +478,11 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
         })
         workItemReferences.push(...workItems)
       }
-      return {error: firstError, workItems: workItemReferences}
+      return {error: null, workItems: workItemReferences}
     })
   }
 
-  async getWorkItems(
+  private async getWorkItems(
     instanceId: string,
     queryString: string | null,
     projectKeyFilters: string[] | null,

--- a/packages/server/utils/AzureDevOpsServerManager.ts
+++ b/packages/server/utils/AzureDevOpsServerManager.ts
@@ -423,7 +423,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     const {instanceId, projectKey} = integration
     const comment = makeCreateAzureTaskComment(viewerName, assigneeName, teamName, teamDashboardUrl)
     const res = await this.post<WorkItemAddCommentResponse>(
-      `https://${instanceId}/${projectKey}/_apis/wit/workItems/${issueId}/comments?api-version=7.1-preview.3`,
+      `https://${instanceId}/${projectKey}/_apis/wit/workItems/${issueId}/comments?api-version=7.1`,
       {text: comment}
     )
     return res instanceof Error ? res : res.url
@@ -433,7 +433,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     return tracer.trace('AzureDevOpsServerManager.getWorkItemData', async () => {
       const workItems = [] as WorkItem[]
       let firstError: Error | undefined
-      const uri = `https://${instanceId}/_apis/wit/workitemsbatch?api-version=7.1-preview.1`
+      const uri = `https://${instanceId}/_apis/wit/workitemsbatch?api-version=7.1`
       // we can fetch at most 200 items at once VS403474
       for (let i = 0; i < workItemIds.length; i += 200) {
         const ids = workItemIds.slice(i, i + 200)
@@ -569,7 +569,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     let azureDevOpsUser: AzureDevOpsUser | undefined
     let firstError: Error | undefined
     const result = await this.get<AzureDevOpsUser>(
-      `https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1-preview.3`
+      `https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1`
     )
 
     if (result instanceof Error) {
@@ -584,7 +584,6 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
 
   async getAllUserProjects() {
     return tracer.trace('AzureDevOpsServerManager.getAllUserProjects', async () => {
-      const teamProjectReferences = [] as TeamProjectReference[]
       let firstError: Error | undefined
       const meResult = await this.getMe()
       const {error: meError, azureDevOpsUser} = meResult
@@ -594,6 +593,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
       const {error: accessibleError, accessibleOrgs} = await this.getAccessibleOrgs(id)
       if (!!accessibleError) return {error: accessibleError, projects: null}
 
+      const teamProjectReferences = [] as TeamProjectReference[]
       for (const resource of accessibleOrgs) {
         const {error: accountProjectsError, accountProjects} = await this.getAccountProjects(
           resource.accountName
@@ -669,7 +669,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     const teamProjectReferences = [] as TeamProjectReference[]
     let firstError: Error | undefined
     const result = await this.get<AccountProjects>(
-      `https://dev.azure.com/${accountName}/_apis/projects?api-version=7.1-preview.4`
+      `https://dev.azure.com/${accountName}/_apis/projects?api-version=7.1`
     )
     if (result instanceof Error) {
       if (!firstError) {
@@ -690,7 +690,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     const accessibleOrgs = [] as Resource[]
     let firstError: Error | undefined
     const result = await this.get<AccessibleResources>(
-      `https://app.vssps.visualstudio.com/_apis/accounts?memberId=${userAccountId}&api-version=7.1-preview.1`
+      `https://app.vssps.visualstudio.com/_apis/accounts?memberId=${userAccountId}&api-version=7.1`
     )
 
     if (result instanceof Error) {
@@ -755,7 +755,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     <div>Powered by <a href='${ExternalLinks.GETTING_STARTED_SPRINT_POKER}'>Parabol</a></div>`
 
     const res = await this.post<WorkItemAddCommentResponse>(
-      `https://${instanceId}/${projectKey}/_apis/wit/workItems/${remoteIssueId}/comments?api-version=7.1-preview.3`,
+      `https://${instanceId}/${projectKey}/_apis/wit/workItems/${remoteIssueId}/comments?api-version=7.1`,
       {
         text: comment
       }
@@ -776,7 +776,7 @@ class AzureDevOpsServerManager implements TaskIntegrationManager {
     projectKey: string
   ) {
     return await this.patch<WorkItemAddFieldResponse>(
-      `https://${instanceId}/${projectKey}/_apis/wit/workitems/${remoteIssueId}?api-version=7.1-preview.3`,
+      `https://${instanceId}/${projectKey}/_apis/wit/workitems/${remoteIssueId}?api-version=7.1`,
       [
         {
           op: 'add',


### PR DESCRIPTION
# Description

Fixes #10906 
Limit the number of work items fetched in ADO scoping phase.

Pagination is still not implemented, but seems to be absent for other integrations in scoping.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
