### PR TITLE
fix: reload page to work around Service Worker context closed

### DIFF
--- a/template.html
+++ b/template.html
@@ -38,20 +38,38 @@
         return tag
       }).join('')
     %>
-    <!-- Safari sometimes kills the service worker before it can load the initial script -->
+    <!-- Safari sometimes kills the current service worker before it can load the initial script to load the updated one -->
     <script>
       if ('serviceWorker' in navigator) {
-        // for debugging, maybe Safari closes the SW because there is an update available?
+        let loadError = false
+        let serviceWorkerUpdateFound = false
+
+        function unregisterSW(event) {
+          if (!loadError || !serviceWorkerUpdateFound) return
+          location.reload()
+        }
+
+        // because the script tag is `defer` we need to attach the handler via script
+        document.querySelectorAll('script').forEach((script) => {
+          if (script.src) {
+            script.onerror = () => {
+              loadError = true
+              unregisterSW()
+            }
+            script.onload = () => {
+              loadError = false
+              script.onerror = null
+              script.onload = null
+            }
+          }
+        })
+
+        // context closed event happens because the old service worker is killed because a new one is found
         navigator.serviceWorker.getRegistration().then((reg) => {
           if (!reg) return
           reg.addEventListener('updatefound', () => {
-            console.log('New service worker found')
+            serviceWorkerUpdateFound = true
           })
-          if (reg.active) {
-            reg.active.addEventListener('error', (e) => {
-              console.log('Service worker error', e)
-            })
-          }
         })
       }
     </script>


### PR DESCRIPTION
The error happens when a service worker update is detected, but the site is not loaded. When Safari then tries to fetch the main <script> it fails, because it's intercepted by the current service worker. Because the load of the script fails, the code for registering the new one is missing, thus the whole load fails.

# Description

Fixes/Partially Fixes #[issue number]
[Please include a summary of the changes and the related issue]

## Demo

[If possible, please include a screenshot or gif/video, it'll make it easier for reviewers to understand the scope of the changes and how the change is supposed to work. If you're introducing something new or changing the existing patterns, please share a Loom and explain what decisions you've made and under what circumstances]

## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Scenario A
  - Step 1
  - Step 2...

- [ ] Scenario B
  - Step 1
  - Step 2....

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
