### PR TITLE
fix: show correct emoji suggestion for :) and :(

### DIFF
--- a/packages/client/utils/tiptapEmojiConfig.ts
+++ b/packages/client/utils/tiptapEmojiConfig.ts
@@ -14,7 +14,10 @@ export const tiptapEmojiConfig: Partial<MentionOptions<any, MentionNodeAttrs>> =
     pluginKey: new PluginKey('emoji'),
     char: ':',
     items: async ({query}) => {
-      const emojis: Emoji[] = await SearchIndex.search(query || '')
+      // for classic emoticons like :), we need to include the : in the search
+      const isEmoticon = /^[^a-zA-Z0-9_]/.test(query)
+      const searchQuery = isEmoticon ? `:${query}` : query
+      const emojis: Emoji[] = await SearchIndex.search(searchQuery || '')
       if (!emojis) return []
       return emojis.map((emoji) => ({
         id: emoji.id,


### PR DESCRIPTION

# Description

Fixes #11358 
: is the trigger for the emoji menu, so we omitted the : from the search for matches. This resulted in :) suggesting :disappointment: and :( suggesting :slightly_smiling_face:. Now we include the : in the search if the next character isn't alphanumerical.


## Demo

<img width="332" alt="image" src="https://github.com/user-attachments/assets/54fb43f7-174e-440d-b6b9-68a1433903af" />

## Testing scenarios

- in a new task add various emojis via `:)`, `:dis`, `:(` etc.

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
