### PR TITLE
fix: integration logo sizing

### DIFF
--- a/packages/client/components/JiraServerSVG.tsx
+++ b/packages/client/components/JiraServerSVG.tsx
@@ -2,7 +2,7 @@ import {memo} from 'react'
 
 const JiraServerSVG = memo(() => {
   return (
-    <svg width='32' height='32' viewBox='0 0 32 32' fill='none' xmlns='http://www.w3.org/2000/svg'>
+    <svg width='24' height='24' viewBox='4 4 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'>
       <path
         d='M26.9143 15.337L16.5718 4.99448L15.5773 4L7.82044 11.7569L4.27348 15.3039C3.90884 15.6685 3.90884 16.2652 4.27348 16.663L11.3674 23.7569L15.5773 28L23.3342 20.2431L23.4668 20.1105L26.9143 16.663C27.279 16.2983 27.279 15.7017 26.9143 15.337ZM15.5773 19.547L12.0304 16L15.5773 12.453L19.1243 16L15.5773 19.547Z'
         fill='#2684FF'

--- a/packages/client/components/LinearProviderLogo.tsx
+++ b/packages/client/components/LinearProviderLogo.tsx
@@ -1,24 +1,15 @@
 import linearLogo from '../styles/theme/images/graphics/linear.svg'
 
-const LinearSVG = () => (
+const LinearProviderLogo = () => (
   <div
     style={{
       backgroundImage: `url("${linearLogo}")`,
       height: '48px',
       width: '48px',
       backgroundSize: 'contain',
-      backgroundRepeat: 'no-repeat',
-      backgroundPosition: 'center'
+      backgroundRepeat: 'no-repeat'
     }}
   />
 )
-
-const LinearProviderLogo = () => {
-  return (
-    <div className='mr-4 flex h-[40px] w-[40px] shrink-0 items-center justify-center rounded-sm'>
-      <LinearSVG />
-    </div>
-  )
-}
 
 export default LinearProviderLogo


### PR DESCRIPTION
# Description

Relates to #11349 
Fix integration logo sizes. Linear and Jira Server were off.

## Demo

<img width="902" alt="image" src="https://github.com/user-attachments/assets/cdc166df-7e8a-4c2a-9214-6a62feea8737" />
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/4a4731b4-f400-4c4d-8931-73d2f247a610" />


## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
