### PR TITLE
fix: add error handling on initial script load

### DIFF
--- a/packages/client/serviceWorker/sw.ts
+++ b/packages/client/serviceWorker/sw.ts
@@ -66,61 +66,55 @@ const onActivate = async (_event: ExtendableEvent) => {
 
 const onFetch = async (event: FetchEvent) => {
   const {request} = event
-  // let's wrap all cache access in a try/catch in case that's causing
-  // 'Service Worker context closed' error on Safari
-  try {
-    const {url} = request
-    const isCacheable =
-      url.startsWith('http') &&
-      url.match(/.(js|json|css|mjs|png|svg|gif|jpg|jpeg|ico|eot|ttf|wav|mp3|woff|woff2|otf)$/)
-    if (isCacheable) {
-      const cachedRes = await caches.match(request.url)
-      // all our assets are hashed, so if the hash matches, it's valid
-      // let's skip opaque responses because we don't know whether they're valid
-      if (cachedRes && cachedRes.type !== 'opaque' && cachedRes.ok) {
-        return cachedRes
-      }
-      try {
-        // request.mode could be 'no-cors'
-        // By fetching the URL without specifying the mode the response will not be opaque
-        const isParabolHosted = url.startsWith(PUBLIC_PATH) || url.startsWith(self.origin)
-        // if one of our assets is not in the service worker cache, then it's either fetched via network or served from the broswer cache.
-        // The browser cache most likely has incorrect CORS headers set, so we better always fetch from the network.
-        const req = isParabolHosted ? fetch(request.url, {cache: 'no-store'}) : fetch(request)
-        const networkRes = await req
-        const cache = await caches.open(DYNAMIC_CACHE)
-        if (isParabolHosted && networkRes.status === 404 && url.match(/.(js|json|mjs)/)) {
-          // If we encounter a 404 for a script file, we most likely have a stale dyanmic cache.
-          // We could clear the cache and the app probably will recover after a reload, however more likely the whole service worker is stale.
-          // Because failing to load a script file might prevent the code to refresh the service worker from loading, it's better to just harakiri.
-          console.error(`Parabol source file ${url} returned 404, updating service worker`)
-          self.registration.update().catch((error) => {
-            console.error('Failed to update service worker, unregistering it', error)
-            self.registration.unregister()
-          })
-          return networkRes
-        }
-        // cloning here because I'm not sure if we must clone before reading the body
-        cache.put(request.url, networkRes.clone()).catch(console.error)
-        return networkRes
-      } catch (e) {
-        // if we have an opaque cached response, it's better than nothing
-        if (cachedRes) return cachedRes
-        throw e
-      }
-      // } else if (request.destination === 'document') {
-      //   // dynamic because index.html isn't hashed (and the server returns an html with keys)
-      //   const dynamicCache = await caches.open(DYNAMIC_CACHE)
-      //   const cachedRes = await dynamicCache.match('/')
-      //   if (cachedRes) return cachedRes
-      //   const networkRes = await fetch(request)
-      //   const cache = await caches.open(DYNAMIC_CACHE)
-      //   // cloning here because I'm not sure if we must clone before reading the body
-      //   cache.put('/', networkRes.clone()).catch(console.error)
-      //   return networkRes
+  const {url} = request
+  const isCacheable =
+    url.startsWith('http') &&
+    url.match(/.(js|json|css|mjs|png|svg|gif|jpg|jpeg|ico|eot|ttf|wav|mp3|woff|woff2|otf)$/)
+  if (isCacheable) {
+    const cachedRes = await caches.match(request.url)
+    // all our assets are hashed, so if the hash matches, it's valid
+    // let's skip opaque responses because we don't know whether they're valid
+    if (cachedRes && cachedRes.type !== 'opaque' && cachedRes.ok) {
+      return cachedRes
     }
-  } catch (e) {
-    console.error('Service worker fetch failed, falling back to network', e)
+    try {
+      // request.mode could be 'no-cors'
+      // By fetching the URL without specifying the mode the response will not be opaque
+      const isParabolHosted = url.startsWith(PUBLIC_PATH) || url.startsWith(self.origin)
+      // if one of our assets is not in the service worker cache, then it's either fetched via network or served from the broswer cache.
+      // The browser cache most likely has incorrect CORS headers set, so we better always fetch from the network.
+      const req = isParabolHosted ? fetch(request.url, {cache: 'no-store'}) : fetch(request)
+      const networkRes = await req
+      const cache = await caches.open(DYNAMIC_CACHE)
+      if (isParabolHosted && networkRes.status === 404 && url.match(/.(js|json|mjs)/)) {
+        // If we encounter a 404 for a script file, we most likely have a stale dyanmic cache.
+        // We could clear the cache and the app probably will recover after a reload, however more likely the whole service worker is stale.
+        // Because failing to load a script file might prevent the code to refresh the service worker from loading, it's better to just harakiri.
+        console.error(`Parabol source file ${url} returned 404, updating service worker`)
+        self.registration.update().catch((error) => {
+          console.error('Failed to update service worker, unregistering it', error)
+          self.registration.unregister()
+        })
+        return networkRes
+      }
+      // cloning here because I'm not sure if we must clone before reading the body
+      cache.put(request.url, networkRes.clone()).catch(console.error)
+      return networkRes
+    } catch (e) {
+      // if we have an opaque cached response, it's better than nothing
+      if (cachedRes) return cachedRes
+      throw e
+    }
+    // } else if (request.destination === 'document') {
+    //   // dynamic because index.html isn't hashed (and the server returns an html with keys)
+    //   const dynamicCache = await caches.open(DYNAMIC_CACHE)
+    //   const cachedRes = await dynamicCache.match('/')
+    //   if (cachedRes) return cachedRes
+    //   const networkRes = await fetch(request)
+    //   const cache = await caches.open(DYNAMIC_CACHE)
+    //   // cloning here because I'm not sure if we must clone before reading the body
+    //   cache.put('/', networkRes.clone()).catch(console.error)
+    //   return networkRes
   }
   return fetch(request)
 }

--- a/template.html
+++ b/template.html
@@ -22,6 +22,18 @@
       }
     </script>
     <!-- End Google Tag Manager -->
+    <!-- Safari sometimes kills the service worker before it can load the initial script -->
+    <script>
+      async function checkAndUnregisterSW(event) {
+        console.error('Error loading main script', event);
+        if (event.message === 'Service Worker context closed') {
+          const reg = await navigator.serviceWorker.getRegistration();
+          await reg?.unregister();
+          location.reload();
+        }
+      }
+    </script>
+    <!-- End Safari hack -->
     <title>Streamline or Replace Meetings | Parabol</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -32,8 +44,15 @@
     />
     <link href="/manifest.json" rel="manifest" crossorigin="use-credentials" />
     <link href="__PUBLIC_PATH__/favicon.ico" rel="shortcut icon" crossorigin="" />
-    <%= htmlWebpackPlugin.tags.headTags.map((tag) => { tag.attributes.crossorigin=''; return tag
-    }).join('') %>
+    <%=
+      htmlWebpackPlugin.tags.headTags.map((tag) => {
+        tag.attributes.crossorigin=''
+        if (tag.tagName === 'script') {
+          tag.attributes.onerror='checkAndUnregisterSW'
+        }
+        return tag
+      }).join('')
+    %>
   </head>
 
   <body>

--- a/template.html
+++ b/template.html
@@ -22,18 +22,6 @@
       }
     </script>
     <!-- End Google Tag Manager -->
-    <!-- Safari sometimes kills the service worker before it can load the initial script -->
-    <script>
-      async function checkAndUnregisterSW(event) {
-        console.error('Error loading main script', event);
-        if (event.message === 'Service Worker context closed') {
-          const reg = await navigator.serviceWorker.getRegistration();
-          await reg?.unregister();
-          location.reload();
-        }
-      }
-    </script>
-    <!-- End Safari hack -->
     <title>Streamline or Replace Meetings | Parabol</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -47,12 +35,41 @@
     <%=
       htmlWebpackPlugin.tags.headTags.map((tag) => {
         tag.attributes.crossorigin=''
-        if (tag.tagName === 'script') {
-          tag.attributes.onerror='checkAndUnregisterSW'
-        }
         return tag
       }).join('')
     %>
+    <!-- Safari sometimes kills the service worker before it can load the initial script -->
+    <script>
+      if ('serviceWorker' in navigator) {
+        function unregisterSW(event) {
+          console.error('Error loading main script', event, event.message)
+          if (event.message === 'Service Worker context closed') {
+            navigator.serviceWorker.getRegistration().then((req) => {
+              if (!req) return
+              req.unregister().then(() => {
+                location.reload()
+              })
+            })
+          }
+        }
+
+        // because the script tag is `defer` we need to attach the handler via script
+        document.querySelectorAll('script').forEach((script) => {
+          if (script.src) {
+            script.onerror = unregisterSW
+          }
+        })
+
+        // for debugging, maybe Safari closes the SW because there is an update available?
+        navigator.serviceWorker.getRegistration().then((reg) => {
+          if (!reg) return
+          reg.addEventListener('updatefound', () => {
+            console.log('New service worker found')
+          })
+        })
+      }
+    </script>
+    <!-- End Safari hack -->
   </head>
 
   <body>


### PR DESCRIPTION
# Description

Relates to #11889
Main objective is to handle the error when Safari decided to close the Service Worker and thus fail all future fetches.


## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
