### PR TITLE
chore: show app version in help menu

### DIFF
--- a/packages/client/components/TopBarHelpMenu.tsx
+++ b/packages/client/components/TopBarHelpMenu.tsx
@@ -1,6 +1,7 @@
 import useBreakpoint from '~/hooks/useBreakpoint'
 import {Breakpoint, ExternalLinks} from '~/types/constEnums'
 import {MenuProps} from '../hooks/useMenu'
+import useSWVersion from '../hooks/useSWVersion'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
 import MenuItemWithIcon from './MenuItemWithIcon'
@@ -13,6 +14,7 @@ interface Props {
 
 const TopBarHelpMenu = (props: Props) => {
   const {menuProps, toggleShortcuts, dataCy} = props
+  const swVersion = useSWVersion()
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const gotoSupport = () => {
     window.open(ExternalLinks.SUPPORT, '_blank', 'noreferrer')
@@ -38,6 +40,10 @@ const TopBarHelpMenu = (props: Props) => {
         label={<MenuItemWithIcon dataCy={`${dataCy}`} label={'Get help'} icon={'comment'} />}
         onClick={gotoContact}
       />
+      <div className='pt-2 pl-4 text-xs text-slate-500'>
+        Version {__APP_VERSION__}
+        {swVersion && swVersion !== __APP_VERSION__ && ` (sw${swVersion})`}
+      </div>
     </Menu>
   )
 }

--- a/packages/client/hooks/useSWVersion.ts
+++ b/packages/client/hooks/useSWVersion.ts
@@ -1,0 +1,24 @@
+import {useEffect, useState} from 'react'
+
+const useSWVersion = () => {
+  const [swVersion, setSWVersion] = useState<string>()
+
+  useEffect(() => {
+    const messageChannel = new MessageChannel()
+
+    messageChannel.port1.onmessage = (event) => {
+      if (event.data?.type === 'version') {
+        setSWVersion(event.data?.payload)
+        messageChannel.port1.close()
+      }
+    }
+
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.controller?.postMessage({type: 'getVersion'}, [messageChannel.port2])
+    }
+  }, [])
+
+  return swVersion
+}
+
+export default useSWVersion

--- a/packages/client/serviceWorker/sw.ts
+++ b/packages/client/serviceWorker/sw.ts
@@ -106,6 +106,15 @@ const onFetch = async (event: FetchEvent) => {
   return fetch(request)
 }
 
+const onMessage = async (event: MessageEvent) => {
+  if (event.data?.type === 'getVersion') {
+    const port = event.ports?.[0]
+    port?.postMessage({type: 'version', payload: `${__APP_VERSION__}`})
+    port?.close()
+  }
+}
+
+self.onmessage = onMessage
 self.oninstall = waitUntil(onInstall)
 self.onactivate = waitUntil(onActivate)
 self.onfetch = (e: FetchEvent) => {


### PR DESCRIPTION
# Description

Fixes #10919

Show the app version in the help menu. Commonly it's in an about dialog in the help menu, but because we don't have anything useful to put there atm. I opted to just put the version directly in the menu. If the service worker version differs from the rest, we print both.

## Demo

<img width="216" alt="image" src="https://github.com/user-attachments/assets/802b42f0-100a-4133-9751-38e92f5fec1b" />
<img width="216" alt="image" src="https://github.com/user-attachments/assets/aa589ccf-82ea-45f9-92f8-d26809645173" />

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
