### PR TITLE
fix: memory leak onError and activeClients

### DIFF
--- a/packages/server/activeClients.ts
+++ b/packages/server/activeClients.ts
@@ -1,3 +1,3 @@
-import type {Extra} from 'graphql-ws/use/uWebSockets'
+import type {WebSocket} from 'uWebSockets.js'
 
-export const activeClients = new Map<string, Extra>()
+export const activeClients = new Map<string, WebSocket<unknown>>()

--- a/packages/server/disconnectAllSockets.ts
+++ b/packages/server/disconnectAllSockets.ts
@@ -8,10 +8,10 @@ export const disconnectAllSockets = async (disconnectWindow: number = 60_000) =>
     const msPerClose = (disconnectWindow - ONDISCONNECT_LIMIT) / connectionsToClose.length
     const closeEvery = Math.min(200, msPerClose)
     await Promise.allSettled(
-      connectionsToClose.map(async (extra, idx) => {
+      connectionsToClose.map(async (socket, idx) => {
         const disconnectIn = idx * closeEvery
         await sleep(disconnectIn)
-        extra.socket.end(1012, 'Closing connection')
+        socket.end(1012, 'Closing connection')
       })
     )
     //socket.end will fire wsHandler.onDisconnect. Give it this long to complete


### PR DESCRIPTION
# Description

little shots in the dark here. we know we're retaining more dataloaders than we should here. in this dump we should be holding onto about 30, but we've got about 170, so ignoring the first 30 or so, we see that there a lot that are held due to the `onError` callback. onError was just calling a dispose function, which is somehow holding onto an async iterator. I don't know where in the context the dispose function was grabbing this! it was defined in the `onSubscribe`, and therefore has access to ctx.subscriptions, so it looks like the async iterable is just 1 of the subscriptions, retained by the resub object. my guess is this is somehow creating a circular reference whenever onError is called that I'm just not seeing.

Since onError isn't necessary (onComplete should get called after that) I just removed it. Additionally, instead of keeping a dispose function that is created in onSubscribe, which would then have access to the parent context, I just store a dictionary of dataLoaders to reduce the stored context. Fewer things in scope means fewer chances that something gets retained. Also, since it mentioned activeClients being retained, I figured I'd only store the sockets in that lookup as well instead of the whole Extra object.

<img width="1127" height="439" alt="Screenshot 2025-08-25 at 3 47 43 PM" src="https://github.com/user-attachments/assets/5c861109-ebce-4541-b1da-c744b7785341" />
