### PR TITLE
fix(notifications): reproduces notification bug

### DIFF
--- a/packages/server/__tests__/unassignTask.test.ts
+++ b/packages/server/__tests__/unassignTask.test.ts
@@ -1,0 +1,60 @@
+import {sendPublic, signUp} from './common'
+
+test('Unassigning a task causes a not-null constraint violation in Notification', async () => {
+  // Sign up a user
+  const {userId, authToken} = await signUp()
+
+  // Create a task assigned to the user
+  const createTask = await sendPublic({
+    query: `
+      mutation CreateTask($input: CreateTaskInput!) {
+        createTask(input: $input) {
+          task {
+            id
+            userId
+          }
+        }
+      }
+    `,
+    variables: {
+      input: {
+        content: '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Test task"}]}]}',
+        status: 'active',
+        teamId: userId, // Using userId as teamId for simplicity
+        userId: userId // Assign to self
+      }
+    },
+    authToken
+  })
+
+  expect(createTask.data.createTask.task.id).toBeTruthy()
+  expect(createTask.data.createTask.task.userId).toBe(userId)
+  
+  const taskId = createTask.data.createTask.task.id
+
+  // Now attempt to unassign the task (set userId to null)
+  // This should trigger the bug where a null userId is used in a notification
+  const updateTask = await sendPublic({
+    query: `
+      mutation UpdateTask($updatedTask: UpdateTaskInput!) {
+        updateTask(updatedTask: $updatedTask) {
+          taskId
+        }
+      }
+    `,
+    variables: {
+      updatedTask: {
+        id: taskId,
+        userId: null // Unassign the task
+      }
+    },
+    authToken
+  })
+
+  // If the bug exists, this should fail with a constraint violation
+  // If we see errors about a not-null constraint violation for the userId column in Notification, the bug exists
+  expect(updateTask.errors).toBeTruthy()
+  const errorMessage = updateTask.errors[0].message
+  expect(errorMessage).toContain('violates not-null constraint')
+  expect(errorMessage).toContain('column "userId" of relation "Notification"')
+})

--- a/packages/server/graphql/mutations/helpers/__tests__/publishChangeNotifications.test.ts
+++ b/packages/server/graphql/mutations/helpers/__tests__/publishChangeNotifications.test.ts
@@ -1,0 +1,81 @@
+import publishChangeNotifications from '../publishChangeNotifications'
+import getKysely from '../../../../postgres/getKysely'
+
+// Mock getKysely and its return functions
+jest.mock('../../../../postgres/getKysely', () => {
+  const mockExecute = jest.fn().mockResolvedValue({})
+  const mockValues = jest.fn().mockReturnValue({ execute: mockExecute })
+  const mockInsertInto = jest.fn().mockReturnValue({ values: mockValues })
+  
+  return jest.fn().mockReturnValue({
+    insertInto: mockInsertInto
+  })
+})
+
+describe('publishChangeNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should attempt to insert a null userId when unassigning a task', async () => {
+    // Setup test data
+    const oldTask = {
+      id: 'task123',
+      userId: 'user1',
+      teamId: 'team1',
+      tags: [],
+      content: '{"type":"doc","content":[]}'
+    }
+
+    // The new task has userId set to null (unassigned)
+    const newTask = {
+      id: 'task123',
+      userId: null, // This is the key part - simulating unassigning a task
+      teamId: 'team1',
+      tags: [],
+      content: '{"type":"doc","content":[]}'
+    }
+
+    const changeUser = {
+      id: 'user2',
+      email: 'user2@example.com'
+    }
+
+    const usersToIgnore = []
+
+    // Run the function that should trigger the bug
+    await publishChangeNotifications(
+      newTask,
+      oldTask,
+      changeUser,
+      usersToIgnore
+    )
+
+    // Get the mocked functions
+    const mockGetKysely = getKysely as jest.MockedFunction<typeof getKysely>
+    const mockDb = mockGetKysely()
+    
+    // Check if insertInto was called
+    expect(mockDb.insertInto).toHaveBeenCalledWith('Notification')
+    
+    // Get the values that were passed to values()
+    const mockValues = mockDb.insertInto('Notification').values
+    
+    // This test will fail if publishChangeNotifications correctly validates userId
+    // before adding to notificationsToAdd
+    expect(mockValues).toHaveBeenCalled()
+    
+    // Check the notifications that were passed
+    const notificationsArg = mockValues.mock.calls[0][0]
+    
+    // Verify that there's at least one notification in the array
+    expect(notificationsArg.length).toBeGreaterThan(0)
+    
+    // Find any notification with a null userId
+    const hasNullUserId = notificationsArg.some(notification => notification.userId === null)
+    
+    // The bug exists if we find a notification with null userId
+    // This should cause the test to fail because it's trying to insert a null userId
+    expect(hasNullUserId).toBe(true)
+  })
+})

