### PR TITLE
fix: fix suUserCount after DB schema migration

### DIFF
--- a/packages/server/graphql/private/queries/suUserCount.ts
+++ b/packages/server/graphql/private/queries/suUserCount.ts
@@ -1,13 +1,17 @@
-import getPg from '../../../postgres/getPg'
+import getKysely from '../../../postgres/getKysely'
 import {QueryResolvers} from '../resolverTypes'
 
 const suUserCount: QueryResolvers['suUserCount'] = async (_source, {tier}) => {
-  const pg = getPg()
-  const result = await pg.query(
-    'SELECT count(*)::float FROM "User" WHERE inactive = FALSE AND tier = $1',
-    [tier]
-  )
-  return result.rows[0].count
+  const pg = getKysely()
+  const result = await pg
+    .selectFrom('OrganizationUser as ou')
+    .innerJoin('Organization as o', 'o.id', 'ou.orgId')
+    .select(({fn}) => fn.count<number>('ou.userId').distinct().as('count'))
+    .where('tier', '=', tier)
+    .where('ou.inactive', '=', false)
+    .where('ou.removedAt', 'is', null)
+    .executeTakeFirstOrThrow()
+  return result.count
 }
 
 export default suUserCount


### PR DESCRIPTION
# Description

`tier` column is deprecate from `User`

## Testing scenarios

Go to `http://localhost:3000/admin/graphql`:

```graphql
query getAllTimeCounts (
    $OneWeekAgo: DateTime = "2025-05-26T00:00:00.000Z",
    $ThirtyDaysAgo: DateTime = "2025-05-02T00:00:00.000Z",
    $AllTimeDate: DateTime = "2016-01-01T00:00:00.000Z",
    ) {
    starterOrgs: suOrgCount(tier: starter)
    teamOrgs: suOrgCount(tier: team)
    enterpriseOrgs: suOrgCount(tier: enterprise)
    starterUsers: suUserCount(tier: starter)
    teamUsers: suUserCount(tier: team)
    enterpriseUsers: suUserCount(tier: enterprise)
    
    signupsLastWeek: signups(after: $OneWeekAgo, isActive: false) {
      total
    }
    
    signups30DaysAgo: signups(after: $ThirtyDaysAgo, isActive: false) {
      total
    }
    
    signupsAllTime: signups(after: $AllTimeDate, isActive: false) {
      total
    }
  }
```

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
