### PR TITLE
chore: hide tips on mobile

### DIFF
--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -109,6 +109,7 @@ const MeetingControlBar = (props: Props) => {
     meetingRef
   )
   const atmosphere = useAtmosphere()
+  const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
   const {viewerId} = atmosphere
   const {
     endedAt,
@@ -130,7 +131,7 @@ const MeetingControlBar = (props: Props) => {
   const getPossibleButtons = () => {
     const buttons = ['music']
     if (isFacilitating && !isComplete && showTimerInPhase(phaseType)) buttons.push('timer')
-    buttons.push('tips')
+    if (isDesktop) buttons.push('tips')
     if (!isFacilitating && !isCheckIn && !isComplete && !isPoker) buttons.push('ready')
     if (!isFacilitating && localStageId !== facilitatorStageId) buttons.push('rejoin')
     if ((isFacilitating || isPoker) && findStageAfterId(phases, localStageId)) buttons.push('next')
@@ -141,7 +142,6 @@ const MeetingControlBar = (props: Props) => {
   const [confirmingButton, setConfirmingButton] = useClickConfirmation()
   const cancelConfirm = confirmingButton ? () => setConfirmingButton('') : undefined
   const tranChildren = useTransition(buttons)
-  const isDesktop = useBreakpoint(Breakpoint.SINGLE_REFLECTION_COLUMN)
   const controlBarWidth =
     buttons.length * ElementWidth.CONTROL_BAR_BUTTON + ElementWidth.CONTROL_BAR_PADDING * 2
   const left = useLeft(controlBarWidth, isRightDrawerOpen, showSidebar)


### PR DESCRIPTION
Now that we've added the background music to the meeting control bar, on mobile, the user can't see the End Meeting button.

As discussed with @ackernaut on Zoom, let's hide the Tips button on mobile so the End Meeting button is clearly visible.

<img width="352" alt="Screenshot 2025-06-09 at 16 22 19" src="https://github.com/user-attachments/assets/464f7fba-5de3-4626-b29e-7abff5a5ef05" />


This is a small, low risk change so I'll merge straight to master. 