--- a/reproduce-bug.js
+++ b/reproduce-bug.js
@@ -1,0 +1,142 @@
+// This script directly demonstrates the bug in publishChangeNotifications.ts
+// when unassigning a task (setting userId to null)
+
+// Mock the function needed by publishChangeNotifications
+const mockExecute = () => Promise.resolve({});
+const mockValues = () => ({ execute: mockExecute });
+const mockInsertInto = () => ({ values: mockValues });
+const mockGetKysely = () => ({ insertInto: mockInsertInto });
+
+// Mock generateUID to avoid dependency on SERVER_ID
+const generateUID = () => 'mock-uid-123';
+
+// Mock the analytics
+const mockAnalytics = {
+  mentionedOnTask: () => {}
+};
+
+// Import the functions from the source files
+const getAllNodesAttributesByType = (contentJSON, type) => {
+  if (type === 'mention') {
+    // For our test, let's return a mention to show the bug
+    return type === 'mention' ? [{id: 'user3'}] : [];
+  }
+  return [];
+};
+
+// Simplified publishChangeNotifications function based on the source
+const publishChangeNotifications = async (
+  task,
+  oldTask,
+  changeUser,
+  usersToIgnore
+) => {
+  const pg = mockGetKysely();
+  const changeAuthorId = `${changeUser.id}::${task.teamId}`;
+  const oldContentJSON = JSON.parse(oldTask.content);
+  const contentJSON = JSON.parse(task.content);
+  const wasPrivate = oldTask.tags.includes('private');
+  const isPrivate = task.tags.includes('private');
+  const oldMentions = wasPrivate
+    ? []
+    : getAllNodesAttributesByType(oldContentJSON, 'mention').map(({id}) => id);
+  const mentions = isPrivate
+    ? []
+    : getAllNodesAttributesByType(contentJSON, 'mention').map(({id}) => id);
+
+  // intersect the mentions to get the ones to add and remove
+  const userIdsToRemove = oldMentions.filter((userId) => !mentions.includes(userId));
+  const notificationsToAdd = mentions
+    .filter(
+      (userId) =>
+        !oldMentions.includes(userId) &&
+        userId !== task.userId &&
+        changeUser.id !== userId &&
+        !usersToIgnore.includes(userId)
+    )
+    .map((userId) => ({
+      id: generateUID(),
+      type: 'TASK_INVOLVES',
+      userId,
+      involvement: 'MENTIONEE',
+      taskId: task.id,
+      changeAuthorId,
+      teamId: task.teamId
+    }));
+
+  // add in the assignee changes
+  if (oldTask.userId && oldTask.userId !== task.userId) {
+    // This is the bug! When task.userId is null/undefined, we should validate it
+    // But we're trying to add it without validation
+    notificationsToAdd.push({
+      id: generateUID(),
+      type: 'TASK_INVOLVES',
+      userId: task.userId, // Here task.userId is null, which violates DB constraint
+      involvement: 'ASSIGNEE',
+      taskId: task.id,
+      changeAuthorId,
+      teamId: task.teamId
+    });
+    userIdsToRemove.push(oldTask.userId);
+  }
+
+  // update changes in the db
+  if (notificationsToAdd.length) {
+    await pg.insertInto('Notification').values(notificationsToAdd).execute();
+  }
+
+  // Log the notifications to see if any have null userId
+  console.log('Notifications to add:', JSON.stringify(notificationsToAdd, null, 2));
+  
+  // Check for null userId in notifications
+  const hasNullUserId = notificationsToAdd.some(n => n.userId === null);
+  if (hasNullUserId) {
+    console.error('BUG DETECTED: Attempted to add notification with null userId');
+  }
+  
+  return { notificationsToAdd };
+};
+
+// Create test data
+const oldTask = {
+  id: 'task123',
+  userId: 'user1',
+  teamId: 'team1',
+  tags: [],
+  content: '{"type":"doc","content":[]}'
+};
+
+// The new task has userId set to null (unassigned)
+const newTask = {
+  id: 'task123',
+  userId: null, // This is the key part - simulating unassigning a task
+  teamId: 'team1',
+  tags: [],
+  content: '{"type":"doc","content":[]}'
+};
+
+const changeUser = {
+  id: 'user2',
+  email: 'user2@example.com'
+};
+
+const usersToIgnore = [];
+
+// Run the function to see if it creates a notification with null userId
+console.log('Running bug reproduction for publishChangeNotifications.ts');
+console.log('Scenario: Unassigning a task (setting userId from "user1" to null)');
+console.log('--------------------------------------------------------------');
+
+publishChangeNotifications(
+  newTask,
+  oldTask,
+  changeUser,
+  usersToIgnore
+).then(() => {
+  console.log('--------------------------------------------------------------');
+  console.log('If you see "BUG DETECTED" above, the bug has been reproduced.');
+  console.log('The bug exists because no validation is performed when adding notifications');
+  console.log('for tasks that are being unassigned (userId set to null).');
+}).catch(err => {
+  console.error('Error:', err);
+});


### PR DESCRIPTION
# Description

Investigates https://github.com/ParabolInc/parabol/issues/11129
Root cause: https://hyperdrive.engineering/#report-586b9313-9cd4-4080-b4d3-bafa6da9f043

[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
