### PR TITLE
fix: user sort order for shared pages

### DIFF
--- a/packages/client/components/DashNavList/LeftNavPageLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavPageLink.tsx
@@ -46,6 +46,7 @@ export const LeftNavPageLink = (props: Props) => {
         isDraggingFirstChild
         isDraggingLastChild
         currentPageAncestorDepth
+        userSortOrder
         sortOrder # used implicityly in store traversal by useDraggingPage
       }
     `,

--- a/packages/client/mutations/useUpdatePageMutation.ts
+++ b/packages/client/mutations/useUpdatePageMutation.ts
@@ -1,7 +1,10 @@
 import graphql from 'babel-plugin-relay/macro'
 import {ConnectionHandler, type UseMutationConfig, useMutation} from 'react-relay'
 import type {RecordProxy, RecordSourceSelectorProxy} from 'relay-runtime'
-import type {useUpdatePageMutation as TuseUpdatePageMutation} from '../__generated__/useUpdatePageMutation.graphql'
+import type {
+  PageSectionEnum,
+  useUpdatePageMutation as TuseUpdatePageMutation
+} from '../__generated__/useUpdatePageMutation.graphql'
 import type {useUpdatePageMutation_notification$data} from '../__generated__/useUpdatePageMutation_notification.graphql'
 
 import type {PageConnectionKey} from '../components/DashNavList/LeftNavPageLink'
@@ -11,9 +14,11 @@ import safePutNodeInConn from './handlers/safePutNodeInConn'
 
 graphql`
   fragment useUpdatePageMutation_notification on UpdatePagePayload {
+    pageSection
     page {
       id
       sortOrder
+      userSortOrder
       teamId
       parentPageId
       isPrivate
@@ -31,33 +36,81 @@ const mutation = graphql`
     $pageId: ID!
     $sortOrder: String!
     $teamId: ID
-    $makePrivate: Boolean
+    $sourceSection: PageSectionEnum!
+    $targetSection: PageSectionEnum!
   ) {
-    updatePage(pageId: $pageId, sortOrder: $sortOrder, teamId: $teamId, makePrivate: $makePrivate) {
+    updatePage(pageId: $pageId, sortOrder: $sortOrder, teamId: $teamId, sourceSection: $sourceSection, targetSection: $targetSection) {
       ...useUpdatePageMutation_notification @relay(mask: false)
     }
   }
 `
 
-const getPageConn = (
+const getSourceConns = (
   viewer: RecordProxy,
   parentPageId: string | null | undefined,
   teamId: string | null | undefined,
   isPrivate: boolean | undefined
 ) => {
-  const connKey =
-    parentPageId || teamId ? 'User_pages' : isPrivate ? 'User_privatePages' : 'User_sharedPages'
+  // there's no deterministic way to know if a page lives under a team or under shared
+  // since e.g. a team page could be shared with the viewer who is external to the team
+  //       e.g. a child page is shared with the viewer, but the parent page is not
 
-  return ConnectionHandler.getConnection(viewer, connKey, {
+  if (isPrivate) {
+    return [
+      ConnectionHandler.getConnection(viewer, 'User_privatePages', {
+        parentPageId: null,
+        teamId: undefined,
+        isPrivate: isPrivatePageConnectionLookup['User_privatePages']
+      })!
+    ]
+  }
+
+  const sharedPageConn = ConnectionHandler.getConnection(viewer, 'User_sharedPages', {
+    parentPageId: null,
+    teamId: undefined,
+    isPrivate: isPrivatePageConnectionLookup['User_sharedPages']
+  })!
+
+  const subPageConn = ConnectionHandler.getConnection(viewer, 'User_pages', {
     parentPageId: parentPageId || null,
     teamId: teamId || undefined,
-    isPrivate: isPrivatePageConnectionLookup[connKey]
+    isPrivate: isPrivatePageConnectionLookup['User_pages']
+  })!
+  return [sharedPageConn, subPageConn]
+}
+
+const getTargetConn = (
+  viewer: RecordProxy,
+  section: PageSectionEnum,
+  parentPageId: string | null | undefined,
+  teamId: string | null | undefined
+) => {
+  if (section === 'private') {
+    return ConnectionHandler.getConnection(viewer, 'User_privatePages', {
+      parentPageId: null,
+      teamId: undefined,
+      isPrivate: isPrivatePageConnectionLookup['User_privatePages']
+    })!
+  }
+  if (section === 'shared') {
+    return ConnectionHandler.getConnection(viewer, 'User_sharedPages', {
+      parentPageId: null,
+      teamId: undefined,
+      isPrivate: isPrivatePageConnectionLookup['User_sharedPages']
+    })!
+  }
+  return ConnectionHandler.getConnection(viewer, 'User_pages', {
+    parentPageId: parentPageId || null,
+    teamId: teamId || undefined,
+    isPrivate: isPrivatePageConnectionLookup['User_pages']
   })!
 }
 export const handleUpdatePage = (
-  page: RecordProxy<useUpdatePageMutation_notification$data['page']>,
+  payload: RecordProxy<Omit<useUpdatePageMutation_notification$data, ' $fragmentType'>>,
   {store}: {store: RecordSourceSelectorProxy}
 ) => {
+  const page = payload.getLinkedRecord('page')
+  const section = payload.getValue('pageSection')
   const connParent = store.getRoot().getLinkedRecord('viewer')!
   const pageId = page.getValue('id')
   const oldRecord = getBaseRecord(store, pageId) as
@@ -68,13 +121,15 @@ export const handleUpdatePage = (
     teamId: sourceTeamId,
     isPrivate: sourceIsPrivate
   } = oldRecord || {}
-  const sourceConn = getPageConn(connParent, sourceParentPageId, sourceTeamId, sourceIsPrivate)
+  const sourceConns = getSourceConns(connParent, sourceParentPageId, sourceTeamId, sourceIsPrivate)
   const targetTeamId = page.getValue('teamId')
   const targetParentPageId = page.getValue('parentPageId')
-  const targetIsPrivate = page.getValue('isPrivate')
-  const targetConn = getPageConn(connParent, targetParentPageId, targetTeamId, targetIsPrivate)
-  safeRemoveNodeFromConn(pageId, sourceConn)
-  safePutNodeInConn(targetConn, page, store, 'sortOrder', true)
+  const targetConn = getTargetConn(connParent, section, targetParentPageId, targetTeamId)
+  sourceConns.forEach((conn) => {
+    safeRemoveNodeFromConn(pageId, conn)
+  })
+  const sortOrder = section === 'shared' ? 'userSortOrder' : 'sortOrder'
+  safePutNodeInConn(targetConn, page, store, sortOrder, true)
 }
 
 export const isPrivatePageConnectionLookup = {
@@ -104,8 +159,7 @@ export const useUpdatePageMutation = () => {
       updater: (store) => {
         const payload = store.getRootField('updatePage')
         if (!payload) return
-        const page = payload.getLinkedRecord('page')
-        handleUpdatePage(page, {store})
+        handleUpdatePage(payload, {store})
       },
       variables,
       ...rest

--- a/packages/client/subscriptions/NotificationSubscription.ts
+++ b/packages/client/subscriptions/NotificationSubscription.ts
@@ -306,8 +306,7 @@ const createPageNotificationUpdater: SharedUpdater<any> = (payload, context) => 
 const updatePageNotificationUpdater: SharedUpdater<
   NotificationSubscription$data['notificationSubscription']['UpdatePagePayload']
 > = (payload, context) => {
-  const updatedPage = payload.getLinkedRecord('page')
-  handleUpdatePage(updatedPage, context)
+  handleUpdatePage(payload, context)
 }
 
 const updateHandlers = {

--- a/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
+++ b/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
@@ -53,7 +53,7 @@ export const dumpTranscriptToPage = async (
   const pg = getKysely()
 
   const isPrivate = false
-  const sortOrder = await getPageNextSortOrder(__START__, viewerId, isPrivate, teamId)
+  const sortOrder = await getPageNextSortOrder(__START__, false, viewerId, isPrivate, teamId)
 
   const docText = generateText(jsonContent, serverTipTapExtensions)
   const {title, contentStartsAt} = getTitleFromPageText(docText)

--- a/packages/server/graphql/public/mutations/updatePage.ts
+++ b/packages/server/graphql/public/mutations/updatePage.ts
@@ -14,22 +14,24 @@ import {privatizePage} from './helpers/privatizePage'
 export const MAX_PAGE_DEPTH = 10
 const updatePage: MutationResolvers['updatePage'] = async (
   _source,
-  {pageId, teamId, sortOrder, makePrivate},
+  {pageId, teamId, sortOrder, sourceSection, targetSection},
   {authToken, dataLoader, socketId: mutatorId}
 ) => {
   const operationId = dataLoader.share()
   const subOptions = {mutatorId, operationId}
   const viewerId = getUserId(authToken)
   const [dbPageId] = CipherId.fromClient(pageId)
-  if (makePrivate && teamId) {
-    throw new GraphQLError('makePrivate can only be true if teamId is null')
+  if (sourceSection === 'private' && targetSection === 'shared') {
+    throw new GraphQLError('Private pages cannot be moved direclty to shared')
   }
-
+  if (targetSection === 'team' && !teamId) {
+    throw new GraphQLError('teamId must be non-null if targetSection is team')
+  }
   const page = await dataLoader.get('pages').load(dbPageId)
   dataLoader.get('pages').clearAll()
   if (!page) throw new GraphQLError('Invalid pageId')
-  const hasChangedParent = page.teamId !== teamId || page.parentPageId !== null
-  if (hasChangedParent || makePrivate) {
+  const isReorder = sourceSection === targetSection && (!teamId || teamId === page.teamId)
+  if (!isReorder) {
     // changing parents will change permissions.
     const userRole = await dataLoader
       .get('pageAccessByUserId')
@@ -40,30 +42,58 @@ const updatePage: MutationResolvers['updatePage'] = async (
     }
   }
 
-  // sortOrder is only used for pages without a parentPageId
+  // sortOrder is only used for pages without a parentPageId, or shared pages
   // else, the sortOrder is determined by the parent's order of canonical page links
   const nextSortOrder = await getPageNextSortOrder(
     sortOrder,
+    targetSection === 'shared',
     viewerId,
     page.isPrivate,
     teamId || null
   )
   const pg = getKysely()
-  if (makePrivate && !page.isPrivate) {
-    await privatizePage(viewerId, dbPageId, nextSortOrder)
-  } else if (teamId && teamId !== page.teamId) {
-    await movePageToNewTeam(viewerId, dbPageId, teamId, nextSortOrder)
-  } else if (teamId === page.teamId && !page.parentPageId) {
-    // simple reorder
-    await pg
-      .updateTable('Page')
-      .set({sortOrder: nextSortOrder})
-      .where('id', '=', dbPageId)
-      .execute()
-  } else if (!teamId) {
-    await movePageToTopLevel(viewerId, dbPageId, nextSortOrder)
+  if (sourceSection === targetSection) {
+    if (targetSection === 'team' && page.teamId !== teamId) {
+      // move from team A to team B
+      await movePageToNewTeam(viewerId, dbPageId, teamId!, nextSortOrder)
+    } else {
+      // simple reorder
+      if (targetSection === 'shared') {
+        await pg
+          .updateTable('PageUserSortOrder')
+          .set({
+            sortOrder: nextSortOrder
+          })
+          .where('userId', '=', viewerId)
+          .where('pageId', '=', dbPageId)
+          .execute()
+      } else {
+        await pg
+          .updateTable('Page')
+          .set({sortOrder: nextSortOrder})
+          .where('id', '=', dbPageId)
+          .execute()
+      }
+    }
   } else {
-    throw new GraphQLError('No page update could be performed')
+    // moving from 1 section to another
+    if (targetSection === 'private') {
+      if (!page.isPrivate) {
+        await privatizePage(viewerId, dbPageId, nextSortOrder)
+      } else {
+        throw new GraphQLError('Page is already private')
+      }
+    } else if (targetSection === 'shared') {
+      if (!page.isPrivate) {
+        // private pages cannot be moved to shared
+        await movePageToTopLevel(viewerId, dbPageId, nextSortOrder)
+      } else {
+        throw new GraphQLError('Private page cannot be moved to shared')
+      }
+    } else {
+      // moving to a team
+      await movePageToNewTeam(viewerId, dbPageId, teamId!, nextSortOrder)
+    }
   }
 
   if (page.parentPageId) {

--- a/packages/server/graphql/public/typeDefs/Mutation.graphql
+++ b/packages/server/graphql/public/typeDefs/Mutation.graphql
@@ -2163,6 +2163,14 @@ type Mutation {
 		"""
 		sortOrder: String!
 		"""
+		The section the page is being moved from
+		"""
+		sourceSection: PageSectionEnum
+		"""
+		The section the page is being moved to
+		"""
+		targetSection: PageSectionEnum
+		"""
 		The new teamId, if moved to a team
 		"""
 		teamId: ID

--- a/packages/server/graphql/public/typeDefs/Page.graphql
+++ b/packages/server/graphql/public/typeDefs/Page.graphql
@@ -14,6 +14,7 @@ type Page implements PagePartial {
 	isParentLinked: Boolean!
 	isPrivate: Boolean!
 	sortOrder: String!
+	userSortOrder: String!
 	deletedAt: DateTime
 	deletedBy: ID
 	deletedByUser: User

--- a/packages/server/graphql/public/typeDefs/PageSectionEnum.graphql
+++ b/packages/server/graphql/public/typeDefs/PageSectionEnum.graphql
@@ -1,0 +1,9 @@
+"""
+The section that a page lives in for a viewer
+"""
+enum PageSectionEnum {
+	private
+	shared
+	team
+	page
+}

--- a/packages/server/graphql/public/typeDefs/UpdatePagePayload.graphql
+++ b/packages/server/graphql/public/typeDefs/UpdatePagePayload.graphql
@@ -1,3 +1,4 @@
 type UpdatePagePayload {
 	page: Page!
+	pageSection: PageSectionEnum!
 }

--- a/packages/server/graphql/public/types/Page.ts
+++ b/packages/server/graphql/public/types/Page.ts
@@ -20,17 +20,11 @@ const Page: Omit<ReqResolvers<'Page'>, 'team'> = {
     }
   },
   parentPageId: ({parentPageId}) => (parentPageId ? CipherId.toClient(parentPageId, 'page') : null),
-  sortOrder: async (
-    {id: pageId, isPrivate, teamId, parentPageId, sortOrder},
-    _args,
-    {authToken, dataLoader}
-  ) => {
-    const isTopLevelShared = !teamId && !parentPageId && !isPrivate
-    if (!isTopLevelShared) return sortOrder
+  userSortOrder: async ({id: pageId, userSortOrder}, _args, {authToken, dataLoader}) => {
+    if (userSortOrder) return userSortOrder
     const viewerId = getUserId(authToken)
-    const userSortOrder = await dataLoader.get('pageUserSortOrder').load({pageId, userId: viewerId})
-    // should never be null, but just in case
-    return userSortOrder || '!'
+    const sortOrder = await dataLoader.get('pageUserSortOrder').load({pageId, userId: viewerId})
+    return sortOrder || '!'
   },
   ancestorIds: ({ancestorIds}) => ancestorIds.map((id) => CipherId.toClient(id, 'page')),
   ancestors: async ({ancestorIds}, _args, {authToken, dataLoader}) => {

--- a/packages/server/graphql/public/types/UpdatePagePayload.ts
+++ b/packages/server/graphql/public/types/UpdatePagePayload.ts
@@ -1,3 +1,4 @@
+import {getUserId, isTeamMember} from '../../../utils/authorization'
 import type {UpdatePagePayloadResolvers} from '../resolverTypes'
 
 export type UpdatePagePayloadSource = {pageId: number}
@@ -5,6 +6,33 @@ export type UpdatePagePayloadSource = {pageId: number}
 const UpdatePagePayload: UpdatePagePayloadResolvers = {
   page: ({pageId}, _args, {dataLoader}) => {
     return dataLoader.get('pages').loadNonNull(pageId)
+  },
+  pageSection: async ({pageId}, _args, {authToken, dataLoader}) => {
+    // this determines what section the page should get put in for the viewer
+    // it follows the same rules are the User.pages query
+    const page = await dataLoader.get('pages').loadNonNull(pageId)
+    const {isPrivate, teamId, parentPageId} = page
+    // If the page is private it's either a subpage of a private page, or its a top-level private page
+    if (isPrivate) {
+      return parentPageId ? 'page' : 'private'
+    }
+    // if it not private, has no team and no parent, it must be in shared
+    if (!teamId && !parentPageId) return 'shared'
+    // if it has a teamId, it's a top-level team page.
+    // If the user has access to that team, it will be there, else shared
+    if (teamId) {
+      return isTeamMember(authToken, teamId) ? 'team' : 'shared'
+    }
+    // if the page has a parent, it will be a subpage unless it doesn't have access to that parent
+    if (parentPageId) {
+      const userId = getUserId(authToken)
+      const hasParentAccess = await dataLoader
+        .get('pageAccessByUserId')
+        .load({pageId: parentPageId, userId})
+      return hasParentAccess ? 'page' : 'shared'
+    }
+    // unreachable as teamId/parentPageId branches have already been exhausted
+    return 'shared'
   }
 }
 

--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -9,6 +9,7 @@ import isTaskPrivate from 'parabol-client/utils/isTaskPrivate'
 import {isNotNull} from 'parabol-client/utils/predicates'
 import toTeamMemberId from 'parabol-client/utils/relay/toTeamMemberId'
 import sortByTier from 'parabol-client/utils/sortByTier'
+import {positionBefore} from '../../../../client/shared/sortOrder'
 import {
   AUTO_GROUPING_THRESHOLD,
   MAX_REDUCTION_PERCENTAGE,
@@ -23,7 +24,6 @@ import {
   selectPages,
   selectTasks
 } from '../../../postgres/select'
-import type {Page} from '../../../postgres/types'
 import {getUserId, isSuperUser, isTeamMember} from '../../../utils/authorization'
 import {CipherId} from '../../../utils/CipherId'
 import getDomainFromEmail from '../../../utils/getDomainFromEmail'
@@ -879,7 +879,7 @@ const User: ReqResolvers<'User'> = {
   pages: async (
     _source,
     {parentPageId, isPrivate, first, after, teamId, isArchived, textFilter},
-    {authToken, dataLoader}
+    {authToken}
   ) => {
     if (parentPageId && teamId) {
       throw new GraphQLError('parentPageId and teamId are mutually exclusive')
@@ -920,11 +920,10 @@ const User: ReqResolvers<'User'> = {
         }))
       }
     }
-    let pagesPlusOne: Page[]
     if (isPrivate === false) {
       const pg = getKysely()
       // this is for shared pages, which only return the top-most accessible page
-      pagesPlusOne = await pg
+      const pagesPlusOne = await pg
         .with('teams', (qc) =>
           qc
             .selectFrom('TeamMember')
@@ -936,9 +935,6 @@ const User: ReqResolvers<'User'> = {
           selectPages(qc as any)
             .innerJoin('PageAccess', 'PageAccess.pageId', 'Page.id')
             .where('PageAccess.userId', '=', viewerId)
-            .where('isPrivate', '=', false)
-            .$if(!!after, (qb) => qb.where('sortOrder', '>', after!))
-            .$if(!!textFilter, (qb) => qb.where('title', 'ilike', `%${textFilter}%`))
             .where('deletedBy', 'is', null)
         )
 
@@ -962,40 +958,77 @@ const User: ReqResolvers<'User'> = {
             eb('teamId', 'not in', selectFrom('teams').select('teamId'))
           ])
         )
-        .orderBy('sortOrder')
+        .where('isPrivate', '=', false) // this must go down here so a shared child of a private page doesn't show up
+        .$if(!!textFilter, (qb) => qb.where('title', 'ilike', `%${textFilter}%`))
+        .leftJoin('PageUserSortOrder', (join) =>
+          join
+            .on('PageUserSortOrder.userId', '=', viewerId)
+            .onRef('PageUserSortOrder.pageId', '=', 'p.id')
+        )
+        .select(({ref}) => ref('PageUserSortOrder.sortOrder').as('userSortOrder'))
+        .orderBy('userSortOrder', (od) => od.asc().nullsFirst())
+        .$if(!!after, (qb) => qb.where('PageUserSortOrder.sortOrder', '>', after!))
         .limit(first + 1)
         .execute()
+      const hasUnsorted = pagesPlusOne[0]?.userSortOrder === null
+      if (hasUnsorted) {
+        let curSortOrder = ' '
+        // the nulls will be at the beginning of the array
+        await Promise.all(
+          pagesPlusOne.toReversed().map((p) => {
+            if (p.userSortOrder) {
+              curSortOrder = p.userSortOrder
+              return undefined
+            } else {
+              p.userSortOrder = positionBefore(curSortOrder)
+              curSortOrder = p.userSortOrder
+              return pg
+                .insertInto('PageUserSortOrder')
+                .values({
+                  pageId: p.id,
+                  userId: viewerId,
+                  sortOrder: p.userSortOrder
+                })
+                .execute()
+            }
+          })
+        )
+      }
       const hasNextPage = pagesPlusOne.length > first
       const pages = hasNextPage ? pagesPlusOne.slice(0, -1) : pagesPlusOne
-      await Promise.all(
-        pages.map(async (page) => {
-          const userSortOrder = await dataLoader
-            .get('pageUserSortOrder')
-            .load({pageId: page.id, userId: viewerId})
-          page.sortOrder = userSortOrder ?? page.sortOrder
-        })
-      )
-    } else {
-      pagesPlusOne = await selectPages()
-        .innerJoin('PageAccess', 'PageAccess.pageId', 'Page.id')
-        .$if(!!dbParentPageId, (qb) => qb.where('parentPageId', '=', dbParentPageId!))
-        .where('PageAccess.userId', '=', viewerId)
-        .$if(!!teamId, (qb) => qb.where('teamId', '=', teamId!))
-        .$if(isPrivateDefined, (qb) => qb.where('isPrivate', '=', isPrivate!))
-        .$if(dbParentPageId === null, (qb) => qb.where('parentPageId', 'is', null))
-        .$if(teamId === null, (qb) => qb.where('teamId', 'is', null))
-        .$if(!!after, (qb) => qb.where('sortOrder', '>', after!))
-        // TODO make this a variable, but for now, hide summaries from everything
-        .where('summaryMeetingId', 'is', null)
-        .$if(!!textFilter, (qb) => qb.where('title', 'ilike', `%${textFilter}%`))
-        .where('deletedBy', 'is', null)
-        .orderBy('sortOrder')
-        .limit(first + 1)
-        .execute()
+      return {
+        pageInfo: {
+          hasNextPage,
+          hasPreviousPage: false,
+          startCursor: pages.at(0)?.userSortOrder!,
+          endCursor: pages.at(-1)?.userSortOrder!
+        },
+        edges: pages.map((page) => ({
+          node: page,
+          cursor: page.userSortOrder!
+        }))
+      }
     }
+    const pagesPlusOne = await selectPages()
+      .innerJoin('PageAccess', 'PageAccess.pageId', 'Page.id')
+      .$if(!!dbParentPageId, (qb) => qb.where('parentPageId', '=', dbParentPageId!))
+      .where('PageAccess.userId', '=', viewerId)
+      .$if(!!teamId, (qb) => qb.where('teamId', '=', teamId!))
+      .$if(isPrivateDefined, (qb) => qb.where('isPrivate', '=', isPrivate!))
+      .$if(dbParentPageId === null, (qb) => qb.where('parentPageId', 'is', null))
+      .$if(teamId === null, (qb) => qb.where('teamId', 'is', null))
+      .$if(!!after, (qb) => qb.where('sortOrder', '>', after!))
+      // TODO make this a variable, but for now, hide summaries from everything
+      .where('summaryMeetingId', 'is', null)
+      .$if(!!textFilter, (qb) => qb.where('title', 'ilike', `%${textFilter}%`))
+      .where('deletedBy', 'is', null)
+      .orderBy('sortOrder')
+      .limit(first + 1)
+      .execute()
     // ok now we have ALL the pages the user has access to, but we need to filter out the ones
     const hasNextPage = pagesPlusOne.length > first
     const pages = hasNextPage ? pagesPlusOne.slice(0, -1) : pagesPlusOne
+
     return {
       pageInfo: {
         hasNextPage,

--- a/packages/server/postgres/migrations/2025-09-17T22:36:51.355Z_userpagesort.ts
+++ b/packages/server/postgres/migrations/2025-09-17T22:36:51.355Z_userpagesort.ts
@@ -1,0 +1,38 @@
+import {type Kysely, sql} from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+	DROP TRIGGER IF EXISTS "trg_page_shared_sort_order" ON "Page";
+	DROP FUNCTION IF EXISTS "addSharedPageSortOrder";
+
+	CREATE OR REPLACE FUNCTION "removePageUserSortOrder"()
+	RETURNS TRIGGER AS $$
+		BEGIN
+			DELETE FROM "PageUserSortOrder"
+      WHERE "pageId" = OLD."pageId"
+			AND "userId" = OLD."userId";
+			RETURN NULL;
+		END;
+	$$ LANGUAGE plpgsql;
+
+	CREATE OR REPLACE TRIGGER trg_delete_page_user_sort
+	AFTER DELETE ON "PageAccess"
+	FOR EACH ROW EXECUTE FUNCTION "removePageUserSortOrder"();
+	`.execute(db)
+  await db.schema
+    .alterTable('PageUserSortOrder')
+    .alterColumn('sortOrder', (ac) => ac.setNotNull())
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  // this trigger function is broken it doesn't generate a sortOrder for all shared pages
+  await sql`
+	DROP TRIGGER IF EXISTS trg_delete_page_user_sort;
+	DROP FUNCTION IF EXISTS "removePageUserSortOrder";
+	`.execute(db)
+  await db.schema
+    .alterTable('PageUserSortOrder')
+    .alterColumn('sortOrder', (ac) => ac.dropNotNull())
+    .execute()
+}

--- a/packages/server/postgres/select.ts
+++ b/packages/server/postgres/select.ts
@@ -315,7 +315,7 @@ export const selectPages = (queryCreator: Kysely<DB> | QueryCreator<DB> = getKys
     'isParentLinked',
     'isPrivate',
     'parentPageId',
-    'sortOrder',
+    'Page.sortOrder',
     'Page.teamId',
     'title',
     'updatedAt',

--- a/packages/server/postgres/types/index.d.ts
+++ b/packages/server/postgres/types/index.d.ts
@@ -110,7 +110,10 @@ export type Task = ExtractTypeFromQueryBuilderSelect<typeof selectTasks>
 export type TaskEstimate = Selectable<TaskEstimatePG>
 
 export type Discussion = ExtractTypeFromQueryBuilderSelect<typeof selectDiscussion>
-export type Page = ExtractTypeFromQueryBuilderSelect<typeof selectPages>
+// userSortOrder comes from PageUserSortOrder table, and is sometimes prefetched for performance
+export type Page = ExtractTypeFromQueryBuilderSelect<typeof selectPages> & {
+  userSortOrder?: string | null
+}
 export type PagePartial = Pick<Page, 'id' | 'title' | 'teamId'> & {
   __typename: 'Page' | 'PagePreview'
 }

--- a/packages/server/postgres/updatePageAccessTable.ts
+++ b/packages/server/postgres/updatePageAccessTable.ts
@@ -66,7 +66,7 @@ export const updatePageAccessTable = (
     )
 
   if (!skipDeleteOld) {
-    res.with('deleteOld', (qc) =>
+    return res.with('deleteOld', (qc) =>
       qc
         .deleteFrom('PageAccess')
         .where('pageId', 'in', (eb) => eb.selectFrom('descendants').select('id'))
@@ -80,7 +80,7 @@ export const updatePageAccessTable = (
             )
           )
         )
-    )
+    ) as any as typeof res
   }
   return res
 }

--- a/packages/server/utils/tiptap/createTopLevelPage.ts
+++ b/packages/server/utils/tiptap/createTopLevelPage.ts
@@ -28,7 +28,13 @@ export const createTopLevelPage = async (
   const viewer = await dataLoader.get('users').loadNonNull(viewerId)
   const pg = getKysely()
   const isPrivate = !teamId
-  const sortOrder = await getPageNextSortOrder(__START__, viewerId, isPrivate, teamId || null)
+  const sortOrder = await getPageNextSortOrder(
+    __START__,
+    false,
+    viewerId,
+    isPrivate,
+    teamId || null
+  )
   const yDoc = content
     ? Buffer.from(
         encodeStateAsUpdate(TiptapTransformer.toYdoc(content, undefined, serverTipTapExtensions))

--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -10,7 +10,7 @@ module.exports = {
     {
       name: 'Socket Server',
       script: 'node',
-      args: ['--inspect', 'scripts/runSocketServer.js'],
+      args: ['scripts/runSocketServer.js'],
       // increase this to test scaling
       instances: 1,
       increment_var: 'SERVER_ID',


### PR DESCRIPTION
# Description

This fixes drag & drop in the Shared Pages section

It also fixes a few other nasty bugs:
- PageAccess remained after removing someone
- Shared Pages included a page if the parent was private & the child was shared