### PR TITLE
fix: undo del snackbar

### DIFF
--- a/packages/client/components/DashNavList/PageActions.tsx
+++ b/packages/client/components/DashNavList/PageActions.tsx
@@ -108,7 +108,7 @@ export const PageActions = (props: Props) => {
             }
           >
             <MenuContent align='center' side={'right'} sideOffset={8} className='max-h-80'>
-              <MenuItem onClick={archivePage}>
+              <MenuItem onSelect={archivePage} onClick={(e) => e.stopPropagation()}>
                 <DeleteIcon className='text-slate-600' />
                 <span className='pl-1'>{'Delete page'}</span>
               </MenuItem>

--- a/packages/client/components/DashNavList/PageActions.tsx
+++ b/packages/client/components/DashNavList/PageActions.tsx
@@ -52,6 +52,20 @@ export const PageActions = (props: Props) => {
             message: firstError,
             autoDismiss: 5
           })
+        } else {
+          atmosphere.eventEmitter.emit('addSnackbar', {
+            key: 'PageActionsArchiveUndo',
+            message: 'Moved to trash',
+            action: {
+              label: 'Undo',
+              callback: () => {
+                executeArchive({
+                  variables: {pageId, action: 'restore'}
+                })
+              }
+            },
+            autoDismiss: 5
+          })
         }
       }
     })

