### PR TITLE
chore(heap-dump): allow customizing the folder where the heap dumps are stored

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ SERVER_ID='1'
 # Websocket port for the websocket server, only used in development
 SOCKET_PORT='3001'
 HOCUS_POCUS_PORT='3003'
+# Folder where heap dumps are generated. If empty, it defaults to system tmp folder
+# HEAP_DUMP_FOLDER=''
 
 # AI MODELS
 AI_EMBEDDING_MODELS='[{"model": "text-embeddings-inference:llmrails/ember-v1", "url": "http://localhost:3040/"}]'

--- a/packages/server/graphql/private/mutations/dumpHeap.ts
+++ b/packages/server/graphql/private/mutations/dumpHeap.ts
@@ -8,7 +8,7 @@ import {setIsBusy} from '../../../getIsBusy'
 import {Logger} from '../../../utils/Logger'
 import type {MutationResolvers} from '../resolverTypes'
 
-const {SERVER_ID} = process.env
+const {SERVER_ID, HEAP_DUMP_FOLDER} = process.env
 
 const dumpHeap: MutationResolvers['dumpHeap'] = async (
   _source,
@@ -34,7 +34,9 @@ const dumpHeap: MutationResolvers['dumpHeap'] = async (
     const usedMB = Math.floor(rss / MB)
     const now = new Date().toJSON()
     const fileName = `Dumpy_${now}_${SERVER_ID}_${usedMB}.heapsnapshot`
-    const pathName = path.join(os.tmpdir(), fileName)
+    const dumpFolder = (HEAP_DUMP_FOLDER ?? '').trim() || os.tmpdir()
+    const pathName = path.join(dumpFolder, fileName)
+    if (!fs.existsSync(dumpFolder)) fs.mkdirSync(dumpFolder, {recursive: true})
     const fd = fs.openSync(pathName, 'w')
     session.connect()
     session.on('HeapProfiler.addHeapSnapshotChunk', (m) => {


### PR DESCRIPTION
# Description

Allows to set a custom folder where heap dumps are stored, so we can use some more persistent storage that is not cleared if the pod is restarted like the /tmp is.

Tested through an [on-demand-environment](https://gitlab.com/parabol1/gcp-parabol-development/kubernetes-parabol-saas-development/on-demand-environments/-/merge_requests/14)