### PR TITLE
feat: background music UI improvements

### DIFF
--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -58,11 +58,7 @@ const BottomControlBarMusic = ({
         >
           <span className='flex flex-col items-center justify-center'>
             <HeadphonesIcon
-              className={cn(
-                'text-gray-500',
-                isPlaying &&
-                  'from-blue-400 via-purple-400 to-green-400 animate-shimmer bg-gradient-to-r bg-[length:200%_200%] bg-clip-text text-transparent'
-              )}
+              className={cn(isPlaying ? 'animate-pulse text-slate-700' : 'text-slate-700')}
               fontSize='medium'
             />
             <span className='mt-0.5 text-xs font-medium text-slate-600'>Music</span>

--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -57,7 +57,14 @@ const BottomControlBarMusic = ({
           onClick={() => setOpen((prev) => !prev)}
         >
           <span className='flex flex-col items-center justify-center'>
-            <HeadphonesIcon className='text-gray-500' fontSize='medium' />
+            <HeadphonesIcon
+              className={cn(
+                'text-gray-500',
+                isPlaying &&
+                  'from-blue-400 via-purple-400 to-green-400 animate-shimmer bg-gradient-to-r bg-[length:200%_200%] bg-clip-text text-transparent'
+              )}
+              fontSize='medium'
+            />
             <span className='mt-0.5 text-xs font-medium text-slate-600'>Music</span>
           </span>
         </BottomNavControl>
@@ -96,12 +103,10 @@ const BottomControlBarMusic = ({
                         }
                       }}
                       className={cn(
-                        'hover:bg-gray-600 box-border flex w-full appearance-none items-center gap-2 rounded-lg border px-3 py-2 text-base leading-tight font-normal transition-colors outline-none focus:outline-none',
+                        'box-border flex w-full appearance-none items-center gap-2 rounded-lg border bg-slate-200 px-3 py-2 text-base leading-tight font-normal transition-colors outline-none focus:outline-none',
                         isSelected
-                          ? isCurrentlyPlaying
-                            ? 'border-green-500 bg-green-50 text-green-700 font-semibold shadow'
-                            : 'border-blue-500 bg-blue-50 text-blue-700 font-semibold shadow'
-                          : 'cursor-pointer border-transparent bg-slate-200 text-slate-700 hover:bg-slate-300 hover:text-slate-900'
+                          ? 'font-semibold shadow'
+                          : 'cursor-pointer border-transparent text-slate-700 hover:bg-slate-300 hover:text-slate-900'
                       )}
                     >
                       <span className='flex-1 truncate'>{track.name}</span>

--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -96,12 +96,12 @@ const BottomControlBarMusic = ({
                         }
                       }}
                       className={cn(
-                        'box-border flex w-full appearance-none items-center gap-2 rounded-lg border px-3 py-2 text-base leading-tight font-normal outline-none focus:outline-none',
+                        'hover:bg-gray-600 box-border flex w-full appearance-none items-center gap-2 rounded-lg border px-3 py-2 text-base leading-tight font-normal transition-colors outline-none focus:outline-none',
                         isSelected
                           ? isCurrentlyPlaying
                             ? 'border-green-500 bg-green-50 text-green-700 font-semibold shadow'
                             : 'border-blue-500 bg-blue-50 text-blue-700 font-semibold shadow'
-                          : 'hover:bg-gray-50 text-gray-700 cursor-pointer border-transparent'
+                          : 'cursor-pointer border-transparent bg-slate-200 text-slate-700 hover:bg-slate-300 hover:text-slate-900'
                       )}
                     >
                       <span className='flex-1 truncate'>{track.name}</span>

--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -64,10 +64,10 @@ const BottomControlBarMusic = ({
       </RadixPopover.Trigger>
       <RadixPopover.Portal>
         <RadixPopover.Content
-          sideOffset={8}
+          sideOffset={2}
           className={`background-music-popover z-10 m-0 w-64 max-w-md min-w-[14rem] p-0`}
         >
-          <div className='border-gray-100 flex flex-col gap-4 rounded-xl border bg-white p-4 shadow-xl'>
+          <div className='flex flex-col gap-4 rounded-lg bg-white p-4 shadow-xl'>
             <div className='mb-1 flex items-center gap-2'>
               <HeadphonesIcon className='text-blue-500' fontSize='small' />
               <span className='text-gray-800 text-base font-semibold'>Background music</span>
@@ -161,7 +161,6 @@ const BottomControlBarMusic = ({
               </div>
             </div>
           </div>
-          <RadixPopover.Arrow className='fill-white' />
         </RadixPopover.Content>
       </RadixPopover.Portal>
     </RadixPopover.Root>

--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -86,7 +86,6 @@ const BottomControlBarMusic = ({
               >
                 {availableTracks.map((track) => {
                   const isSelected = currentTrackSrc === track.src
-                  const isCurrentlyPlaying = isSelected && isPlaying
 
                   return (
                     <button

--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -67,7 +67,7 @@ const BottomControlBarMusic = ({
           sideOffset={2}
           className={`background-music-popover z-10 m-0 w-64 max-w-md min-w-[14rem] p-0`}
         >
-          <div className='flex flex-col gap-4 rounded-lg bg-white p-4 shadow-xl'>
+          <div className='flex flex-col gap-4 rounded-lg bg-white p-4 shadow-2xl'>
             <div className='mb-1 flex items-center gap-2'>
               <HeadphonesIcon className='text-blue-500' fontSize='small' />
               <span className='text-gray-800 text-base font-semibold'>Background music</span>

--- a/packages/client/hooks/useMeetingMusicSync.ts
+++ b/packages/client/hooks/useMeetingMusicSync.ts
@@ -97,6 +97,13 @@ const useMeetingMusicSync = (meetingId: string) => {
           audioRef.current!.volume = volume
         }
       })
+
+      audioRef.current.addEventListener('ended', () => {
+        if (audioRef.current && isPlaying) {
+          audioRef.current.currentTime = 0
+          audioRef.current.play()
+        }
+      })
     }
 
     return () => {


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/11389

![hover-and-animate](https://github.com/user-attachments/assets/b05128e7-bd8c-464c-97f4-5612380c81ae)

### Updates in this PR

- [ ] When the track ends, it loops back and starts again
- [ ] The music modal looks is more consistent with the other modals: position, box shadow, no border
- [ ] Added feedback when hovering over a track
- [ ] Add feedback when the music is playing. The headphones icon pulsates