### PR TITLE
chore: add dataloader cache debugging field

### DIFF
--- a/packages/embedder/WorkflowOrchestrator.ts
+++ b/packages/embedder/WorkflowOrchestrator.ts
@@ -93,7 +93,7 @@ export class WorkflowOrchestrator {
     if (!step)
       return this.failJob(jobId, retryCount, new JobQueueError(`Step ${stepName} not found`))
     const {run, getNextStep} = step
-    const dataLoader = getNewDataLoader()
+    const dataLoader = getNewDataLoader('WorkflowOrchestrator')
     let result: Awaited<ReturnType<typeof run>> = false
     const data = {...jobData, embeddingsMetadataId, model}
     try {

--- a/packages/server/dataloader/DataLoaderCache.ts
+++ b/packages/server/dataloader/DataLoaderCache.ts
@@ -3,17 +3,20 @@ export class CacheWorker<T extends {clearAll: (pkLoaderName: any) => void; get: 
   dataLoaderWorker: T
   did: string
   disposeId: NodeJS.Timeout | undefined
+  // who added this to the cache?
+  source: string | undefined
 
   shared = false
   get: T['get']
   clearAll: T['clearAll']
   onDispose: () => void
-  constructor(dataLoaderWorker: T, did: string, onDispose: () => void) {
+  constructor(dataLoaderWorker: T, did: string, onDispose: () => void, source: string) {
     this.dataLoaderWorker = dataLoaderWorker
     this.did = did
     this.get = this.dataLoaderWorker.get
     this.clearAll = this.dataLoaderWorker.clearAll
     this.onDispose = onDispose
+    this.source = source
   }
 
   dispose() {
@@ -47,12 +50,12 @@ export default class DataLoaderCache<
     this.DataLoaderWorkerConstructor = DataLoaderWorkerConstructor
   }
 
-  add(did: string) {
+  add(did: string, source: string) {
     const dataLoaderWorker = new this.DataLoaderWorkerConstructor()
     const onDispose = () => {
       delete this.workers[did]
     }
-    this.workers[did] = new CacheWorker(dataLoaderWorker, did, onDispose)
+    this.workers[did] = new CacheWorker(dataLoaderWorker, did, onDispose, source)
     return this.workers[did]!
   }
 

--- a/packages/server/dataloader/__tests__/activeOrganizationUsersCustomLoader.test.ts
+++ b/packages/server/dataloader/__tests__/activeOrganizationUsersCustomLoader.test.ts
@@ -94,7 +94,7 @@ test('Result is mapped to correct id', async () => {
     }
   ])
 
-  const dataloader = getNewDataLoader()
+  const dataloader = getNewDataLoader('test')
 
   const activeOrgUsers = await dataloader
     .get('activeOrganizationUsersByOrgId')
@@ -158,7 +158,7 @@ test('Inactive users are ignored', async () => {
     }
   ])
 
-  const dataloader = getNewDataLoader()
+  const dataloader = getNewDataLoader('test')
 
   const activeOrgUsers = await dataloader
     .get('activeOrganizationUsersByOrgId')

--- a/packages/server/dataloader/__tests__/isCompanyDomain.test.ts
+++ b/packages/server/dataloader/__tests__/isCompanyDomain.test.ts
@@ -1,7 +1,7 @@
 import '../../../../scripts/webpack/utils/dotenv'
 import {getNewDataLoader} from '../getNewDataLoader'
 
-const dataloader = getNewDataLoader()
+const dataloader = getNewDataLoader('test')
 
 afterAll(async () => {
   dataloader.dispose()

--- a/packages/server/dataloader/__tests__/usersCustomRedisQueries.test.ts
+++ b/packages/server/dataloader/__tests__/usersCustomRedisQueries.test.ts
@@ -5,7 +5,7 @@ import getKysely from '../../postgres/getKysely'
 import {getNewDataLoader} from '../getNewDataLoader'
 
 test('Result is mapped to correct id', async () => {
-  const dataloader = getNewDataLoader()
+  const dataloader = getNewDataLoader('test')
 
   const existingUsers = await getKysely()
     .selectFrom('User')

--- a/packages/server/dataloader/getNewDataLoader.ts
+++ b/packages/server/dataloader/getNewDataLoader.ts
@@ -3,7 +3,7 @@ import numToBase64 from '../utils/numToBase64'
 import {dataLoaderCache} from './RootDataLoader'
 
 let nextId = 0
-export const getNewDataLoader = (creator: string) => {
+export const getNewDataLoader = (source: string) => {
   const id = `${INSTANCE_ID}:${numToBase64(nextId++)}`
-  return dataLoaderCache.add(id, creator)
+  return dataLoaderCache.add(id, source)
 }

--- a/packages/server/dataloader/getNewDataLoader.ts
+++ b/packages/server/dataloader/getNewDataLoader.ts
@@ -3,7 +3,7 @@ import numToBase64 from '../utils/numToBase64'
 import {dataLoaderCache} from './RootDataLoader'
 
 let nextId = 0
-export const getNewDataLoader = () => {
+export const getNewDataLoader = (creator: string) => {
   const id = `${INSTANCE_ID}:${numToBase64(nextId++)}`
-  return dataLoaderCache.add(id)
+  return dataLoaderCache.add(id, creator)
 }

--- a/packages/server/dataloader/hydrateDataLoader.ts
+++ b/packages/server/dataloader/hydrateDataLoader.ts
@@ -5,7 +5,7 @@ import {dataLoaderCache} from './RootDataLoader'
 
 export const hydrateDataLoader = (id: string, packedDataloader: Buffer) => {
   const loaders = unpack(packedDataloader)
-  const cacheWorker = dataLoaderCache.add(id)
+  const cacheWorker = dataLoaderCache.add(id, 'hydrate')
   // treat this as shared so if the first subscriber tries to dispose of it, it will wait 500ms (see wsHandler.onComplete)
   // which should be enough time for other subscribers to grab it
   cacheWorker.share()

--- a/packages/server/graphql/getDataLoader.ts
+++ b/packages/server/graphql/getDataLoader.ts
@@ -21,7 +21,7 @@ const getDataLoader = async (id: string) => {
     }
   }, 3000)
   // Anything past this line is a bug, but we handle bugs gracefully
-  const fallback = getNewDataLoader()
+  const fallback = getNewDataLoader('getDataLoader-fallback')
   fallback.share()
   fallback.dispose()
   return fallback

--- a/packages/server/graphql/public/mutations/helpers/__tests__/getIsEmailApprovedByOrg.test.ts
+++ b/packages/server/graphql/public/mutations/helpers/__tests__/getIsEmailApprovedByOrg.test.ts
@@ -50,7 +50,7 @@ test.each([
   'foo@other.subtest.com',
   'foo@notwildtest.com'
 ])('Unapproved email fails: %s', async (email) => {
-  const dataloader = getNewDataLoader()
+  const dataloader = getNewDataLoader('test')
   const error = await getIsEmailApprovedByOrg(email, 'testOrgId', dataloader)
   expect(error).toBeInstanceOf(Error)
 })
@@ -58,7 +58,7 @@ test.each([
 test.each(['foo@test.com', 'foo@sub.subtest.com', 'foo@wildtest.com', 'foo@sub.wildtest.com'])(
   'Approved email passes: %s',
   async (email) => {
-    const dataloader = getNewDataLoader()
+    const dataloader = getNewDataLoader('test')
     const error = await getIsEmailApprovedByOrg(email, 'testOrgId', dataloader)
     expect(error).toBe(undefined)
   }

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
@@ -267,7 +267,7 @@ export const movePageToNewParent = async (
       .execute()
   }
   await trx.commit().execute()
-  const dataLoader = getNewDataLoader()
+  const dataLoader = getNewDataLoader('movePageToNewParent')
   const operationId = dataLoader.share()
   const subOptions = {operationId, mutatorId: undefined}
   const data = {pageId}

--- a/packages/server/hocusPocus.ts
+++ b/packages/server/hocusPocus.ts
@@ -28,7 +28,7 @@ if (isNaN(port) || port < 0 || port > 65536) {
 
 const pushGQLTitleUpdates = async (pageId: number) => {
   // This is necessary for titles of top-level items (shared, team, private) to propagate in real time
-  const dataLoader = getNewDataLoader()
+  const dataLoader = getNewDataLoader('pushGQLTitleUpdates')
   const operationId = dataLoader.share()
   const subOptions = {operationId, mutatorId: undefined}
   const data = {pageId}

--- a/packages/server/integrations/mattermost/mattermostWebhookHandler.ts
+++ b/packages/server/integrations/mattermost/mattermostWebhookHandler.ts
@@ -65,7 +65,7 @@ const mattermostWebhookHandler = uWSAsyncHandler(async (res, req) => {
     return
   }
 
-  const dataLoader = getNewDataLoader()
+  const dataLoader = getNewDataLoader('mattermostWebhookHandler')
   try {
     const [mattermostProvider] = await dataLoader
       .get('sharedIntegrationProviders')

--- a/packages/server/utils/callGQL.ts
+++ b/packages/server/utils/callGQL.ts
@@ -7,7 +7,7 @@ import {yoga} from '../yoga'
 // Only call this from the server that is running yoga! e.g. a webhook endpoint or similar
 export const callGQL = async <TData>(query: string, variables?: Record<string, any>) => {
   const authToken = new ServerAuthToken()
-  const dataLoader = getNewDataLoader()
+  const dataLoader = getNewDataLoader('callGQL')
   const {execute, parse} = yoga.getEnveloped()
   const result = await execute({
     document: parse(query),

--- a/packages/server/utils/tiptap/createChildPage.ts
+++ b/packages/server/utils/tiptap/createChildPage.ts
@@ -72,7 +72,7 @@ export const createChildPage = async (parentPageId: number, userId: string) => {
     .selectNoFrom(sql`1`.as('t'))
     .execute()
   analytics.pageCreated(viewer, pageId)
-  const dataLoader = getNewDataLoader()
+  const dataLoader = getNewDataLoader('createChildPage')
   const operationId = dataLoader.share()
   const subOptions = {operationId, mutatorId: undefined}
   const data = {page}

--- a/packages/server/utils/useDisposeDataloader.ts
+++ b/packages/server/utils/useDisposeDataloader.ts
@@ -8,7 +8,7 @@ export const useDisposeDataloader: Plugin<DataLoaderContext, DataLoaderContext> 
     if (context.dataLoader) {
       throw new Error('Dataloader already exists. This is a mem leak')
     }
-    const dataLoader = getNewDataLoader()
+    const dataLoader = getNewDataLoader('useDisposeDataloader')
     extendContext({dataLoader})
   },
   onResultProcess: ({serverContext}) => {

--- a/packages/server/wsHandler.ts
+++ b/packages/server/wsHandler.ts
@@ -112,7 +112,7 @@ export const wsHandler = makeBehavior<{token?: string}>({
     extra.resubscribe = {}
     extra.dataLoaders = {}
     const {execute, parse} = yoga.getEnveloped(ctx)
-    const dataLoader = getNewDataLoader()
+    const dataLoader = getNewDataLoader('wsHandler.onConnect')
     const {data} = await execute({
       document: parse(connectQuery),
       variableValues: {socketInstanceId: INSTANCE_ID},
@@ -192,7 +192,7 @@ export const wsHandler = makeBehavior<{token?: string}>({
       }
     } else {
       // subscribe functions don't need a dataloader since they just kickstart an async iterator
-      extra.dataLoaders[id] = getNewDataLoader()
+      extra.dataLoaders[id] = getNewDataLoader('wsHandler.onSubscribe')
     }
     const args: EnvelopedExecutionArgs = {
       schema: authToken.rol === 'su' ? privateSchema : schema,
@@ -227,7 +227,7 @@ export const wsHandler = makeBehavior<{token?: string}>({
     extra.dataLoaders = {} // should not be necessary, but doing in case of memory leak
     activeClients.delete(extra.socketId)
     const {execute, parse} = yoga.getEnveloped(ctx)
-    const dataLoader = getNewDataLoader()
+    const dataLoader = getNewDataLoader('wsHandler.onDisconnect')
     extra.socket.closed = true
     await execute({
       document: parse(disconnectQuery),


### PR DESCRIPTION
# Description

Relates to: #11684 
In heap dumps we see that we're retaining dataloaders in the cache which we don't clean up properly. Let's add a field to see who doesn't clean up after themselves.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
