### PR TITLE
fix: hide access to teams and orgs

### DIFF
--- a/packages/client/mutations/useUpdatePageAccessMutation.ts
+++ b/packages/client/mutations/useUpdatePageAccessMutation.ts
@@ -37,6 +37,14 @@ const mutation = graphql`
   }
 `
 
+// since all preview types (e.g. TeamPreview) start with the `preview:` in their ID
+// this is because relay forces a GUID, so it can't have the same ID as a Team type
+// We need to use a TeamPreview type here
+// so someone with viewer access doesn't access all the props on the Team object
+const getServerSubjectId = (subjectId: string) => {
+  const PREFIX = 'preview:'
+  return subjectId.startsWith(PREFIX) ? subjectId.slice(PREFIX.length) : subjectId
+}
 export const useUpdatePageAccessMutation = () => {
   const [commit, submitting] = useMutation<TuseUpdatePageAccessMutation>(mutation)
   const execute = (config: UseMutationConfig<TuseUpdatePageAccessMutation>) => {
@@ -65,7 +73,11 @@ export const useUpdatePageAccessMutation = () => {
         ConnectionHandler.deleteNode(sourceConn, pageId)
         safePutNodeInConn(targetConn, page, store, 'sortOrder', true)
       },
-      ...config
+      ...config,
+      variables: {
+        ...config.variables,
+        subjectId: getServerSubjectId(config.variables.subjectId)
+      }
     })
   }
   return [execute, submitting] as const

