### PR TITLE
fix: shared pages include top-level accessible

### DIFF
--- a/packages/server/graphql/public/typeDefs/User.graphql
+++ b/packages/server/graphql/public/typeDefs/User.graphql
@@ -541,7 +541,7 @@ type User implements UserPartial {
 		"""
 		after: String
 		"""
-		true to query top-level private pages. false to query top-level shard pages. ignored if parentPageId or teamId is present
+		true to query top-level private pages. false to query top-level sharerd pages. ignored if parentPageId or teamId is present
 		"""
 		isPrivate: Boolean
 		"""

--- a/packages/server/postgres/select.ts
+++ b/packages/server/postgres/select.ts
@@ -1,5 +1,5 @@
 import type {JSONContent} from '@tiptap/core'
-import type {ControlledTransaction, Kysely} from 'kysely'
+import type {ControlledTransaction, Kysely, QueryCreator} from 'kysely'
 import {type NotNull, type SelectQueryBuilder, sql} from 'kysely'
 import type {NewMeetingPhaseTypeEnum} from '../graphql/public/resolverTypes'
 import getKysely from './getKysely'
@@ -306,8 +306,8 @@ export const selectTasks = () =>
 export const selectNotifications = () =>
   getKysely().selectFrom('Notification').selectAll().$narrowType<AnyNotification>()
 
-export const selectPages = () =>
-  getKysely().selectFrom('Page').select([
+export const selectPages = (queryCreator: Kysely<DB> | QueryCreator<DB> = getKysely()) =>
+  queryCreator.selectFrom('Page').select([
     // do not select plaintextContent or yDoc.
     // yDoc is large and can't be sent via graphql
     'createdAt',


### PR DESCRIPTION
# Description

fix #11663

Assume Page B is a child of Page A.
If Page A lives under a team & I'm not on the team, then Page A should appear in my shared pages.
If Page B is shared with me but not Page A, Page B should show up in shared pages.
