### PR TITLE
chore: bump sharp version in webpack

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -115,7 +115,7 @@
     "rrule-rust": "^2.0.2",
     "samlify": "^2.10.0",
     "sanitize-html": "^2.13.0",
-    "sharp": "^0.34.1",
+    "sharp": "^0.34.3",
     "string-similarity": "^3.0.0",
     "stripe": "^9.13.0",
     "tseep": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,7 +1061,7 @@ importers:
         specifier: ^2.13.0
         version: 2.17.0
       sharp:
-        specifier: ^0.34.1
+        specifier: ^0.34.3
         version: 0.34.3
       string-similarity:
         specifier: ^3.0.0

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -114,7 +114,7 @@ module.exports = (config) => {
             // copy sharp's libvips to the output
             from: path.resolve(
               PROJECT_ROOT,
-              `node_modules/.pnpm/sharp@0.34.1/node_modules/@img/sharp-libvips-${runtimePlatform}`
+              `node_modules/.pnpm/sharp@0.34.3/node_modules/@img/sharp-libvips-${runtimePlatform}`
             ),
             to: `sharp-libvips-${runtimePlatform}`
           },


### PR DESCRIPTION
# Description

sharp version got bumped, which broke the build, so rather than rollback I'm just bumping it in webpack, too.