### PR TITLE
chore: reduce error logs when onStoreDocument fails

### DIFF
--- a/packages/server/utils/tiptap/hocusPocusRedis.ts
+++ b/packages/server/utils/tiptap/hocusPocusRedis.ts
@@ -256,8 +256,7 @@ export class Redis implements Extension {
         // Do not throw an error with a message here as that crashes the server.
         // https://github.com/ueberdosis/hocuspocus/issues/754#issuecomment-2288844459
         throw {
-          name: 'LockError',
-          cause: error
+          name: 'LockError'
         }
       }
       throw error


### PR DESCRIPTION
Hocuspocus is printing the error, but we already logged it, so no need to add additional information in it.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
