### PR TITLE
chore: proxy websockets in local dev

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -160,14 +160,7 @@
       "attributePosition": "auto",
       "bracketSpacing": false
     },
-    "globals": [
-      "__PRODUCTION__",
-      "__APP_VERSION__",
-      "__SOCKET_PORT__",
-      "__HOCUS_POCUS_PORT__",
-      "__webpack_public_path__",
-      "__COMMIT_HASH__"
-    ]
+    "globals": ["__PRODUCTION__", "__APP_VERSION__", "__webpack_public_path__", "__COMMIT_HASH__"]
   },
   "html": {"formatter": {"selfCloseVoidElements": "always"}},
   "overrides": [

--- a/packages/client/tiptap/providerManager.ts
+++ b/packages/client/tiptap/providerManager.ts
@@ -14,9 +14,7 @@ class ProviderManager {
   getSocket() {
     if (!this.socket) {
       const wsProtocol = window.location.protocol.replace('http', 'ws')
-      const host = __PRODUCTION__
-        ? `${window.location.host}/hocuspocus`
-        : `${window.location.hostname}:${__HOCUS_POCUS_PORT__}`
+      const host = `${window.location.host}/hocuspocus`
       const baseUrl = `${wsProtocol}//${host}?token=${this.authToken || ''}`
       this.socket = new HocuspocusProviderWebsocket({
         url: baseUrl

--- a/packages/client/types/modules.d.ts
+++ b/packages/client/types/modules.d.ts
@@ -22,8 +22,6 @@ declare module 'react/jsx-runtime'
 declare let __webpack_public_path__: string
 declare const __PRODUCTION__: string
 declare const __APP_VERSION__: string
-declare const __SOCKET_PORT__: string
-declare const __HOCUS_POCUS_PORT__: string
 interface Window {
   __ACTION__: {
     atlassian: string

--- a/packages/client/utils/createWSClient.ts
+++ b/packages/client/utils/createWSClient.ts
@@ -52,9 +52,7 @@ export const onReconnect = (atmosphere: Atmosphere) => {
 export function createWSClient(atmosphere: Atmosphere) {
   return new Promise<Client>((resolve, reject) => {
     const wsProtocol = window.location.protocol.replace('http', 'ws')
-    const host = __PRODUCTION__
-      ? window.location.host
-      : `${window.location.hostname}:${__SOCKET_PORT__}`
+    const host = window.location.host
     const url = `${wsProtocol}//${host}`
     let hasConnected = false
     let abruptlyClosed = false

--- a/packages/mattermost-plugin/types/modules.d.ts
+++ b/packages/mattermost-plugin/types/modules.d.ts
@@ -4,8 +4,6 @@ declare module 'string-score'
 declare let __webpack_public_path__: string
 declare const __PRODUCTION__: string
 declare const __APP_VERSION__: string
-declare const __SOCKET_PORT__: string
-declare const __HOCUS_POCUS_PORT__: string
 interface Window {
   // the mattermost plugin does not have window.__ACTION__ set, so let's make this optional to enforce proper checks in all included client code
   __ACTION__?: {

--- a/packages/server/types/modules.d.ts
+++ b/packages/server/types/modules.d.ts
@@ -26,8 +26,6 @@ declare module 'md-to-adf'
 
 declare const __APP_VERSION__: string
 declare const __PRODUCTION__: boolean
-declare const __SOCKET_PORT__: string
-declare const __HOCUS_POCUS_PORT__: string
 declare const __webpack_public_path__: string
 
 interface Window {

--- a/scripts/webpack/dev.client.config.js
+++ b/scripts/webpack/dev.client.config.js
@@ -11,7 +11,7 @@ const {makeOAuth2Redirect} = require('../../packages/server/utils/makeOAuth2Redi
 const PROJECT_ROOT = getProjectRoot()
 const CLIENT_ROOT = path.join(PROJECT_ROOT, 'packages', 'client')
 const STATIC_ROOT = path.join(PROJECT_ROOT, 'static')
-const {PORT, SOCKET_PORT} = process.env
+const {PORT, SOCKET_PORT, HOCUS_POCUS_PORT} = process.env
 
 const USE_REFRESH = false
 module.exports = {
@@ -64,6 +64,16 @@ module.exports = {
         context: '/components',
         pathRewrite: {'^/components': ''},
         target: `http://localhost:3002`
+      },
+      {
+        context: (path) => path === '/',
+        target: `http://localhost:${SOCKET_PORT}`,
+        ws: true
+      },
+      {
+        context: '/hocuspocus',
+        target: `http://localhost:${HOCUS_POCUS_PORT}`,
+        ws: true
       }
     ]
   },
@@ -151,9 +161,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __CLIENT__: true,
       __PRODUCTION__: false,
-      __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
-      __SOCKET_PORT__: JSON.stringify(process.env.SOCKET_PORT),
-      __HOCUS_POCUS_PORT__: JSON.stringify(process.env.HOCUS_POCUS_PORT)
+      __APP_VERSION__: JSON.stringify(process.env.npm_package_version)
       // Environment variables go in the __ACTION__ object above, not here
       // This build may be deployed to many different environments
     })


### PR DESCRIPTION

# Description

Relates to #8364
Instead of having the graphql and hocuspocus websockets on different ports in dev, proxy those. This is closer to production. It is necessary because Safari does not treat localhost special with regards to cookies, meaning localhost:3000 and localhost:3001 appear as 2 different domains to it.

This came up during work on moving the auth token to a cookie. It would block local development on Safari otherwise.

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
