### PR TITLE
chore(gh-actions): docker-external runs only with tags and do not need to set up Docker

### DIFF
--- a/.github/workflows/docker-external.yml
+++ b/.github/workflows/docker-external.yml
@@ -1,11 +1,6 @@
 name: Docker publish externally
 
-on:
-  workflow_dispatch:
-    inputs:
-      version_number:
-        description: "Version number of the Parabol application image to process"
-        required: true
+on: workflow_dispatch
 
 jobs:
   pull-and-upload:
@@ -14,8 +9,13 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+      - name: Verify if running from a Tag
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "This workflow is intended to run only from a Git Tag (e.g., v1.0.0)."
+          echo "Current reference is: ${{ github.ref }}"
+          # Force fail the job
+          exit 1
 
       - id: "auth"
         name: "Authenticate to Google Cloud"
@@ -25,20 +25,11 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WI_PROVIDER_NAME }}
           service_account: ${{ secrets.GCP_SA_EMAIL }}
 
-      - uses: "docker/login-action@v3"
-        with:
-          registry: ${{ secrets.GCP_DOCKER_REGISTRY }}
-          username: "oauth2accesstoken"
-          password: "${{ steps.auth.outputs.access_token }}"
-
-      - name: Pull Docker image from GCP
-        run: docker pull ${{ secrets.GCP_AR_PARABOL}}:v${{ github.event.inputs.version_number }}
-
       - name: Push Docker image to the external repository
         run: |-
           gcloud container images add-tag -q \
-          ${{ secrets.GCP_AR_PARABOL }}:v${{ github.event.inputs.version_number }}  \
-          ${{ secrets.GCP_AR_PARABOL_EXTERNAL }}:v${{ github.event.inputs.version_number }}
+          ${{ secrets.GCP_AR_PARABOL }}:${{ github.ref_name	 }}  \
+          ${{ secrets.GCP_AR_PARABOL_EXTERNAL }}:${{ github.ref_name	 }}
 
       - name: Report Status
         if: failure()


### PR DESCRIPTION
# Description

Partially fixes #12137 