### PR TITLE
fix: clear typing notification on submit

### DIFF
--- a/packages/client/components/DiscussionThreadInput.tsx
+++ b/packages/client/components/DiscussionThreadInput.tsx
@@ -170,7 +170,7 @@ const DiscussionThreadInput = (props: Props) => {
       threadSortOrder: getMaxSortOrder() + SORT_STEP
     }
     AddCommentMutation(atmosphere, {comment}, {onError, onCompleted})
-    editor?.commands.clearContent()
+    editor?.commands.clearOnSubmit()
     clearReplyingTo()
   }
   const addTask = () => {

--- a/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
+++ b/packages/client/components/RetroReflectPhase/PhaseItemEditor.tsx
@@ -126,7 +126,7 @@ const PhaseItemEditor = (props: Props) => {
     }
     openPortal()
     cardsInFlightRef.current = [...cardsInFlightRef.current, cardInFlight]
-    editor.commands.clearContent()
+    editor.commands.clearOnSubmit()
     forceUpdateColumn()
     requestAnimationFrame(() => {
       const stackBBox = getBBox(stackTopRef.current)

--- a/packages/client/hooks/useIsEditing.ts
+++ b/packages/client/hooks/useIsEditing.ts
@@ -2,12 +2,12 @@ import {Editor} from '@tiptap/core'
 import {useEffect, useRef, useState} from 'react'
 import useEventCallback from './useEventCallback'
 
-const useIsEditing = (p: {
+const useIsEditing = (props: {
   editor: Editor | null
   onStartEditing?: () => void
   onStopEditing?: () => void
 }) => {
-  const {editor, onStartEditing, onStopEditing} = p
+  const {editor, onStartEditing, onStopEditing} = props
 
   const [isEditing, setIsEditing] = useState(false)
   const idleTimerIdRef = useRef<number>()
@@ -59,10 +59,12 @@ const useIsEditing = (p: {
     editor?.on('update', editorUpdating)
     editor?.on('focus', editorFocusing)
     editor?.on('blur', editorBlurring)
+    editor?.on('clearOnSubmit', ensureNotEditing)
     return () => {
       editor?.off('update', editorUpdating)
       editor?.off('focus', editorFocusing)
       editor?.off('blur', editorBlurring)
+      editor?.off('clearOnSubmit', ensureNotEditing)
       ensureNotEditing()
     }
   }, [editor, editorUpdating, ensureEditing, ensureNotEditing])

--- a/packages/client/hooks/useTipTapCommentEditor.ts
+++ b/packages/client/hooks/useTipTapCommentEditor.ts
@@ -8,6 +8,7 @@ import Atmosphere from '../Atmosphere'
 import {LoomExtension} from '../components/promptResponse/loomExtension'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
 import {mentionConfig} from '../shared/tiptap/serverTipTapExtensions'
+import {ClearOnSubmit} from '../tiptap/extensions/ClearOnSubmit'
 import {tiptapEmojiConfig} from '../utils/tiptapEmojiConfig'
 import {tiptapMentionConfig} from '../utils/tiptapMentionConfig'
 import {tiptapTagConfig} from '../utils/tiptapTagConfig'
@@ -54,6 +55,7 @@ export const useTipTapCommentEditor = (
         TiptapLinkExtension.configure({
           openOnClick: false
         }),
+        ClearOnSubmit,
         onEnter &&
           onEscape &&
           Extension.create({

--- a/packages/client/hooks/useTipTapReflectionEditor.ts
+++ b/packages/client/hooks/useTipTapReflectionEditor.ts
@@ -14,6 +14,7 @@ import {LoomExtension} from '../components/promptResponse/loomExtension'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
 import {isEqualWhenSerialized} from '../shared/isEqualWhenSerialized'
 import {mentionConfig, serverTipTapExtensions} from '../shared/tiptap/serverTipTapExtensions'
+import {ClearOnSubmit} from '../tiptap/extensions/ClearOnSubmit'
 import ImageBlock from '../tiptap/extensions/imageBlock/ImageBlock'
 import {ImageUpload} from '../tiptap/extensions/imageUpload/ImageUpload'
 import {SlashCommand} from '../tiptap/extensions/slashCommand/SlashCommand'
@@ -54,6 +55,7 @@ export const useTipTapReflectionEditor = (
           'To-do list': false,
           Insights: false
         }),
+        ClearOnSubmit,
         Focus,
         ImageUpload.configure({
           editorWidth: ElementWidth.REFLECTION_CARD - 16 * 2,

--- a/packages/client/tiptap/extensions/ClearOnSubmit.ts
+++ b/packages/client/tiptap/extensions/ClearOnSubmit.ts
@@ -1,0 +1,30 @@
+import {Extension} from '@tiptap/core'
+
+declare module '@tiptap/core' {
+  interface EditorEvents {
+    clearOnSubmit: {}
+  }
+
+  interface Commands<ReturnType> {
+    clearOnSubmit: {
+      clearOnSubmit: () => ReturnType
+    }
+  }
+}
+
+// Same as clearContent but conveys the intent and emits an event
+export const ClearOnSubmit = Extension.create({
+  name: 'clearOnSubmit',
+
+  addCommands() {
+    return {
+      clearOnSubmit:
+        () =>
+        ({editor, commands}) => {
+          const ret = commands.setContent('')
+          editor.emit('clearOnSubmit', {})
+          return ret
+        }
+    }
+  }
+})


### PR DESCRIPTION
# Description

Fixes #11378 
Added an extension to emit a signal when we clear the editor on submit. This way the `useIsEditing` hook and others can react to this update knowing the intent.

## Demo

https://www.loom.com/share/5db7cedd76cd41ffb6f354ea76977468?sid=bc3129cd-9a61-4f77-9eaf-758ef7b7fc2a

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
