### PR TITLE
fix: show correct meeting phase in dashboard

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -207,9 +207,11 @@ const MeetingCard = (props: Props) => {
         phases {
           phaseType
           stages {
+            id
             isComplete
           }
         }
+        facilitatorStageId
         team {
           id
           name
@@ -230,7 +232,17 @@ const MeetingCard = (props: Props) => {
     `,
     meetingRef
   )
-  const {name, team, id: meetingId, meetingType, phases, meetingSeries, endedAt, locked} = meeting
+  const {
+    name,
+    team,
+    id: meetingId,
+    meetingType,
+    phases,
+    facilitatorStageId,
+    meetingSeries,
+    endedAt,
+    locked
+  } = meeting
   const connectedUsers = useMeetingMemberAvatars(meeting)
   const {label: dateLabel, tooltip: readableNextMeetingDate} = useMeetingSeriesDate(meeting)
   const maybeTabletPlus = useBreakpoint(Breakpoint.FUZZY_TABLET)
@@ -264,7 +276,7 @@ const MeetingCard = (props: Props) => {
 
   const isRecurring = !!(meetingSeries && !meetingSeries.cancelledAt)
   const isCompleted = !!endedAt
-  const meetingPhase = getMeetingPhase(phases)
+  const meetingPhase = getMeetingPhase(phases, facilitatorStageId)
   const meetingPhaseLabel = isCompleted
     ? 'Completed'
     : (meetingPhase && phaseLabelLookup[meetingPhase.phaseType]) || 'Complete'

--- a/packages/client/components/SelectMeetingDropdownItem.tsx
+++ b/packages/client/components/SelectMeetingDropdownItem.tsx
@@ -28,9 +28,11 @@ const SelectMeetingDropdownItem = (props: Props) => {
         phases {
           phaseType
           stages {
+            id
             isComplete
           }
         }
+        facilitatorStageId
         team {
           name
         }
@@ -39,7 +41,7 @@ const SelectMeetingDropdownItem = (props: Props) => {
     meetingRef
   )
   const {history} = useRouter()
-  const {name, team, id: meetingId, meetingType, phases} = meeting
+  const {name, team, id: meetingId, meetingType, phases, facilitatorStageId} = meeting
   if (!team) {
     // 95% sure there's a bug in relay causing this
     const errObj = {id: meetingId} as any
@@ -52,7 +54,7 @@ const SelectMeetingDropdownItem = (props: Props) => {
   }
   //FIXME 6062: change to React.ComponentType
   const IconOrSVG = meetingTypeToIcon[meetingType]!
-  const meetingPhase = getMeetingPhase(phases)
+  const meetingPhase = getMeetingPhase(phases, facilitatorStageId)
   const meetingPhaseLabel = (meetingPhase && phaseLabelLookup[meetingPhase.phaseType]) || 'Complete'
 
   return (
@@ -75,7 +77,7 @@ const SelectMeetingDropdownItem = (props: Props) => {
       <div className='flex flex-col px-2'>
         <div className='text-base font-semibold text-slate-700'>{name}</div>
         <div className='text-xs text-slate-600'>
-          {meetingPhaseLabel} • {teamName}
+          {teamName} • {meetingPhaseLabel}
         </div>
       </div>
       <div className='flex size-6 grow items-center justify-end'>

--- a/packages/client/utils/getMeetingPhase.ts
+++ b/packages/client/utils/getMeetingPhase.ts
@@ -1,13 +1,28 @@
+import findStageById from './meetings/findStageById'
+
 interface Phase {
   stages: ReadonlyArray<{
+    id: string
     isComplete: boolean
   }>
 }
 
-const getMeetingPhase = <T extends Phase>(phases: readonly T[]) => {
-  return phases.find((phase) => {
-    return !phase.stages.every((stage) => stage.isComplete)
-  })
+const getMeetingPhase = <T extends Phase>(phases: readonly T[], facilitatorStageId?: string) => {
+  if (facilitatorStageId) {
+    const facilitatorStage = findStageById(phases, facilitatorStageId)
+    if (facilitatorStage) {
+      return facilitatorStage.phase
+    }
+  }
+
+  const lastPhaseInProgress = phases.findLast((phase) =>
+    phase.stages.some((stage) => stage.isComplete)
+  )
+
+  if (!lastPhaseInProgress || lastPhaseInProgress.stages.every((stage) => stage.isComplete)) {
+    return phases.find((phase) => !phase.stages.some((stage) => stage.isComplete))
+  }
+  return lastPhaseInProgress
 }
 
 export default getMeetingPhase


### PR DESCRIPTION
# Description

Fixes #11443 
We're showing the facilitator phase if available, otherwise the last phase with partially completed stages if it exists, otherwise the first non-started stage.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
