### PR TITLE
fix: don't send EditReflectionMutation when it's read only

### DIFF
--- a/packages/client/components/ReflectionCard/ReflectionCard.tsx
+++ b/packages/client/components/ReflectionCard/ReflectionCard.tsx
@@ -165,6 +165,7 @@ const ReflectionCard = (props: Props) => {
   )
 
   const handleModEnter = useEventCallback(() => {
+    if (readOnly) return
     handleContentUpdate()
     updateIsEditing(false)
     EditReflectionMutation(atmosphere, {isEditing: false, meetingId, promptId})
@@ -179,7 +180,7 @@ const ReflectionCard = (props: Props) => {
   const [isHovering, setIsHovering] = useState(false)
   const isDesktop = useBreakpoint(Breakpoint.SIDEBAR_LEFT)
   const handleEditorFocus = () => {
-    if (isTempId(reflectionId)) return
+    if (isTempId(reflectionId) || readOnly) return
     if (isEditing) {
       return
     }
@@ -239,7 +240,7 @@ const ReflectionCard = (props: Props) => {
   }, [editor, isEditing, content])
 
   const handleEditorBlur = (e: React.FocusEvent<HTMLDivElement>) => {
-    if (isTempId(reflectionId)) return
+    if (isTempId(reflectionId) || readOnly) return
     // Creating a reflection in the group phase is different than in reflect phase. We're creating an empty reflection and start editing it.
     // For the user however we want to have a consistent behaviour with the reflect phase. This means when they blur without editing, we don't want to submit the reflection.
     if (isFirstEdit) return


### PR DESCRIPTION
# Description

Fixes #11534 
This was causing the excessive Meeting phase already completed error messages. It can be reproduced by opening and closing the reactji menu which triggers focus events on the reflection card.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
