### PR TITLE
feat: add transcript to Page

### DIFF
--- a/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
+++ b/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
@@ -23,7 +23,7 @@ export const dumpTranscriptToPage = async (
     new RecallAIServerManager()
   ])
 
-  if (!meeting || meeting.meetingType !== 'retrospective') return null
+  if (!meeting || meeting.meetingType !== 'retrospective' || !meeting.facilitatorUserId) return null
 
   const transcription = await manager.getBotTranscript(recallBotId)
 

--- a/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
+++ b/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
@@ -1,0 +1,133 @@
+import {type JSONContent} from '@tiptap/core'
+import {generateJSON} from '@tiptap/html'
+import {sql} from 'kysely'
+import {__START__} from 'parabol-client/shared/sortOrder'
+import {serverTipTapExtensions} from 'parabol-client/shared/tiptap/serverTipTapExtensions'
+import * as Y from 'yjs'
+import getKysely from '../../../postgres/getKysely'
+import {updatePageAccessTable} from '../../../postgres/updatePageAccessTable'
+import {analytics} from '../../../utils/analytics/analytics'
+import RecallAIServerManager from '../../../utils/RecallAIServerManager'
+import {updatePageContent} from '../../../utils/tiptap/updatePageContent'
+import {getPageNextSortOrder} from '../../public/mutations/helpers/getPageNextSortOrder'
+
+export const dumpTranscriptToPage = async (
+  recallBotId: string | null,
+  meetingId: string,
+  dataLoader: any
+) => {
+  if (!recallBotId) return null
+
+  const [meeting, manager] = await Promise.all([
+    dataLoader.get('newMeetings').load(meetingId),
+    new RecallAIServerManager()
+  ])
+
+  if (!meeting || meeting.meetingType !== 'retrospective') return null
+
+  // const transcription = await manager.getBotTranscript(recallBotId)
+  const transcription = [
+    {
+      speaker: "Nick O'Ferrall",
+      words:
+        'Test up, transcription, test, test, test. And see if these words show up at the end of the meeting.'
+    }
+  ]
+  console.log('🚀 ~ transcription:', transcription)
+
+  if (!transcription || transcription.length === 0) return null
+
+  const viewerId = meeting.facilitatorUserId
+  const {teamId, name: meetingName} = meeting
+
+  const transcriptionText = transcription
+    .map((block) => `${block.speaker}: ${block.words}`)
+    .join('\n\n')
+
+  const meetingTitle = `Meeting Transcript: ${meetingName}`
+  const contentHtml = `<h1>${meetingTitle}</h1><p>${transcriptionText.replace(/\n\n/g, '</p><p>')}</p>`
+
+  console.log('🚀 ~ contentHtml:', contentHtml)
+
+  const jsonContent = generateJSON(contentHtml, serverTipTapExtensions) as JSONContent
+
+  console.log('🚀 ~ jsonContent:', JSON.stringify(jsonContent, null, 2))
+
+  // Create Y.js document from TipTap content
+  const yDoc = new Y.Doc()
+  const xmlFragment = yDoc.getXmlFragment('default')
+
+  // Create a simple document structure
+  const docElement = new Y.XmlElement()
+  docElement.nodeName = 'doc'
+
+  // Add heading
+  const headingElement = new Y.XmlElement()
+  headingElement.nodeName = 'heading'
+  headingElement.setAttribute('level', '1')
+  const headingText = new Y.XmlText()
+  headingText.insert(0, meetingTitle)
+  headingElement.insert(0, [headingText])
+  docElement.insert(0, [headingElement])
+
+  // Add paragraph with transcript
+  const paragraphElement = new Y.XmlElement()
+  paragraphElement.nodeName = 'paragraph'
+  const paragraphText = new Y.XmlText()
+  paragraphText.insert(0, transcriptionText)
+  paragraphElement.insert(0, [paragraphText])
+  docElement.insert(1, [paragraphElement])
+
+  xmlFragment.insert(0, [docElement])
+
+  const yDocState = Y.encodeStateAsUpdate(yDoc)
+
+  console.log('🚀 ~ yDocState length:', yDocState.length)
+
+  const pg = getKysely()
+  const isPrivate = false
+  const sortOrder = await getPageNextSortOrder(__START__, viewerId, isPrivate, teamId, null)
+
+  const page = await pg
+    .insertInto('Page')
+    .values({
+      userId: viewerId,
+      parentPageId: null,
+      isPrivate,
+      ancestorIds: [],
+      teamId,
+      sortOrder
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  const {id: pageId} = page
+
+  const viewerAccessPromise = pg
+    .insertInto('PageUserAccess')
+    .values({userId: viewerId, pageId, role: 'owner'})
+    .execute()
+
+  await pg.insertInto('PageTeamAccess').values({teamId, pageId, role: 'editor'}).execute()
+  await viewerAccessPromise
+
+  try {
+    const updateResult = await updatePageContent(pageId, jsonContent, Buffer.from(yDocState))
+    console.log(`📄 updatePageContent result:`, updateResult)
+  } catch (error) {
+    console.error(`❌ Error updating page content:`, error)
+  }
+
+  await updatePageAccessTable(pg, pageId, {skipDeleteOld: true})
+    .selectNoFrom(sql`1`.as('t'))
+    .execute()
+
+  console.log(`📄 Page content saved for page ID: ${pageId}`)
+
+  const viewer = await dataLoader.get('users').loadNonNull(viewerId)
+  analytics.pageCreated(viewer, pageId)
+
+  console.log(`📄 Transcript page created with ID: ${pageId}`)
+
+  return {transcription, pageId}
+}

--- a/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
+++ b/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
@@ -3,12 +3,12 @@ import {generateJSON} from '@tiptap/html'
 import {sql} from 'kysely'
 import {__START__} from 'parabol-client/shared/sortOrder'
 import {serverTipTapExtensions} from 'parabol-client/shared/tiptap/serverTipTapExtensions'
+import {DataLoaderWorker} from '../../../graphql/graphql'
 import getKysely from '../../../postgres/getKysely'
 import {updatePageAccessTable} from '../../../postgres/updatePageAccessTable'
 import {analytics} from '../../../utils/analytics/analytics'
 import RecallAIServerManager from '../../../utils/RecallAIServerManager'
 import {updatePageContent} from '../../../utils/tiptap/updatePageContent'
-import {DataLoaderWorker} from '../../graphql/graphql'
 import {getPageNextSortOrder} from '../../public/mutations/helpers/getPageNextSortOrder'
 
 export const dumpTranscriptToPage = async (

--- a/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
+++ b/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
@@ -3,18 +3,18 @@ import {generateJSON} from '@tiptap/html'
 import {sql} from 'kysely'
 import {__START__} from 'parabol-client/shared/sortOrder'
 import {serverTipTapExtensions} from 'parabol-client/shared/tiptap/serverTipTapExtensions'
-import * as Y from 'yjs'
 import getKysely from '../../../postgres/getKysely'
 import {updatePageAccessTable} from '../../../postgres/updatePageAccessTable'
 import {analytics} from '../../../utils/analytics/analytics'
 import RecallAIServerManager from '../../../utils/RecallAIServerManager'
 import {updatePageContent} from '../../../utils/tiptap/updatePageContent'
+import {DataLoaderWorker} from '../../graphql/graphql'
 import {getPageNextSortOrder} from '../../public/mutations/helpers/getPageNextSortOrder'
 
 export const dumpTranscriptToPage = async (
   recallBotId: string | null,
   meetingId: string,
-  dataLoader: any
+  dataLoader: DataLoaderWorker
 ) => {
   if (!recallBotId) return null
 
@@ -25,66 +25,24 @@ export const dumpTranscriptToPage = async (
 
   if (!meeting || meeting.meetingType !== 'retrospective') return null
 
-  // const transcription = await manager.getBotTranscript(recallBotId)
-  const transcription = [
-    {
-      speaker: "Nick O'Ferrall",
-      words:
-        'Test up, transcription, test, test, test. And see if these words show up at the end of the meeting.'
-    }
-  ]
-  console.log('🚀 ~ transcription:', transcription)
+  const transcription = await manager.getBotTranscript(recallBotId)
 
   if (!transcription || transcription.length === 0) return null
 
   const viewerId = meeting.facilitatorUserId
   const {teamId, name: meetingName} = meeting
 
-  const transcriptionText = transcription
-    .map((block) => `${block.speaker}: ${block.words}`)
-    .join('\n\n')
+  const meetingTitleHtml = `<h1>Meeting Transcript: ${meetingName}</h1>`
+  const transcriptHtml = transcription
+    .map((block) => `<p>${block.speaker}: ${block.words}</p>`)
+    .join('')
+  const fullHtml = meetingTitleHtml + transcriptHtml
 
-  const meetingTitle = `Meeting Transcript: ${meetingName}`
-  const contentHtml = `<h1>${meetingTitle}</h1><p>${transcriptionText.replace(/\n\n/g, '</p><p>')}</p>`
-
-  console.log('🚀 ~ contentHtml:', contentHtml)
-
-  const jsonContent = generateJSON(contentHtml, serverTipTapExtensions) as JSONContent
-
-  console.log('🚀 ~ jsonContent:', JSON.stringify(jsonContent, null, 2))
-
-  // Create Y.js document from TipTap content
-  const yDoc = new Y.Doc()
-  const xmlFragment = yDoc.getXmlFragment('default')
-
-  // Create a simple document structure
-  const docElement = new Y.XmlElement()
-  docElement.nodeName = 'doc'
-
-  // Add heading
-  const headingElement = new Y.XmlElement()
-  headingElement.nodeName = 'heading'
-  headingElement.setAttribute('level', '1')
-  const headingText = new Y.XmlText()
-  headingText.insert(0, meetingTitle)
-  headingElement.insert(0, [headingText])
-  docElement.insert(0, [headingElement])
-
-  // Add paragraph with transcript
-  const paragraphElement = new Y.XmlElement()
-  paragraphElement.nodeName = 'paragraph'
-  const paragraphText = new Y.XmlText()
-  paragraphText.insert(0, transcriptionText)
-  paragraphElement.insert(0, [paragraphText])
-  docElement.insert(1, [paragraphElement])
-
-  xmlFragment.insert(0, [docElement])
-
-  const yDocState = Y.encodeStateAsUpdate(yDoc)
-
-  console.log('🚀 ~ yDocState length:', yDocState.length)
+  const jsonContent = generateJSON(fullHtml, serverTipTapExtensions) as JSONContent
+  const yDocState = Buffer.alloc(0)
 
   const pg = getKysely()
+
   const isPrivate = false
   const sortOrder = await getPageNextSortOrder(__START__, viewerId, isPrivate, teamId, null)
 
@@ -103,31 +61,19 @@ export const dumpTranscriptToPage = async (
 
   const {id: pageId} = page
 
-  const viewerAccessPromise = pg
-    .insertInto('PageUserAccess')
-    .values({userId: viewerId, pageId, role: 'owner'})
-    .execute()
+  await Promise.all([
+    pg.insertInto('PageTeamAccess').values({teamId, pageId, role: 'editor'}).execute(),
+    pg.insertInto('PageUserAccess').values({userId: viewerId, pageId, role: 'owner'}).execute()
+  ])
 
-  await pg.insertInto('PageTeamAccess').values({teamId, pageId, role: 'editor'}).execute()
-  await viewerAccessPromise
-
-  try {
-    const updateResult = await updatePageContent(pageId, jsonContent, Buffer.from(yDocState))
-    console.log(`📄 updatePageContent result:`, updateResult)
-  } catch (error) {
-    console.error(`❌ Error updating page content:`, error)
-  }
+  await updatePageContent(pageId, jsonContent, Buffer.from(yDocState))
 
   await updatePageAccessTable(pg, pageId, {skipDeleteOld: true})
     .selectNoFrom(sql`1`.as('t'))
     .execute()
 
-  console.log(`📄 Page content saved for page ID: ${pageId}`)
-
   const viewer = await dataLoader.get('users').loadNonNull(viewerId)
   analytics.pageCreated(viewer, pageId)
-
-  console.log(`📄 Transcript page created with ID: ${pageId}`)
 
   return {transcription, pageId}
 }

--- a/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
+++ b/packages/server/graphql/mutations/helpers/safeEndRetrospective.ts
@@ -8,7 +8,6 @@ import getKysely from '../../../postgres/getKysely'
 import {RetrospectiveMeeting} from '../../../postgres/types/Meeting'
 import removeSuggestedAction from '../../../safeMutations/removeSuggestedAction'
 import {Logger} from '../../../utils/Logger'
-import RecallAIServerManager from '../../../utils/RecallAIServerManager'
 import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId} from '../../../utils/authorization'
 import getPhase from '../../../utils/getPhase'
@@ -16,6 +15,7 @@ import publish from '../../../utils/publish'
 import standardError from '../../../utils/standardError'
 import {InternalContext} from '../../graphql'
 import isValid from '../../isValid'
+import {dumpTranscriptToPage} from './dumpTranscriptToPage'
 import sendNewMeetingSummary from './endMeeting/sendNewMeetingSummary'
 import gatherInsights from './gatherInsights'
 import {generateRetroSummary} from './generateRetroSummary'
@@ -25,25 +25,23 @@ import {IntegrationNotifier} from './notifications/IntegrationNotifier'
 import removeEmptyTasks from './removeEmptyTasks'
 import updateQualAIMeetingsCount from './updateQualAIMeetingsCount'
 
-const getTranscription = async (recallBotId?: string | null) => {
-  if (!recallBotId) return
-  const manager = new RecallAIServerManager()
-  return await manager.getBotTranscript(recallBotId)
-}
-
 const summarizeRetroMeeting = async (meeting: RetrospectiveMeeting, context: InternalContext) => {
   const {dataLoader} = context
   const operationId = dataLoader.share()
   const subOptions = {operationId}
   const {id: meetingId, phases, teamId, recallBotId} = meeting
   const pg = getKysely()
-  const [reflectionGroups, reflections, sentimentScore, transcription] = await Promise.all([
+
+  const [reflectionGroups, reflections, sentimentScore, transcriptResult] = await Promise.all([
     dataLoader.get('retroReflectionGroupsByMeetingId').load(meetingId),
     dataLoader.get('retroReflectionsByMeetingId').load(meetingId),
     generateWholeMeetingSentimentScore(meetingId, dataLoader),
-    getTranscription(recallBotId),
+    dumpTranscriptToPage(recallBotId, meetingId, dataLoader),
     generateRetroSummary(meetingId, dataLoader)
   ])
+
+  const transcription = transcriptResult?.transcription
+
   const discussPhase = getPhase(phases, 'discuss')
   const {stages} = discussPhase
   const discussionIds = stages.map((stage) => stage.discussionId)


### PR DESCRIPTION
This PR adds the meeting transcription into a Parabol Page.

### To test

- [ ] Apply the `zoomTranscription` feature flag to your org
- [ ] Add the Zoom meeting URL to the transcription input, end the Zoom meeting, and then the Parabol meeting
- [ ] See the new page in the org that has the Zoom transcription
