### PR TITLE
feat: send page invites to externals via email

### DIFF
--- a/packages/client/modules/email/components/PageSharedInvite.tsx
+++ b/packages/client/modules/email/components/PageSharedInvite.tsx
@@ -1,0 +1,197 @@
+import DescriptionIcon from '@mui/icons-material/Description'
+import {ExternalLinks} from 'parabol-client/types/constEnums'
+import {PageRoleEnum} from '../../../__generated__/NotificationSubscription.graphql'
+import {PALETTE} from '../../../styles/paletteV3'
+import type {CorsOptions} from '../../../types/cors'
+import {emailCopyStyle, emailLinkStyle, emailProductTeamSignature, emailTableBase} from '../styles'
+import Button from './Button'
+import EmailBlock from './EmailBlock/EmailBlock'
+import EmailFooter from './EmailFooter/EmailFooter'
+import EmptySpace from './EmptySpace/EmptySpace'
+import Layout from './Layout/Layout'
+
+const innerMaxWidth = 480
+
+const boldStyle = {
+  ...emailCopyStyle,
+  fontWeight: 600
+}
+
+const emailHeadingStyle = {
+  ...emailCopyStyle,
+  fontWeight: 600,
+  fontSize: '24px',
+  color: PALETTE.SLATE_900,
+  paddingTop: '24px'
+}
+
+const imageStyle = {
+  border: '0px',
+  display: 'block',
+  margin: '0px'
+}
+
+const imageLinkStyle = {
+  display: 'block',
+  textDecoration: 'none'
+}
+
+const subTitleStyle = {
+  ...emailCopyStyle,
+  fontSize: '18px',
+  fontWeight: 600,
+  paddingTop: '8px',
+  color: PALETTE.SLATE_900
+}
+
+const utmParams = {
+  utm_source: 'shared page email',
+  utm_medium: 'email',
+  utm_campaign: 'invitations'
+}
+function appendUTM(url: string) {
+  const newUrl = new URL(url)
+  Object.entries(utmParams).forEach(([name, value]) => {
+    newUrl.searchParams.append(name, value)
+  })
+  return newUrl.toString()
+}
+
+export const pageRoles = {
+  owner: 'edit',
+  editor: 'edit',
+  commenter: 'comment on',
+  viewer: 'view'
+} as const satisfies Record<PageRoleEnum, string>
+
+export interface PageSharedInviteProps {
+  appOrigin: string
+  inviterName: string
+  inviterEmail: string
+  inviterAvatar: string
+  pageLink: string
+  pageName: string
+  role: PageRoleEnum
+  corsOptions: CorsOptions
+}
+
+const PageSharedInvite = (props: PageSharedInviteProps) => {
+  const {
+    appOrigin,
+    inviterName,
+    inviterEmail,
+    inviterAvatar,
+    pageLink,
+    pageName,
+    role,
+    corsOptions
+  } = props
+  const pageAccess = pageRoles[role] || 'view'
+  return (
+    <Layout maxWidth={544}>
+      <EmailBlock innerMaxWidth={innerMaxWidth}>
+        <h1 style={emailHeadingStyle}>{inviterName} shared a page</h1>
+        <p style={emailCopyStyle}>
+          <table style={emailTableBase} width='100%'>
+            <tbody>
+              <tr>
+                <td valign='top' width='48px'>
+                  <img
+                    width='48px'
+                    height='48px'
+                    alt='Avatar'
+                    style={{borderRadius: '24px'}}
+                    src={inviterAvatar}
+                  />
+                </td>
+                <td style={{paddingLeft: '18px'}}>
+                  <span style={boldStyle}>{inviterName}</span>
+                  {' ('}
+                  <a href={`mailto:${inviterEmail}`} style={emailLinkStyle}>
+                    {inviterEmail}
+                  </a>
+                  {') has invited you to '}
+                  <b>{pageAccess}</b>
+                  {' this page in Parabol.'}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <table
+            style={{
+              border: `2px solid ${PALETTE.SLATE_300}`,
+              borderRadius: '8px',
+              borderCollapse: 'separate',
+              margin: '16px 0',
+              padding: '4px'
+            }}
+            width='100%'
+          >
+            <tbody>
+              <tr>
+                <td align='center' valign='middle' width='32px'>
+                  <DescriptionIcon
+                    style={{verticalAlign: 'middle', width: '24px', height: '24px'}}
+                  />
+                </td>
+                <td
+                  valign='baseline'
+                  style={{
+                    lineHeight: '20px',
+                    padding: '8px 0 6px',
+                    fontWeight: 600,
+                    color: PALETTE.SLATE_900
+                  }}
+                >
+                  {pageName}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <Button url={appendUTM(pageLink)}>Open Page</Button>
+        </p>
+        <EmptySpace height={24} />
+        <p style={emailCopyStyle}>
+          <table style={emailTableBase} width='100%'>
+            <tbody>
+              <tr>
+                <td align='left'>
+                  <a style={imageLinkStyle} href={appOrigin}>
+                    <img
+                      alt='Parabol, Inc. Logo'
+                      height={42}
+                      src={`${ExternalLinks.EMAIL_CDN}email-header-branding-color@3x.png`}
+                      style={imageStyle}
+                      width={204}
+                      {...corsOptions}
+                    />
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td align='left' style={subTitleStyle}>
+                  {'Collaborative Workflows & Insights'}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </p>
+        <p style={emailCopyStyle}>
+          {'Get in touch if we can help in any way,'}
+          <br />
+          {emailProductTeamSignature}
+          <br />
+          <a href='mailto:love@parabol.co' style={emailLinkStyle} title='love@parabol.co'>
+            {'love@parabol.co'}
+          </a>
+        </p>
+        <EmptySpace height={16} />
+      </EmailBlock>
+      <EmailBlock hasBackgroundColor innerMaxWidth={innerMaxWidth}>
+        <EmailFooter />
+      </EmailBlock>
+    </Layout>
+  )
+}
+
+export default PageSharedInvite

