### PR TITLE
chore(docker): upgrade from Debian Bookworm to Trixie

### DIFF
--- a/docker/images/parabol-ubi/dockerfiles/basic.dockerfile
+++ b/docker/images/parabol-ubi/dockerfiles/basic.dockerfile
@@ -1,5 +1,5 @@
 ARG _NODE_VERSION=${_NODE_VERSION}
-FROM node:${_NODE_VERSION}-bookworm-slim as base
+FROM node:${_NODE_VERSION}-trixie-slim as base
 
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA


### PR DESCRIPTION
# Description
Upgrades our containers from Debian Bookworm to Trixie. [Tested in an on-demand-env](https://gitlab.com/parabol1/gcp-parabol-development/kubernetes-parabol-saas-development/on-demand-environments/-/pipelines?page=1&scope=all&ref=od-trixie)