### PR TITLE
feat: use uWS for hocus pocus

### DIFF
--- a/packages/client/tiptap/providerManager.ts
+++ b/packages/client/tiptap/providerManager.ts
@@ -16,8 +16,8 @@ class ProviderManager {
     if (!this.socket) {
       const wsProtocol = window.location.protocol.replace('http', 'ws')
       const host = __PRODUCTION__
-        ? `${window.location.host}/hocuspocus`
-        : `${window.location.hostname}:${__HOCUS_POCUS_PORT__}`
+        ? `${window.location.host}/yjs`
+        : `${window.location.hostname}:${__SOCKET_PORT__}/yjs`
       const baseUrl = `${wsProtocol}//${host}?token=${this.authToken || ''}`
       this.socket = new HocuspocusProviderWebsocket({
         url: baseUrl

--- a/packages/server/HocusPocusWebSocket.ts
+++ b/packages/server/HocusPocusWebSocket.ts
@@ -1,0 +1,26 @@
+import type {WebSocket} from 'uWebSockets.js'
+import {EventEmitter} from 'tseep'
+
+// This is a mock WebSocket that fills as much of the standard WebSocket contract that HocusPocus requires
+export class HocusPocusWebSocket extends EventEmitter {
+  private ws: WebSocket<any>
+  readyState = 1
+  remoteAddress: string
+  constructor(ws: WebSocket<any>, ip: string) {
+    super()
+    this.ws = ws
+    this.remoteAddress = ip
+    this.on('close', () => {
+      this.readyState = 3
+    })
+  }
+  close(code?: number, reason?: string) {
+    this.ws.end(code, reason)
+  }
+  ping() {
+    this.ws.ping()
+  }
+  send(message: Uint8Array) {
+    this.ws.send(message, true)
+  }
+}

--- a/packages/server/graphql/mutations/helpers/summaryPage/streamSummaryBlocksToPage.ts
+++ b/packages/server/graphql/mutations/helpers/summaryPage/streamSummaryBlocksToPage.ts
@@ -3,7 +3,7 @@ import type {GraphQLResolveInfo} from 'graphql'
 import {sleep} from 'openai/core.mjs'
 import {AbstractType, XmlElement} from 'yjs'
 import {serverTipTapExtensions} from '../../../../../client/shared/tiptap/serverTipTapExtensions'
-import {server} from '../../../../hocusPocus'
+import {hocuspocus} from '../../../../hocusPocus'
 import {CipherId} from '../../../../utils/CipherId'
 import type {InternalContext} from '../../../graphql'
 import {generateMeetingSummaryPage} from './generateMeetingSummaryPage'
@@ -31,7 +31,7 @@ export const streamSummaryBlocksToPage = async (
 ) => {
   const contentGenerator = await generateMeetingSummaryPage(meetingId, context, info)
   const name = CipherId.toClient(pageId, 'page')
-  const conn = await server.hocuspocus.openDirectConnection(name, {})
+  const conn = await hocuspocus.openDirectConnection(name, {})
   await conn.transact((doc) => {
     const frag = doc.getXmlFragment('default')
     const el = new XmlElement()

--- a/packages/server/hocusPocusHandler.ts
+++ b/packages/server/hocusPocusHandler.ts
@@ -1,0 +1,58 @@
+import './hocusPocus'
+import type {IncomingHttpHeaders} from 'node:http2'
+import type {UpgradeData} from 'graphql-ws/use/uWebSockets'
+import {hocuspocus} from './hocusPocus'
+import './hocusPocus'
+import type {WebSocketBehavior} from 'uWebSockets.js'
+import {HocusPocusWebSocket} from './HocusPocusWebSocket'
+
+type HocusPocusRequest = UpgradeData['persistedRequest'] & {socket: HocusPocusWebSocket}
+type HocusPocusSocketData = {
+  ip: string
+  persistedRequest: HocusPocusRequest
+}
+export const hocusPocusHandler: WebSocketBehavior<HocusPocusSocketData> = {
+  upgrade(res, req, context) {
+    const headers: IncomingHttpHeaders = {}
+    req.forEach((key, value) => {
+      headers[key] = value
+    })
+    const ip =
+      Buffer.from(res.getProxiedRemoteAddressAsText()).toString() ||
+      Buffer.from(res.getRemoteAddressAsText()).toString()
+
+    res.upgrade<HocusPocusSocketData>(
+      {
+        ip,
+        persistedRequest: {
+          method: req.getMethod(),
+          url: req.getUrl(),
+          query: req.getQuery(),
+          headers,
+          socket: undefined as any
+        }
+      },
+      req.getHeader('sec-websocket-key'),
+      new Uint8Array(),
+      req.getHeader('sec-websocket-extensions'),
+      context
+    )
+  },
+  open(ws) {
+    const userData = ws.getUserData()
+    const hocusPocusWebSocket = new HocusPocusWebSocket(ws, userData.ip)
+    userData.persistedRequest.socket = hocusPocusWebSocket
+    hocuspocus.handleConnection(hocusPocusWebSocket as any, userData.persistedRequest as any, {})
+  },
+  pong(ws, message) {
+    ws.getUserData().persistedRequest.socket.emit('pong', message)
+  },
+  message(ws, message) {
+    // hocuspocus message handler is (needlessly) async and uws detaches the arraybuffer
+    // before await gets called so we have to clone the entire buffer first
+    ws.getUserData().persistedRequest.socket.emit('message', message.slice())
+  },
+  close(ws, code, message) {
+    ws.getUserData().persistedRequest.socket.emit('close', code, message)
+  }
+}

--- a/packages/server/server.ts
+++ b/packages/server/server.ts
@@ -1,3 +1,4 @@
+import './hocusPocus'
 import uws from 'uWebSockets.js'
 import stripeWebhookHandler from './billing/stripeWebhookHandler'
 import {stopChronos} from './chronos'
@@ -7,6 +8,7 @@ import {setIsShuttingDown} from './getIsShuttingDown'
 import ICSHandler from './ICSHandler'
 import PWAHandler from './PWAHandler'
 import './hocusPocus'
+import {hocusPocusHandler} from './hocusPocusHandler'
 import mattermostWebhookHandler from './integrations/mattermost/mattermostWebhookHandler'
 import jiraImagesHandler from './jiraImagesHandler'
 import listenHandler from './listenHandler'
@@ -71,6 +73,7 @@ const app = uws
     return yoga(res, req, {authToken, ip})
   })
   .post('/saml/:domain', SAMLHandler)
+  .ws('/yjs', hocusPocusHandler)
   .ws('/*', wsHandler)
 
 if (ENABLE_STATIC_FILE_HANDLER) {

--- a/packages/server/utils/tiptap/hocusPocusHub.ts
+++ b/packages/server/utils/tiptap/hocusPocusHub.ts
@@ -1,5 +1,5 @@
 import type {Document} from '@hocuspocus/server'
-import {server} from '../../hocusPocus'
+import {hocuspocus} from '../../hocusPocus'
 import getKysely from '../../postgres/getKysely'
 import {CipherId} from '../CipherId'
 import {updateYDocNodes} from './updateYDocNodes'
@@ -17,7 +17,7 @@ export const withBacklinks = async (
   await Promise.all(
     backLinks.map(async ({fromPageId}) => {
       const pageKey = CipherId.toClient(fromPageId, 'page')
-      const docConnection = await server.hocuspocus.openDirectConnection(pageKey, {})
+      const docConnection = await hocuspocus.openDirectConnection(pageKey, {})
       await docConnection.transact(fn)
       await docConnection.disconnect()
     })

--- a/packages/server/utils/tiptap/withDoc.ts
+++ b/packages/server/utils/tiptap/withDoc.ts
@@ -1,10 +1,10 @@
 import type {Document} from '@hocuspocus/server'
-import {server} from '../../hocusPocus'
+import {hocuspocus} from '../../hocusPocus'
 import {CipherId} from '../CipherId'
 
 export const withDoc = async (pageId: number, fn: (doc: Document) => void | Promise<void>) => {
   const name = CipherId.toClient(pageId, 'page')
-  const conn = await server.hocuspocus.openDirectConnection(name, {})
+  const conn = await hocuspocus.openDirectConnection(name, {})
   await conn.transact(fn)
   await conn.disconnect()
 }


### PR DESCRIPTION
# Description

handle hocus pocus with uWS. no more 2 servers.
Any websocket traffic going to /yjs will be handled by the hocus pocus handler.