### PR TITLE
fix: remove poker template dimensions

### DIFF
--- a/packages/server/graphql/mutations/removePokerTemplateDimension.ts
+++ b/packages/server/graphql/mutations/removePokerTemplateDimension.ts
@@ -54,7 +54,7 @@ const removePokerTemplateDimension = {
       .where('id', '=', dimensionId)
       .execute()
     dataLoader.clearAll('templateDimensions')
-    const data = {dimensionId, templateId}
+    const data = {dimension, templateId}
     publish(
       SubscriptionChannel.TEAM,
       teamId,

--- a/packages/server/graphql/types/RemovePokerTemplateDimensionPayload.ts
+++ b/packages/server/graphql/types/RemovePokerTemplateDimensionPayload.ts
@@ -18,11 +18,7 @@ const RemovePokerTemplateDimensionPayload = new GraphQLObjectType<any, GQLContex
       }
     },
     dimension: {
-      type: TemplateDimension,
-      resolve: ({dimensionId}, _args: unknown, {dataLoader}) => {
-        if (!dimensionId) return null
-        return dataLoader.get('templateDimensions').load(dimensionId)
-      }
+      type: TemplateDimension
     }
   })
 })


### PR DESCRIPTION
# Description

Fixes #10545, #11708
The mutation payload source contained only the id of the now removed template dimension, which could not be loaded anymore.


## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

- [ ] Create Poker Template
- [ ] add a new dimension
- [ ] delete it, see it gone (#10545)
- [ ] press the back button top left to go back to activity library (#11708) and see no error

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
