### PR TITLE
feat: add audit logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,3 +194,4 @@ DEV_RUN_ONLY="Webpack Servers,Socket Server,Embedder,Dev Server,Flush Redis,PG M
 # PGAdmin - used only with `db:start` command
 PGADMIN_DEFAULT_EMAIL='pgadmin4@pgadmin.org'
 PGADMIN_DEFAULT_PASSWORD='admin'
+SOC2_LOGS='true'

--- a/.env.example
+++ b/.env.example
@@ -194,4 +194,6 @@ DEV_RUN_ONLY="Webpack Servers,Socket Server,Embedder,Dev Server,Flush Redis,PG M
 # PGAdmin - used only with `db:start` command
 PGADMIN_DEFAULT_EMAIL='pgadmin4@pgadmin.org'
 PGADMIN_DEFAULT_PASSWORD='admin'
-SOC2_LOGS='true'
+
+# Enable additional audit logs for select mutations
+AUDIT_LOGS='true'

--- a/packages/server/utils/useAuditLogs.ts
+++ b/packages/server/utils/useAuditLogs.ts
@@ -10,13 +10,13 @@ interface Config {
    */
   excludeArgs?: Record<string, string[]>
   /**
-   * A set of operations that do not need to be audited
+   * A set of operations that do need to be audited
    */
   includeOps: Set<string>
 }
 
-export const useSOC2AuditLogs = (config: Config): Plugin<ServerContext> => {
-  if (process.env.SOC2_LOGS !== 'true') return {}
+export const useAuditLogs = (config: Config): Plugin<ServerContext> => {
+  if (process.env.AUDIT_LOGS !== 'true') return {}
   return {
     onExecute({args, context}) {
       const operationAst = getOperationAST(args.document, args.operationName)!

--- a/packages/server/utils/useSOC2AuditLogs.ts
+++ b/packages/server/utils/useSOC2AuditLogs.ts
@@ -1,0 +1,51 @@
+import {getOperationAST, Kind} from 'graphql'
+import type {Plugin} from 'graphql-yoga'
+import type {ServerContext} from '../yoga'
+
+interface Config {
+  /**
+   * A record where the key is the operationName and the value is
+   * an array of variables to exclude.
+   * Useful for excluding private variables like passwords
+   */
+  excludeArgs?: Record<string, string[]>
+  /**
+   * A set of operations that do not need to be audited
+   */
+  includeOps: Set<string>
+}
+
+export const useSOC2AuditLogs = (config: Config): Plugin<ServerContext> => {
+  if (process.env.SOC2_LOGS !== 'true') return {}
+  return {
+    onExecute({args, context}) {
+      const operationAst = getOperationAST(args.document, args.operationName)!
+      const {selections} = operationAst.selectionSet
+      const fieldNode = selections.find((s) => s.kind === Kind.FIELD)
+      if (!fieldNode) return
+      const operationName = fieldNode.name.value
+      const {includeOps, excludeArgs} = config
+      const {variableValues} = args
+      if (!includeOps.has(operationName)) return
+      const excludedOpArgs = excludeArgs?.[operationName] || []
+      const sanitizedVaribles = Object.fromEntries(
+        Object.entries(variableValues).map(([key, val]) => {
+          const nextVal = excludedOpArgs.includes(key) ? '******' : val
+          return [key, nextVal]
+        })
+      )
+      const {authToken, ip} = context
+      const userId = authToken?.sub ?? ''
+      const auditLog = {
+        time: new Date().toISOString(),
+        level: 'info',
+        type: 'audit',
+        userId,
+        ipAddress: ip,
+        operation: operationName,
+        variables: sanitizedVaribles
+      }
+      console.log(auditLog)
+    }
+  }
+}

--- a/packages/server/yoga.ts
+++ b/packages/server/yoga.ts
@@ -13,10 +13,10 @@ import type {MutationResolvers, QueryResolvers, Resolver} from './graphql/privat
 import rootSchema from './graphql/public/rootSchema'
 import getKysely from './postgres/getKysely'
 import getVerifiedAuthToken from './utils/getVerifiedAuthToken'
+import {useAuditLogs} from './utils/useAuditLogs'
 import {useDatadogTracing} from './utils/useDatadogTracing'
 import {useDisposeDataloader} from './utils/useDisposeDataloader'
 import {usePrivateSchemaForSuperUser} from './utils/usePrivateSchemaForSuperUser'
-import {useSOC2AuditLogs} from './utils/useSOC2AuditLogs'
 
 type OperationResolvers = QueryResolvers & MutationResolvers
 type ExtractArgs<T> = T extends Resolver<any, any, any, infer Args> ? Args : never
@@ -74,7 +74,7 @@ export const yoga = createYoga<ServerContext, UserContext>({
   graphqlEndpoint: '/graphql',
   landingPage: false,
   plugins: [
-    useSOC2AuditLogs({
+    useAuditLogs({
       excludeArgs: {
         acceptTeamInvitation: ['invitationToken'],
         loginWithPassword: ['password'],


### PR DESCRIPTION
# Description

fix #11555

This PR logs to stdout all the included operations and their sanitized variables.

It'll look like this:

```ts
{
  time: '2025-09-15T23:36:08.523Z',
  level: 'info',
  type: 'audit',
  userId: 'google-oauth2|HrMru7cVgI',
  ipAddress: '0000:0000:0000:0000:0000:0000:0000:0001',
  operation: 'setOrgUserRole',
  variables: { orgId: 'HrMruc26tO', userId: 'local|HuUCEsQe4M', role: null }
}
```

Do we want to replace variables with a human-readable message? eh, that seems like a lot of work for little return. 