### PR TITLE
fix: show correct ready number if user goes offline

### DIFF
--- a/packages/client/components/BottomControlBarReady.tsx
+++ b/packages/client/components/BottomControlBarReady.tsx
@@ -21,6 +21,7 @@ import BottomNavIconLabel from './BottomNavIconLabel'
 interface Props {
   isNext: boolean
   isPoker: boolean
+  isFacilitating: boolean
   cancelConfirm: undefined | (() => void)
   isConfirming: boolean
   setConfirmingButton: (button: string) => void
@@ -56,6 +57,7 @@ const BottomControlBarReady = (props: Props) => {
     isConfirming,
     isPoker,
     isNext,
+    isFacilitating,
     setConfirmingButton,
     handleGotoNext,
     meeting: meetingRef,
@@ -112,6 +114,14 @@ const BottomControlBarReady = (props: Props) => {
     )
   }, [meetingMembers])
   const activeCount = connectedMeetingMembers.length
+  const readyUserIds = localStage.readyUserIds ?? []
+  const readyCount = useMemo(() => {
+    return readyUserIds.filter(
+      (userId) =>
+        (!isFacilitating || userId !== viewerId) &&
+        connectedMeetingMembers.find((member) => member.userId === userId)
+    ).length
+  }, [readyUserIds, connectedMeetingMembers, isFacilitating, viewerId])
 
   const {openTooltip, tooltipPortal, originRef} = useTooltip<HTMLDivElement>(
     MenuPosition.UPPER_CENTER,
@@ -119,7 +129,6 @@ const BottomControlBarReady = (props: Props) => {
       delay: Times.MEETING_CONFIRM_TOOLTIP_DELAY
     }
   )
-  const readyCount = localStage.readyCount || 0
   const isOnlyViewer = activeCount === 1 // viewer is the only active meeting member
   const progress = isOnlyViewer || isPoker ? 1.0 : readyCount / (activeCount - 1)
   const isLastStageInPhase = stages[stages.length - 1]?.id === localStage?.id
@@ -180,7 +189,7 @@ graphql`
   fragment BottomControlBarReadyStage on NewMeetingStage {
     id
     isComplete
-    readyCount
+    readyUserIds
     isViewerReady
     phaseType
   }

--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -185,6 +185,7 @@ const MeetingControlBar = (props: Props) => {
                 <BottomControlBarReady
                   {...tranProps}
                   isNext={isPoker ? true : isFacilitating}
+                  isFacilitating={isFacilitating}
                   isPoker={isPoker}
                   cancelConfirm={
                     isPoker ? undefined : confirmingButton === 'next' ? undefined : cancelConfirm

--- a/packages/client/components/RetroMeetingSidebar.tsx
+++ b/packages/client/components/RetroMeetingSidebar.tsx
@@ -57,7 +57,7 @@ const RetroMeetingSidebar = (props: Props) => {
             isComplete
             isNavigable
             isNavigableByFacilitator
-            readyCount
+            readyUserIds
           }
         }
       }
@@ -103,11 +103,12 @@ const RetroMeetingSidebar = (props: Props) => {
               ? getSidebarItemStage(prevPhaseType, phases, facilitatorStageId)
               : null
 
-            const {isComplete: isPrevItemStageComplete = true, readyCount = 0} = prevItemStage ?? {}
+            const {isComplete: isPrevItemStageComplete = true, readyUserIds = []} =
+              prevItemStage ?? {}
 
             const activeCount = meetingMembers.length
             const isConfirmRequired =
-              isViewerFacilitator && readyCount < activeCount - 1 && activeCount > 1
+              isViewerFacilitator && readyUserIds.length < activeCount - 1 && activeCount > 1
 
             if (
               isComplete ||

--- a/packages/client/modules/demo/ClientGraphQLServer.ts
+++ b/packages/client/modules/demo/ClientGraphQLServer.ts
@@ -732,8 +732,10 @@ class ClientGraphQLServer extends (EventEmitter as GQLDemoEmitter) {
       const {phases} = meeting
       const stageRes = findStageById(phases, stageId)
       const {stage} = stageRes!
-      const increment = isReady ? 1 : -1
-      stage.readyCount += increment
+      const readyUserIds = (stage.readyUserIds ?? []) as readonly string[]
+      stage.readyUserIds = isReady
+        ? [...readyUserIds, userId]
+        : readyUserIds.filter((id) => id !== userId)
 
       const data = {
         __typename: 'FlagReadyToAdvanceSuccess',

--- a/packages/client/modules/demo/DemoDiscussStage.ts
+++ b/packages/client/modules/demo/DemoDiscussStage.ts
@@ -13,7 +13,7 @@ export default class DemoDiscussStage extends DemoGenericMeetingStage {
   phaseType = 'discuss' as const
   startAt = new Date().toJSON()
   viewCount = 0
-  readyCount = 0
+  readyUserIds = []
   reflectionGroupId: string
   discussion: DemoDiscussion
   constructor(

--- a/packages/client/modules/demo/DemoGenericMeetingStage.ts
+++ b/packages/client/modules/demo/DemoGenericMeetingStage.ts
@@ -13,7 +13,7 @@ export default class DemoGenericMeetingStage {
   isNavigableByFacilitator = false
   startAt = new Date().toJSON()
   viewCount = 0
-  readyCount = 0
+  readyUserIds = []
   scheduledEndTime = null
   suggestedEndTime = null
   suggestedTimeLimit = null

--- a/packages/client/mutations/PromoteNewMeetingFacilitatorMutation.ts
+++ b/packages/client/mutations/PromoteNewMeetingFacilitatorMutation.ts
@@ -22,7 +22,7 @@ graphql`
       preferredName
     }
     facilitatorStage {
-      readyCount
+      readyUserIds
       isViewerReady
     }
   }

