### PR TITLE
chore: more Safari SW debugging

### DIFF
--- a/template.html
+++ b/template.html
@@ -41,31 +41,17 @@
     <!-- Safari sometimes kills the service worker before it can load the initial script -->
     <script>
       if ('serviceWorker' in navigator) {
-        function unregisterSW(event) {
-          console.error('Error loading main script', event, event.message)
-          if (event.message === 'Service Worker context closed') {
-            navigator.serviceWorker.getRegistration().then((req) => {
-              if (!req) return
-              req.unregister().then(() => {
-                location.reload()
-              })
-            })
-          }
-        }
-
-        // because the script tag is `defer` we need to attach the handler via script
-        document.querySelectorAll('script').forEach((script) => {
-          if (script.src) {
-            script.onerror = unregisterSW
-          }
-        })
-
         // for debugging, maybe Safari closes the SW because there is an update available?
         navigator.serviceWorker.getRegistration().then((reg) => {
           if (!reg) return
           reg.addEventListener('updatefound', () => {
             console.log('New service worker found')
           })
+          if (reg.active) {
+            reg.active.addEventListener('error', (e) => {
+              console.log('Service worker error', e)
+            })
+          }
         })
       }
     </script>


### PR DESCRIPTION

# Description

Relates to #11889 
Safari closes the context on initial load because a service worker update is available. I wonder if we can also catch the error coming from the SW. If that's the case, then we can simplify the reload logic and need to do less guessing.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
