### PR TITLE
fix: prefix breadcrumbs with team name

### DIFF
--- a/packages/client/modules/pages/PageBreadCrumbs.tsx
+++ b/packages/client/modules/pages/PageBreadCrumbs.tsx
@@ -40,15 +40,23 @@ export const PageBreadCrumbs = (props: Props) => {
       fragment PageBreadCrumbs_page on Page {
         id
         title
+        team {
+          id
+          name
+        }
         ancestors {
           id
           title
+          team {
+            id
+            name
+          }
         }
       }
     `,
     pageRef
   )
-  const {ancestors, id, title} = page
+  const {ancestors, id, title, team} = page
   const self = {id, title}
   useSetCurrentPageAncestor(id, ancestors)
   let visibleAncestors: typeof ancestors = []
@@ -63,8 +71,23 @@ export const PageBreadCrumbs = (props: Props) => {
     ] as const
     hiddenAncestors = ancestors.slice(1, -1) // All middle ancestors
   }
+  const renderTeamCrumb = (team: {id: string; name: string}) => {
+    return (
+      <>
+        <Link
+          draggable={false}
+          to={`/team/${team.id}`}
+          className='rounded-md px-1 hover:bg-slate-200'
+        >
+          {team.name}
+        </Link>
+        <span className='px-1'>/</span>
+      </>
+    )
+  }
   const renderBreadcrumbItem = (page: (typeof ancestors)[number]) => (
     <React.Fragment key={page.id}>
+      {page.team && renderTeamCrumb(page.team)}
       <Link
         draggable={false}
         to={`/pages/${getPageSlug(Number(page.id.split(':')[1]), page.title)}`}
@@ -115,6 +138,7 @@ export const PageBreadCrumbs = (props: Props) => {
       {visibleAncestors.length > 1 && renderBreadcrumbItem(visibleAncestors[1]!)}
 
       {/* Self (not a link) */}
+      {ancestors.length === 0 && team && renderTeamCrumb(team)}
       <span className='font-medium text-slate-900'>{self.title}</span>
     </nav>
   )

--- a/packages/client/mutations/useUpdatePageMutation.ts
+++ b/packages/client/mutations/useUpdatePageMutation.ts
@@ -20,6 +20,8 @@ graphql`
       isParentLinked
       title
       ...LeftNavPageLink_page
+      ...Page_page
+
     }
   }
 `

--- a/packages/server/graphql/public/typeDefs/PagePartial.graphql
+++ b/packages/server/graphql/public/typeDefs/PagePartial.graphql
@@ -1,4 +1,6 @@
 interface PagePartial {
 	id: ID!
 	title: String
+	teamId: ID
+	team: TeamPartial
 }

--- a/packages/server/graphql/public/typeDefs/PagePreview.graphql
+++ b/packages/server/graphql/public/typeDefs/PagePreview.graphql
@@ -1,4 +1,6 @@
 type PagePreview implements PagePartial {
 	id: ID!
 	title: String
+	teamId: ID
+	team: TeamPartial
 }

--- a/packages/server/graphql/public/types/Page.ts
+++ b/packages/server/graphql/public/types/Page.ts
@@ -1,11 +1,11 @@
 import {GraphQLError} from 'graphql'
-import TeamMemberId from '../../../../client/shared/gqlIds/TeamMemberId'
 import {getUserId} from '../../../utils/authorization'
 import {CipherId} from '../../../utils/CipherId'
 import isValid from '../../isValid'
 import type {ReqResolvers} from './ReqResolvers'
 
-const Page: ReqResolvers<'Page'> = {
+// team is captured in PagePartial so it's not needed here
+const Page: Omit<ReqResolvers<'Page'>, 'team'> = {
   access: ({id}) => ({id}),
   parentPage: async ({parentPageId}, _args, {authToken, dataLoader}) => {
     if (!parentPageId) return null
@@ -53,15 +53,6 @@ const Page: ReqResolvers<'Page'> = {
         __typename: access ? 'Page' : 'PagePreview'
       }
     })
-  },
-  team: async ({teamId}, _args, {authToken, dataLoader}) => {
-    if (!teamId) return null
-    const [teamMember, team] = await Promise.all([
-      dataLoader.get('teamMembers').load(TeamMemberId.join(teamId, authToken.sub)),
-      dataLoader.get('teams').load(teamId)
-    ])
-    if (!teamMember) return null
-    return team || null
   },
   deletedByUser: async ({deletedBy}, _args, {dataLoader}) => {
     if (!deletedBy) return null

--- a/packages/server/graphql/public/types/PagePartial.ts
+++ b/packages/server/graphql/public/types/PagePartial.ts
@@ -1,10 +1,23 @@
+import TeamMemberId from '../../../../client/shared/gqlIds/TeamMemberId'
 import {CipherId} from '../../../utils/CipherId'
 import type {ReqResolvers} from './ReqResolvers'
 
 const PagePartial: ReqResolvers<'PagePartial'> = {
   __resolveType: (source) =>
     (source as any).__typename === 'PagePreview' ? 'PagePreview' : 'Page',
-  id: ({id}) => CipherId.toClient(id, 'page')
+  id: ({id}) => CipherId.toClient(id, 'page'),
+  team: async ({teamId}, _args, {authToken, dataLoader}) => {
+    if (!teamId) return null
+    const [teamMember, team] = await Promise.all([
+      dataLoader.get('teamMembers').load(TeamMemberId.join(teamId, authToken.sub)),
+      dataLoader.get('teams').load(teamId)
+    ])
+    if (!team) return null
+    return {
+      ...team,
+      __typename: teamMember ? 'Team' : 'TeamPreview'
+    }
+  }
 }
 
 export default PagePartial


### PR DESCRIPTION
# Description

fix #11612

adds the team name to the front of the breadcrumbs for pages (if the page is under a team).
Also fixes a bug where dragging pages around didn't update the breadcrumbs