### PR TITLE
fix: normalize smart quote to regular quote before comparison

### DIFF
--- a/packages/client/components/DeleteTeamDialog.tsx
+++ b/packages/client/components/DeleteTeamDialog.tsx
@@ -37,6 +37,17 @@ const DeleteTeamDialog = (props: Props) => {
     history.push(`/me/organizations/${teamOrgId}/teams`)
   }
 
+  const handleTypeTeamName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault()
+
+    // Convert smart quote to regular quote before comparison
+    if (e.target.value.replace(`’`, `'`) === teamName) {
+      setTypedTeamName(true)
+    } else {
+      setTypedTeamName(false)
+    }
+  }
+
   return (
     <Dialog isOpen={isOpen} onClose={onClose}>
       <DialogContent className='z-10'>
@@ -46,15 +57,7 @@ const DeleteTeamDialog = (props: Props) => {
           <label className='mb-3 text-left font-semibold text-slate-600 text-sm'>
             Please type your team name to confirm. <b>This action can't be undone.</b>
           </label>
-          <Input
-            autoFocus
-            onChange={(e) => {
-              e.preventDefault()
-              if (e.target.value === teamName) setTypedTeamName(true)
-              else setTypedTeamName(false)
-            }}
-            placeholder={teamName}
-          />
+          <Input autoFocus onChange={handleTypeTeamName} placeholder={teamName} />
           {error && (
             <div className='mt-2 font-semibold text-sm text-tomato-500'>{error.message}</div>
           )}

--- a/packages/client/components/DeleteTeamDialog.tsx
+++ b/packages/client/components/DeleteTeamDialog.tsx
@@ -41,7 +41,7 @@ const DeleteTeamDialog = (props: Props) => {
     e.preventDefault()
 
     // Convert smart quote to regular quote before comparison
-    if (e.target.value.replaceAll(`’`, `'`) === teamName) {
+    if (e.target.value.replaceAll(`’`, `'`) === teamName.replaceAll(`’`, `'`)) {
       setTypedTeamName(true)
     } else {
       setTypedTeamName(false)

--- a/packages/client/components/DeleteTeamDialog.tsx
+++ b/packages/client/components/DeleteTeamDialog.tsx
@@ -41,7 +41,7 @@ const DeleteTeamDialog = (props: Props) => {
     e.preventDefault()
 
     // Convert smart quote to regular quote before comparison
-    if (e.target.value.replace(`’`, `'`) === teamName) {
+    if (e.target.value.replaceAll(`’`, `'`) === teamName) {
       setTypedTeamName(true)
     } else {
       setTypedTeamName(false)


### PR DESCRIPTION
# Description

Fixes #10256

This is a simple change that converts any smart quotes within the team name input into regular quotes before comparing it with the actual team name. This has been known to prevent users from deleting a team, because the condition for the button enablement is tied to the team name comparison. This fix should allow users to input smart quotes and still get an accurate comparison of the team name vs input.

## Demo

Loom coming in a bit!

## Testing scenarios

- [ ] Scenario A
  - Step 1: Create a team instance within the current org (organization -> settings & members -> teams -> add team)
  - Step 2: Click the button to delete the newly created team
  - Step 3: Type in the team name in order to enable the delete button
  - Step 4: Replace the normal quote with the smart quote (copy from here: `’`)
  - Step 5: The button should be enabled
 

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [x] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [x] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [x] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