--- a/packages/client/modules/email/components/PageSharedInvite.tsx
+++ b/packages/client/modules/email/components/PageSharedInvite.tsx
@@ -44,19 +44,6 @@ const subTitleStyle = {
   color: PALETTE.SLATE_900
 }
 
-const utmParams = {
-  utm_source: 'shared page email',
-  utm_medium: 'email',
-  utm_campaign: 'invitations'
-}
-function appendUTM(url: string) {
-  const newUrl = new URL(url)
-  Object.entries(utmParams).forEach(([name, value]) => {
-    newUrl.searchParams.append(name, value)
-  })
-  return newUrl.toString()
-}
-
 export const pageRoles = {
   owner: 'edit',
   editor: 'edit',
@@ -66,9 +53,9 @@ export const pageRoles = {
 
 export interface PageSharedInviteProps {
   appOrigin: string
-  inviterName: string
-  inviterEmail: string
-  inviterAvatar: string
+  ownerName: string
+  ownerEmail: string
+  ownerAvatar: string
   pageLink: string
   pageName: string
   role: PageRoleEnum
@@ -76,21 +63,13 @@ export interface PageSharedInviteProps {
 }
 
 const PageSharedInvite = (props: PageSharedInviteProps) => {
-  const {
-    appOrigin,
-    inviterName,
-    inviterEmail,
-    inviterAvatar,
-    pageLink,
-    pageName,
-    role,
-    corsOptions
-  } = props
+  const {appOrigin, ownerName, ownerEmail, ownerAvatar, pageLink, pageName, role, corsOptions} =
+    props
   const pageAccess = pageRoles[role] || 'view'
   return (
     <Layout maxWidth={544}>
       <EmailBlock innerMaxWidth={innerMaxWidth}>
-        <h1 style={emailHeadingStyle}>{inviterName} shared a page</h1>
+        <h1 style={emailHeadingStyle}>{ownerName} shared a page</h1>
         <p style={emailCopyStyle}>
           <table style={emailTableBase} width='100%'>
             <tbody>
@@ -101,14 +80,14 @@ const PageSharedInvite = (props: PageSharedInviteProps) => {
                     height='48px'
                     alt='Avatar'
                     style={{borderRadius: '24px'}}
-                    src={inviterAvatar}
+                    src={ownerAvatar}
                   />
                 </td>
                 <td style={{paddingLeft: '18px'}}>
-                  <span style={boldStyle}>{inviterName}</span>
+                  <span style={boldStyle}>{ownerName}</span>
                   {' ('}
-                  <a href={`mailto:${inviterEmail}`} style={emailLinkStyle}>
-                    {inviterEmail}
+                  <a href={`mailto:${ownerEmail}`} style={emailLinkStyle}>
+                    {ownerEmail}
                   </a>
                   {') has invited you to '}
                   <b>{pageAccess}</b>
@@ -148,7 +127,7 @@ const PageSharedInvite = (props: PageSharedInviteProps) => {
               </tr>
             </tbody>
           </table>
-          <Button url={appendUTM(pageLink)}>Open Page</Button>
+          <Button url={pageLink}>Open Page</Button>
         </p>
         <EmptySpace height={24} />
         <p style={emailCopyStyle}>

--- a/packages/client/modules/pages/PageNoAccess.tsx
+++ b/packages/client/modules/pages/PageNoAccess.tsx
@@ -1,8 +1,9 @@
 import LockIcon from '@mui/icons-material/Lock'
 import {DialogTitle} from '@mui/material'
-import {useHistory} from 'react-router'
+import {useHistory, useLocation} from 'react-router'
 import {Button} from '../../ui/Button/Button'
 import {Dialog} from '../../ui/Dialog/Dialog'
+import {DialogActions} from '../../ui/Dialog/DialogActions'
 import {DialogContent} from '../../ui/Dialog/DialogContent'
 import {DialogDescription} from '../../ui/Dialog/DialogDescription'
 
@@ -11,6 +12,9 @@ interface Props {}
 export const PageNoAccess = (_props: Props) => {
   const email = localStorage.getItem('email')
   const history = useHistory()
+  const searchParams = new URLSearchParams(useLocation().search)
+  const inviteEmail = searchParams.get('email')
+
   return (
     <div>
       <Dialog isOpen>
@@ -18,37 +22,57 @@ export const PageNoAccess = (_props: Props) => {
           className='flex w-80 flex-col items-center justify-center p-6 md:w-80'
           noClose
         >
-          <DialogTitle className='mb-0 flex w-full flex-col items-center justify-center'>
+          <DialogTitle className='flex w-full flex-col items-center justify-center'>
             <LockIcon />
             <div>No access to this page</div>
-            <div className='text-xs'>
+            <div className='text-center text-xs'>
               {email && (
-                <span>
-                  You are logged in as <b>{email}</b>
-                </span>
+                <>
+                  You are logged in as
+                  <br />
+                  <b>{email}</b>
+                </>
+              )}
+              {inviteEmail && (
+                <>
+                  This page was shared with
+                  <br />
+                  <b>{inviteEmail}</b>
+                </>
               )}
             </div>
           </DialogTitle>
           <DialogDescription className='text-center'>
-            {email ? 'Ask a page owner to share the page with you' : 'Try logging in first'}
+            {email
+              ? 'Ask a page owner to share the page with you'
+              : inviteEmail
+                ? 'Create an account first'
+                : 'Try logging in first'}
           </DialogDescription>
-          <Button
-            shape='pill'
-            variant='secondary'
-            className='p-2 px-3'
-            onClick={() => {
-              if (email) {
-                history.push('/me')
-              } else {
-                history.replace({
-                  pathname: '/',
-                  search: `?redirectTo=${encodeURIComponent(window.location.pathname)}`
-                })
-              }
-            }}
-          >
-            {email ? 'Go home' : 'Login'}
-          </Button>
+          <DialogActions>
+            <Button
+              shape='pill'
+              variant='secondary'
+              className='p-3 px-4'
+              onClick={() => {
+                if (email) {
+                  history.push('/me')
+                } else if (inviteEmail) {
+                  history.replace({
+                    pathname: '/create-account',
+                    search: `?redirectTo=${encodeURIComponent(window.location.pathname)}&email=${encodeURIComponent(inviteEmail)}`
+                  })
+                } else {
+                  history.replace({
+                    pathname: '/',
+                    search: `?redirectTo=${encodeURIComponent(window.location.pathname)}`
+                  })
+                }
+              }}
+            >
+              {email ? 'Go home' : inviteEmail ? 'Create Account' : 'Login'}
+            </Button>
+          </DialogActions>
         </DialogContent>
       </Dialog>
     </div>

--- a/packages/client/utils/makeAppURL.ts
+++ b/packages/client/utils/makeAppURL.ts
@@ -10,6 +10,7 @@ interface Options {
     openNotifs?: string
     responseId?: string
     redirectTo?: string
+    email?: string
   } & (UTMParams | Partial<Record<keyof UTMParams, never>>)
 }
 

--- a/packages/server/email/pageSharedEmailCreator.tsx
+++ b/packages/server/email/pageSharedEmailCreator.tsx
@@ -1,0 +1,35 @@
+import Oy from 'oy-vey'
+import PageSharedInvite, {
+  type PageSharedInviteProps,
+  pageRoles
+} from 'parabol-client/modules/email/components/PageSharedInvite'
+import {headCSS} from 'parabol-client/modules/email/styles'
+
+const subjectLine = (inviterName: string): string =>
+  `${inviterName} has shared a Page with you on Parabol`
+
+const teamInviteText = (props: PageSharedInviteProps) => {
+  const {inviterName, inviterEmail, pageName, pageLink, role} = props
+  const pageAccess = pageRoles[role] || 'view'
+  return `
+${inviterName} (${inviterEmail}) has invited you to ${pageAccess} this page in Parabol: ${pageName}
+
+Open Page here: ${pageLink}
+
+Your friends,
+The Parabol Product Team
+`
+}
+
+export default (props: PageSharedInviteProps) => {
+  const subject = subjectLine(props.inviterName)
+  return {
+    subject,
+    body: teamInviteText(props),
+    html: Oy.renderTemplate(<PageSharedInvite {...props} />, {
+      headCSS,
+      title: subject,
+      previewText: subject
+    })
+  }
+}

--- a/packages/server/email/pageSharedEmailCreator.tsx
+++ b/packages/server/email/pageSharedEmailCreator.tsx
@@ -5,14 +5,14 @@ import PageSharedInvite, {
 } from 'parabol-client/modules/email/components/PageSharedInvite'
 import {headCSS} from 'parabol-client/modules/email/styles'
 
-const subjectLine = (inviterName: string): string =>
-  `${inviterName} has shared a Page with you on Parabol`
+const subjectLine = (ownerName: string): string =>
+  `${ownerName} has shared a Page with you on Parabol`
 
 const teamInviteText = (props: PageSharedInviteProps) => {
-  const {inviterName, inviterEmail, pageName, pageLink, role} = props
+  const {ownerName, ownerEmail, pageName, pageLink, role} = props
   const pageAccess = pageRoles[role] || 'view'
   return `
-${inviterName} (${inviterEmail}) has invited you to ${pageAccess} this page in Parabol: ${pageName}
+${ownerName} (${ownerEmail}) has invited you to ${pageAccess} this page in Parabol: ${pageName}
 
 Open Page here: ${pageLink}
 
@@ -22,7 +22,7 @@ The Parabol Product Team
 }
 
 export default (props: PageSharedInviteProps) => {
-  const subject = subjectLine(props.inviterName)
+  const subject = subjectLine(props.ownerName)
   return {
     subject,
     body: teamInviteText(props),


### PR DESCRIPTION
# Description

Fixes #11316
For now we only send emails to external users if they gain access to a page.
For existing users we'll do notifications first until we have the notification setting to disable emails for page sharing.

## Demo

<img width="671" height="747" alt="image" src="https://github.com/user-attachments/assets/cb633417-59cb-4ef1-88e8-890488eb69ae" />

<img width="396" height="392" alt="image" src="https://github.com/user-attachments/assets/f7c65a83-0707-4108-871e-4a716eb2e96c" />


## Testing scenarios

- [ ] Share a page with an external email

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