--- a/packages/client/mutations/RemoveTeamMemberMutation.ts
+++ b/packages/client/mutations/RemoveTeamMemberMutation.ts
@@ -46,7 +46,7 @@ graphql`
       phases {
         stages {
           id
-          readyCount
+          readyUserIds
         }
       }
     }

--- a/packages/client/utils/getSidebarItemStage.ts
+++ b/packages/client/utils/getSidebarItemStage.ts
@@ -7,7 +7,7 @@ interface Phase {
     isNavigable: boolean
     isNavigableByFacilitator: boolean
     isComplete: boolean
-    readyCount?: number
+    readyUserIds?: readonly string[]
   }[]
 }
 

--- a/packages/server/graphql/public/typeDefs/AgendaItemsStage.graphql
+++ b/packages/server/graphql/public/typeDefs/AgendaItemsStage.graphql
@@ -68,9 +68,9 @@ type AgendaItemsStage implements NewMeetingStage & DiscussionThreadStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/CheckInStage.graphql
+++ b/packages/server/graphql/public/typeDefs/CheckInStage.graphql
@@ -68,9 +68,9 @@ type CheckInStage implements NewMeetingStage & NewMeetingTeamMemberStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/EstimateStage.graphql
+++ b/packages/server/graphql/public/typeDefs/EstimateStage.graphql
@@ -68,9 +68,9 @@ type EstimateStage implements NewMeetingStage & DiscussionThreadStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/FlagReadyToAdvanceSuccess.graphql
+++ b/packages/server/graphql/public/typeDefs/FlagReadyToAdvanceSuccess.graphql
@@ -1,11 +1,11 @@
 type FlagReadyToAdvanceSuccess {
   """
-  the meeting with the updated readyCount
+  the meeting with the updated readyUserIds
   """
   meeting: NewMeeting!
 
   """
-  the stage with the updated readyCount
+  the stage with the updated readyUserIds
   """
   stage: NewMeetingStage!
 }

--- a/packages/server/graphql/public/typeDefs/GenericMeetingStage.graphql
+++ b/packages/server/graphql/public/typeDefs/GenericMeetingStage.graphql
@@ -68,9 +68,9 @@ type GenericMeetingStage implements NewMeetingStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/NewMeetingStage.graphql
+++ b/packages/server/graphql/public/typeDefs/NewMeetingStage.graphql
@@ -68,9 +68,9 @@ interface NewMeetingStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/RetroDiscussStage.graphql
+++ b/packages/server/graphql/public/typeDefs/RetroDiscussStage.graphql
@@ -68,9 +68,9 @@ type RetroDiscussStage implements NewMeetingStage & DiscussionThreadStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/TeamHealthStage.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamHealthStage.graphql
@@ -65,9 +65,9 @@ type TeamHealthStage implements NewMeetingStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/TeamPromptResponseStage.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamPromptResponseStage.graphql
@@ -68,9 +68,9 @@ type TeamPromptResponseStage implements NewMeetingStage & DiscussionThreadStage 
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/typeDefs/UpdatesStage.graphql
+++ b/packages/server/graphql/public/typeDefs/UpdatesStage.graphql
@@ -68,9 +68,9 @@ type UpdatesStage implements NewMeetingStage & NewMeetingTeamMemberStage {
   isViewerReady: Boolean!
 
   """
-  the number of meeting members ready to advance, excluding the facilitator
+  User ids of those who are ready to advance to the next stage
   """
-  readyCount: Int!
+  readyUserIds: [ID!]!
 
   """
   The datetime the phase is scheduled to be finished, null if no time limit or end time is set

--- a/packages/server/graphql/public/types/NewMeetingStage.ts
+++ b/packages/server/graphql/public/types/NewMeetingStage.ts
@@ -1,6 +1,5 @@
 import isValidDate from '../../../../client/utils/isValidDate'
 import GenericMeetingStage from '../../../database/types/GenericMeetingStage'
-import {Logger} from '../../../utils/Logger'
 import {getUserId} from '../../../utils/authorization'
 import {NewMeetingPhaseTypeEnum, NewMeetingStageResolvers} from '../resolverTypes'
 
@@ -26,12 +25,8 @@ const NewMeetingStage: NewMeetingStageResolvers = {
     return readyToAdvance?.includes(viewerId) ?? false
   },
 
-  readyCount: async ({meetingId, readyToAdvance}, _args, {dataLoader}, ref) => {
-    if (!readyToAdvance) return 0
-    if (!meetingId) Logger.log('no meetingid', ref)
-    const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
-    const {facilitatorUserId} = meeting
-    return readyToAdvance.filter((userId: string) => userId !== facilitatorUserId).length
+  readyUserIds: async ({readyToAdvance}, _args) => {
+    return readyToAdvance ?? []
   },
 
   timeRemaining: ({scheduledEndTime}) => {

--- a/packages/server/graphql/types/FlagReadyToAdvancePayload.ts
+++ b/packages/server/graphql/types/FlagReadyToAdvancePayload.ts
@@ -10,14 +10,14 @@ export const FlagReadyToAdvanceSuccess = new GraphQLObjectType<any, GQLContext>(
   fields: () => ({
     meeting: {
       type: new GraphQLNonNull(NewMeeting),
-      description: 'the meeting with the updated readyCount',
+      description: 'the meeting with the updated readyUserIds',
       resolve: async ({meetingId}, _args: unknown, {dataLoader}) => {
         return dataLoader.get('newMeetings').load(meetingId)
       }
     },
     stage: {
       type: new GraphQLNonNull(NewMeetingStage),
-      description: 'the stage with the updated readyCount',
+      description: 'the stage with the updated readyUserIds',
       resolve: async ({meetingId, stageId}, _args: unknown, {dataLoader}) => {
         const meeting = await dataLoader.get('newMeetings').loadNonNull(meetingId)
         return resolveGQLStageFromId(stageId, meeting)


### PR DESCRIPTION
# Description

Fixes #11343 
When a user goes offline, they get filtered from the total number of required ready users, but weren't removed from the number of ready users.
First idea was to adapt the number of ready users to only include currently online users, but this is difficult to update if users come and go. Instead we expose the list of ready users to the client and do the online/offline filter there, just as we do with the participants.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
