### PR TITLE
fix: fix update button on team prompt response on second edit

### DIFF
--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -100,6 +100,18 @@ interface Props {
   onTransitionEnd: () => void
 }
 
+graphql`
+  fragment TeamPromptResponseCard_response on TeamPromptResponse {
+    id
+    userId
+    content
+    plaintextContent
+    updatedAt
+    createdAt
+    ...TeamPromptResponseEmojis_response
+  }
+`
+
 const TeamPromptResponseCard = (props: Props) => {
   const {stageRef, status, onTransitionEnd, displayIdx} = props
   const responseStage = useFragment(
@@ -130,13 +142,7 @@ const TeamPromptResponseCard = (props: Props) => {
           }
         }
         response {
-          id
-          userId
-          content
-          plaintextContent
-          updatedAt
-          createdAt
-          ...TeamPromptResponseEmojis_response
+          ...TeamPromptResponseCard_response @relay(mask: false)
         }
       }
     `,

--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -83,19 +83,6 @@ const PromptResponseEditor = (props: Props) => {
     [setEditing, draftStorageKey]
   )
 
-  const onSubmit = useCallback(() => {
-    if (!editor) return
-    setEditing(false)
-    const newContentJSON = editor.getJSON()
-
-    // to avoid creating an empty post on first blur
-    if (!content && editor.isEmpty) return
-
-    if (isEqualWhenSerialized(content, newContentJSON)) return
-
-    handleSubmit?.(editor)
-  }, [setEditing, content, handleSubmit])
-
   const onCancel = () => {
     setEditing(false)
     editor?.commands.setContent(content)
@@ -125,8 +112,21 @@ const PromptResponseEditor = (props: Props) => {
       onUpdate,
       editable: !readOnly
     },
-    [content, readOnly, onSubmit, onUpdate]
+    [content, readOnly, onUpdate]
   )
+
+  const onSubmit = useCallback(() => {
+    if (!editor) return
+    setEditing(false)
+    const newContentJSON = editor.getJSON()
+
+    // to avoid creating an empty post on first blur
+    if (!content && editor.isEmpty) return
+
+    if (isEqualWhenSerialized(content, newContentJSON)) return
+
+    handleSubmit?.(editor)
+  }, [setEditing, content, editor, handleSubmit])
 
   useEffect(() => {
     // Attempt to reload draft persisted to localstorage.

--- a/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
+++ b/packages/client/mutations/UpsertTeamPromptResponseMutation.ts
@@ -9,13 +9,7 @@ graphql`
   fragment UpsertTeamPromptResponseMutation_meeting on UpsertTeamPromptResponseSuccess {
     meetingId
     teamPromptResponse {
-      id
-      userId
-      content
-      plaintextContent
-      updatedAt
-      createdAt
-      ...TeamPromptResponseEmojis_response
+      ...TeamPromptResponseCard_response @relay(mask: false)
     }
   }
 `


### PR DESCRIPTION
# Description

Fixes #10934 
The button would only work once per refresh. This happened because onSubmit depends on the editor, but dependencies were declared the other way round.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] submit a standup response
- [ ] edit the response and submit the edit
- [ ] observe the change in the discussion window or with another participant

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
