### PR TITLE
fix: increase maximum OAuth token length for Atlassian

### DIFF
--- a/packages/server/postgres/migrations/2025-08-19T13:30:51.353Z_maxOAuthTokenSize.ts
+++ b/packages/server/postgres/migrations/2025-08-19T13:30:51.353Z_maxOAuthTokenSize.ts
@@ -1,0 +1,19 @@
+import type {Kysely} from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+  db.schema
+    .alterTable('AtlassianAuth')
+    .alterColumn('accessToken', (ac) => ac.setDataType('varchar(8192)'))
+    .alterColumn('refreshToken', (ac) => ac.setDataType('varchar(8192)'))
+    .execute()
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+  db.schema
+    .alterTable('AtlassianAuth')
+    .alterColumn('accessToken', (ac) => ac.setDataType('varchar(2600)'))
+    .alterColumn('refreshToken', (ac) => ac.setDataType('varchar(2600)'))
+    .execute()
+}


### PR DESCRIPTION

# Description

Fixes #11851 
There is no size limit specified, but it's passed as a header and most servers accept maximum of 8k.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