--- a/packages/client/components/MeetingOptions.tsx
+++ b/packages/client/components/MeetingOptions.tsx
@@ -97,7 +97,7 @@ const MeetingOptions = (props: Props) => {
         <Tooltip open={openTooltip}>
           <div onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
             <TooltipTrigger asChild>
-              <MenuItem onClick={handleClick} isDisabled={isDisabled}>
+              <MenuItem onSelect={handleClick} isDisabled={isDisabled}>
                 <div className='mr-3 flex text-slate-700'>{<SwapHorizIcon />}</div>
                 Change template
               </MenuItem>

--- a/packages/client/components/OrgAdminActionMenu.tsx
+++ b/packages/client/components/OrgAdminActionMenu.tsx
@@ -97,28 +97,28 @@ export const OrgAdminActionMenu = (props: Props) => {
     >
       <MenuContent align='end' sideOffset={4}>
         {isViewerOrgAdmin && !isOrgAdmin && (
-          <MenuItem onClick={setRole('ORG_ADMIN')}>{'Promote to Org Admin'}</MenuItem>
+          <MenuItem onSelect={setRole('ORG_ADMIN')}>{'Promote to Org Admin'}</MenuItem>
         )}
         {isViewerBillingLeaderPlus && !isOrgAdmin && !isBillingLeader && (
-          <MenuItem onClick={setRole('BILLING_LEADER')}>{'Promote to Billing Leader'}</MenuItem>
+          <MenuItem onSelect={setRole('BILLING_LEADER')}>{'Promote to Billing Leader'}</MenuItem>
         )}
         {isViewerOrgAdmin && isOrgAdmin && (!isSelf || !isViewerLastOrgAdmin) && (
-          <MenuItem onClick={setRole('BILLING_LEADER')}>{'Change to Billing Leader'}</MenuItem>
+          <MenuItem onSelect={setRole('BILLING_LEADER')}>{'Change to Billing Leader'}</MenuItem>
         )}
-        {canRemoveRole && <MenuItem onClick={setRole(null)}>{`Remove ${roleName} role`}</MenuItem>}
+        {canRemoveRole && <MenuItem onSelect={setRole(null)}>{`Remove ${roleName} role`}</MenuItem>}
         {isSelf &&
           ((isOrgAdmin && !isViewerLastOrgAdmin) ||
             (isBillingLeader && !isViewerLastRole) ||
             !isViewerBillingLeaderPlus) && (
-            <MenuItem onClick={toggleLeave}>{'Leave Organization'}</MenuItem>
+            <MenuItem onSelect={toggleLeave}>{'Leave Organization'}</MenuItem>
           )}
         {!isSelf && (isViewerOrgAdmin || (isViewerBillingLeaderPlus && !isOrgAdmin)) && (
-          <MenuItem onClick={toggleRemove}>{'Remove from Organization'}</MenuItem>
+          <MenuItem onSelect={toggleRemove}>{'Remove from Organization'}</MenuItem>
         )}
         {isSelf &&
           ((isOrgAdmin && isViewerLastOrgAdmin) || (isBillingLeader && isViewerLastRole)) && (
             <MenuItem
-              onClick={() => {
+              onSelect={() => {
                 window.location.href =
                   'mailto:support@parabol.co?subject=Request to be removed from organization'
               }}

--- a/packages/client/components/SelectMeetingDropdownItem.tsx
+++ b/packages/client/components/SelectMeetingDropdownItem.tsx
@@ -58,7 +58,7 @@ const SelectMeetingDropdownItem = (props: Props) => {
   const meetingPhaseLabel = (meetingPhase && phaseLabelLookup[meetingPhase.phaseType]) || 'Complete'
 
   return (
-    <MenuItem onClick={gotoMeeting}>
+    <MenuItem onSelect={gotoMeeting}>
       {typeof IconOrSVG === 'string' ? (
         <div className='m-2 size-6 text-slate-600'>
           {

--- a/packages/client/components/promptResponse/isTextSelected.ts
+++ b/packages/client/components/promptResponse/isTextSelected.ts
@@ -1,11 +1,9 @@
-import {isTextSelection} from '@tiptap/core'
 import type {Editor} from '@tiptap/react'
 
 export const isTextSelected = (editor: Editor) => {
   const {
     state: {
       doc,
-      selection,
       selection: {empty, from, to}
     }
   } = editor
@@ -13,8 +11,10 @@ export const isTextSelected = (editor: Editor) => {
   // Sometime check for `empty` is not enough.
   // Doubleclick an empty paragraph returns a node size of 2.
   // So we check also for an empty text size.
-  const isEmptyTextBlock = !doc.textBetween(from, to).length && isTextSelection(selection)
-  return !(empty || isEmptyTextBlock || !editor.isEditable)
+
+  // when deleting a pageLinkBlock from the first line, from:4, to:6, but the selection is a Node, not text
+  const isEmptyBlock = !doc.textBetween(from, to).length // && isTextSelection(selection)
+  return !(empty || isEmptyBlock || !editor.isEditable)
 }
 
 export default isTextSelected

--- a/packages/client/modules/pages/PageAccessCombobox.tsx
+++ b/packages/client/modules/pages/PageAccessCombobox.tsx
@@ -75,6 +75,7 @@ export const PageAccessCombobox = (props: Props) => {
         onClick={toggleRole}
         defaultRole={defaultRole}
         noOwner={subjectId === '*'}
+        canRemove
       />
       {attemptedRole && (
         <UnlinkPageDialog approveUnlink={approveUnlink} closeDialog={closeDialog} />

--- a/packages/client/modules/pages/PageAccessComboboxControl.tsx
+++ b/packages/client/modules/pages/PageAccessComboboxControl.tsx
@@ -46,7 +46,7 @@ export const PageAccessComboboxControl = (props: Props) => {
           return (
             <MenuItem
               key={value}
-              onClick={() => {
+              onSelect={() => {
                 onClick(value)
               }}
             >
@@ -63,7 +63,7 @@ export const PageAccessComboboxControl = (props: Props) => {
             <MenuItem
               className={'hover:text-tomato-700'}
               key={'remove'}
-              onClick={() => {
+              onSelect={() => {
                 onClick(null)
               }}
             >

--- a/packages/client/modules/pages/PageSharingGeneralAccess.tsx
+++ b/packages/client/modules/pages/PageSharingGeneralAccess.tsx
@@ -89,7 +89,7 @@ export const PageSharingGeneralAccess = (props: Props) => {
                       <MenuItem
                         className='py-1'
                         key={value}
-                        onClick={() => {
+                        onSelect={() => {
                           updateGAValue(value)
                         }}
                       >

--- a/packages/client/modules/pages/StarterActions.tsx
+++ b/packages/client/modules/pages/StarterActions.tsx
@@ -13,7 +13,6 @@ export const StarterActions = (props: Props) => {
   const transformRef = useRef<undefined | string>(undefined)
   const getTransform = () => {
     const coords = editor.view.coordsAtPos(1)
-    console.log('coords', coords)
     const {left, top} = coords
     if (left !== 0 && top !== 0) {
       transformRef.current = `translate(${coords.left}px,${coords.top + 90}px)`

--- a/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
+++ b/packages/client/modules/userDashboard/components/OrgIntegrations/GitLabProviderRow.tsx
@@ -53,8 +53,8 @@ const GitLabProviderRow = (props: Props) => {
             }
           >
             <MenuContent>
-              <MenuItem onClick={openEdit}>Edit</MenuItem>
-              <MenuItem onClick={openDelete}>Delete</MenuItem>
+              <MenuItem onSelect={openEdit}>Edit</MenuItem>
+              <MenuItem onSelect={openDelete}>Delete</MenuItem>
             </MenuContent>
           </Menu>
         </ProviderActions>

--- a/packages/client/tiptap/extensions/insightsBlock/InsightsBlockPrompt.tsx
+++ b/packages/client/tiptap/extensions/insightsBlock/InsightsBlockPrompt.tsx
@@ -68,7 +68,7 @@ export const InsightsBlockPrompt = (props: Props) => {
                   return (
                     <MenuItem
                       key={id}
-                      onClick={() => {
+                      onSelect={() => {
                         updateAttributes({prompt: content})
                       }}
                       className='w-80 flex-col items-start justify-start'

--- a/packages/client/tiptap/extensions/pageLinkBlock/PageLinkBlockView.tsx
+++ b/packages/client/tiptap/extensions/pageLinkBlock/PageLinkBlockView.tsx
@@ -32,14 +32,29 @@ export const PageLinkBlockView = (props: NodeViewProps) => {
     view.focus()
   }
   const archivePage = () => {
+    const pageId = `page:${pageCode}`
     executeArchive({
-      variables: {pageId: `page:${pageCode}`, action: 'archive'},
+      variables: {pageId, action: 'archive'},
       onCompleted(_res, errors) {
         const firstError = errors?.[0]?.message
         if (firstError) {
           atmosphere.eventEmitter.emit('addSnackbar', {
             key: 'PageActionsArchive',
             message: firstError,
+            autoDismiss: 5
+          })
+        } else {
+          atmosphere.eventEmitter.emit('addSnackbar', {
+            key: 'PageActionsArchiveUndo',
+            message: 'Moved to trash',
+            action: {
+              label: 'Undo',
+              callback: () => {
+                executeArchive({
+                  variables: {pageId, action: 'restore'}
+                })
+              }
+            },
             autoDismiss: 5
           })
         }
@@ -77,7 +92,12 @@ export const PageLinkBlockView = (props: NodeViewProps) => {
           }
         >
           <MenuContent align='end' side={'bottom'} sideOffset={8} className='max-h-80'>
-            <MenuItem onClick={archivePage}>
+            <MenuItem
+              onSelect={archivePage}
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+            >
               <DeleteIcon className='text-slate-600' />
               <span className='pl-1'>{'Delete page'}</span>
             </MenuItem>

--- a/packages/client/tiptap/extensions/pageLinkBlock/PageLinkBlockView.tsx
+++ b/packages/client/tiptap/extensions/pageLinkBlock/PageLinkBlockView.tsx
@@ -25,13 +25,11 @@ export const PageLinkBlockView = (props: NodeViewProps) => {
   const [executeArchive] = useArchivePageMutation()
   const atmosphere = useAtmosphere()
   const focusLink = () => {
-    console.log('focus')
     const pos = getPos()
     if (!pos) return
     const tr = view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos))
     view.dispatch(tr)
     view.focus()
-    console.log('focused view', view)
   }
   const archivePage = () => {
     executeArchive({

--- a/packages/client/tiptap/isCustomNodeSelected.ts
+++ b/packages/client/tiptap/isCustomNodeSelected.ts
@@ -15,31 +15,34 @@ const customNodes = [
   TaskBlock.name
 ]
 
-export const isTableGripSelected = (editor: Editor) => {
-  const {view, state} = editor
-  const {selection} = state
-  const {from} = selection
-  if (view.isDestroyed) return false // domAtPos will throw if not mounted
-  const domAtPos = view.domAtPos(from || 0).node as HTMLElement
-  const nodeDOM = view.nodeDOM(from || 0) as HTMLElement
-  const node = nodeDOM || domAtPos
-  let container = node
+// if the view is not mounted yet, view.domAtPos will throw a fatal.
+// there's no way to check if it is mounted in tiptap yet, so leaving this out for now
 
-  while (container && !['TD', 'TH'].includes(container.tagName)) {
-    container = container.parentElement!
-  }
+// export const isTableGripSelected = (editor: Editor) => {
+//   const {view, state} = editor
+//   const {selection} = state
+//   const {from} = selection
+//   if (view.isDestroyed || editor) return false // domAtPos will throw if not mounted
+//   const domAtPos = view.domAtPos(from || 0).node as HTMLElement
+//   const nodeDOM = view.nodeDOM(from || 0) as HTMLElement
+//   const node = nodeDOM || domAtPos
+//   let container = node
 
-  const gripColumn =
-    container && container.querySelector && container.querySelector('a.grip-column.selected')
-  const gripRow =
-    container && container.querySelector && container.querySelector('a.grip-row.selected')
+//   while (container && !['TD', 'TH'].includes(container.tagName)) {
+//     container = container.parentElement!
+//   }
 
-  if (gripColumn || gripRow) {
-    return true
-  }
+//   const gripColumn =
+//     container && container.querySelector && container.querySelector('a.grip-column.selected')
+//   const gripRow =
+//     container && container.querySelector && container.querySelector('a.grip-row.selected')
 
-  return false
-}
+//   if (gripColumn || gripRow) {
+//     return true
+//   }
+
+//   return false
+// }
 export const isCustomNodeSelected = (editor: Editor) => {
-  return customNodes.some((type) => editor.isActive(type)) || isTableGripSelected(editor)
+  return customNodes.some((type) => editor.isActive(type))
 }

--- a/packages/client/ui/Menu/MenuItem.tsx
+++ b/packages/client/ui/Menu/MenuItem.tsx
@@ -3,14 +3,15 @@ import * as React from 'react'
 import {cn} from '../cn'
 
 interface MenuItemProps {
-  onClick?: (event: Event) => void
+  onSelect?: (event: Event) => void
+  onClick?: React.MouseEventHandler
   isDisabled?: boolean
   className?: string
   children: React.ReactNode
 }
 
 export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
-  ({onClick, isDisabled, className, children}, ref) => {
+  ({onSelect, onClick, isDisabled, className, children}, ref) => {
     return (
       <DropdownMenu.Item
         className={cn(
@@ -20,7 +21,8 @@ export const MenuItem = React.forwardRef<HTMLDivElement, MenuItemProps>(
         )}
         // FIX ME: onClick has a MouseEvent handler, onSelect has a custom event that can't do things like e.stopPropagation()
         // Refactor: onClick -> onSelect here & in all dependencies
-        onSelect={onClick}
+        onSelect={onSelect}
+        onClick={onClick}
         ref={ref}
       >
         {children}


### PR DESCRIPTION
# Description

fixes #11467 adds a snackbar to undo archiving pages.

Also fixes:
- [ ] clicking delete page from a pagelink block no longer navigates to the just deleted page
- [ ] The MenuItem component does not internally pass in onClick as onSelect (different events, different uses)
- [ ] the bubble menu does not pop up after deleting a page link block
- [ ] isTableGripSelected is ignored (it was getting called before the editor got mounted, causing fatal errors)
- [ ] Shared Pages query hides children of top-level team pages (you can access them by drilling down from the team)