### PR TITLE
fix: return only affected team ids when removing org users

### DIFF
--- a/packages/server/graphql/mutations/helpers/removeFromOrg.ts
+++ b/packages/server/graphql/mutations/helpers/removeFromOrg.ts
@@ -20,9 +20,10 @@ const removeFromOrg = async (
     dataLoader.get('teamsByOrgIds').load(orgId),
     dataLoader.get('teamMembersByUserId').load(userId)
   ])
-  const teamIds = orgTeams.map((team) => team.id)
-  const teamMembers = allTeamMembers.filter((teamMember) => teamIds.includes(teamMember.teamId))
+  const orgTeamIds = orgTeams.map((team) => team.id)
+  const teamMembers = allTeamMembers.filter((teamMember) => orgTeamIds.includes(teamMember.teamId))
   const teamMemberIds = teamMembers.map((teamMember) => teamMember.id)
+  const teamIds = teamMembers.map((teamMember) => teamMember.teamId)
 
   const perTeamRes = await Promise.all(
     teamMemberIds.map((teamMemberId) => {


### PR DESCRIPTION
# Description

We were returning all organization team ids before, but we only need to know the teams which were actually affected by the removal of the user.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
