### PR TITLE
fix: allow meeting queries with 0 own teams

### DIFF
--- a/packages/server/graphql/public/types/User.ts
+++ b/packages/server/graphql/public/types/User.ts
@@ -180,9 +180,15 @@ const User: ReqResolvers<'User'> = {
       const allTeamIds = teamMembers.map(({teamId}) => teamId)
       validTeamIds = teamIds.filter((teamId) => allTeamIds.includes(teamId))
     }
-    if (validTeamIds.length < 1)
-      throw new Error('Must provide at least 1 teamId the viewer is a member of')
-    if (meetingTypes.length < 1) throw new Error('Must provide at least 1 meetingType')
+    if (validTeamIds.length < 1) {
+      return {
+        edges: [],
+        pageInfo: {hasNextPage: false, hasPreviousPage: false, startCursor: null, endCursor: null}
+      }
+    }
+    if (meetingTypes.length < 1) {
+      throw new GraphQLError('Must provide at least 1 meetingType')
+    }
 
     const nodes = await selectNewMeetings()
       .where('teamId', 'in', validTeamIds)


### PR DESCRIPTION


# Description

Fixes #12158 
Normally this would be a user input error, but it can happen naturally in insights when a page is shared with members outside of a team. We could either manually filter an check on the client, or simply allow the meeting query with 0 teams and just return an empty result. The latter seems cleaner and still correct to me.

## Testing scenarios

* share a page with Peter
* add insights
* in edit mode add only teams Peter is not a member of
* Peter will see the error on that page

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
