### PR TITLE
fix: update top-level title updates

### DIFF
--- a/packages/server/hocusPocus.ts
+++ b/packages/server/hocusPocus.ts
@@ -105,7 +105,7 @@ export const server = new Server({
         const [{updatedTitle}] = await Promise.all([updatePageContent(dbId, content, state)])
         if (updatedTitle) {
           await Promise.all([
-            pushGQLTitleUpdates,
+            pushGQLTitleUpdates(dbId),
             withBacklinks(dbId, (doc) => {
               updateYDocNodes(doc, 'pageLinkBlock', {pageCode}, (node) => {
                 node.setAttribute('title', updatedTitle)


### PR DESCRIPTION
# Description

fixes #11798 (at least the title renaming part)
i probably hit undo before committing this originally :-(.
basically when the title gets changed, we now push that via GQL