### PR TITLE
fix/orgAdminTeamRenameInline

### DIFF
--- a/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
@@ -8,6 +8,7 @@ import InviteTeamMemberAvatar from '../../../../components/InviteTeamMemberAvata
 import {Button} from '../../../../ui/Button/Button'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
 import {ORGANIZATIONS} from '../../../../utils/constants'
+import EditableTeamName from '../../../teamDashboard/components/EditTeamName/EditableTeamName'
 import {OrgTeamMembersRow} from './OrgTeamMembersRow'
 
 interface Props {
@@ -32,6 +33,7 @@ const query = graphql`
           ...InviteTeamMemberAvatar_teamMembers
         }
         tier
+        ...EditableTeamName_team
       }
     }
   }
@@ -61,7 +63,7 @@ export const OrgTeamMembers = (props: Props) => {
             <ArrowBack />
           </Link>
         </Button>
-        <h1 className='flex-1 text-2xl leading-7 font-semibold'>{team.name}</h1>
+        <EditableTeamName team={team} />
         <div className='ml-auto flex items-center'>
           <InviteTeamMemberAvatar teamId={team.id} teamMembers={teamMembers} />
           {showDeleteButton && (

--- a/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeamMembers/OrgTeamMembers.tsx
@@ -8,6 +8,7 @@ import InviteTeamMemberAvatar from '../../../../components/InviteTeamMemberAvata
 import {Button} from '../../../../ui/Button/Button'
 import {useDialogState} from '../../../../ui/Dialog/useDialogState'
 import {ORGANIZATIONS} from '../../../../utils/constants'
+import plural from '../../../../utils/plural'
 import EditableTeamName from '../../../teamDashboard/components/EditTeamName/EditableTeamName'
 import {OrgTeamMembersRow} from './OrgTeamMembersRow'
 
@@ -52,8 +53,8 @@ export const OrgTeamMembers = (props: Props) => {
   } = useDialogState()
 
   if (!team) return null
-  const {isViewerLead, isOrgAdmin: isViewerOrgAdmin, teamMembers} = team
-  const showDeleteButton = isViewerLead || isViewerOrgAdmin
+  const {name: teamName, isViewerLead, isOrgAdmin: isViewerOrgAdmin, teamMembers} = team
+  const canEditTeam = isViewerLead || isViewerOrgAdmin
 
   return (
     <div className='max-w-4xl pb-4'>
@@ -63,10 +64,12 @@ export const OrgTeamMembers = (props: Props) => {
             <ArrowBack />
           </Link>
         </Button>
-        <EditableTeamName team={team} />
+        <div className='text-gray-700 hover:text-gray-900 text-lg font-bold'>
+          {canEditTeam ? <EditableTeamName team={team} /> : {teamName}}
+        </div>
         <div className='ml-auto flex items-center'>
           <InviteTeamMemberAvatar teamId={team.id} teamMembers={teamMembers} />
-          {showDeleteButton && (
+          {canEditTeam && (
             <div className='group mx-1.5 cursor-pointer' onClick={openDeleteTeamDialog}>
               <div className='flex h-7 justify-center'>
                 <span className='h-6 w-6 self-center text-slate-500 group-hover:text-slate-600'>
@@ -84,7 +87,9 @@ export const OrgTeamMembers = (props: Props) => {
       <div className='divide-y divide-slate-300 overflow-hidden rounded-md border border-slate-300 bg-white shadow-xs'>
         <div className='bg-slate-100 px-4 py-2'>
           <div className='flex w-full justify-between'>
-            <div className='flex items-center font-bold'>{teamMembers.length} Active</div>
+            <div className='flex items-center font-bold'>
+              {teamMembers.length} {plural(teamMembers.length, 'User')}
+            </div>
           </div>
         </div>
         {teamMembers.map((teamMember) => (

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -33,7 +33,7 @@ const OrgTeamsRow = (props: Props) => {
 
   return (
     <tr className='hover:bg-slate-50 border-b border-slate-300'>
-      <td className='p-3'>
+      <td className='flex items-center p-3'>
         <Link
           to={`teams/${teamId}`}
           className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'

--- a/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgTeams/OrgTeamsRow.tsx
@@ -4,7 +4,6 @@ import {format} from 'date-fns'
 import {useFragment} from 'react-relay'
 import {Link} from 'react-router-dom'
 import {OrgTeamsRow_team$key} from '../../../../__generated__/OrgTeamsRow_team.graphql'
-import EditableTeamName from '../../../teamDashboard/components/EditTeamName/EditableTeamName'
 
 type Props = {
   teamRef: OrgTeamsRow_team$key
@@ -22,13 +21,11 @@ const OrgTeamsRow = (props: Props) => {
           isLead
         }
         lastMetAt
-        isOrgAdmin
-        ...EditableTeamName_team
       }
     `,
     teamRef
   )
-  const {id: teamId, teamMembers, name: teamName, lastMetAt, isOrgAdmin} = team
+  const {id: teamId, teamMembers, name, lastMetAt} = team
   const teamMembersCount = teamMembers.length
   const viewerTeamMember = teamMembers.find((m) => m.isSelf)
   const isLead = viewerTeamMember?.isLead
@@ -37,22 +34,25 @@ const OrgTeamsRow = (props: Props) => {
   return (
     <tr className='hover:bg-slate-50 border-b border-slate-300'>
       <td className='p-3'>
-        <div className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'>
-          <div className='flex items-center gap-2'>
-            {isLead || isOrgAdmin ? <EditableTeamName team={team} /> : <span>{teamName}</span>}
+        <Link
+          to={`teams/${teamId}`}
+          className='text-gray-700 hover:text-gray-900 flex items-center text-lg font-bold'
+        >
+          <div className='flex flex-1 items-center'>
+            {name}
             {isLead && (
-              <span className='rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
+              <span className='ml-2 rounded-full bg-primary px-2 py-0.5 text-xs text-white'>
                 Team Lead
               </span>
             )}
             {isMember && (
-              <span className='rounded-full bg-sky-500 px-2 py-0.5 text-xs text-white'>Member</span>
+              <span className='ml-2 rounded-full bg-sky-500 px-2 py-0.5 text-xs text-white'>
+                Member
+              </span>
             )}
           </div>
-          <Link to={`teams/${teamId}`}>
-            <ChevronRight className='ml-auto text-slate-600' />
-          </Link>
-        </div>
+          <ChevronRight className='ml-2 text-slate-600' />
+        </Link>
       </td>
       <td className='text-gray-600 p-3'>{teamMembersCount}</td>
       <td className='text-gray-600 p-3'>


### PR DESCRIPTION
- **fix(orgAdmin): revert the in-line team name change on the org teams row**
- **move the chevron right icon to be close by the team name**
- **Being able to edit team name inline on the OrgTeamMembers page**
- **Change some styling & fix team member size text**

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
