### PR TITLE
fix: 12099 selectable tasks on pages

### DIFF
--- a/packages/client/hooks/useTipTapEditorContent.ts
+++ b/packages/client/hooks/useTipTapEditorContent.ts
@@ -8,10 +8,14 @@ export const useTipTapEditorContent = (content: string) => {
   // When receiving new content, it's important to make sure it's different from the current value
   // Unnecessary re-renders mess up things like the coordinates of the link menu
   const contentJSON = useMemo(() => {
-    const newContentJSON = JSON.parse(content) as JSONContent
-    const oldContentJSON = editorRef.current ? editorRef.current.getJSON() : {}
-    if (!isEqualWhenSerialized(newContentJSON, oldContentJSON)) {
-      contentJSONRef.current = newContentJSON
+    try {
+      const newContentJSON = JSON.parse(content) as JSONContent
+      const oldContentJSON = editorRef.current ? editorRef.current.getJSON() : {}
+      if (!isEqualWhenSerialized(newContentJSON, oldContentJSON)) {
+        contentJSONRef.current = newContentJSON
+      }
+    } catch (e) {
+      console.error(e, content)
     }
     return contentJSONRef.current!
   }, [content])

--- a/packages/client/tiptap/extensions/insightsBlock/TaskBlockView.tsx
+++ b/packages/client/tiptap/extensions/insightsBlock/TaskBlockView.tsx
@@ -17,8 +17,15 @@ export const TaskBlockView = (props: NodeViewProps) => {
           status={(status as TaskStatusEnum) || 'active'}
           className='mb-1'
         />
-        {editor && <EditorContent editor={editor} />}
-        <div className='pt-2'>
+        {editor && (
+          <EditorContent
+            editor={editor}
+            onMouseDown={(e) => {
+              e.stopPropagation()
+            }}
+          />
+        )}
+        <div className='select-none pt-2'>
           <div className='flex'>
             <Avatar className='size-6' picture={avatar} />
             <div className='break-words pl-2 font-semibold text-slate-600 text-xs leading-6'>

--- a/packages/server/graphql/mutations/helpers/summaryPage/getTaskBlocks.ts
+++ b/packages/server/graphql/mutations/helpers/summaryPage/getTaskBlocks.ts
@@ -25,12 +25,17 @@ export const getTaskBlocks = async (meetingId: string, dataLoader: DataLoaderIns
   const validTaskBlocks = taskBlocks.filter(isValid)
   const taskCount = validTaskBlocks.length
   if (taskCount === 0) return []
+  const spacedBlocks = validTaskBlocks.flatMap((taskBlock, idx) => {
+    if (idx === 0) return [taskBlock]
+    return [{type: 'paragraph'}, taskBlock]
+  })
+
   return [
     {
       type: 'heading',
       attrs: {level: 2},
       content: [{type: 'text', text: `${taskCount} ${plural(taskCount, 'Task')}`}]
     },
-    ...validTaskBlocks
+    ...spacedBlocks
   ]
 }


### PR DESCRIPTION
# Description

fixes #12099

previously, mouse down events on TaskBlocks would be on a paragraph node, which is draggable. 

in the future, we may make all nodes undraggable & just rely on the global drag handler. 

in fact, we may want to do this now...