### PR TITLE
fix: reduce MS Teams error logs

### DIFF
--- a/packages/server/utils/MSTeamsServerManager.ts
+++ b/packages/server/utils/MSTeamsServerManager.ts
@@ -33,7 +33,7 @@ class MSTeamsServerManager {
         body: payload,
         signal: AbortSignal.timeout(MAX_REQUEST_TIME)
       })
-      if (res.status !== 200) {
+      if (res.status < 200 || res.status >= 300) {
         if (res.headers.get('content-type') === 'application/json') {
           const {message: error} = await res.json()
           return new Error(`${res.status}: ${error}`)

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -15,12 +15,6 @@ const {PORT, SOCKET_PORT} = process.env
 
 const USE_REFRESH = false
 module.exports = {
-  cache: {
-    type: 'filesystem',
-    buildDependencies: {
-      config: [__filename]
-    }
-  },
   stats: 'errors-warnings',
   devServer: {
     allowedHosts: ['localhost', 'host.docker.internal'],


### PR DESCRIPTION
The server usually replies with 202 which is not an error code, but was logged as such. This cleans up the logs a bit.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
