### PR TITLE
fix: flashing placeholders on pages

### DIFF
--- a/packages/client/hooks/usePageProvider.ts
+++ b/packages/client/hooks/usePageProvider.ts
@@ -1,7 +1,7 @@
 import {TiptapCollabProvider, TiptapCollabProviderWebsocket} from '@hocuspocus/provider'
 import {generateJSON, generateText} from '@tiptap/react'
 import type {History} from 'history'
-import {useEffect, useMemo, useRef} from 'react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {commitLocalUpdate} from 'relay-runtime'
 import * as Y from 'yjs'
 import type Atmosphere from '../Atmosphere'
@@ -50,6 +50,7 @@ const makeHocusPocusSocket = (authToken: string | null) => {
 
 export const usePageProvider = (pageId: string) => {
   const atmosphere = useAtmosphere()
+  const [isLoaded, setIsLoaded] = useState(false)
   const {history} = useRouter<{meetingId: string}>()
   const clientPageNum = Number(pageId.split(':')[1])
   const providerRef = useRef<TiptapCollabProvider>()
@@ -58,6 +59,7 @@ export const usePageProvider = (pageId: string) => {
     if (!pageId) return undefined
     if (providerRef.current) {
       providerRef.current.destroy()
+      setIsLoaded(false)
     }
     const doc = new Y.Doc()
     const frag = doc.getXmlFragment('default')
@@ -83,6 +85,7 @@ export const usePageProvider = (pageId: string) => {
       }
     }
     nextProvider.on('synced', () => {
+      setIsLoaded(true)
       const headerElement = frag.get(0) as Y.XmlElement | null
       const headerText = headerElement?.get(0) as Y.XmlText
       if (headerText) {
@@ -100,5 +103,5 @@ export const usePageProvider = (pageId: string) => {
       providerRef.current?.destroy()
     }
   }, [])
-  return providerRef.current!
+  return {provider: providerRef.current!, isLoaded}
 }

--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -53,8 +53,8 @@ export const useTipTapPageEditor = (
   )
   const preferredName = user?.preferredName
   const atmosphere = useAtmosphere()
-  const provider = usePageProvider(pageId)
   const placeholderRef = useRef<string | undefined>(undefined)
+  const {provider, isLoaded} = usePageProvider(pageId)
   const editor = useEditor(
     {
       content: '',
@@ -145,5 +145,5 @@ export const useTipTapPageEditor = (
 
   usePageLinkPlaceholder(editor!, placeholderRef)
 
-  return {editor}
+  return {editor, isLoaded}
 }

--- a/packages/client/modules/pages/Page.tsx
+++ b/packages/client/modules/pages/Page.tsx
@@ -3,6 +3,7 @@ import type {useTipTapPageEditor_viewer$key} from '../../__generated__/useTipTap
 import {TipTapEditor} from '../../components/promptResponse/TipTapEditor'
 import useRouter from '../../hooks/useRouter'
 import {useTipTapPageEditor} from '../../hooks/useTipTapPageEditor'
+import {cn} from '../../ui/cn'
 import {PageSharingRoot} from './PageSharingRoot'
 
 interface Props {
@@ -16,7 +17,7 @@ export const Page = (props: Props) => {
   const {pageSlug} = params
   const pageIdIdx = pageSlug.lastIndexOf('-')
   const pageId = `page:${Number(pageIdIdx === -1 ? pageSlug : pageSlug.slice(pageIdIdx + 1))}`
-  const {editor} = useTipTapPageEditor(pageId, {viewerRef})
+  const {editor, isLoaded} = useTipTapPageEditor(pageId, {viewerRef})
   if (!editor) return <div>No editor</div>
   if (!pageSlug) return <div>No page ID provided in route</div>
   return (
@@ -38,7 +39,10 @@ export const Page = (props: Props) => {
             </Popover.Portal>
           </Popover.Root>
         </div>
-        <TipTapEditor editor={editor} className='page-editor flex w-full px-6' />
+        <TipTapEditor
+          editor={editor}
+          className={cn('page-editor flex w-full px-6 opacity-0', isLoaded && 'opacity-100')}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
# Description

I hate how the placeholders would appear until the content loaded 200ms later.
This fixes it. by setting isLoaded to true when the doc is synced & false when we destroy the provider.