### PR TITLE
fix: enable Update button correctly in PromptResponseEditor after cle…

### DIFF
--- a/packages/client/components/promptResponse/PromptResponseEditor.tsx
+++ b/packages/client/components/promptResponse/PromptResponseEditor.tsx
@@ -59,6 +59,7 @@ const PromptResponseEditor = (props: Props) => {
   const atmosphere = useAtmosphere()
   const [isEditing, setIsEditing] = useState(false)
   const [autoFocus, setAutoFocus] = useState(autoFocusProp)
+  const [isEditorEmpty, setIsEditorEmpty] = useState(true)
 
   const content = useMemo(
     () => (rawContent && readOnly ? unfurlLoomLinks(rawContent) : rawContent),
@@ -76,6 +77,7 @@ const PromptResponseEditor = (props: Props) => {
   const onUpdate = useCallback(
     ({editor}: {editor: Editor}) => {
       setEditing(true)
+      setIsEditorEmpty(editor.isEmpty)
       if (draftStorageKey) {
         window.localStorage.setItem(draftStorageKey, JSON.stringify(editor.getJSON()))
       }
@@ -180,7 +182,7 @@ const PromptResponseEditor = (props: Props) => {
             <SubmitButton
               onClick={() => onSubmit()}
               size='medium'
-              disabled={!editor || editor.isEmpty}
+              disabled={!editor || isEditorEmpty}
               aria-label={`${buttonTitle} your response`}
               title={`${buttonTitle} your response ${modEnter}`}
             >


### PR DESCRIPTION
# Description
Fixes #11970 
This fixes the issue where the Update button in Response Editor remained disabled after clearing all content and then typing again. The button now correctly reflects the current editor content.

## Demo
https://github.com/user-attachments/assets/118fddd3-73a3-477a-bd57-a795458bd67e
The video shows the correct state for the Update Button.

**Before:** Button stayed disabled even when editor had content.
**After:** Button enables immediately as soon as content exists.

## Testing scenarios
- Submit button enables on typing:
  - Open PromptResponseEditor with empty content.
  - Type something → button should enable.

- Button disables on clearing content:
  - Delete all content → button should disable.

## Final checklist

- [x] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [x] I have performed a self-review of my code, the same way I'd do it for any other team member
- [x] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [x] PR title is human readable and could be used in changelog
