### PR TITLE
chore: background music loops

### DIFF
--- a/packages/client/hooks/useMeetingMusicSync.ts
+++ b/packages/client/hooks/useMeetingMusicSync.ts
@@ -89,6 +89,7 @@ const useMeetingMusicSync = (meetingId: string) => {
       audioRef.current = new Audio()
       audioRef.current.volume = volume
       audioRef.current.setAttribute('playsinline', 'true')
+      audioRef.current.loop = true
       audioRef.current.muted = true
 
       audioRef.current.src = '/static/sounds/quiet-lofi.mp3'
@@ -104,13 +105,6 @@ const useMeetingMusicSync = (meetingId: string) => {
         if (pendingPlay.current) {
           audioRef.current!.muted = false
           audioRef.current!.volume = volume
-        }
-      })
-
-      audioRef.current.addEventListener('ended', () => {
-        if (audioRef.current && isPlaying) {
-          audioRef.current.currentTime = 0
-          audioRef.current.play()
         }
       })
     }


### PR DESCRIPTION
Fix https://github.com/ParabolInc/parabol/issues/11441

This PR ensures that the background music loops on repeat.

The event listener wasn't working properly; there's the native loop property which should be more reliable. 

### To test

- [ ] You can add a short track like `tic-tac.mp3` to the array of tracks in `useMeetingMusicSync`
- [ ] See that after the track ends, it loops back to the beginning and continues playing