### PR TITLE
chore: remove ReactRenderingError

### DIFF
--- a/packages/client/components/ErrorBoundary.tsx
+++ b/packages/client/components/ErrorBoundary.tsx
@@ -47,11 +47,8 @@ class ErrorBoundary extends Component<Props & {atmosphere: Atmosphere}, State> {
       isOldBrowserErr
     })
 
-    const renderingError = new Error(error.message)
-    renderingError.name = 'ReactRenderingError'
-    renderingError.stack = errorInfo.componentStack
-    renderingError.cause = error
-    datadogRum.addError(renderingError, {viewerId, email})
+    const {componentStack} = errorInfo
+    datadogRum.addError(error, {viewerId, email, componentStack})
   }
 
   render() {


### PR DESCRIPTION
The error was added to provide a way to encapsulate the component stack rather than the stack trace, but it leads to all these errors being reported twice. Instead let's try adding the component stack to the metadata.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
