### PR TITLE
chore: create ai titles for single reflections

### DIFF
--- a/packages/server/graphql/mutations/createReflection.ts
+++ b/packages/server/graphql/mutations/createReflection.ts
@@ -16,6 +16,7 @@ import standardError from '../../utils/standardError'
 import {GQLContext} from '../graphql'
 import CreateReflectionInput, {CreateReflectionInputType} from '../types/CreateReflectionInput'
 import CreateReflectionPayload from '../types/CreateReflectionPayload'
+import updateGroupTitle from './helpers/updateGroupTitle'
 
 export default {
   type: CreateReflectionPayload,
@@ -85,6 +86,17 @@ export default {
       sortOrder
     })
 
+    // Upgrade the simple title to an AI-generated one. Don't await to keep things snappy
+    updateGroupTitle({
+      reflections: [reflection],
+      reflectionGroupId,
+      meetingId,
+      teamId,
+      dataLoader
+    }).catch((e) => {
+      console.error('Error generating AI title for new reflection:', e)
+    })
+
     await pg
       .with('Group', (qc) => qc.insertInto('RetroReflectionGroup').values(reflectionGroup))
       .insertInto('RetroReflection')
@@ -106,6 +118,7 @@ export default {
       dataLoader.clearAll('newMeetings')
     }
     analytics.reflectionAdded(viewer, teamId, meetingId)
+
     const data = {
       meetingId,
       reflectionId: reflection.id,

--- a/packages/server/graphql/mutations/helpers/updateGroupTitle.ts
+++ b/packages/server/graphql/mutations/helpers/updateGroupTitle.ts
@@ -17,7 +17,7 @@ const updateGroupTitle = async (input: Input) => {
   const {reflections, reflectionGroupId, meetingId, teamId, dataLoader} = input
   const team = await dataLoader.get('teams').loadNonNull(teamId)
   const hasAIAccess = await canAccessAI(team, dataLoader)
-  if (reflections.length === 1 || !hasAIAccess) {
+  if (!hasAIAccess) {
     const smartTitle = getSimpleGroupTitle(reflections)
     await updateSmartGroupTitle(reflectionGroupId, smartTitle)
     return

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -429,7 +429,7 @@ Important: Respond with ONLY the title itself. Do not include any prefixes like 
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o-mini',
         messages: [
           {
             role: 'user',


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/11276

This PR:

- Creates AI titles for single reflection groups
-  Upgrades the model from 3.5-turbo to 4o-mini for higher quality results at the same speed

<img width="621" alt="Screenshot 2025-06-17 at 15 13 25" src="https://github.com/user-attachments/assets/a1054c3e-0d5b-4c20-bf73-59cc3f224876" />

### To test

- [ ] Create a retro meeting and add several reflections
- [ ] Group some together and see that the group title is an AI-generated title
- [ ] Leave some ungrouped, so that the reflection groups only have one reflection. See that they now have an AI-generated title