### PR TITLE
fix: show meeting series without active meetings in dash

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -209,6 +209,7 @@ const MeetingCard = (props: Props) => {
         name
         meetingType
         locked
+        endedAt
         phases {
           phaseType
           stages {
@@ -235,7 +236,7 @@ const MeetingCard = (props: Props) => {
     `,
     meetingRef
   )
-  const {name, team, id: meetingId, meetingType, phases, meetingSeries, locked} = meeting
+  const {name, team, id: meetingId, meetingType, phases, meetingSeries, endedAt, locked} = meeting
   const connectedUsers = useMeetingMemberAvatars(meeting)
   const meetingPhase = getMeetingPhase(phases)
   const meetingPhaseLabel = (meetingPhase && phaseLabelLookup[meetingPhase.phaseType]) || 'Complete'
@@ -269,6 +270,7 @@ const MeetingCard = (props: Props) => {
   const {id: teamId, name: teamName, orgId} = team
 
   const isRecurring = !!(meetingSeries && !meetingSeries.cancelledAt)
+  const isCompleted = !!endedAt
   const meetingLink = isRecurring ? `/meeting-series/${meetingId}` : `/meet/${meetingId}`
 
   return (
@@ -299,16 +301,30 @@ const MeetingCard = (props: Props) => {
           <MeetingImgWrapper>
             <MeetingImgBackground meetingType={meetingType} />
             <MeetingTypeLabel>{MEETING_TYPE_LABEL[meetingType]}</MeetingTypeLabel>
-            {isRecurring && (
-              <span
-                className={cn(
-                  'absolute top-2 right-2 rounded-[64px] px-2 py-1 text-[11px] leading-3 font-medium',
-                  RECURRING_LABEL_COLORS[meetingType]
-                )}
-              >
-                Recurring
-              </span>
-            )}
+            <div className='absolute top-2 right-2 flex items-center gap-1'>
+              {isRecurring && (
+                <>
+                  {isCompleted && (
+                    <span
+                      className={clsx(
+                        'rounded-[64px] px-2 py-1 text-[11px] leading-3 font-medium',
+                        RECURRING_LABEL_COLORS[meetingType]
+                      )}
+                    >
+                      Completed
+                    </span>
+                  )}
+                  <span
+                    className={clsx(
+                      'rounded-[64px] px-2 py-1 text-[11px] leading-3 font-medium',
+                      RECURRING_LABEL_COLORS[meetingType]
+                    )}
+                  >
+                    Recurring
+                  </span>
+                </>
+              )}
+            </div>
             <Link to={meetingLink}>
               <MeetingImg src={ILLUSTRATIONS[meetingType]} alt='' />
             </Link>

--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -72,20 +72,6 @@ const MeetingsDash = (props: Props) => {
       .filter(Boolean)
       .filter((meeting) => !meeting.meetingSeries || meeting.meetingSeries.cancelledAt)
       .sort((a, b) => {
-        const aRecurring = !!(a.meetingSeries && !a.meetingSeries.cancelledAt)
-        const bRecurring = !!(b.meetingSeries && !b.meetingSeries.cancelledAt)
-        if (aRecurring && !bRecurring) {
-          return -1
-        }
-        if (bRecurring && !aRecurring) {
-          return 1
-        }
-
-        if (aRecurring && bRecurring) {
-          // When ordering recurring meetings, sort based on when the series was created to maintain
-          // consistency when meetings are restarted.
-          return a.meetingSeries.createdAt > b.meetingSeries.createdAt ? -1 : 1
-        }
         return a.createdAt > b.createdAt ? -1 : 1
       })
     return [...meetingSeriesMeetings, ...otherActiveMeetings]

--- a/packages/client/components/MeetingsDash.tsx
+++ b/packages/client/components/MeetingsDash.tsx
@@ -59,31 +59,37 @@ const MeetingsDash = (props: Props) => {
   const atmosphere = useAtmosphere()
   const {teamIds: teamFilterIds} = useQueryParameterParser(atmosphere.viewerId)
   const {teams = [], preferredName = '', dashSearch} = viewer ?? {}
-  const activeMeetings = useMemo(
-    () =>
-      teams
-        .flatMap((team) => team.activeMeetings)
-        .filter(Boolean)
-        .sort((a, b) => {
-          const aRecurring = !!(a.meetingSeries && !a.meetingSeries.cancelledAt)
-          const bRecurring = !!(b.meetingSeries && !b.meetingSeries.cancelledAt)
-          if (aRecurring && !bRecurring) {
-            return -1
-          }
-          if (bRecurring && !aRecurring) {
-            return 1
-          }
+  const activeMeetings = useMemo(() => {
+    const meetingSeriesMeetings = teams
+      .flatMap((team) => team.activeMeetingSeries)
+      .filter(Boolean)
+      .sort((a, b) => {
+        return a.createdAt > b.createdAt ? -1 : 1
+      })
+      .map((meetingSeries) => meetingSeries.mostRecentMeeting)
+    const otherActiveMeetings = teams
+      .flatMap((team) => team.activeMeetings)
+      .filter(Boolean)
+      .filter((meeting) => !meeting.meetingSeries || meeting.meetingSeries.cancelledAt)
+      .sort((a, b) => {
+        const aRecurring = !!(a.meetingSeries && !a.meetingSeries.cancelledAt)
+        const bRecurring = !!(b.meetingSeries && !b.meetingSeries.cancelledAt)
+        if (aRecurring && !bRecurring) {
+          return -1
+        }
+        if (bRecurring && !aRecurring) {
+          return 1
+        }
 
-          if (aRecurring && bRecurring) {
-            // When ordering recurring meetings, sort based on when the series was created to maintain
-            // consistency when meetings are restarted.
-            return a.meetingSeries.createdAt > b.meetingSeries.createdAt ? -1 : 1
-          }
-
-          return a.createdAt > b.createdAt ? -1 : 1
-        }),
-    [teams]
-  )
+        if (aRecurring && bRecurring) {
+          // When ordering recurring meetings, sort based on when the series was created to maintain
+          // consistency when meetings are restarted.
+          return a.meetingSeries.createdAt > b.meetingSeries.createdAt ? -1 : 1
+        }
+        return a.createdAt > b.createdAt ? -1 : 1
+      })
+    return [...meetingSeriesMeetings, ...otherActiveMeetings]
+  }, [teams])
   const filteredMeetings = useMemo(() => {
     const searchedMeetings = dashSearch
       ? activeMeetings.filter(({name}) => name && name.match(getSafeRegex(dashSearch, 'i')))
@@ -150,23 +156,31 @@ const MeetingsDash = (props: Props) => {
 }
 
 graphql`
+  fragment MeetingsDash_meeting on NewMeeting {
+    ...MeetingCard_meeting
+    ...useSnacksForNewMeetings_meetings
+    id
+    teamId
+    name
+    createdAt
+  }
+`
+
+graphql`
   fragment MeetingsDashActiveMeetings on Team {
     activeMeetings {
-      ...MeetingCard_meeting
-      ...useSnacksForNewMeetings_meetings
-      id
-      teamId
-      name
-      createdAt
-      meetingMembers {
-        user {
-          isConnected
-          lastSeenAtURLs
-        }
-      }
+      ...MeetingsDash_meeting @relay(mask: false)
       meetingSeries {
         createdAt
         cancelledAt
+      }
+    }
+    activeMeetingSeries {
+      id
+      createdAt
+      cancelledAt
+      mostRecentMeeting {
+        ...MeetingsDash_meeting @relay(mask: false)
       }
     }
   }

--- a/packages/client/utils/date/relativeDate.ts
+++ b/packages/client/utils/date/relativeDate.ts
@@ -22,6 +22,38 @@ interface Opts {
   smallDiff?: string
 }
 
+const weekDayFormatter = new Intl.DateTimeFormat('en-US', {weekday: 'long'})
+/**
+ * Creates a human-readable string representing of the next meeting date,
+ * for example: Friday; tomorrow; in 12 hours; next week; in 2 weeks; etc or null if the date is in the past
+ * @param date
+ */
+export const humanReadableNextStart = (date: string | Date) => {
+  const then = new Date(date)
+  const now = new Date()
+  const abs = then.getTime() - now.getTime()
+  if (abs < 0) return null
+  const periods = {
+    week: abs / (DAY * 7),
+    day: abs / DAY,
+    hour: abs / HOUR
+  } as const
+
+  const weeks = Math.floor(periods.week)
+  if (weeks > 0) {
+    return weeks === 1 ? 'next week' : `in ${weeks} weeks`
+  }
+
+  const days = Math.floor(periods.day)
+  const hours = Math.floor(periods.hour)
+
+  if (days > 0 || now.getDate() !== then.getDate()) {
+    return hours < 24 ? 'tomorrow' : weekDayFormatter.format(then)
+  }
+
+  return hours > 0 ? `in ${hours} ${plural(hours, 'hour', 'hours')}` : `soon`
+}
+
 /**
  * Creates a human-readable string representing the time till the given date,
  * for example: 2 days; 13 hours; 2 days, etc or null if the date is in the past

--- a/packages/server/dataloader/foreignKeyLoaderMakers.ts
+++ b/packages/server/dataloader/foreignKeyLoaderMakers.ts
@@ -256,6 +256,19 @@ export const completedMeetingsByTeamId = foreignKeyLoaderMaker(
       .execute()
   }
 )
+export const activeMeetingSeriesByTeamId = foreignKeyLoaderMaker(
+  'meetingSeries',
+  'teamId',
+  async (teamIds) => {
+    return getKysely()
+      .selectFrom('MeetingSeries')
+      .selectAll()
+      .where('teamId', 'in', teamIds)
+      .where('cancelledAt', 'is', null)
+      .orderBy('createdAt', 'desc')
+      .execute()
+  }
+)
 
 export const meetingMembersByMeetingId = foreignKeyLoaderMaker(
   'meetingMembers',

--- a/packages/server/graphql/public/typeDefs/Team.graphql
+++ b/packages/server/graphql/public/typeDefs/Team.graphql
@@ -102,9 +102,14 @@ type Team implements Node {
   scales: [TemplateScale!]!
 
   """
-  a list of meetings that are currently in progress
+  list of meetings that are currently in progress including active meetings of activeMeetingSeries
   """
   activeMeetings: [NewMeeting!]!
+
+  """
+  list of all active meeting series, a series can be active without having an active meeting
+  """
+  activeMeetingSeries: [MeetingSeries!]!
 
   """
   Whether the team has a feature flag enabled or not

--- a/packages/server/graphql/public/types/Team.ts
+++ b/packages/server/graphql/public/types/Team.ts
@@ -63,6 +63,16 @@ const Team: TeamResolvers = {
   },
   featureFlag: async ({id: teamId}, {featureName}, {dataLoader}) => {
     return await dataLoader.get('featureFlagByOwnerId').load({ownerId: teamId, featureName})
+  },
+  activeMeetings: async ({id: teamId}, _args, {authToken, dataLoader}) => {
+    if (!isTeamMember(authToken, teamId)) return []
+    // this is by team, not by meeting member, which caused an err in dev, not sure about prod
+    // we need better perms for people to view/not view a meeting that happened before they joined the team
+    return dataLoader.get('activeMeetingsByTeamId').load(teamId)
+  },
+  activeMeetingSeries: async ({id: teamId}, _args, {authToken, dataLoader}) => {
+    if (!isTeamMember(authToken, teamId)) return []
+    return dataLoader.get('activeMeetingSeriesByTeamId').load(teamId)
   }
 }
 

--- a/packages/server/graphql/types/Team.ts
+++ b/packages/server/graphql/types/Team.ts
@@ -198,20 +198,6 @@ const Team: GraphQLObjectType = new GraphQLObjectType<ITeam, GQLContext>({
         return availableScales.filter(isValid).flat()
       }
     },
-    activeMeetings: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(NewMeeting))),
-      description: 'a list of meetings that are currently in progress',
-      resolve: async (
-        {id: teamId}: {id: string},
-        _args: unknown,
-        {authToken, dataLoader}: GQLContext
-      ) => {
-        if (!isTeamMember(authToken, teamId)) return []
-        // this is by team, not by meeting member, which caused an err in dev, not sure about prod
-        // we need better perms for people to view/not view a meeting that happened before they joined the team
-        return dataLoader.get('activeMeetingsByTeamId').load(teamId)
-      }
-    },
     qualAIMeetingsCount: {
       type: new GraphQLNonNull(GraphQLInt),
       description:

--- a/packages/server/postgres/queries/src/TierEnum.sql
+++ b/packages/server/postgres/queries/src/TierEnum.sql
@@ -1,5 +1,6 @@
 /*
   @name TierEnumType
 */
+-- We just want to generate the enum type
 SELECT tier FROM "Organization" WHERE id = 'aGhostOrg';
 


### PR DESCRIPTION
# Description

Fixes #11344
Always show active meeting series, even if there is currently no active meeting. We will always show the last meeting in the series, even if it's ended. In that case another bubble with "completed" is added.

## Demo

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/023e9201-56ef-41c4-99f9-35ae9af09b87" />

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
