### PR TITLE
fix(pages): support null nodeBefore

### DIFF
--- a/packages/client/tiptap/extensions/pageLinkPicker/PageLinkMenu.tsx
+++ b/packages/client/tiptap/extensions/pageLinkPicker/PageLinkMenu.tsx
@@ -3,27 +3,14 @@ import React, {forwardRef, useEffect, useImperativeHandle, useRef, useState} fro
 
 export const PageLinkMenu = forwardRef(
   (props: SuggestionProps<{pageId: string; title: string}>, ref) => {
-    const {editor, items} = props
+    const {items, command} = props
     const [selectedIndex, setSelectedIndex] = useState(0)
     const activeRef = useRef<HTMLDivElement>(null)
     const activeItem = items[selectedIndex]
     const selectItem = (pageId: string) => {
       const item = items.find((item) => item.pageId === pageId)
       if (!item) return
-      const pageNum = Number(pageId.split(':')[1])
-      const {state} = editor
-      const {selection} = state
-      const {$from} = selection
-      const nodeBefore = $from.nodeBefore!
-      const from = $from.pos - nodeBefore.nodeSize
-      const to = $from.pos
-      editor
-        .chain()
-        .focus()
-        .deleteRange({from, to})
-        .setPageLinkBlock({pageId: pageNum, title: item.title})
-        .run()
-      editor.emit('pageLinkPicker', {willOpen: false})
+      command(item)
     }
 
     const upHandler = () => {

--- a/packages/client/tiptap/extensions/pageLinkPicker/PageLinkPicker.ts
+++ b/packages/client/tiptap/extensions/pageLinkPicker/PageLinkPicker.ts
@@ -67,20 +67,19 @@ export const PageLinkPicker = Extension.create<{atmosphere: Atmosphere}, {open: 
           }
         },
         command: ({editor, props}: {editor: Editor; props: any}) => {
-          const {view, state} = editor
-          const {$head, $from} = view.state.selection
+          const {pageId, title} = props
+          const pageNum = Number(pageId.split(':')[1])
 
-          const end = $from.pos
-          const from = $head?.nodeBefore
-            ? end -
-              ($head.nodeBefore.text?.substring($head.nodeBefore.text?.indexOf('/')).length ?? 0)
-            : $from.start()
-
-          const tr = state.tr.deleteRange(from, end)
-          view.dispatch(tr)
-
-          props.action(editor)
-          view.focus()
+          const {state} = editor
+          const {selection} = state
+          const {$from} = selection
+          const nodeBefore = $from.nodeBefore
+          editor.emit('pageLinkPicker', {willOpen: false})
+          const command = editor.chain().focus()
+          if (nodeBefore) {
+            command.deleteRange({from: $from.pos - nodeBefore.nodeSize, to: $from.pos})
+          }
+          command.setPageLinkBlock({pageId: pageNum, title}).run()
         },
         items: async ({query}) => {
           const res = await this.options.atmosphere.fetchQuery<PageLinkPickerQuery>(


### PR DESCRIPTION
# Description

Sometimes a page link can get added without anything behind it, so this supports that