--- a/packages/server/__tests__/createPage.test.ts
+++ b/packages/server/__tests__/createPage.test.ts
@@ -123,12 +123,12 @@ test('Access propagates to linked children', async () => {
             users: expect.toIncludeSameMembers([
               {
                 user: {
-                  id: user1.userId
+                  id: `preview:${user1.userId}`
                 }
               },
               {
                 user: {
-                  id: user2.userId
+                  id: `preview:${user2.userId}`
                 }
               }
             ])
@@ -157,7 +157,7 @@ test('Access propagates to linked children', async () => {
             teams: [
               {
                 team: {
-                  id: user1.teamId
+                  id: `preview:${user1.teamId}`
                 }
               }
             ]
@@ -186,7 +186,7 @@ test('Access propagates to linked children', async () => {
             organizations: [
               {
                 organization: {
-                  id: user1.orgId
+                  id: `preview:${user1.orgId}`
                 }
               }
             ]
@@ -294,14 +294,14 @@ test('Access propagates to linked children', async () => {
             organizations: [
               {
                 organization: {
-                  id: user1.orgId
+                  id: `preview:${user1.orgId}`
                 }
               }
             ],
             teams: [
               {
                 team: {
-                  id: user1.teamId
+                  id: `preview:${user1.teamId}`
                 }
               }
             ]

--- a/packages/server/graphql/public/typeDefs/Organization.graphql
+++ b/packages/server/graphql/public/typeDefs/Organization.graphql
@@ -1,7 +1,7 @@
 """
 An organization
 """
-type Organization {
+type Organization implements OrganizationPartial {
 	"""
 	The unique organization ID
 	"""

--- a/packages/server/graphql/public/typeDefs/OrganizationPartial.graphql
+++ b/packages/server/graphql/public/typeDefs/OrganizationPartial.graphql
@@ -1,0 +1,5 @@
+interface OrganizationPartial {
+	id: ID!
+	name: String!
+	picture: URL
+}

--- a/packages/server/graphql/public/typeDefs/OrganizationPreview.graphql
+++ b/packages/server/graphql/public/typeDefs/OrganizationPreview.graphql
@@ -1,0 +1,5 @@
+type OrganizationPreview implements OrganizationPartial {
+	id: ID!
+	name: String!
+	picture: URL
+}

--- a/packages/server/graphql/public/typeDefs/PageAccessOrganization.graphql
+++ b/packages/server/graphql/public/typeDefs/PageAccessOrganization.graphql
@@ -1,4 +1,4 @@
 type PageAccessOrganization {
-	organization: Organization!
+	organization: OrganizationPreview!
 	role: PageRoleEnum!
 }

--- a/packages/server/graphql/public/typeDefs/PageAccessTeam.graphql
+++ b/packages/server/graphql/public/typeDefs/PageAccessTeam.graphql
@@ -1,4 +1,4 @@
 type PageAccessTeam {
-	team: Team!
+	team: TeamPreview!
 	role: PageRoleEnum!
 }

--- a/packages/server/graphql/public/typeDefs/PageAccessUser.graphql
+++ b/packages/server/graphql/public/typeDefs/PageAccessUser.graphql
@@ -1,4 +1,4 @@
 type PageAccessUser {
-	user: User!
+	user: UserPreview!
 	role: PageRoleEnum!
 }

--- a/packages/server/graphql/public/typeDefs/Team.graphql
+++ b/packages/server/graphql/public/typeDefs/Team.graphql
@@ -5,7 +5,7 @@ interface Node {
 """
 A team
 """
-type Team implements Node {
+type Team implements Node & TeamPartial {
 	"""
 	A shortid for the team
 	"""

--- a/packages/server/graphql/public/typeDefs/TeamPartial.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamPartial.graphql
@@ -1,0 +1,4 @@
+interface TeamPartial {
+	id: ID!
+	name: String!
+}

--- a/packages/server/graphql/public/typeDefs/TeamPreview.graphql
+++ b/packages/server/graphql/public/typeDefs/TeamPreview.graphql
@@ -1,0 +1,4 @@
+type TeamPreview implements Node & TeamPartial {
+	id: ID!
+	name: String!
+}

--- a/packages/server/graphql/public/typeDefs/User.graphql
+++ b/packages/server/graphql/public/typeDefs/User.graphql
@@ -2,7 +2,7 @@ directive @stream_HACK on FIELD
 """
 The user account profile
 """
-type User {
+type User implements UserPartial {
 	"""
 	The userId provided by us
 	"""

--- a/packages/server/graphql/public/typeDefs/UserPartial.graphql
+++ b/packages/server/graphql/public/typeDefs/UserPartial.graphql
@@ -1,0 +1,8 @@
+directive @stream_HACK on FIELD
+
+interface UserPartial {
+	id: ID!
+	email: Email!
+	preferredName: String!
+	picture: URL!
+}

--- a/packages/server/graphql/public/typeDefs/UserPreview.graphql
+++ b/packages/server/graphql/public/typeDefs/UserPreview.graphql
@@ -1,0 +1,6 @@
+type UserPreview implements UserPartial {
+	id: ID!
+	email: Email!
+	preferredName: String!
+	picture: URL!
+}

--- a/packages/server/graphql/public/types/ActionMeeting.ts
+++ b/packages/server/graphql/public/types/ActionMeeting.ts
@@ -1,4 +1,3 @@
-import toTeamMemberId from '../../../../client/utils/relay/toTeamMemberId'
 import type {ActionMeetingMember} from '../../../postgres/types/Meeting'
 import {getUserId} from '../../../utils/authorization'
 import filterTasksByMeeting from '../../../utils/filterTasksByMeeting'
@@ -36,12 +35,6 @@ const ActionMeeting: ActionMeetingResolvers = {
     const {teamId} = meeting
     const teamTasks = await dataLoader.get('tasksByTeamId').load(teamId)
     return filterTasksByMeeting(teamTasks, meetingId, viewerId)
-  },
-  viewerMeetingMember: async ({id: meetingId}, _args, {authToken, dataLoader}) => {
-    const viewerId = getUserId(authToken)
-    const meetingMemberId = toTeamMemberId(meetingId, viewerId)
-    const meetingMember = await dataLoader.get('meetingMembers').load(meetingMemberId)
-    return (meetingMember as ActionMeetingMember) || null
   }
 }
 

--- a/packages/server/graphql/public/types/PageAccessOrganization.ts
+++ b/packages/server/graphql/public/types/PageAccessOrganization.ts
@@ -2,7 +2,11 @@ import type {PageAccessOrganizationResolvers} from '../resolverTypes'
 
 const PageAccessOrganization: PageAccessOrganizationResolvers = {
   organization: async ({orgId}, _args, {dataLoader}) => {
-    return dataLoader.get('organizations').loadNonNull(orgId)
+    const organization = await dataLoader.get('organizations').loadNonNull(orgId)
+    return {
+      ...organization,
+      id: `preview:${organization.id}`
+    }
   }
 }
 

--- a/packages/server/graphql/public/types/PageAccessTeam.ts
+++ b/packages/server/graphql/public/types/PageAccessTeam.ts
@@ -2,7 +2,11 @@ import type {PageAccessTeamResolvers} from '../resolverTypes'
 
 const PageAccessTeam: PageAccessTeamResolvers = {
   team: async ({teamId}, _args, {dataLoader}) => {
-    return dataLoader.get('teams').loadNonNull(teamId)
+    const team = await dataLoader.get('teams').loadNonNull(teamId)
+    return {
+      ...team,
+      id: `preview:${team.id}`
+    }
   }
 }
 

--- a/packages/server/graphql/public/types/PageAccessUser.ts
+++ b/packages/server/graphql/public/types/PageAccessUser.ts
@@ -2,7 +2,11 @@ import type {PageAccessUserResolvers} from '../resolverTypes'
 
 const PageAccessUser: PageAccessUserResolvers = {
   user: async ({userId}, _args, {dataLoader}) => {
-    return dataLoader.get('users').loadNonNull(userId)
+    const user = await dataLoader.get('users').loadNonNull(userId)
+    return {
+      ...user,
+      id: `preview:${user.id}`
+    }
   }
 }
 

--- a/packages/server/graphql/public/types/PokerMeeting.ts
+++ b/packages/server/graphql/public/types/PokerMeeting.ts
@@ -1,6 +1,4 @@
-import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import type {PokerMeetingMember} from '../../../postgres/types/Meeting'
-import {getUserId} from '../../../utils/authorization'
 import {Logger} from '../../../utils/Logger'
 import {PokerMeetingResolvers} from '../resolverTypes'
 
@@ -19,15 +17,6 @@ const PokerMeeting: PokerMeetingResolvers = {
       return null
     }
     return task
-  },
-
-  viewerMeetingMember: async ({id: meetingId}, _args, {authToken, dataLoader}) => {
-    const viewerId = getUserId(authToken)
-    const meetingMemberId = toTeamMemberId(meetingId, viewerId)
-    const meetingMember = (await dataLoader
-      .get('meetingMembers')
-      .loadNonNull(meetingMemberId)) as PokerMeetingMember
-    return meetingMember as typeof meetingMember
   }
 }
 

--- a/packages/server/graphql/public/types/RetrospectiveMeeting.ts
+++ b/packages/server/graphql/public/types/RetrospectiveMeeting.ts
@@ -1,4 +1,3 @@
-import toTeamMemberId from '../../../../client/utils/relay/toTeamMemberId'
 import type {RetroMeetingMember} from '../../../postgres/types/Meeting'
 import {getUserId} from '../../../utils/authorization'
 import filterTasksByMeeting from '../../../utils/filterTasksByMeeting'
@@ -63,14 +62,6 @@ const RetrospectiveMeeting: RetrospectiveMeetingResolvers = {
       .get('meetingMembersByMeetingId')
       .load(meetingId)) as RetroMeetingMember[]
     return meetingMembers.reduce((sum, member) => sum + member.votesRemaining, 0)
-  },
-  viewerMeetingMember: async ({id: meetingId}, _args, {authToken, dataLoader}) => {
-    const viewerId = getUserId(authToken)
-    const meetingMemberId = toTeamMemberId(meetingId, viewerId)
-    const meetingMember = (await dataLoader
-      .get('meetingMembers')
-      .load(meetingMemberId)) as RetroMeetingMember
-    return meetingMember || null
   }
 }
 


### PR DESCRIPTION
# Description

just because you have access to a page does not mean you should be able to view fields on any team or org that has access to that page

fixes #11329