### PR TITLE
fix: rbac performance

### DIFF
--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -13,7 +13,7 @@ import {generateJSON, generateText, useEditor} from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import graphql from 'babel-plugin-relay/macro'
 import type {History} from 'history'
-import {useMemo, useRef} from 'react'
+import {useEffect, useMemo, useRef} from 'react'
 import {commitLocalUpdate, readInlineData} from 'relay-runtime'
 import AutoJoiner from 'tiptap-extension-auto-joiner'
 import GlobalDragHandle from 'tiptap-extension-global-drag-handle'
@@ -218,5 +218,10 @@ export const useTipTapPageEditor = (
     },
     [provider]
   )
+  useEffect(() => {
+    return () => {
+      provider?.destroy()
+    }
+  }, [])
   return {editor}
 }

--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -99,7 +99,7 @@ export const useTipTapPageEditor = (
   providerRef.current = useMemo(() => {
     if (!pageId) return undefined
     if (providerRef.current) {
-      providerRef.current.disconnect()
+      providerRef.current.destroy()
     }
     const doc = new Y.Doc()
     const frag = doc.getXmlFragment('default')

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
@@ -1,6 +1,7 @@
 import {sql} from 'kysely'
 import getKysely from '../../../../postgres/getKysely'
 import {selectDescendantPages} from '../../../../postgres/select'
+import {updatePageAccessTable} from '../../../../postgres/updatePageAccessTable'
 
 export const movePageToNewParent = async (
   viewerId: string,
@@ -19,6 +20,7 @@ export const movePageToNewParent = async (
       qc
         .deleteFrom('PageUserAccess')
         .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+        .where('userId', '!=', viewerId)
         .where(({eb, not, exists}) =>
           not(
             exists(
@@ -29,7 +31,6 @@ export const movePageToNewParent = async (
             )
           )
         )
-        .where('userId', '!=', viewerId)
     )
     .with('delTeams', (qc) =>
       qc
@@ -190,71 +191,7 @@ export const movePageToNewParent = async (
 
   // upsert viewer as owner IIF nothing else is the owner
   // nothing else is the owner if PageAccess(pageId) has no owner
-  const strongestRole = await selectDescendantPages(trx, pageId)
-    .with('unionAccess', (qc) =>
-      qc
-        .selectFrom('PageUserAccess')
-        .select(['userId', 'pageId', 'role'])
-        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
-        .unionAll(({parens, selectFrom}) =>
-          parens(
-            selectFrom('PageTeamAccess')
-              .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
-              .innerJoin('TeamMember', 'PageTeamAccess.teamId', 'TeamMember.teamId')
-              .where('TeamMember.isNotRemoved', '=', true)
-              .select(['TeamMember.userId', 'pageId', 'role'])
-          )
-        )
-        .unionAll(({parens, selectFrom}) =>
-          parens(
-            selectFrom('PageOrganizationAccess')
-              .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
-              .innerJoin(
-                'OrganizationUser',
-                'PageOrganizationAccess.orgId',
-                'OrganizationUser.orgId'
-              )
-              .where('OrganizationUser.removedAt', 'is', null)
-              .select(['OrganizationUser.userId', 'pageId', 'PageOrganizationAccess.role'])
-          )
-        )
-    )
-    .with('nextPageAccess', (qc) =>
-      qc
-        .selectFrom('unionAccess')
-        .select(({fn}) => ['userId', 'pageId', fn.min('role').as('role')])
-        .groupBy(['userId', 'pageId'])
-    )
-    .with('insertNew', (qc) =>
-      qc
-        .insertInto('PageAccess')
-        .columns(['userId', 'pageId', 'role'])
-        .expression((eb) => eb.selectFrom('nextPageAccess').select(['userId', 'pageId', 'role']))
-        .onConflict((oc) =>
-          oc
-
-            .columns(['userId', 'pageId'])
-            .doUpdateSet((eb) => ({
-              role: eb.ref('excluded.role')
-            }))
-            .where(({eb, ref}) => eb('PageAccess.role', 'is distinct from', ref('excluded.role')))
-        )
-    )
-    .with('deleteOld', (qc) =>
-      qc
-        .deleteFrom('PageAccess')
-        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
-        .where(({not, exists, selectFrom}) =>
-          not(
-            exists(
-              selectFrom('nextPageAccess')
-                .select('userId')
-                .whereRef('nextPageAccess.userId', '=', 'PageAccess.userId')
-                .whereRef('nextPageAccess.pageId', '=', 'PageAccess.pageId')
-            )
-          )
-        )
-    )
+  const strongestRole = await updatePageAccessTable(trx, pageId)
     .selectFrom('PageAccess')
     .select(({fn}) => fn.min('role').as('role'))
     // since all children will have identical access, no need to query descendants
@@ -293,17 +230,6 @@ export const movePageToNewParent = async (
       .expression((eb) =>
         eb
           .selectFrom('descendants as d')
-          // .where(({not, exists, selectFrom}) =>
-          //   not(
-          //     exists(
-          //       selectFrom('PageAccess')
-          //         .select('pageId')
-          //         .whereRef('PageAccess.pageId', '=', 'd.id')
-          //         .where('PageAccess.userId', '=', viewerId)
-          //         .where('PageAccess.role', '=', 'owner')
-          //     )
-          //   )
-          // )
           .select((eb) => [
             eb.ref('d.id').as('pageId'),
             eb.val(viewerId).as('userId'),

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
@@ -11,6 +11,7 @@ export const movePageToNewParent = async (
 ) => {
   const pg = getKysely()
   const trx = await pg.startTransaction().execute()
+
   await selectDescendantPages(trx, pageId)
     // Remove previous access for all descendants _that doesn't match the new parent's access_ (the exclusion means fewer writes)
     // Copy parent access to all descendants (if new parent has a different role, adopt that)
@@ -97,7 +98,7 @@ export const movePageToNewParent = async (
             .doUpdateSet((eb) => ({
               role: eb.ref('excluded.role')
             }))
-            .where((eb) => eb(eb.ref('PageUserAccess.role'), '!=', eb.ref('excluded.role')))
+            .whereRef('PageUserAccess.role', '!=', 'excluded.role')
         )
     )
     .with('upsertTeams', (qc) =>
@@ -122,7 +123,7 @@ export const movePageToNewParent = async (
             .doUpdateSet((eb) => ({
               role: eb.ref('excluded.role')
             }))
-            .where((eb) => eb(eb.ref('PageTeamAccess.role'), '!=', eb.ref('excluded.role')))
+            .whereRef('PageTeamAccess.role', '!=', 'excluded.role')
         )
     )
     .with('upsertOrganizations', (qc) =>
@@ -147,7 +148,7 @@ export const movePageToNewParent = async (
             .doUpdateSet((eb) => ({
               role: eb.ref('excluded.role')
             }))
-            .where((eb) => eb(eb.ref('PageOrganizationAccess.role'), '!=', eb.ref('excluded.role')))
+            .whereRef('PageOrganizationAccess.role', '!=', 'excluded.role')
         )
     )
     .with('upsertExternals', (qc) =>
@@ -172,53 +173,153 @@ export const movePageToNewParent = async (
             .doUpdateSet((eb) => ({
               role: eb.ref('excluded.role')
             }))
-            .where((eb) => eb(eb.ref('PageExternalAccess.role'), '!=', eb.ref('excluded.role')))
+            .whereRef('PageExternalAccess.role', '!=', 'excluded.role')
         )
     )
     .updateTable('Page')
-    .set({
+    .set((eb) => ({
       teamId: null,
       parentPageId,
+      isPrivate: eb.selectFrom('Page').select('isPrivate').where('id', '=', parentPageId),
       isParentLinked: true,
       sortOrder,
       ancestorIds: [...ancestorIds, parentPageId]
-    })
+    }))
     .where('id', '=', pageId)
     .execute()
 
-  // make sure the viewer stays an owner no matter what so they can undo the action
-  await selectDescendantPages(trx, pageId)
-    .insertInto('PageUserAccess')
-    .columns(['pageId', 'userId', 'role'])
-    .expression((eb) =>
-      eb
-        .selectFrom('descendants as d')
+  // upsert viewer as owner IIF nothing else is the owner
+  // nothing else is the owner if PageAccess(pageId) has no owner
+  const strongestRole = await selectDescendantPages(trx, pageId)
+    .with('unionAccess', (qc) =>
+      qc
+        .selectFrom('PageUserAccess')
+        .select(['userId', 'pageId', 'role'])
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+        .unionAll(({parens, selectFrom}) =>
+          parens(
+            selectFrom('PageTeamAccess')
+              .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+              .innerJoin('TeamMember', 'PageTeamAccess.teamId', 'TeamMember.teamId')
+              .where('TeamMember.isNotRemoved', '=', true)
+              .select(['TeamMember.userId', 'pageId', 'role'])
+          )
+        )
+        .unionAll(({parens, selectFrom}) =>
+          parens(
+            selectFrom('PageOrganizationAccess')
+              .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+              .innerJoin(
+                'OrganizationUser',
+                'PageOrganizationAccess.orgId',
+                'OrganizationUser.orgId'
+              )
+              .where('OrganizationUser.removedAt', 'is', null)
+              .select(['OrganizationUser.userId', 'pageId', 'PageOrganizationAccess.role'])
+          )
+        )
+    )
+    .with('nextPageAccess', (qc) =>
+      qc
+        .selectFrom('unionAccess')
+        .select(({fn}) => ['userId', 'pageId', fn.min('role').as('role')])
+        .groupBy(['userId', 'pageId'])
+    )
+    .with('insertNew', (qc) =>
+      qc
+        .insertInto('PageAccess')
+        .columns(['userId', 'pageId', 'role'])
+        .expression((eb) => eb.selectFrom('nextPageAccess').select(['userId', 'pageId', 'role']))
+        .onConflict((oc) =>
+          oc
+
+            .columns(['userId', 'pageId'])
+            .doUpdateSet((eb) => ({
+              role: eb.ref('excluded.role')
+            }))
+            .where(({eb, ref}) => eb('PageAccess.role', 'is distinct from', ref('excluded.role')))
+        )
+    )
+    .with('deleteOld', (qc) =>
+      qc
+        .deleteFrom('PageAccess')
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
         .where(({not, exists, selectFrom}) =>
           not(
             exists(
-              selectFrom('PageAccess')
-                .select('pageId')
-                .whereRef('PageAccess.pageId', '=', 'd.id')
-                .where('PageAccess.userId', '=', viewerId)
-                .where('PageAccess.role', '=', 'owner')
+              selectFrom('nextPageAccess')
+                .select('userId')
+                .whereRef('nextPageAccess.userId', '=', 'PageAccess.userId')
+                .whereRef('nextPageAccess.pageId', '=', 'PageAccess.pageId')
             )
           )
         )
-        .select((eb) => [
-          eb.ref('d.id').as('pageId'),
-          eb.val(viewerId).as('userId'),
-          sql`'owner'::"PageRoleEnum"`.as('role')
-        ])
-        .distinct()
     )
-    .onConflict((oc) =>
-      oc
-        .columns(['pageId', 'userId'])
-        .doUpdateSet((eb) => ({
-          role: eb.ref('excluded.role')
-        }))
-        .where(({eb, ref}) => eb(ref('PageUserAccess.role'), '!=', 'owner'))
-    )
-    .execute()
+    .selectFrom('PageAccess')
+    .select(({fn}) => fn.min('role').as('role'))
+    // since all children will have identical access, no need to query descendants
+    .where('pageId', '=', pageId)
+    .where('userId', '=', viewerId)
+    .executeTakeFirstOrThrow()
+
+  if (strongestRole.role !== 'owner') {
+    // make sure the viewer stays an owner no matter what so they can undo the action
+    await selectDescendantPages(trx, pageId)
+      .with('insertNew', (qc) =>
+        qc
+          .insertInto('PageAccess')
+          .columns(['userId', 'pageId', 'role'])
+          .expression((eb) =>
+            eb
+              .selectFrom('descendants')
+              .select((eb) => [
+                eb.ref('descendants.id').as('pageId'),
+                eb.val(viewerId).as('userId'),
+                sql`'owner'::"PageRoleEnum"`.as('role')
+              ])
+          )
+          .onConflict((oc) =>
+            oc
+
+              .columns(['userId', 'pageId'])
+              .doUpdateSet((eb) => ({
+                role: eb.ref('excluded.role')
+              }))
+              .where(({eb, ref}) => eb('PageAccess.role', 'is distinct from', ref('excluded.role')))
+          )
+      )
+      .insertInto('PageUserAccess')
+      .columns(['pageId', 'userId', 'role'])
+      .expression((eb) =>
+        eb
+          .selectFrom('descendants as d')
+          // .where(({not, exists, selectFrom}) =>
+          //   not(
+          //     exists(
+          //       selectFrom('PageAccess')
+          //         .select('pageId')
+          //         .whereRef('PageAccess.pageId', '=', 'd.id')
+          //         .where('PageAccess.userId', '=', viewerId)
+          //         .where('PageAccess.role', '=', 'owner')
+          //     )
+          //   )
+          // )
+          .select((eb) => [
+            eb.ref('d.id').as('pageId'),
+            eb.val(viewerId).as('userId'),
+            sql`'owner'::"PageRoleEnum"`.as('role')
+          ])
+          .distinct()
+      )
+      .onConflict((oc) =>
+        oc
+          .columns(['pageId', 'userId'])
+          .doUpdateSet((eb) => ({
+            role: eb.ref('excluded.role')
+          }))
+          .whereRef('PageUserAccess.role', '!=', 'excluded.role')
+      )
+      .execute()
+  }
   await trx.commit().execute()
 }

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewTeam.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewTeam.ts
@@ -1,5 +1,7 @@
+import {sql} from 'kysely'
 import getKysely from '../../../../postgres/getKysely'
 import {selectDescendantPages} from '../../../../postgres/select'
+import {updatePageAccessTable} from '../../../../postgres/updatePageAccessTable'
 
 export const movePageToNewTeam = async (
   viewerId: string,
@@ -8,122 +10,87 @@ export const movePageToNewTeam = async (
   sortOrder: string
 ) => {
   const pg = getKysely()
-
-  const descendants = await selectDescendantPages(pg, pageId)
-    .selectFrom('descendants')
-    .select('id')
-    .execute()
-
-  const pageIds = descendants.map(({id}) => id)
-  const viewerInserts = pageIds.map((pageId) => ({
-    pageId,
-    userId: viewerId,
-    role: 'owner' as const
-  }))
-  const teamInserts = pageIds.map((pageId) => ({
-    pageId,
-    teamId,
-    role: 'editor' as const
-  }))
   const trx = await pg.startTransaction().execute()
 
-  await Promise.all([
-    trx
-      .deleteFrom('PageUserAccess')
-      .where('pageId', 'in', pageIds)
-      .where('userId', '!=', viewerId)
-      .execute(),
-    trx
-      .deleteFrom('PageTeamAccess')
-      .where('pageId', 'in', pageIds)
-      .where('teamId', '!=', teamId)
-      .execute(),
-    trx.deleteFrom('PageOrganizationAccess').where('pageId', 'in', pageIds).execute(),
-    trx.deleteFrom('PageExternalAccess').where('pageId', 'in', pageIds).execute(),
-    // viewer ownership may have come from a team/org, so re-add it here
-    trx
-      .insertInto('PageUserAccess')
-      .values(viewerInserts)
-      .onConflict((oc) =>
-        oc
-          .columns(['pageId', 'userId'])
-          .doUpdateSet({role: 'owner'})
-          .whereRef('PageUserAccess.role', '!=', 'excluded.role')
-      )
-      .execute(),
-    trx
-      .insertInto('PageTeamAccess')
-      .values(teamInserts)
-      .onConflict((oc) =>
-        oc
-          .columns(['pageId', 'teamId'])
-          .doUpdateSet({role: 'editor'})
-          .whereRef('PageTeamAccess.role', '!=', 'excluded.role')
-      )
-      .execute(),
-    trx
-      .updateTable('Page')
-      .set({
-        teamId,
-        parentPageId: null,
-        isParentLinked: true,
-        isPrivate: false,
-        sortOrder,
-        ancestorIds: []
-      })
-      .where('id', '=', pageId)
-      .execute()
-  ])
-
-  await trx
-    .with('unionAccess', (qc) =>
+  await selectDescendantPages(trx, pageId)
+    .with('delUsers', (qc) =>
       qc
-        .selectFrom('PageUserAccess')
-        .select(['userId', 'pageId', 'role'])
-        .where('pageId', 'in', pageIds)
-        .unionAll(({parens, selectFrom}) =>
-          parens(
-            selectFrom('PageTeamAccess')
-              .innerJoin('TeamMember', 'PageTeamAccess.teamId', 'TeamMember.teamId')
-              .where('pageId', 'in', pageIds)
-              .where('TeamMember.isNotRemoved', '=', true)
-              .select(['TeamMember.userId', 'pageId', 'role'])
-          )
+        .deleteFrom('PageUserAccess')
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+        .where('userId', '!=', viewerId)
+    )
+    .with('delTeams', (qc) =>
+      qc
+        .deleteFrom('PageTeamAccess')
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+        .where('teamId', '!=', teamId)
+    )
+    .with('delOrgs', (qc) =>
+      qc
+        .deleteFrom('PageOrganizationAccess')
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+    )
+    .with('delExts', (qc) =>
+      qc
+        .deleteFrom('PageExternalAccess')
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+    )
+    .with('upsertViewerOwner', (qc) =>
+      qc
+        .insertInto('PageUserAccess')
+        .columns(['pageId', 'userId', 'role'])
+        .expression((eb) =>
+          eb
+            .selectFrom('descendants as d')
+            .select((eb) => [
+              eb.ref('d.id').as('pageId'),
+              eb.val(viewerId).as('userId'),
+              sql`'owner'::"PageRoleEnum"`.as('role')
+            ])
         )
-    )
-    .with('nextPageAccess', (qc) =>
-      qc
-        .selectFrom('unionAccess')
-        .select(({fn}) => ['userId', 'pageId', fn.min('role').as('role')])
-        .groupBy(['userId', 'pageId'])
-    )
-    .with('insertNew', (qc) =>
-      qc
-        .insertInto('PageAccess')
-        .columns(['userId', 'pageId', 'role'])
-        .expression((eb) => eb.selectFrom('nextPageAccess').select(['userId', 'pageId', 'role']))
         .onConflict((oc) =>
           oc
-
-            .columns(['userId', 'pageId'])
+            .columns(['pageId', 'userId'])
             .doUpdateSet((eb) => ({
               role: eb.ref('excluded.role')
             }))
-            .where(({eb, ref}) => eb('PageAccess.role', 'is distinct from', ref('excluded.role')))
+            .whereRef('PageUserAccess.role', '!=', 'excluded.role')
         )
     )
-    .deleteFrom('PageAccess')
-    .where('pageId', 'in', pageIds)
-    .where(({not, exists, selectFrom}) =>
-      not(
-        exists(
-          selectFrom('nextPageAccess')
-            .select('userId')
-            .whereRef('nextPageAccess.userId', '=', 'PageAccess.userId')
-            .whereRef('nextPageAccess.pageId', '=', 'PageAccess.pageId')
+    .with('upsertTeamEditor', (qc) =>
+      qc
+        .insertInto('PageTeamAccess')
+        .columns(['pageId', 'teamId', 'role'])
+        .expression((eb) =>
+          eb
+            .selectFrom('descendants as d')
+            .select((eb) => [
+              eb.ref('d.id').as('pageId'),
+              eb.val(teamId).as('teamId'),
+              sql`'editor'::"PageRoleEnum"`.as('role')
+            ])
         )
-      )
+        .onConflict((oc) =>
+          oc
+            .columns(['pageId', 'teamId'])
+            .doUpdateSet({role: 'editor'})
+            .whereRef('PageTeamAccess.role', '!=', 'excluded.role')
+        )
     )
+    .updateTable('Page')
+    .set({
+      teamId,
+      parentPageId: null,
+      isParentLinked: true,
+      isPrivate: false,
+      sortOrder,
+      ancestorIds: []
+    })
+    .where('id', '=', pageId)
+    .execute()
+
+  await updatePageAccessTable(trx, pageId, {skipUnionOrg: true})
+    .selectNoFrom(sql`1`.as('t'))
     .execute()
   await trx.commit().execute()
 }

--- a/packages/server/graphql/public/mutations/updatePage.ts
+++ b/packages/server/graphql/public/mutations/updatePage.ts
@@ -8,7 +8,7 @@ import {movePageToNewTeam} from './helpers/movePageToNewTeam'
 import {movePageToTopLevel} from './helpers/movePageToTopLevel'
 import {privatizePage} from './helpers/privatizePage'
 
-export const MAX_PAGE_DEPTH = 10
+export const MAX_PAGE_DEPTH = 23
 const updatePage: MutationResolvers['updatePage'] = async (
   _source,
   {pageId, teamId, sortOrder, parentPageId, makePrivate},
@@ -47,8 +47,10 @@ const updatePage: MutationResolvers['updatePage'] = async (
     teamId || null,
     dbParentPageId
   )
+  const start = Date.now()
   if (makePrivate && !page.isPrivate) {
     await privatizePage(viewerId, dbPageId, nextSortOrder)
+    return {pageId: dbPageId}
   } else if (teamId && teamId !== page.teamId) {
     await movePageToNewTeam(viewerId, dbPageId, teamId, nextSortOrder)
   } else if (dbParentPageId && dbParentPageId !== page.parentPageId) {
@@ -69,6 +71,9 @@ const updatePage: MutationResolvers['updatePage'] = async (
   } else {
     await movePageToTopLevel(viewerId, dbPageId, nextSortOrder)
   }
+  const end = Date.now()
+  const actionType = teamId && teamId !== page.teamId ? '(team)' : '(parent)'
+  console.log('run time', end - start, actionType)
   return {pageId: dbPageId}
 }
 

--- a/packages/server/graphql/public/mutations/updatePage.ts
+++ b/packages/server/graphql/public/mutations/updatePage.ts
@@ -8,7 +8,7 @@ import {movePageToNewTeam} from './helpers/movePageToNewTeam'
 import {movePageToTopLevel} from './helpers/movePageToTopLevel'
 import {privatizePage} from './helpers/privatizePage'
 
-export const MAX_PAGE_DEPTH = 23
+export const MAX_PAGE_DEPTH = 10
 const updatePage: MutationResolvers['updatePage'] = async (
   _source,
   {pageId, teamId, sortOrder, parentPageId, makePrivate},
@@ -47,10 +47,8 @@ const updatePage: MutationResolvers['updatePage'] = async (
     teamId || null,
     dbParentPageId
   )
-  const start = Date.now()
   if (makePrivate && !page.isPrivate) {
     await privatizePage(viewerId, dbPageId, nextSortOrder)
-    return {pageId: dbPageId}
   } else if (teamId && teamId !== page.teamId) {
     await movePageToNewTeam(viewerId, dbPageId, teamId, nextSortOrder)
   } else if (dbParentPageId && dbParentPageId !== page.parentPageId) {
@@ -71,9 +69,6 @@ const updatePage: MutationResolvers['updatePage'] = async (
   } else {
     await movePageToTopLevel(viewerId, dbPageId, nextSortOrder)
   }
-  const end = Date.now()
-  const actionType = teamId && teamId !== page.teamId ? '(team)' : '(parent)'
-  console.log('run time', end - start, actionType)
   return {pageId: dbPageId}
 }
 

--- a/packages/server/postgres/migrations/2025-06-11T23:57:44.052Z_rbac-simple.ts
+++ b/packages/server/postgres/migrations/2025-06-11T23:57:44.052Z_rbac-simple.ts
@@ -1,0 +1,66 @@
+import {sql, type Kysely} from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    DROP TRIGGER IF EXISTS "trg_org_page_access" ON "PageOrganizationAccess";
+    DROP TRIGGER IF EXISTS "trg_team_page_access" ON "PageTeamAccess";
+    DROP TRIGGER IF EXISTS "trg_user_page_access" ON "PageUserAccess";
+    DROP TRIGGER IF EXISTS "trg_add_access_on_new_page" ON "Page";
+    DROP FUNCTION IF EXISTS "updateOrganizationPageAccess";
+    DROP FUNCTION IF EXISTS "updateTeamPageAccess";
+    DROP FUNCTION IF EXISTS "updateUserPageAccess";
+    DROP FUNCTION IF EXISTS "addAccessOnNewPage";
+
+    -- HANDLE JOIN/LEAVE ORG
+CREATE OR REPLACE FUNCTION "updateOrgPageAccessByOrgUser"()
+RETURNS TRIGGER AS $$
+DECLARE
+  "_pageIds" INT[];
+  "_userId" VARCHAR := COALESCE(NEW."userId", OLD."userId");
+BEGIN
+  IF TG_OP != 'UPDATE' OR NEW."removedAt" != OLD."removedAt" THEN
+    IF TG_OP = 'INSERT' THEN
+      INSERT INTO "PageAccess" ("pageId", role, "userId")
+      SELECT "pageId", role, "_userId"
+      FROM "PageOrganizationAccess"
+      WHERE "orgId" = NEW."orgId"
+      ON CONFLICT ("userId", "pageId") DO UPDATE
+      SET role = EXCLUDED.role
+      WHERE "PageAccess".role > EXCLUDED.role;
+    ELSE
+      SELECT ARRAY(
+        SELECT "pageId" FROM "PageOrganizationAccess" WHERE "orgId" = COALESCE(NEW."orgId", OLD."orgId")
+      ) INTO "_pageIds";
+      PERFORM "updatePageAccess"(ARRAY["_userId"], "_pageIds");
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION "removePageAccessOnTeamArchive"() RETURNS TRIGGER AS $$
+DECLARE
+  "_pageIds" INT[];
+  "_userIds" VARCHAR[];
+BEGIN
+  IF NEW."isArchived" = TRUE AND OLD."isArchived" != TRUE THEN
+    DELETE FROM "PageTeamAccess"
+    WHERE "teamId" = NEW."id"
+    RETURNING "pageId"
+    INTO "_pageIds";
+     SELECT ARRAY(
+        SELECT "userId" FROM "TeamMember" WHERE "teamId" = NEW."id"
+      ) INTO "_userIds";
+    PERFORM "updatePageAccess"("_userIds", "_pageIds");
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+    `.execute(db)
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+  // noop
+}

--- a/packages/server/postgres/updatePageAccessTable.ts
+++ b/packages/server/postgres/updatePageAccessTable.ts
@@ -1,0 +1,86 @@
+import type {ControlledTransaction, Kysely} from 'kysely'
+import {selectDescendantPages} from './select'
+import type {DB} from './types/pg'
+
+export const updatePageAccessTable = (
+  trx: ControlledTransaction<DB, []> | Kysely<DB>,
+  pageId: number,
+  options?: {
+    skipUnionOrg?: boolean
+    skipDeleteOld?: boolean
+  }
+) => {
+  const skipUnionOrg = options?.skipUnionOrg
+  const skipDeleteOld = options?.skipDeleteOld
+  const res = selectDescendantPages(trx, pageId)
+    .with('unionAccess', (qc) =>
+      qc
+        .selectFrom('PageUserAccess')
+        .select(['userId', 'pageId', 'role'])
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+        .unionAll(({parens, selectFrom}) =>
+          parens(
+            selectFrom('PageTeamAccess')
+              .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+              .innerJoin('TeamMember', 'PageTeamAccess.teamId', 'TeamMember.teamId')
+              .where('TeamMember.isNotRemoved', '=', true)
+              .select(['TeamMember.userId', 'pageId', 'role'])
+          )
+        )
+        .$if(!skipUnionOrg, (qb) =>
+          qb.unionAll(({parens, selectFrom}) =>
+            parens(
+              selectFrom('PageOrganizationAccess')
+                .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+                .innerJoin(
+                  'OrganizationUser',
+                  'PageOrganizationAccess.orgId',
+                  'OrganizationUser.orgId'
+                )
+                .where('OrganizationUser.removedAt', 'is', null)
+                .select(['OrganizationUser.userId', 'pageId', 'PageOrganizationAccess.role'])
+            )
+          )
+        )
+    )
+    .with('nextPageAccess', (qc) =>
+      qc
+        .selectFrom('unionAccess')
+        .select(({fn}) => ['userId', 'pageId', fn.min('role').as('role')])
+        .groupBy(['userId', 'pageId'])
+    )
+    .with('insertNew', (qc) =>
+      qc
+        .insertInto('PageAccess')
+        .columns(['userId', 'pageId', 'role'])
+        .expression((eb) => eb.selectFrom('nextPageAccess').select(['userId', 'pageId', 'role']))
+        .onConflict((oc) =>
+          oc
+
+            .columns(['userId', 'pageId'])
+            .doUpdateSet((eb) => ({
+              role: eb.ref('excluded.role')
+            }))
+            .where(({eb, ref}) => eb('PageAccess.role', 'is distinct from', ref('excluded.role')))
+        )
+    )
+
+  if (!skipDeleteOld) {
+    res.with('deleteOld', (qc) =>
+      qc
+        .deleteFrom('PageAccess')
+        .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
+        .where(({not, exists, selectFrom}) =>
+          not(
+            exists(
+              selectFrom('nextPageAccess')
+                .select('userId')
+                .whereRef('nextPageAccess.userId', '=', 'PageAccess.userId')
+                .whereRef('nextPageAccess.pageId', '=', 'PageAccess.pageId')
+            )
+          )
+        )
+    )
+  }
+  return res
+}


### PR DESCRIPTION
# Description

the root cause of the slow page access changes were the row-level triggers.
for example, when i drag a page from A to B, it has to remove all the permissions it had with A & get all the new permissions with B. Simple!
Buuuut it is doing that for all its descendants too.
A row level trigger means each change happens in serial, so only 1 update at a time for....turtles all the way down.

A better way to do this is per-statement, which is what's done here.
it's harder to do this inside the DB because we'd have to track all the rows that changed in that statement in a temp table, and then act on that, but prevent other transactions from writing to it... yeah, messy.
