### PR TITLE
fix: when restoring child without parent, remove parent from ancestorIds

### DIFF
--- a/packages/server/graphql/public/mutations/archivePage.ts
+++ b/packages/server/graphql/public/mutations/archivePage.ts
@@ -68,6 +68,10 @@ const archivePage: MutationResolvers['archivePage'] = async (
       .set({
         deletedAt: null,
         deletedBy: null,
+        ancestorIds:
+          parentPageId === null
+            ? page.ancestorIds.filter((id) => id !== page.parentPageId)
+            : undefined,
         parentPageId,
         teamId,
         sortOrder


### PR DESCRIPTION
# Description

Make sure the ancestorIds array is inline with parentPageId