### PR TITLE
chore: facilitator music overrides non facilitator's music

### DIFF
--- a/packages/client/hooks/useMeetingMusicSync.ts
+++ b/packages/client/hooks/useMeetingMusicSync.ts
@@ -51,7 +51,6 @@ const useMeetingMusicSync = (meetingId: string) => {
   const [currentTrackSrc, setCurrentTrackSrc] = useState<string | null>(null)
   const [isPlaying, setIsPlaying] = useState<boolean>(false)
   const [volume, setVolume] = useState<number>(0.5)
-  const [localOverride, setLocalOverride] = useState(false)
 
   // Stores track info when autoplay is blocked by browser, waits for user interaction to play
   const pendingPlay = useRef<{trackSrc: string} | null>(null)
@@ -59,7 +58,7 @@ const useMeetingMusicSync = (meetingId: string) => {
 
   // Sync music state from server for non-facilitators
   useEffect(() => {
-    if (isFacilitator || localOverride || !audioRef.current) return
+    if (isFacilitator || !audioRef.current) return
 
     const {musicSettings} = meeting || {}
     if (!musicSettings) return
@@ -70,7 +69,8 @@ const useMeetingMusicSync = (meetingId: string) => {
     const shouldStartPlaying = shouldPlay && !isPlaying
     const shouldStopPlaying = !shouldPlay && isPlaying
 
-    if (shouldStartPlaying || (trackChanged && shouldPlay)) {
+    // Override local control when facilitator plays a track
+    if (shouldStartPlaying) {
       playTrack(trackSrc || currentTrackSrc)
     } else if (shouldStopPlaying) {
       audioRef.current.pause()
@@ -81,7 +81,7 @@ const useMeetingMusicSync = (meetingId: string) => {
       audioRef.current.load()
       setCurrentTrackSrc(trackSrc)
     }
-  }, [musicSettings?.trackSrc, musicSettings?.isPlaying, isFacilitator, localOverride])
+  }, [musicSettings?.trackSrc, musicSettings?.isPlaying, isFacilitator])
 
   // Initialize audio element and prepare for autoplay restrictions
   useEffect(() => {
@@ -188,8 +188,6 @@ const useMeetingMusicSync = (meetingId: string) => {
 
     if (isFacilitator) {
       syncMusicState(currentTrackSrc, false)
-    } else {
-      setLocalOverride(true)
     }
   }
 
@@ -203,8 +201,6 @@ const useMeetingMusicSync = (meetingId: string) => {
 
     if (isFacilitator) {
       syncMusicState(trackSrc, false)
-    } else {
-      setLocalOverride(true)
     }
   }
 


### PR DESCRIPTION
See Slack discussion [here](https://parabol.slack.com/archives/C4JAUUZ9P/p1749669389990999?thread_ts=1749569905.263499&cid=C4JAUUZ9P) 🔒 

Currently in prod, if a non-facilitator plays their own track, they become disconnected from the facilitator. So, if the facilitator then plays a track, they don't hear it.

In a recent Growth meeting, this felt like a bug.

In this PR, if the non-facilitator starts playing their own track, and then the facilitator plays a track, the non-facilitator's music is overridden so that they hear the facilitator's track.

### To test

- [ ] Open two browsers, one with a facilitator and one with a non-facilitator. Start a meeting
- [ ] The facilitator plays a track and the non-facilitator hears it
- [ ] The non-facilitator can stop the track and play a different track
- [ ] The facilitator then plays a new track and it overrides the track the non-facilitator started playing. The non-facilitator now hears the track the facilitator played
