### PR TITLE
fix: approve oxide for tailwindcss builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 packages:
   - packages/*
-
 onlyBuiltDependencies:
   - '@datadog/native-appsec'
   - '@datadog/native-iast-taint-tracking'
@@ -9,6 +8,7 @@ onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@scarf/scarf'
   - '@swc/core'
+  - '@tailwindcss/oxide'
   - core-js
   - core-js-pure
   - cpu-features


### PR DESCRIPTION
# Description

oxide is the rust compiler for tailwindcss. should make builds a little faster & smaller