### PR TITLE
fix: use watwg-node/fetch for everything on server

### DIFF
--- a/packages/server/graphql/nestedSchema/nestLinearEndpoint.ts
+++ b/packages/server/graphql/nestedSchema/nestLinearEndpoint.ts
@@ -1,3 +1,4 @@
+import {fetch} from '@whatwg-node/fetch'
 import {
   type GraphQLObjectType,
   type GraphQLResolveInfo,

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -7,6 +7,7 @@ import {setIsShuttingDown} from './getIsShuttingDown'
 import ICSHandler from './ICSHandler'
 import PWAHandler from './PWAHandler'
 import './hocusPocus'
+import {fetch} from '@whatwg-node/fetch'
 import mattermostWebhookHandler from './integrations/mattermost/mattermostWebhookHandler'
 import jiraImagesHandler from './jiraImagesHandler'
 import listenHandler from './listenHandler'
@@ -19,6 +20,10 @@ import SAMLHandler from './utils/SAMLHandler'
 import uwsGetIP from './utils/uwsGetIP'
 import {wsHandler} from './wsHandler'
 import {yoga} from './yoga'
+
+// undici has a memory leak in Node v22 (and it looks like v24 as well).
+// by monkeypatching fetch, we fix it for all our code as well as calls that exist in our dependencies
+globalThis.fetch = fetch
 
 export const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
   ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -7,7 +7,6 @@ import {setIsShuttingDown} from './getIsShuttingDown'
 import ICSHandler from './ICSHandler'
 import PWAHandler from './PWAHandler'
 import './hocusPocus'
-import {fetch} from '@whatwg-node/fetch'
 import mattermostWebhookHandler from './integrations/mattermost/mattermostWebhookHandler'
 import jiraImagesHandler from './jiraImagesHandler'
 import listenHandler from './listenHandler'
@@ -20,10 +19,6 @@ import SAMLHandler from './utils/SAMLHandler'
 import uwsGetIP from './utils/uwsGetIP'
 import {wsHandler} from './wsHandler'
 import {yoga} from './yoga'
-
-// undici has a memory leak in Node v22 (and it looks like v24 as well).
-// by monkeypatching fetch, we fix it for all our code as well as calls that exist in our dependencies
-globalThis.fetch = fetch
 
 export const RECONNECT_WINDOW = process.env.WEB_SERVER_RECONNECT_WINDOW
   ? parseInt(process.env.WEB_SERVER_RECONNECT_WINDOW, 10) * 1000


### PR DESCRIPTION
# Description

We know the memory leak is undici fetch-related. linear was the only piece of our code using the native undici fetch, so my assumption is that a dependency is using undici fetch, for example, the `FetchTransport` in amplitude.

monkeypatching a global like fetch doesn't feel great, but I'd like to try it for a bit just to see if this fixes it.
Wanna get @Dschoordsch's opinion on this before doing it though
