### PR TITLE
fix: sql query column ordering

### DIFF
--- a/packages/client/components/DashNavList/LeftNavPageLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavPageLink.tsx
@@ -26,6 +26,8 @@ interface Props {
   isLastChild: boolean
   nextPeerId: string | null
   connectionKey: PageConnectionKey
+  // pass this down from the parent to reduce query complexity, since it's only needed in dragging edge cases
+  parentPageViewerAccess?: PageRoleEnum
 }
 export const LeftNavPageLink = (props: Props) => {
   const {
@@ -38,7 +40,8 @@ export const LeftNavPageLink = (props: Props) => {
     dropIdx,
     isLastChild,
     nextPeerId,
-    connectionKey
+    connectionKey,
+    parentPageViewerAccess
   } = props
   const depth = pageAncestors.length
   const page = useFragment(
@@ -47,13 +50,6 @@ export const LeftNavPageLink = (props: Props) => {
         ...PageActions_page
         access {
           viewer
-        }
-        parentPage {
-          ... on Page {
-            access {
-              viewer
-            }
-          }
         }
         id
         title
@@ -71,7 +67,6 @@ export const LeftNavPageLink = (props: Props) => {
   )
   const {
     access,
-    parentPage,
     title,
     id,
     parentPageId,
@@ -82,7 +77,6 @@ export const LeftNavPageLink = (props: Props) => {
     currentPageAncestorDepth
   } = page
   const {viewer: viewerAccess} = access
-  const parentPageViewerAccess = parentPage?.access?.viewer
 
   const pageCode = id.split(':')[1]
   const slug = getPageSlug(Number(pageCode), title)
@@ -187,7 +181,11 @@ export const LeftNavPageLink = (props: Props) => {
           className={cn('rounded-md', canDropIn && 'peer-hover:bg-sky-200/70')}
           data-pages-connection={'User_pages'}
         >
-          <SubPagesRoot parentPageId={id} pageAncestors={nextPageAncestors} />
+          <SubPagesRoot
+            parentPageId={id}
+            pageAncestors={nextPageAncestors}
+            parentPageViewerAccess={viewerAccess ?? undefined}
+          />
         </div>
       )}
     </div>

--- a/packages/client/components/DashNavList/LeftNavPrivatePagesSection.tsx
+++ b/packages/client/components/DashNavList/LeftNavPrivatePagesSection.tsx
@@ -9,7 +9,7 @@ import {cn} from '../../ui/cn'
 import {LeftNavHeader} from './LeftNavHeader'
 import {LeftNavHeaderButton} from './LeftNavHeaderButton'
 import {LeftNavItemButtons} from './LeftNavItemButtons'
-import {LeftNavPageLink} from './LeftNavPageLink'
+import {LeftNavPageLink, type PageParentSection} from './LeftNavPageLink'
 
 interface Props {
   viewerRef: LeftNavPrivatePagesSection_viewer$key
@@ -22,6 +22,8 @@ export const LeftNavPrivatePagesSection = (props: Props) => {
       fragment LeftNavPrivatePagesSection_viewer on User {
         draggingPageId
         draggingPageIsPrivate
+        draggingPageParentSection
+        draggingPageViewerAccess
         privatePages: pages(parentPageId: $nullId, first: 500, isPrivate: true)
           @connection(key: "User_privatePages") {
           edges {
@@ -37,10 +39,18 @@ export const LeftNavPrivatePagesSection = (props: Props) => {
     `,
     viewerRef
   )
-  const {draggingPageId, draggingPageIsPrivate, privatePages} = viewer
+  const {
+    draggingPageId,
+    draggingPageIsPrivate,
+    privatePages,
+    draggingPageParentSection,
+    draggingPageViewerAccess
+  } = viewer
   const {edges} = privatePages
   const firstPageId = edges[0]?.node.id
-  const canDropBelow = draggingPageId && draggingPageId !== firstPageId
+  const isViewerOwnerOfDraggingPage = draggingPageViewerAccess === 'owner'
+  const canDropBelow =
+    draggingPageId && draggingPageId !== firstPageId && isViewerOwnerOfDraggingPage
   const lastPageId = edges.at(-1)?.node.id
   const canDropIn = draggingPageId && draggingPageId !== lastPageId
   const [execute, submitting] = useCreatePageMutation()
@@ -106,6 +116,8 @@ export const LeftNavPrivatePagesSection = (props: Props) => {
               nextPeerId={edges[idx + 1]?.node.id || null}
               connectionKey={connectionKey}
               draggingPageIsPrivate={draggingPageIsPrivate || null}
+              draggingPageParentSection={(draggingPageParentSection as PageParentSection) || null}
+              draggingPageViewerAccess={draggingPageViewerAccess || null}
             />
           )
         })}

--- a/packages/client/components/DashNavList/LeftNavSharedPagesSection.tsx
+++ b/packages/client/components/DashNavList/LeftNavSharedPagesSection.tsx
@@ -4,7 +4,7 @@ import {useFragment} from 'react-relay'
 import type {LeftNavSharedPagesSection_viewer$key} from '../../__generated__/LeftNavSharedPagesSection_viewer.graphql'
 import {cn} from '../../ui/cn'
 import {LeftNavHeader} from './LeftNavHeader'
-import {LeftNavPageLink} from './LeftNavPageLink'
+import {LeftNavPageLink, type PageParentSection} from './LeftNavPageLink'
 
 interface Props {
   viewerRef: LeftNavSharedPagesSection_viewer$key
@@ -17,6 +17,8 @@ export const LeftNavSharedPagesSection = (props: Props) => {
       fragment LeftNavSharedPagesSection_viewer on User {
         draggingPageId
         draggingPageIsPrivate
+        draggingPageParentSection
+        draggingPageViewerAccess
         sharedPages: pages(parentPageId: $nullId, first: 500, isPrivate: false)
           @connection(key: "User_sharedPages") {
           edges {
@@ -32,7 +34,13 @@ export const LeftNavSharedPagesSection = (props: Props) => {
     `,
     viewerRef
   )
-  const {draggingPageId, draggingPageIsPrivate, sharedPages} = viewer
+  const {
+    draggingPageId,
+    draggingPageIsPrivate,
+    sharedPages,
+    draggingPageParentSection,
+    draggingPageViewerAccess
+  } = viewer
   const {edges} = sharedPages
   const firstPageId = edges[0]?.node.id
   const canDropBelow = draggingPageId && draggingPageId !== firstPageId && !draggingPageIsPrivate
@@ -77,6 +85,8 @@ export const LeftNavSharedPagesSection = (props: Props) => {
               nextPeerId={edges[idx + 1]?.node.id || null}
               connectionKey={connectionKey}
               draggingPageIsPrivate={draggingPageIsPrivate || null}
+              draggingPageParentSection={(draggingPageParentSection as PageParentSection) || null}
+              draggingPageViewerAccess={draggingPageViewerAccess || null}
             />
           )
         })}

--- a/packages/client/components/DashNavList/LeftNavTeamLink.tsx
+++ b/packages/client/components/DashNavList/LeftNavTeamLink.tsx
@@ -7,21 +7,31 @@ import {useFragment} from 'react-relay'
 import {useHistory, useRouteMatch} from 'react-router'
 import {Link} from 'react-router-dom'
 import type {LeftNavTeamLink_team$key} from '../../__generated__/LeftNavTeamLink_team.graphql'
+import type {PageRoleEnum} from '../../__generated__/NotificationSubscription.graphql'
 import {useCreatePageMutation} from '../../mutations/useCreatePageMutation'
 import {cn} from '../../ui/cn'
 import {ExpandPageChildrenButton} from './ExpandPageChildrenButton'
 import {LeftNavItem} from './LeftNavItem'
 import {LeftNavItemButton} from './LeftNavItemButton'
 import {LeftNavItemButtons} from './LeftNavItemButtons'
+import type {PageParentSection} from './LeftNavPageLink'
 import {SubPagesRoot} from './SubPagesRoot'
 
 interface Props {
   teamRef: LeftNavTeamLink_team$key
   draggingPageId: string | null
+  draggingPageViewerAccess: PageRoleEnum | null
+  draggingPageParentSection: PageParentSection | null
   closeMobileSidebar?: () => void
 }
 export const LeftNavTeamLink = (props: Props) => {
-  const {closeMobileSidebar, teamRef, draggingPageId} = props
+  const {
+    closeMobileSidebar,
+    teamRef,
+    draggingPageId,
+    draggingPageViewerAccess,
+    draggingPageParentSection
+  } = props
   const team = useFragment(
     graphql`
       fragment LeftNavTeamLink_team on Team {
@@ -34,7 +44,10 @@ export const LeftNavTeamLink = (props: Props) => {
     `,
     teamRef
   )
+  const isViewerOwnerOfDraggingPage = draggingPageViewerAccess === 'owner'
   const {name: teamName, id: teamId, isDraggingFirstChild, isDraggingLastChild, orgId} = team
+  const isDraggingPageFromTheTeam = draggingPageParentSection === teamId
+  const isViewerOwnerOrIsReorder = isViewerOwnerOfDraggingPage || isDraggingPageFromTheTeam
   const match = useRouteMatch(`/team/${teamId}`)
   const isActive = match ?? false
   const [showChildren, setShowChildren] = useState(false)
@@ -45,6 +58,7 @@ export const LeftNavTeamLink = (props: Props) => {
   const [execute, submitting] = useCreatePageMutation()
   const addChildPage = (e: React.MouseEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     if (submitting) return
     execute({
       variables: {teamId},
@@ -58,8 +72,10 @@ export const LeftNavTeamLink = (props: Props) => {
       }
     })
   }
-  const canDropIn = draggingPageId && (showChildren ? !isDraggingLastChild : true)
-  const canDropBelow = draggingPageId && showChildren && !isDraggingFirstChild
+  const canDropIn =
+    draggingPageId && (showChildren ? !isDraggingLastChild : true) && isViewerOwnerOrIsReorder
+  const canDropBelow =
+    draggingPageId && showChildren && !isDraggingFirstChild && isViewerOwnerOrIsReorder
   return (
     <div className='relative rounded-md'>
       <div
@@ -117,12 +133,7 @@ export const LeftNavTeamLink = (props: Props) => {
       </div>
       {showChildren && (
         <div className={cn('rounded-md', canDropIn && 'peer-hover:bg-sky-200/70')}>
-          <SubPagesRoot
-            teamId={teamId}
-            pageAncestors={['', teamId]}
-            draggingPageId={draggingPageId}
-            draggingPageIsPrivate={null}
-          />
+          <SubPagesRoot teamId={teamId} pageAncestors={['', teamId]} />
         </div>
       )}
     </div>

--- a/packages/client/components/DashNavList/LeftNavTeamsSection.tsx
+++ b/packages/client/components/DashNavList/LeftNavTeamsSection.tsx
@@ -10,6 +10,7 @@ import {getSortOrder} from '../../shared/sortOrder'
 import {LeftNavHeader} from './LeftNavHeader'
 import {LeftNavHeaderButton} from './LeftNavHeaderButton'
 import {LeftNavItemButtons} from './LeftNavItemButtons'
+import type {PageParentSection} from './LeftNavPageLink'
 import {LeftNavTeamLink} from './LeftNavTeamLink'
 import PublicTeamsOverflow from './PublicTeamsOverflow'
 
@@ -25,6 +26,8 @@ export const LeftNavTeamsSection = (props: Props) => {
         ...PublicTeamsOverflow_viewer
         draggingPageId
         draggingPageIsPrivate
+        draggingPageViewerAccess
+        draggingPageParentSection
         teams {
           id
           sortOrder
@@ -35,7 +38,7 @@ export const LeftNavTeamsSection = (props: Props) => {
     viewerRef
   )
   const [execute, submitting] = useUpdateTeamSortOrderMutation()
-  const {teams, draggingPageId} = viewer
+  const {teams, draggingPageId, draggingPageViewerAccess, draggingPageParentSection} = viewer
   const onDragEnd = useEventCallback((result: DropResult) => {
     const {source, destination} = result
     if (!destination || submitting) return
@@ -91,6 +94,10 @@ export const LeftNavTeamsSection = (props: Props) => {
                               closeMobileSidebar={closeMobileSidebar}
                               teamRef={team}
                               draggingPageId={draggingPageId ?? null}
+                              draggingPageViewerAccess={draggingPageViewerAccess ?? null}
+                              draggingPageParentSection={
+                                (draggingPageParentSection as PageParentSection) ?? null
+                              }
                             />
                           </div>
                         )

--- a/packages/client/components/DashNavList/PageActions.tsx
+++ b/packages/client/components/DashNavList/PageActions.tsx
@@ -108,7 +108,13 @@ export const PageActions = (props: Props) => {
             }
           >
             <MenuContent align='center' side={'right'} sideOffset={8} className='max-h-80'>
-              <MenuItem onSelect={archivePage} onClick={(e) => e.stopPropagation()}>
+              <MenuItem
+                onSelect={archivePage}
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                }}
+              >
                 <DeleteIcon className='text-slate-600' />
                 <span className='pl-1'>{'Delete page'}</span>
               </MenuItem>

--- a/packages/client/components/DashNavList/SubPages.tsx
+++ b/packages/client/components/DashNavList/SubPages.tsx
@@ -3,11 +3,15 @@ import {useMemo} from 'react'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
 import query, {type SubPagesQuery} from '../../__generated__/SubPagesQuery.graphql'
 import type {PageLinkBlockAttributes} from '../../shared/tiptap/extensions/PageLinkBlockBase'
-import {LeftNavPageLink} from './LeftNavPageLink'
+import {LeftNavPageLink, type PageParentSection} from './LeftNavPageLink'
 
 graphql`
   query SubPagesQuery($parentPageId: ID, $teamId: ID) {
     viewer {
+      draggingPageId
+      draggingPageIsPrivate
+      draggingPageParentSection
+      draggingPageViewerAccess
       pages(first: 500, parentPageId: $parentPageId, teamId: $teamId)
         @connection(key: "User_pages") {
         edges {
@@ -23,17 +27,21 @@ graphql`
 interface Props {
   queryRef: PreloadedQuery<SubPagesQuery>
   pageAncestors: string[]
-  draggingPageId: string | null | undefined
-  draggingPageIsPrivate: boolean | null
   pageLinks: PageLinkBlockAttributes[] | null | undefined
 }
 
 export const SubPages = (props: Props) => {
   const connectionKey = 'User_pages'
-  const {pageAncestors, queryRef, draggingPageId, draggingPageIsPrivate, pageLinks} = props
+  const {pageAncestors, queryRef, pageLinks} = props
   const data = usePreloadedQuery<SubPagesQuery>(query, queryRef)
   const {viewer} = data
-  const {pages} = viewer
+  const {
+    pages,
+    draggingPageId,
+    draggingPageIsPrivate,
+    draggingPageParentSection,
+    draggingPageViewerAccess
+  } = viewer
   const {edges} = pages
   const depth = pageAncestors.length
   const children = useMemo(() => {
@@ -76,7 +84,9 @@ export const SubPages = (props: Props) => {
             isLastChild={idx === children.length - 1}
             nextPeerId={nextPeerId}
             connectionKey={connectionKey}
-            draggingPageIsPrivate={draggingPageIsPrivate}
+            draggingPageIsPrivate={draggingPageIsPrivate || null}
+            draggingPageParentSection={(draggingPageParentSection as PageParentSection) || null}
+            draggingPageViewerAccess={draggingPageViewerAccess || null}
           />
         )
       })}

--- a/packages/client/components/DashNavList/SubPages.tsx
+++ b/packages/client/components/DashNavList/SubPages.tsx
@@ -1,6 +1,7 @@
 import graphql from 'babel-plugin-relay/macro'
 import {useMemo} from 'react'
 import {type PreloadedQuery, usePreloadedQuery} from 'react-relay'
+import type {PageRoleEnum} from '../../__generated__/NotificationSubscription.graphql'
 import query, {type SubPagesQuery} from '../../__generated__/SubPagesQuery.graphql'
 import type {PageLinkBlockAttributes} from '../../shared/tiptap/extensions/PageLinkBlockBase'
 import {LeftNavPageLink, type PageParentSection} from './LeftNavPageLink'
@@ -28,11 +29,12 @@ interface Props {
   queryRef: PreloadedQuery<SubPagesQuery>
   pageAncestors: string[]
   pageLinks: PageLinkBlockAttributes[] | null | undefined
+  parentPageViewerAccess?: PageRoleEnum
 }
 
 export const SubPages = (props: Props) => {
   const connectionKey = 'User_pages'
-  const {pageAncestors, queryRef, pageLinks} = props
+  const {pageAncestors, queryRef, pageLinks, parentPageViewerAccess} = props
   const data = usePreloadedQuery<SubPagesQuery>(query, queryRef)
   const {viewer} = data
   const {
@@ -87,6 +89,7 @@ export const SubPages = (props: Props) => {
             draggingPageIsPrivate={draggingPageIsPrivate || null}
             draggingPageParentSection={(draggingPageParentSection as PageParentSection) || null}
             draggingPageViewerAccess={draggingPageViewerAccess || null}
+            parentPageViewerAccess={parentPageViewerAccess}
           />
         )
       })}

--- a/packages/client/components/DashNavList/SubPagesRoot.tsx
+++ b/packages/client/components/DashNavList/SubPagesRoot.tsx
@@ -10,12 +10,10 @@ interface Props {
   parentPageId?: string
   teamId?: string
   pageAncestors: string[]
-  draggingPageId: string | null | undefined
-  draggingPageIsPrivate: boolean | null
 }
 
 export const SubPagesRoot = (props: Props) => {
-  const {parentPageId, pageAncestors, draggingPageId, draggingPageIsPrivate, teamId} = props
+  const {parentPageId, pageAncestors, teamId} = props
   const queryRef = useQueryLoaderNow<SubPagesQuery>(query, {
     parentPageId,
     teamId
@@ -27,13 +25,7 @@ export const SubPagesRoot = (props: Props) => {
   return (
     <Suspense fallback={<Loader />}>
       {queryRef && (
-        <SubPages
-          queryRef={queryRef}
-          pageAncestors={pageAncestors}
-          draggingPageId={draggingPageId}
-          draggingPageIsPrivate={draggingPageIsPrivate}
-          pageLinks={pageLinks}
-        />
+        <SubPages queryRef={queryRef} pageAncestors={pageAncestors} pageLinks={pageLinks} />
       )}
     </Suspense>
   )

--- a/packages/client/components/DashNavList/SubPagesRoot.tsx
+++ b/packages/client/components/DashNavList/SubPagesRoot.tsx
@@ -1,4 +1,5 @@
 import {Suspense} from 'react'
+import type {PageRoleEnum} from '../../__generated__/NotificationSubscription.graphql'
 import type {SubPagesQuery} from '../../__generated__/SubPagesQuery.graphql'
 import query from '../../__generated__/SubPagesQuery.graphql'
 import {usePageChildren} from '../../hooks/usePageChildren'
@@ -10,10 +11,11 @@ interface Props {
   parentPageId?: string
   teamId?: string
   pageAncestors: string[]
+  parentPageViewerAccess?: PageRoleEnum
 }
 
 export const SubPagesRoot = (props: Props) => {
-  const {parentPageId, pageAncestors, teamId} = props
+  const {parentPageId, pageAncestors, teamId, parentPageViewerAccess} = props
   const queryRef = useQueryLoaderNow<SubPagesQuery>(query, {
     parentPageId,
     teamId
@@ -25,7 +27,12 @@ export const SubPagesRoot = (props: Props) => {
   return (
     <Suspense fallback={<Loader />}>
       {queryRef && (
-        <SubPages queryRef={queryRef} pageAncestors={pageAncestors} pageLinks={pageLinks} />
+        <SubPages
+          queryRef={queryRef}
+          pageAncestors={pageAncestors}
+          pageLinks={pageLinks}
+          parentPageViewerAccess={parentPageViewerAccess}
+        />
       )}
     </Suspense>
   )

--- a/packages/client/hooks/useDraggablePage.tsx
+++ b/packages/client/hooks/useDraggablePage.tsx
@@ -268,7 +268,6 @@ export const useDraggablePage = (
           .get(pageId)
           ?.getLinkedRecord('access')
           ?.getValue('viewer')
-        console.log('starting drag', draggingPageViewerAccess)
         store
           .getRoot()
           .getLinkedRecord('viewer')

--- a/packages/client/hooks/useDraggablePage.tsx
+++ b/packages/client/hooks/useDraggablePage.tsx
@@ -259,11 +259,23 @@ export const useDraggablePage = (
       startVisualDragImage(e)
 
       commitLocalUpdate(atmosphere, (store) => {
+        const draggingPageParentSection =
+          sourceConnectionKey === 'User_pages'
+            ? `${sourceConnectionKey}:${sourceParentPageId || sourceTeamId}`
+            : sourceConnectionKey
+
+        const draggingPageViewerAccess = store
+          .get(pageId)
+          ?.getLinkedRecord('access')
+          ?.getValue('viewer')
+        console.log('starting drag', draggingPageViewerAccess)
         store
           .getRoot()
           .getLinkedRecord('viewer')
           ?.setValue(pageId, 'draggingPageId')
           .setValue(isPageIdPrivate, 'draggingPageIsPrivate')
+          .setValue(draggingPageParentSection, 'draggingPageParentSection')
+          .setValue(draggingPageViewerAccess, 'draggingPageViewerAccess')
         const parentId = sourceParentPageId || sourceTeamId
         const parent = parentId ? store.get(parentId) : null
         parent
@@ -323,6 +335,8 @@ export const useDraggablePage = (
           .getLinkedRecord('viewer')
           ?.setValue(null, 'draggingPageId')
           .setValue(null, 'draggingPageIsPrivate')
+          .setValue(null, 'draggingPageParentSection')
+          .setValue(null, 'draggingPageViewerAccess')
         const parentId = sourceParentPageId || sourceTeamId
         const parent = parentId ? store.get(parentId) : null
         parent?.setValue(null, 'isDraggingFirstChild').setValue(null, 'isDraggingLastChild')

--- a/packages/client/schemaExtensions/clientSchema.graphql
+++ b/packages/client/schemaExtensions/clientSchema.graphql
@@ -95,6 +95,10 @@ extend type User {
 	draggingPageId: ID
 	# True if the page being dragged is private (private pages cannot be dragged to top-level shared)
 	draggingPageIsPrivate: Boolean
+	# The area the drag started from, either 'User_privatePages', 'User_sharedPages', teamId, or parentPageId
+	draggingPageParentSection: String
+	# The level of access the viewer has on the dragging page
+	draggingPageViewerAccess: PageRoleEnum
 }
 
 extend type Page {

--- a/packages/client/tiptap/extensions/pageLinkBlock/PageLinkBlockView.tsx
+++ b/packages/client/tiptap/extensions/pageLinkBlock/PageLinkBlockView.tsx
@@ -76,7 +76,7 @@ export const PageLinkBlockView = (props: NodeViewProps) => {
         )}
       >
         <Icon />
-        <div className='flex-1 pl-1'>{title}</div>
+        <div className='flex-1 pl-1'>{title || '<Untitled>'}</div>
         <Menu
           onOpenChange={(open) => {
             if (open) {

--- a/packages/server/dataloader/pageLoaderMakers.ts
+++ b/packages/server/dataloader/pageLoaderMakers.ts
@@ -32,40 +32,43 @@ export const pageAccessByPageId = (parent: RootDataLoader) => {
   )
 }
 
+export const pageAccessByUserIdBatchFn = async (
+  keys: readonly {pageId: number; userId: string}[]
+) => {
+  const pageIds = keys.map((k) => k.pageId)
+  const res = await selectPageAccess()
+    .where(({eb, refTuple, tuple}) =>
+      eb(
+        refTuple('pageId', 'userId'),
+        'in',
+        keys.map((key) => tuple(key.pageId, key.userId))
+      )
+    )
+    .unionAll((eb) =>
+      eb.parens(
+        eb
+          .selectFrom('PageExternalAccess')
+          .select(['pageId', eb.val('*').as('userId'), 'role'])
+          .where('pageId', 'in', pageIds)
+          .where('email', '=', '*')
+      )
+    )
+    .execute()
+  const publicRules = res.filter(({userId}) => userId === '*')
+  return keys.map((key) => {
+    const rule = res.find(({pageId, userId}) => pageId === key.pageId && userId === key.userId)
+    const userRole = rule?.role ?? null
+    if (userRole === 'owner') return userRole
+    const publicRule = publicRules.find((rule) => rule.pageId === key.pageId)
+    if (!publicRule) return userRole
+    const publicRole = publicRule.role
+    if (!userRole) return publicRole
+    return PAGE_ROLES.indexOf(userRole) < PAGE_ROLES.indexOf(publicRole) ? userRole : publicRole
+  })
+}
 export const pageAccessByUserId = (parent: RootDataLoader) => {
   return new DataLoader<{pageId: number; userId: string}, Pageroleenum | null, string>(
-    async (keys) => {
-      const pageIds = keys.map((k) => k.pageId)
-      const res = await selectPageAccess()
-        .where(({eb, refTuple, tuple}) =>
-          eb(
-            refTuple('pageId', 'userId'),
-            'in',
-            keys.map((key) => tuple(key.pageId, key.userId))
-          )
-        )
-        .unionAll((eb) =>
-          eb.parens(
-            eb
-              .selectFrom('PageExternalAccess')
-              .select(['pageId', eb.val('*').as('userId'), 'role'])
-              .where('pageId', 'in', pageIds)
-              .where('email', '=', '*')
-          )
-        )
-        .execute()
-      const publicRules = res.filter(({userId}) => userId === '*')
-      return keys.map((key) => {
-        const rule = res.find(({pageId, userId}) => pageId === key.pageId && userId === key.userId)
-        const userRole = rule?.role ?? null
-        if (userRole === 'owner') return userRole
-        const publicRule = publicRules.find((rule) => rule.pageId === key.pageId)
-        if (!publicRule) return userRole
-        const publicRole = publicRule.role
-        if (!userRole) return publicRole
-        return PAGE_ROLES.indexOf(userRole) < PAGE_ROLES.indexOf(publicRole) ? userRole : publicRole
-      })
-    },
+    pageAccessByUserIdBatchFn,
     {
       ...parent.dataLoaderOptions,
       cacheKeyFn: (key) => `${key.pageId}:${key.userId}`

--- a/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
+++ b/packages/server/graphql/mutations/helpers/dumpTranscriptToPage.ts
@@ -1,5 +1,4 @@
 import {generateText, type JSONContent} from '@tiptap/core'
-import {sql} from 'kysely'
 import {__START__} from 'parabol-client/shared/sortOrder'
 import {getTitleFromPageText} from 'parabol-client/shared/tiptap/getTitleFromPageText'
 import {serverTipTapExtensions} from 'parabol-client/shared/tiptap/serverTipTapExtensions'
@@ -83,8 +82,6 @@ export const dumpTranscriptToPage = async (
   ])
 
   await updatePageAccessTable(pg, pageId, {skipDeleteOld: true})
-    .selectNoFrom(sql`1`.as('t'))
-    .execute()
 
   const viewer = await dataLoader.get('users').loadNonNull(viewerId)
   analytics.pageCreated(viewer, pageId)

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
@@ -1,13 +1,13 @@
 import {GraphQLError} from 'graphql'
 import {sql} from 'kysely'
-import {getNewDataLoader} from '../../dataloader/getNewDataLoader'
-import {pageAccessByUserIdBatchFn} from '../../dataloader/pageLoaderMakers'
-import getKysely from '../../postgres/getKysely'
-import {selectDescendantPages} from '../../postgres/select'
-import {updatePageAccessTable} from '../../postgres/updatePageAccessTable'
-import {publishPageNotification} from '../publishPageNotification'
-import {removeCanonicalPageLinkFromPage} from './removeCanonicalPageLinkFromPage'
-import {validateParentPage} from './validateParentPage'
+import {getNewDataLoader} from '../../../../dataloader/getNewDataLoader'
+import {pageAccessByUserIdBatchFn} from '../../../../dataloader/pageLoaderMakers'
+import getKysely from '../../../../postgres/getKysely'
+import {selectDescendantPages} from '../../../../postgres/select'
+import {updatePageAccessTable} from '../../../../postgres/updatePageAccessTable'
+import {publishPageNotification} from '../../../../utils/publishPageNotification'
+import {removeCanonicalPageLinkFromPage} from '../../../../utils/tiptap/removeCanonicalPageLinkFromPage'
+import {validateParentPage} from '../../../../utils/tiptap/validateParentPage'
 
 export const movePageToNewParent = async (
   viewerId: string,

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewParent.ts
@@ -229,8 +229,8 @@ export const movePageToNewParent = async (
             eb
               .selectFrom('descendants')
               .select((eb) => [
-                eb.ref('descendants.id').as('pageId'),
                 eb.val(viewerId).as('userId'),
+                eb.ref('descendants.id').as('pageId'),
                 sql`'owner'::"PageRoleEnum"`.as('role')
               ])
           )

--- a/packages/server/graphql/public/mutations/helpers/movePageToNewTeam.ts
+++ b/packages/server/graphql/public/mutations/helpers/movePageToNewTeam.ts
@@ -90,7 +90,5 @@ export const movePageToNewTeam = async (
     .execute()
 
   await updatePageAccessTable(trx, pageId, {skipUnionOrg: true})
-    .selectNoFrom(sql`1`.as('t'))
-    .execute()
   await trx.commit().execute()
 }

--- a/packages/server/graphql/public/mutations/updatePageAccess.ts
+++ b/packages/server/graphql/public/mutations/updatePageAccess.ts
@@ -149,13 +149,21 @@ const updatePageAccess: MutationResolvers['updatePageAccess'] = async (
       .execute()
   }
 
-  const strongestRole = await updatePageAccessTable(trx, dbPageId)
+  await updatePageAccessTable(trx, dbPageId)
+  const strongestRole = await trx
     .selectFrom('PageAccess')
     .select(({fn}) => fn.min('role').as('role'))
     // since all children will have identical access, no need to query descendants
     .where('pageId', '=', dbPageId)
     .executeTakeFirst()
 
+  const s2 = await trx
+    .selectFrom('PageAccess')
+    .select(({fn}) => fn.min('role').as('role'))
+    .where('pageId', '=', dbPageId)
+    .execute()
+  console.log({s2})
+  console.log({strongestRole})
   if (!strongestRole || strongestRole.role !== 'owner') {
     await trx.rollback().execute()
     throw new GraphQLError('A Page must have at least one owner')

--- a/packages/server/graphql/public/mutations/updatePageAccess.ts
+++ b/packages/server/graphql/public/mutations/updatePageAccess.ts
@@ -157,13 +157,6 @@ const updatePageAccess: MutationResolvers['updatePageAccess'] = async (
     .where('pageId', '=', dbPageId)
     .executeTakeFirst()
 
-  const s2 = await trx
-    .selectFrom('PageAccess')
-    .select(({fn}) => fn.min('role').as('role'))
-    .where('pageId', '=', dbPageId)
-    .execute()
-  console.log({s2})
-  console.log({strongestRole})
   if (!strongestRole || strongestRole.role !== 'owner') {
     await trx.rollback().execute()
     throw new GraphQLError('A Page must have at least one owner')

--- a/packages/server/utils/tiptap/afterLoadDocument.ts
+++ b/packages/server/utils/tiptap/afterLoadDocument.ts
@@ -2,13 +2,13 @@ import type {Extension} from '@hocuspocus/server'
 import {sql} from 'kysely'
 import * as Y from 'yjs'
 import type {PageLinkBlockAttributes} from '../../../client/shared/tiptap/extensions/PageLinkBlockBase'
-import {movePageToNewParent} from '../../graphql/public/mutations/helpers/movePageToNewParent'
 import getKysely from '../../postgres/getKysely'
 import {CipherId} from '../CipherId'
 import {Logger} from '../Logger'
 import {NEW_PAGE_SENTINEL_CODE} from './constants'
 import {createChildPage} from './createChildPage'
 import {removeBacklinkedPageLinkBlocks} from './hocusPocusHub'
+import {movePageToNewParent} from './movePageToNewParent'
 
 const updateBacklinks = async (
   fromPageId: number,

--- a/packages/server/utils/tiptap/afterLoadDocument.ts
+++ b/packages/server/utils/tiptap/afterLoadDocument.ts
@@ -157,7 +157,7 @@ export const afterLoadDocument: Extension['afterLoadDocument'] = async ({
               } else {
                 // a page link either got moved or the viewer is trying to programmatically add one
                 // in either case, move the page link from the old parent to new
-                movePageToNewParent(userId, CipherId.decrypt(childPageCode), pageId)
+                await movePageToNewParent(userId, CipherId.decrypt(childPageCode), pageId)
               }
             }
           } else {

--- a/packages/server/utils/tiptap/createChildPage.ts
+++ b/packages/server/utils/tiptap/createChildPage.ts
@@ -1,4 +1,3 @@
-import {sql} from 'kysely'
 import {getNewDataLoader} from '../../dataloader/getNewDataLoader'
 import getKysely from '../../postgres/getKysely'
 import {updatePageAccessTable} from '../../postgres/updatePageAccessTable'
@@ -69,8 +68,6 @@ export const createChildPage = async (parentPageId: number, userId: string) => {
       .execute()
   ])
   await updatePageAccessTable(pg, pageId, {skipDeleteOld: true})
-    .selectNoFrom(sql`1`.as('t'))
-    .execute()
   analytics.pageCreated(viewer, pageId)
   const dataLoader = getNewDataLoader('createChildPage')
   const operationId = dataLoader.share()

--- a/packages/server/utils/tiptap/createTopLevelPage.ts
+++ b/packages/server/utils/tiptap/createTopLevelPage.ts
@@ -1,6 +1,5 @@
 import {TiptapTransformer} from '@hocuspocus/transformer'
 import type {JSONContent} from '@tiptap/core'
-import {sql} from 'kysely'
 import {encodeStateAsUpdate} from 'yjs'
 import {__START__} from '../../../client/shared/sortOrder'
 import {serverTipTapExtensions} from '../../../client/shared/tiptap/serverTipTapExtensions'
@@ -64,8 +63,6 @@ export const createTopLevelPage = async (
   }
   await viewerAccessPromise
   await updatePageAccessTable(pg, pageId, {skipDeleteOld: true})
-    .selectNoFrom(sql`1`.as('t'))
-    .execute()
   analytics.pageCreated(viewer, pageId)
   const data = {page}
   await publishPageNotification(pageId, 'CreatePagePayload', data, subOptions, dataLoader)

--- a/packages/server/utils/tiptap/movePageToNewParent.ts
+++ b/packages/server/utils/tiptap/movePageToNewParent.ts
@@ -1,13 +1,13 @@
 import {GraphQLError} from 'graphql'
 import {sql} from 'kysely'
-import {getNewDataLoader} from '../../../../dataloader/getNewDataLoader'
-import {pageAccessByUserId} from '../../../../dataloader/pageLoaderMakers'
-import getKysely from '../../../../postgres/getKysely'
-import {selectDescendantPages} from '../../../../postgres/select'
-import {updatePageAccessTable} from '../../../../postgres/updatePageAccessTable'
-import {publishPageNotification} from '../../../../utils/publishPageNotification'
-import {removeCanonicalPageLinkFromPage} from '../../../../utils/tiptap/removeCanonicalPageLinkFromPage'
-import {validateParentPage} from '../../../../utils/tiptap/validateParentPage'
+import {getNewDataLoader} from '../../dataloader/getNewDataLoader'
+import {pageAccessByUserIdBatchFn} from '../../dataloader/pageLoaderMakers'
+import getKysely from '../../postgres/getKysely'
+import {selectDescendantPages} from '../../postgres/select'
+import {updatePageAccessTable} from '../../postgres/updatePageAccessTable'
+import {publishPageNotification} from '../publishPageNotification'
+import {removeCanonicalPageLinkFromPage} from './removeCanonicalPageLinkFromPage'
+import {validateParentPage} from './validateParentPage'
 
 export const movePageToNewParent = async (
   viewerId: string,
@@ -15,7 +15,7 @@ export const movePageToNewParent = async (
   parentPageId: number
 ) => {
   const pg = getKysely()
-  const viewerAccess = await pageAccessByUserId({} as any).load({pageId, userId: viewerId})
+  const [viewerAccess] = await pageAccessByUserIdBatchFn([{pageId, userId: viewerId}])
   if (viewerAccess !== 'owner') {
     throw new GraphQLError(`Viewer must own the Page in order to move it to a new parent`)
   }


### PR DESCRIPTION
# Description

fixes #12038

column order is important, even when using aliases 😞 

to reproduce:
- User 1 is editor of parent page, User 2 is owner of parent page
- User 1 is editor of page 2, User 2 is owner of page 2
- User 1 drags page 2 to be a child of parent page, it works & User 1 is now owner of that page. 

uncovered 2 more bugs from this:
- you should only be able to change a page's parent if you OWN the child document. if you 're just an editor, you cannot move it to a parent that you have full access to, thus giving you full access. If you are an editor, you can only move pages around in the same parent.
- there should always be an owner of a document. decreasing your role from owner to editor if no one else exists should be disallowed