### PR TITLE
fix: window.__ACTION__ is not defined for MattermostPlugin

### DIFF
--- a/packages/client/components/promptResponse/BubbleMenuButton.tsx
+++ b/packages/client/components/promptResponse/BubbleMenuButton.tsx
@@ -13,7 +13,10 @@ export const BubbleMenuButton = (props: Props) => {
     <Button
       variant='flat'
       data-highlighted={isActive ? '' : undefined}
-      className={cn('h-7 w-7 rounded-xs hover:bg-slate-300 data-highlighted:bg-slate-300', className)}
+      className={cn(
+        'h-7 w-7 rounded-xs hover:bg-slate-300 data-highlighted:bg-slate-300',
+        className
+      )}
       {...rest}
     >
       {children}

--- a/packages/client/components/promptResponse/BubbleMenuButton.tsx
+++ b/packages/client/components/promptResponse/BubbleMenuButton.tsx
@@ -1,17 +1,19 @@
 import type {ReactNode} from 'react'
 import {Button} from '../../ui/Button/Button'
+import {cn} from '../../ui/cn'
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isActive?: boolean
+  className?: string
   children: ReactNode
 }
 export const BubbleMenuButton = (props: Props) => {
-  const {children, isActive, ...rest} = props
+  const {children, isActive, className, ...rest} = props
   return (
     <Button
       variant='flat'
       data-highlighted={isActive ? '' : undefined}
-      className='h-7 w-7 rounded-xs hover:bg-slate-300 data-highlighted:bg-slate-300'
+      className={cn('h-7 w-7 rounded-xs hover:bg-slate-300 data-highlighted:bg-slate-300', className)}
       {...rest}
     >
       {children}

--- a/packages/client/components/promptResponse/StandardBubbleMenu.tsx
+++ b/packages/client/components/promptResponse/StandardBubbleMenu.tsx
@@ -7,9 +7,11 @@ import {BubbleMenuButton} from './BubbleMenuButton'
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   editor: Editor
+  className?: string
+  buttonClassName?: string
 }
 export const StandardBubbleMenu = (props: Props) => {
-  const {editor} = props
+  const {editor, className, buttonClassName} = props
   const openLinkEditor = () => {
     editor.emit('linkStateChange', {editor, linkState: 'edit'})
   }
@@ -22,6 +24,7 @@ export const StandardBubbleMenu = (props: Props) => {
       shouldShow={({editor}) => {
         return getShouldShow(editor)
       }}
+      className={cn(className)}
       options={{
         offset: 6,
         placement: 'top'
@@ -35,28 +38,36 @@ export const StandardBubbleMenu = (props: Props) => {
         <BubbleMenuButton
           onClick={() => editor.chain().focus().toggleBold().run()}
           isActive={isBold}
+          className={cn(buttonClassName)}
         >
           <b>B</b>
         </BubbleMenuButton>
         <BubbleMenuButton
           onClick={() => editor.chain().focus().toggleItalic().run()}
           isActive={isItalic}
+          className={cn(buttonClassName)}
         >
           <i>I</i>
         </BubbleMenuButton>
         <BubbleMenuButton
           onClick={() => editor.chain().focus().toggleUnderline().run()}
           isActive={isUnderline}
+          className={cn(buttonClassName)}
         >
           <u>U</u>
         </BubbleMenuButton>
         <BubbleMenuButton
           onClick={() => editor.chain().focus().toggleStrike().run()}
           isActive={isStrike}
+          className={cn(buttonClassName)}
         >
           <s>S</s>
         </BubbleMenuButton>
-        <BubbleMenuButton onClick={openLinkEditor} isActive={isLink}>
+        <BubbleMenuButton
+          onClick={openLinkEditor}
+          isActive={isLink}
+          className={cn(buttonClassName)}
+        >
           <Link className='h-[18px] w-[18px]' />
         </BubbleMenuButton>
       </div>

--- a/packages/client/tiptap/extensions/imageUpload/ImageSelector.tsx
+++ b/packages/client/tiptap/extensions/imageUpload/ImageSelector.tsx
@@ -27,7 +27,7 @@ const tabs = [
     id: 'addGif',
     label: 'Add Gif',
     Component: ImageSelectorSearchTabRoot,
-    isVisible: !!window.__ACTION__.GIF_PROVIDER
+    isVisible: !!window.__ACTION__?.GIF_PROVIDER
   }
 ] as const
 

--- a/packages/client/tiptap/extensions/imageUpload/ImageSelectorSearchTab.tsx
+++ b/packages/client/tiptap/extensions/imageUpload/ImageSelectorSearchTab.tsx
@@ -53,7 +53,7 @@ export const ImageSelectorSearchTab = (props: Props) => {
   const {data} = paginationRes
   const {searchGifs} = data
   const {edges} = searchGifs!
-  const service = window.__ACTION__.GIF_PROVIDER
+  const service = window.__ACTION__?.GIF_PROVIDER
   // Per attribution spec, the exact wording is required
   // https://developers.google.com/tenor/guides/attribution
   const placeholder = service === 'tenor' ? 'Search Tenor' : 'Search Gifs'

--- a/packages/mattermost-plugin/components/TipTap/Editor.tsx
+++ b/packages/mattermost-plugin/components/TipTap/Editor.tsx
@@ -12,7 +12,7 @@ export const TipTapEditor = (props: Props) => {
   const {className, editor, showBubbleMenu, useLinkEditor, ref, ...rest} = props
   return (
     <>
-      <StandardBubbleMenu editor={editor} />
+      <StandardBubbleMenu editor={editor} buttonClassName='btn' />
       <TipTapLinkMenu editor={editor} useLinkEditor={useLinkEditor} />
       <EditorContent
         ref={ref as any}

--- a/packages/mattermost-plugin/types/modules.d.ts
+++ b/packages/mattermost-plugin/types/modules.d.ts
@@ -7,7 +7,8 @@ declare const __APP_VERSION__: string
 declare const __SOCKET_PORT__: string
 declare const __HOCUS_POCUS_PORT__: string
 interface Window {
-  __ACTION__: {
+  // the mattermost plugin does not have window.__ACTION__ set, so let's make this optional to enforce proper checks in all included client code
+  __ACTION__?: {
     atlassian: string
     datadogClientToken: string | undefined
     datadogApplicationId: string | undefined

--- a/packages/mattermost-plugin/webpack.config.js
+++ b/packages/mattermost-plugin/webpack.config.js
@@ -12,7 +12,7 @@ const clientTransformRules = () => {
     {
       test: /\.tsx?$/,
       // things that need the relay plugin
-      include: [PLUGIN_ROOT],
+      include: [PLUGIN_ROOT, CLIENT_ROOT],
       use: [
         {
           loader: 'babel-loader',
@@ -78,6 +78,10 @@ module.exports = {
         options: {
           presets: ['@babel/preset-react', '@babel/preset-typescript']
         }
+      },
+      {
+        test: /\.(png|jpg|jpeg|gif|svg)$/,
+        type: 'asset/resource'
       },
       {
         test: /\.css$/,


### PR DESCRIPTION

# Description

The plugin does not set the object. The easiest way to make client components work anyways is by setting the object to optional. This is done in the mattermost plugin, so only client components which are actually used by mattermost are affected. So far this is only the image selector.
Also fixed the formatting bubble menu to be somewhat presentable.

## Demo
<img width="412" height="153" alt="image" src="https://github.com/user-attachments/assets/68ec0d2d-a81f-4726-a4ec-4020953fee50" />
## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
