### PR TITLE
feat: add starter actions for adding insights

### DIFF
--- a/packages/client/modules/pages/Page.tsx
+++ b/packages/client/modules/pages/Page.tsx
@@ -9,6 +9,7 @@ import {useTipTapPageEditor} from '../../hooks/useTipTapPageEditor'
 import {cn} from '../../ui/cn'
 import {PageHeader} from './PageHeader'
 import {PageHeaderPublic} from './PageHeaderPublic'
+import {StarterActions} from './StarterActions'
 
 interface Props {
   viewerRef: useTipTapPageEditor_viewer$key | null
@@ -48,7 +49,7 @@ export const Page = (props: Props) => {
   return (
     <div className='relative flex w-full flex-col items-center bg-white'>
       {isPublic ? <PageHeaderPublic /> : <PageHeader pageRef={page} />}
-      <div className='flex min-h-screen w-full max-w-[960px] justify-center bg-white pt-28 pb-10'>
+      <div className='relative flex min-h-screen w-full max-w-[960px] justify-center bg-white pt-28 pb-10'>
         <TipTapEditor
           editor={editor}
           className={cn(
@@ -56,6 +57,7 @@ export const Page = (props: Props) => {
             synced && 'opacity-100'
           )}
         />
+        <StarterActions editor={editor} />
       </div>
     </div>
   )

--- a/packages/client/modules/pages/StarterActions.tsx
+++ b/packages/client/modules/pages/StarterActions.tsx
@@ -1,0 +1,56 @@
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome'
+import type {Editor} from '@tiptap/core'
+import {useEffect, useRef, useState} from 'react'
+import {Button} from '../../ui/Button/Button'
+
+interface Props {
+  editor: Editor
+}
+
+export const StarterActions = (props: Props) => {
+  const {editor} = props
+  const [isEmpty, setIsEmpty] = useState(false)
+  const transformRef = useRef<undefined | string>(undefined)
+  const getTransform = () => {
+    const coords = editor.view.coordsAtPos(1)
+    console.log('coords', coords)
+    const {left, top} = coords
+    if (left !== 0 && top !== 0) {
+      transformRef.current = `translate(${coords.left}px,${coords.top + 90}px)`
+    }
+    return transformRef.current
+  }
+
+  useEffect(() => {
+    if (!editor) return
+    const handleUpdate = () => {
+      const {doc} = editor.state
+      const nextIsEmpty = doc.childCount === 2 && doc.child(1).content.size === 0
+      if (nextIsEmpty) {
+        getTransform()
+      }
+      setIsEmpty(nextIsEmpty)
+    }
+    handleUpdate()
+    editor.on('update', handleUpdate)
+    return () => {
+      editor.off('update', handleUpdate)
+    }
+  }, [editor])
+  if (!isEmpty) return null
+
+  return (
+    <div className='fixed top-0 left-0' style={{transform: transformRef.current}}>
+      <Button
+        variant='outline'
+        className='rounded-full text-slate-600 text-sm'
+        onClick={() => {
+          editor.chain().focus().setInsights().run()
+        }}
+      >
+        <AutoAwesomeIcon className='size-4' />
+        <span className='pl-1'>Add Insights</span>
+      </Button>
+    </div>
+  )
+}

--- a/packages/client/shared/tiptap/extensions/InsightsBlockBase.ts
+++ b/packages/client/shared/tiptap/extensions/InsightsBlockBase.ts
@@ -12,10 +12,6 @@ export const InsightsBlockBase = Node.create({
 
   content: 'block*',
 
-  draggable: true,
-
-  selectable: true,
-
   inline: false,
 
   addAttributes() {

--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -467,6 +467,14 @@
       @apply overflow-hidden rounded-md;
     }
   }
+
+  .node-insightsBlock {
+    @apply relative;
+    &.has-focus > div::after {
+      content: '';
+      @apply pointer-events-none absolute inset-0 h-full w-full bg-[#2383e247] select-none;
+    }
+  }
   .search-result {
     background-color: rgba(255, 217, 0, 0.5);
   }

--- a/packages/client/tiptap/isCustomNodeSelected.ts
+++ b/packages/client/tiptap/isCustomNodeSelected.ts
@@ -2,6 +2,7 @@ import type {Editor} from '@tiptap/core'
 import {TiptapLinkExtension} from '../components/promptResponse/TiptapLinkExtension'
 import {ImageBlock} from './extensions/imageBlock/ImageBlock'
 import {ImageUpload} from './extensions/imageUpload/ImageUpload'
+import {InsightsBlock} from './extensions/insightsBlock/InsightsBlock'
 import {TaskBlock} from './extensions/insightsBlock/TaskBlock'
 import {PageLinkBlock} from './extensions/pageLinkBlock/PageLinkBlock'
 
@@ -9,6 +10,7 @@ const customNodes = [
   TiptapLinkExtension.name,
   PageLinkBlock.name,
   ImageUpload.name,
+  InsightsBlock.name,
   ImageBlock.name,
   TaskBlock.name
 ]


### PR DESCRIPTION
# Description

fix #11614 adds an "add insights" button to empty documents.
This PR should make it real obvious why we added pages!