### PR TITLE
fix: dont download packages newer than 2 days old by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,5 +194,5 @@
     "tiptap-markdown": "^0.8.10",
     "tslib": "^2.8.1"
   },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
+  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
   - packages/*
-
+minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - nest-graphql-endpoint
 onlyBuiltDependencies:
   - '@datadog/native-appsec'
   - '@datadog/native-iast-taint-tracking'


### PR DESCRIPTION
# Description

we've seen a lot of npm packages get taken over recently. we've been lucky that it hasn't affected us.
pnpm has a clever mitigation for this. since most malicious packages are identified within a few hours, you can tell it to ignore downloading packages that are less than x hours old. https://pnpm.io/settings#minimumreleaseage

I've set the minimum to 2 days & ignored a package that we control as a starting point. This should let us all sleep better