### PR TITLE
feat: Mixed nested list types in Pages

### DIFF
--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -247,7 +247,7 @@ export const useTipTapPageEditor = (
           }
         }),
         InsightsBlock,
-        AutoJoiner,
+        AutoJoiner.configure({elementsToJoin: ['taskList']}),
         Markdown,
         PageLinkPicker.configure({
           atmosphere

--- a/packages/client/shared/tiptap/TipTapSerializedContent.d.ts
+++ b/packages/client/shared/tiptap/TipTapSerializedContent.d.ts
@@ -62,12 +62,20 @@ interface TipTapOrderedListNode {
     start: number
     type: null
   }
-  content: [TipTapListItemNode]
+  content: TipTapListItemNode[]
 }
+
+// A list item (or nested task item) may hold a paragraph plus nested lists of
+// any type — mixed nesting is a valid document structure.
+type TipTapListItemChild =
+  | TipTapParagraphNode
+  | TipTapBulletListNode
+  | TipTapOrderedListNode
+  | TipTapTaskListNode
 
 interface TipTapListItemNode {
   type: 'listItem'
-  content: TipTapParagraphNode[]
+  content: TipTapListItemChild[]
 }
 
 interface TipTapTaskListNode {
@@ -80,7 +88,7 @@ interface TipTapTaskItemNode {
   attrs: {
     checked: boolean
   }
-  content: TipTapParagraphNode[]
+  content: TipTapListItemChild[]
 }
 interface TipTapTaskBlockNode {
   type: 'taskBlock'

--- a/packages/client/shared/tiptap/__tests__/convertTipTapToADF.test.ts
+++ b/packages/client/shared/tiptap/__tests__/convertTipTapToADF.test.ts
@@ -1,0 +1,103 @@
+import convertTiptapToADF, {type AdfNode} from '../convertTipTapToADF'
+
+const para = (text: string) => ({type: 'paragraph', content: [{type: 'text', text}]})
+const title = {type: 'heading', attrs: {level: 1}, content: [{type: 'text', text: 'T'}]}
+const docOf = (...body: unknown[]) => ({type: 'doc', content: [title, ...body]}) as never
+
+const find = (node: AdfNode, type: string): AdfNode | undefined => {
+  if (node.type === type) return node
+  for (const c of node.content ?? []) {
+    const hit = find(c, type)
+    if (hit) return hit
+  }
+  return undefined
+}
+
+test('nested taskList inside an ordered listItem degrades to a prefixed bulletList', () => {
+  const adf = convertTiptapToADF(
+    docOf({
+      type: 'orderedList',
+      attrs: {start: 1},
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            para('First'),
+            {
+              type: 'taskList',
+              content: [{type: 'taskItem', attrs: {checked: false}, content: [para('This is one')]}]
+            }
+          ]
+        },
+        {type: 'listItem', content: [para('Second')]}
+      ]
+    })
+  )
+  const ol = find(adf, 'orderedList')!
+  const li0 = ol.content![0]!
+  expect(li0.content![0]!.type).toBe('paragraph')
+  const nested = li0.content![1]!
+  expect(nested.type).toBe('bulletList')
+  const firstPara = nested.content![0]!.content![0]!
+  expect(firstPara.content![0]).toEqual({type: 'text', text: '☐ '})
+  expect(firstPara.content![1]).toEqual({type: 'text', text: 'This is one'})
+})
+
+test('checked task renders ☑ prefix', () => {
+  const adf = convertTiptapToADF(
+    docOf({
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            para('x'),
+            {
+              type: 'taskList',
+              content: [{type: 'taskItem', attrs: {checked: true}, content: [para('done')]}]
+            }
+          ]
+        }
+      ]
+    })
+  )
+  const nestedBullet = find(adf, 'bulletList')!.content![0]!.content![1]!
+  const firstPara = nestedBullet.content![0]!.content![0]!
+  expect(firstPara.content![0]).toEqual({type: 'text', text: '☑ '})
+})
+
+test('nested orderedList inside a listItem recurses (ADF-legal)', () => {
+  const adf = convertTiptapToADF(
+    docOf({
+      type: 'orderedList',
+      attrs: {start: 1},
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            para('First'),
+            {
+              type: 'orderedList',
+              attrs: {start: 1},
+              content: [{type: 'listItem', content: [para('sub')]}]
+            }
+          ]
+        }
+      ]
+    })
+  )
+  const outer = find(adf, 'orderedList')!
+  expect(outer.content![0]!.content![1]!.type).toBe('orderedList')
+})
+
+test('flat top-level taskList stays a native ADF taskList', () => {
+  const adf = convertTiptapToADF(
+    docOf({
+      type: 'taskList',
+      content: [{type: 'taskItem', attrs: {checked: false}, content: [para('todo')]}]
+    })
+  )
+  const tl = find(adf, 'taskList')
+  expect(tl).toBeDefined()
+  expect(tl!.content![0]!.type).toBe('taskItem')
+})

--- a/packages/client/shared/tiptap/convertTipTapToADF.ts
+++ b/packages/client/shared/tiptap/convertTipTapToADF.ts
@@ -17,6 +17,7 @@ import type {
   TipTapTableHeaderNode,
   TipTapTableNode,
   TipTapTableRowNode,
+  TipTapTaskListNode,
   TipTapTextNode,
   TiptapInsightsBlock
 } from './TipTapSerializedContent.d'
@@ -107,6 +108,63 @@ function convertInlineContent(nodes?: TipTapTextNode[]): AdfNode[] {
 }
 
 // ---------------------------------------------------------------------------
+// List content (recursive — supports mixed nesting)
+// ---------------------------------------------------------------------------
+
+const CHECKBOX_PREFIX = (checked: boolean) => (checked ? '☑ ' : '☐ ')
+
+// Convert the children of a bullet/ordered listItem into ADF-legal content.
+// Recurses into nested lists; degrades nested taskLists (illegal in an ADF
+// listItem) to a bulletList. When `checkboxState` is set, the first paragraph
+// is prefixed with a ☑/☐ glyph (used when a taskItem is rendered as a listItem).
+function convertListItemChildren(
+  children: TipTapContentNode[],
+  checkboxState?: boolean
+): AdfNode[] {
+  return children.flatMap((child, i) => {
+    if (child.type === 'paragraph') {
+      const content = convertInlineContent(child.content)
+      if (i === 0 && checkboxState !== undefined) {
+        content.unshift({type: 'text', text: CHECKBOX_PREFIX(checkboxState)})
+      }
+      return [{type: 'paragraph', ...(content.length > 0 ? {content} : {})}]
+    }
+    if (child.type === 'taskList') return [convertTaskList(child, true)]
+    const result = convertNode(child)
+    if (!result) return []
+    return Array.isArray(result) ? result : [result]
+  })
+}
+
+// Native ADF taskList when every item is inline-only; otherwise degrade to a
+// bulletList with ☑/☐ prefixes (ADF taskItems can't hold blocks, and ADF
+// listItems can't hold taskLists).
+function convertTaskList(node: TipTapTaskListNode, forceBullet: boolean): AdfNode {
+  const needsBullet =
+    forceBullet || node.content.some((item) => item.content.some((c) => c.type !== 'paragraph'))
+  if (needsBullet) {
+    return {
+      type: 'bulletList',
+      content: node.content.map((item) => ({
+        type: 'listItem',
+        content: convertListItemChildren(item.content, !!item.attrs.checked)
+      }))
+    }
+  }
+  return {
+    type: 'taskList',
+    attrs: {localId: crypto.randomUUID()},
+    content: node.content.map((item) => ({
+      type: 'taskItem',
+      attrs: {state: item.attrs.checked ? 'DONE' : 'TODO', localId: crypto.randomUUID()},
+      content: item.content.flatMap((p) =>
+        p.type === 'paragraph' ? convertInlineContent(p.content) : []
+      )
+    }))
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Block node conversion
 // ---------------------------------------------------------------------------
 
@@ -136,10 +194,7 @@ function convertNode(node: TipTapContentNode): AdfNode | AdfNode[] | null {
         type: 'bulletList',
         content: node.content.map((item) => ({
           type: 'listItem',
-          content: item.content.map((p) => ({
-            type: 'paragraph',
-            content: convertInlineContent(p.content)
-          }))
+          content: convertListItemChildren(item.content)
         }))
       }
 
@@ -150,25 +205,13 @@ function convertNode(node: TipTapContentNode): AdfNode | AdfNode[] | null {
         attrs: {order: node.attrs.start ?? 1},
         content: node.content.map((item) => ({
           type: 'listItem',
-          content: item.content.map((p) => ({
-            type: 'paragraph',
-            content: convertInlineContent(p.content)
-          }))
+          content: convertListItemChildren(item.content)
         }))
       }
 
     // -----------------------------------------------------------------------
     case 'taskList':
-      return {
-        type: 'taskList',
-        attrs: {localId: crypto.randomUUID()},
-        content: node.content.map((item) => ({
-          type: 'taskItem',
-          attrs: {state: item.attrs.checked ? 'DONE' : 'TODO', localId: crypto.randomUUID()},
-          // ADF taskItem contains inline nodes directly, not block nodes
-          content: item.content.flatMap((p) => convertInlineContent(p.content))
-        }))
-      }
+      return convertTaskList(node, false)
 
     // -----------------------------------------------------------------------
     case 'codeBlock':

--- a/packages/client/tiptap/extensions/IndentHandler.ts
+++ b/packages/client/tiptap/extensions/IndentHandler.ts
@@ -1,6 +1,34 @@
 import type {Editor} from '@tiptap/core'
 import {Extension} from '@tiptap/core'
 import {TextSelection} from '@tiptap/pm/state'
+import {indentItem, outdentItem} from './listNestingCommands'
+import {isListNode} from './nestListDrop'
+
+const ITEM_TYPES = new Set(['listItem', 'taskItem'])
+
+interface ListContext {
+  itemType: 'listItem' | 'taskItem'
+  itemPos: number
+}
+
+// Resolve, from the current selection, the innermost list item and its position.
+// Innermost matters: in a mixed nest both isActive checks are true, but only the
+// deepest item should drive Tab/Shift-Tab.
+const getListContext = (editor: Editor): ListContext | null => {
+  const {$from} = editor.state.selection
+  for (let d = $from.depth; d >= 1; d--) {
+    const node = $from.node(d)
+    if (ITEM_TYPES.has(node.type.name)) {
+      const listNode = $from.node(d - 1)
+      if (!isListNode(listNode)) return null
+      return {
+        itemType: node.type.name === 'taskItem' ? 'taskItem' : 'listItem',
+        itemPos: $from.before(d)
+      }
+    }
+  }
+  return null
+}
 
 // See also: https://github.com/ueberdosis/tiptap/issues/457#issuecomment-2285456957
 // TipTap has troble receiving the Tab input in certain contexts
@@ -111,12 +139,16 @@ export const IndentHandler = Extension.create({
   addKeyboardShortcuts() {
     return {
       Tab: ({editor}) => {
-        if (editor.isActive('listItem')) {
-          editor.chain().sinkListItem('listItem').run()
-          return true
-        }
-        if (editor.isActive('taskItem')) {
-          editor.chain().sinkListItem('taskItem').run()
+        const ctx = getListContext(editor)
+        if (ctx) {
+          // Adopt the previous item's sublist type if one exists…
+          const tr = indentItem(editor.state, ctx.itemPos)
+          if (tr) {
+            editor.view.dispatch(tr)
+            return true
+          }
+          // …otherwise stock sink (creates a same-type sublist)
+          editor.chain().sinkListItem(ctx.itemType).run()
           return true
         }
         if (editor.isActive('detailsSummary')) {
@@ -125,12 +157,16 @@ export const IndentHandler = Extension.create({
         return true
       },
       'Shift-Tab': ({editor}) => {
-        if (editor.isActive('listItem')) {
-          editor.chain().liftListItem('listItem').run()
-          return true
-        }
-        if (editor.isActive('taskItem')) {
-          editor.chain().liftListItem('taskItem').run()
+        const ctx = getListContext(editor)
+        if (ctx) {
+          // Lift into the ancestor list, adopting its type…
+          const tr = outdentItem(editor.state, ctx.itemPos)
+          if (tr) {
+            editor.view.dispatch(tr)
+            return true
+          }
+          // …otherwise stock lift (top-level list / same-type)
+          editor.chain().liftListItem(ctx.itemType).run()
           return true
         }
         if (editor.isActive('detailsSummary')) {

--- a/packages/client/tiptap/extensions/PageDragHandle.ts
+++ b/packages/client/tiptap/extensions/PageDragHandle.ts
@@ -1,7 +1,7 @@
 import {type Editor, Extension} from '@tiptap/core'
 import DragHandle from '@tiptap/extension-drag-handle'
 import type {Node} from '@tiptap/pm/model'
-import {NodeSelection} from '@tiptap/pm/state'
+import {NodeSelection, Plugin, PluginKey} from '@tiptap/pm/state'
 import {isNodeSelection, ReactRenderer} from '@tiptap/react'
 import graphql from 'babel-plugin-relay/macro'
 import {commitLocalUpdate} from 'relay-runtime'
@@ -10,6 +10,10 @@ import type Atmosphere from '../../Atmosphere'
 import type {PageLinkBlockAttrs} from '../../shared/tiptap/extensions/PageLinkBlockBase'
 import {GQLID} from '../../utils/GQLID'
 import DragHandleMenu from './DragHandleMenu'
+import {findNestDropTarget, isListNode, moveListIntoItem} from './nestListDrop'
+
+// px the cursor must be indented past a list item's left edge to nest into it
+const NEST_INDENT_PX = 24
 
 const queryNode = graphql`
   query PageDragHandleQuery($pageId: ID!) {
@@ -47,7 +51,9 @@ export const PageDragHandle = Extension.create<Options>({
   addStorage() {
     return {
       dragHandleElement: null as HTMLDivElement | null,
-      closeMenu: null as (() => void) | null
+      closeMenu: null as (() => void) | null,
+      // position of the list node being dragged, or -1 when the drag isn't a list
+      draggedListPos: -1 as number
     }
   },
 
@@ -95,6 +101,81 @@ export const PageDragHandle = Extension.create<Options>({
     }
   },
 
+  addProseMirrorPlugins() {
+    const storage = this.storage
+    let dropIndicator: HTMLDivElement | null = null
+    const getIndicator = () => {
+      if (dropIndicator) return dropIndicator
+      const el = document.createElement('div')
+      el.className = 'pointer-events-none fixed z-50 h-0.5 rounded-full bg-accent'
+      el.style.display = 'none'
+      document.body.appendChild(el)
+      dropIndicator = el
+      return el
+    }
+    const hideIndicator = () => {
+      if (dropIndicator) dropIndicator.style.display = 'none'
+    }
+    return [
+      new Plugin({
+        key: new PluginKey('pageListNestDrop'),
+        props: {
+          handleDrop: (view, event, _slice, moved) => {
+            if (!moved) return false
+            const sourcePos = storage.draggedListPos
+            if (sourcePos < 0) return false
+            const sourceNode = view.state.doc.nodeAt(sourcePos)
+            if (!sourceNode || !isListNode(sourceNode)) return false
+            const target = findNestDropTarget(view, event, NEST_INDENT_PX)
+            if (!target) return false // fall back to default (sibling) placement
+            // Never nest a list into its own descendant
+            if (
+              target.targetItemPos > sourcePos &&
+              target.targetItemPos < sourcePos + sourceNode.nodeSize
+            ) {
+              return false
+            }
+            const tr = moveListIntoItem(view.state, sourcePos, target.targetItemPos)
+            view.dispatch(tr)
+            hideIndicator()
+            event.preventDefault()
+            return true
+          },
+          handleDOMEvents: {
+            dragover: (view, event) => {
+              const indicator = getIndicator()
+              const sourcePos = storage.draggedListPos
+              if (sourcePos < 0) {
+                indicator.style.display = 'none'
+                return false
+              }
+              const target = findNestDropTarget(view, event, NEST_INDENT_PX)
+              const dom = target ? view.nodeDOM(target.targetItemPos) : null
+              if (!target || !(dom instanceof HTMLElement)) {
+                indicator.style.display = 'none'
+                return false
+              }
+              const rect = dom.getBoundingClientRect()
+              indicator.style.display = 'block'
+              indicator.style.left = `${rect.left + NEST_INDENT_PX}px`
+              indicator.style.top = `${rect.bottom}px`
+              indicator.style.width = `${Math.max(rect.width - NEST_INDENT_PX, 0)}px`
+              return false
+            },
+            drop: () => {
+              hideIndicator()
+              return false
+            },
+            dragend: () => {
+              hideIndicator()
+              return false
+            }
+          }
+        }
+      })
+    ]
+  },
+
   addExtensions() {
     const dragHandleElement = document.createElement('div')
     this.storage.dragHandleElement = dragHandleElement
@@ -103,6 +184,7 @@ export const PageDragHandle = Extension.create<Options>({
     let menuRenderer: ReactRenderer<typeof DragHandleMenu> | null = null
     let editorRef: Editor | null = null
     const {atmosphere, pageId} = this.options
+    const storage = this.storage
 
     const closeMenu = () => {
       if (!menuRenderer) return
@@ -174,6 +256,10 @@ export const PageDragHandle = Extension.create<Options>({
       // Tells ProseMirror this is an internal drag-move so drop deletes the source
       view.dragging = {slice, move: true}
 
+      // Record the source list position so handleDrop can relocate it (rather
+      // than let the default sibling placement run) on a nest gesture.
+      storage.draggedListPos = isListNode(dragHandleNode) ? from : -1
+
       const selection = NodeSelection.create(doc, from)
       const {tr} = view.state
       tr.setSelection(selection)
@@ -210,6 +296,7 @@ export const PageDragHandle = Extension.create<Options>({
     })
 
     dragHandleElement.addEventListener('dragend', () => {
+      storage.draggedListPos = -1
       commitLocalUpdate(atmosphere, (store) => {
         store
           .getRoot()

--- a/packages/client/tiptap/extensions/__tests__/listNestingCommands.test.ts
+++ b/packages/client/tiptap/extensions/__tests__/listNestingCommands.test.ts
@@ -1,0 +1,182 @@
+import {getSchema} from '@tiptap/core'
+import {Document} from '@tiptap/extension-document'
+import {TaskItem, TaskList} from '@tiptap/extension-list'
+import type {Node as PMNode} from '@tiptap/pm/model'
+import {EditorState} from '@tiptap/pm/state'
+import StarterKit from '@tiptap/starter-kit'
+import {indentItem, outdentItem} from '../listNestingCommands'
+
+const schema = getSchema([
+  Document,
+  StarterKit.configure({document: false}),
+  TaskList,
+  TaskItem.configure({nested: true})
+])
+
+const para = (text: string) => ({type: 'paragraph', content: [{type: 'text', text}]})
+const stateFrom = (docJSON: unknown) =>
+  EditorState.create({schema, doc: schema.nodeFromJSON(docJSON as never)})
+
+const ITEM = new Set(['listItem', 'taskItem'])
+const itemPosByText = (doc: PMNode, text: string): number => {
+  let pos = -1
+  doc.descendants((node, p) => {
+    if (ITEM.has(node.type.name) && node.textContent.startsWith(text)) pos = p
+    return true
+  })
+  return pos
+}
+
+describe('outdentItem (adopt ancestor list type)', () => {
+  test('nested taskItem becomes an ordered sibling, adopting ordered type', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                para('First'),
+                {
+                  type: 'taskList',
+                  content: [
+                    {type: 'taskItem', attrs: {checked: false}, content: [para('This is one')]}
+                  ]
+                }
+              ]
+            },
+            {type: 'listItem', content: [para('Second')]},
+            {type: 'listItem', content: [para('Third')]}
+          ]
+        }
+      ]
+    })
+    const tr = outdentItem(state, itemPosByText(state.doc, 'This is one'))
+    expect(tr).not.toBeNull()
+    const result = state.apply(tr!)
+    expect(() => result.doc.check()).not.toThrow()
+    const ol = result.doc.child(0)
+    expect(ol.childCount).toBe(4)
+    expect(ol.child(1).type.name).toBe('listItem')
+    expect(ol.child(1).textContent).toBe('This is one')
+    expect(ol.child(2).textContent).toBe('Second')
+  })
+
+  test('leaves siblings behind when the item is not the only one in its list', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                para('First'),
+                {
+                  type: 'taskList',
+                  content: [
+                    {type: 'taskItem', attrs: {checked: false}, content: [para('one')]},
+                    {type: 'taskItem', attrs: {checked: false}, content: [para('two')]}
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+    const tr = outdentItem(state, itemPosByText(state.doc, 'one'))
+    expect(tr).not.toBeNull()
+    const result = state.apply(tr!)
+    expect(() => result.doc.check()).not.toThrow()
+    const ol = result.doc.child(0)
+    expect(ol.childCount).toBe(2)
+    expect(ol.child(1).textContent).toBe('one')
+    // 'two' remains nested under First
+    expect(ol.child(0).child(1).type.name).toBe('taskList')
+    expect(ol.child(0).child(1).textContent).toBe('two')
+  })
+
+  test('returns null for a top-level list (not nested)', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [{type: 'taskItem', attrs: {checked: false}, content: [para('x')]}]
+        }
+      ]
+    })
+    expect(outdentItem(state, itemPosByText(state.doc, 'x'))).toBeNull()
+  })
+})
+
+describe('indentItem (adopt previous sublist type)', () => {
+  test('item joins the previous item trailing sublist, adopting its type', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {
+              type: 'listItem',
+              content: [
+                para('First'),
+                {
+                  type: 'taskList',
+                  content: [
+                    {type: 'taskItem', attrs: {checked: false}, content: [para('existing')]}
+                  ]
+                }
+              ]
+            },
+            {type: 'listItem', content: [para('Second')]}
+          ]
+        }
+      ]
+    })
+    const tr = indentItem(state, itemPosByText(state.doc, 'Second'))
+    expect(tr).not.toBeNull()
+    const result = state.apply(tr!)
+    expect(() => result.doc.check()).not.toThrow()
+    const ol = result.doc.child(0)
+    expect(ol.childCount).toBe(1)
+    const sublist = ol.child(0).child(1)
+    expect(sublist.type.name).toBe('taskList')
+    expect(sublist.childCount).toBe(2)
+    expect(sublist.child(1).textContent).toBe('Second')
+  })
+
+  test('returns null when previous item has no trailing sublist (stock sink applies)', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [
+            {type: 'listItem', content: [para('First')]},
+            {type: 'listItem', content: [para('Second')]}
+          ]
+        }
+      ]
+    })
+    expect(indentItem(state, itemPosByText(state.doc, 'Second'))).toBeNull()
+  })
+
+  test('returns null for the first item (nothing to indent under)', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [{type: 'listItem', content: [para('First')]}]
+        }
+      ]
+    })
+    expect(indentItem(state, itemPosByText(state.doc, 'First'))).toBeNull()
+  })
+})

--- a/packages/client/tiptap/extensions/__tests__/mixedListSchema.test.ts
+++ b/packages/client/tiptap/extensions/__tests__/mixedListSchema.test.ts
@@ -1,0 +1,87 @@
+import {getSchema} from '@tiptap/core'
+import {Document} from '@tiptap/extension-document'
+import {TaskItem, TaskList} from '@tiptap/extension-list'
+import StarterKit from '@tiptap/starter-kit'
+
+// Mirror the Pages editor's list configuration (see useTipTapPageEditor.ts /
+// serverTipTapExtensions.ts): StarterKit supplies bulletList/orderedList/
+// listItem; TaskList + nested TaskItem supply the checkbox list.
+const schema = getSchema([
+  Document,
+  StarterKit.configure({document: false}),
+  TaskList,
+  TaskItem.configure({nested: true})
+])
+
+const taskItem = (text: string) => ({
+  type: 'taskItem',
+  attrs: {checked: false},
+  content: [{type: 'paragraph', content: [{type: 'text', text}]}]
+})
+
+const listItem = (...content: unknown[]) => ({type: 'listItem', content})
+
+const para = (text: string) => ({type: 'paragraph', content: [{type: 'text', text}]})
+
+describe('Pages list schema permits mixed nesting', () => {
+  test('taskList nests inside an orderedList listItem', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'orderedList',
+          content: [listItem(para('A'), {type: 'taskList', content: [taskItem('B')]})]
+        }
+      ]
+    }
+    expect(() => schema.nodeFromJSON(doc).check()).not.toThrow()
+  })
+
+  test('orderedList nests inside a taskItem', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            {
+              type: 'taskItem',
+              attrs: {checked: false},
+              content: [para('A'), {type: 'orderedList', content: [listItem(para('B'))]}]
+            }
+          ]
+        }
+      ]
+    }
+    expect(() => schema.nodeFromJSON(doc).check()).not.toThrow()
+  })
+
+  test('bulletList nests inside a taskItem', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            {
+              type: 'taskItem',
+              attrs: {checked: false},
+              content: [para('A'), {type: 'bulletList', content: [listItem(para('B'))]}]
+            }
+          ]
+        }
+      ]
+    }
+    expect(() => schema.nodeFromJSON(doc).check()).not.toThrow()
+  })
+
+  test('control: check() rejects a listItem containing bare text', () => {
+    const invalid = {
+      type: 'doc',
+      content: [
+        {type: 'orderedList', content: [{type: 'listItem', content: [{type: 'text', text: 'x'}]}]}
+      ]
+    }
+    expect(() => schema.nodeFromJSON(invalid).check()).toThrow()
+  })
+})

--- a/packages/client/tiptap/extensions/__tests__/nestListDrop.test.ts
+++ b/packages/client/tiptap/extensions/__tests__/nestListDrop.test.ts
@@ -1,0 +1,88 @@
+import {getSchema} from '@tiptap/core'
+import {Document} from '@tiptap/extension-document'
+import {TaskItem, TaskList} from '@tiptap/extension-list'
+import type {Node as PMNode} from '@tiptap/pm/model'
+import {EditorState} from '@tiptap/pm/state'
+import StarterKit from '@tiptap/starter-kit'
+import {isListNode, moveListIntoItem} from '../nestListDrop'
+
+const schema = getSchema([
+  Document,
+  StarterKit.configure({document: false}),
+  TaskList,
+  TaskItem.configure({nested: true})
+])
+
+const para = (text: string) => ({type: 'paragraph', content: [{type: 'text', text}]})
+const stateFrom = (docJSON: unknown) =>
+  EditorState.create({schema, doc: schema.nodeFromJSON(docJSON as never)})
+
+const posOfType = (doc: PMNode, typeName: string): number => {
+  let found = -1
+  doc.descendants((node, pos) => {
+    if (found === -1 && node.type.name === typeName) found = pos
+    return found === -1
+  })
+  return found
+}
+
+describe('isListNode', () => {
+  test('recognizes the three list wrappers', () => {
+    const {nodes} = schema
+    expect(isListNode(nodes.taskList!.create())).toBe(true)
+    expect(isListNode(nodes.bulletList!.create())).toBe(true)
+    expect(isListNode(nodes.orderedList!.create())).toBe(true)
+    expect(isListNode(nodes.paragraph!.create())).toBe(false)
+  })
+})
+
+describe('moveListIntoItem', () => {
+  test('nests a taskList (below) into the listItem above it, keeping type', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {type: 'orderedList', content: [{type: 'listItem', content: [para('A')]}]},
+        {
+          type: 'taskList',
+          content: [{type: 'taskItem', attrs: {checked: false}, content: [para('B')]}]
+        }
+      ]
+    })
+    const tr = moveListIntoItem(
+      state,
+      posOfType(state.doc, 'taskList'),
+      posOfType(state.doc, 'listItem')
+    )
+    const result = state.apply(tr)
+    expect(() => result.doc.check()).not.toThrow()
+    expect(result.doc.childCount).toBe(1)
+    const li = result.doc.child(0).child(0)
+    expect(li.childCount).toBe(2)
+    expect(li.child(1).type.name).toBe('taskList')
+    expect(li.child(1).child(0).type.name).toBe('taskItem')
+  })
+
+  test('nests an orderedList (above) into a taskItem below it', () => {
+    const state = stateFrom({
+      type: 'doc',
+      content: [
+        {type: 'orderedList', content: [{type: 'listItem', content: [para('B')]}]},
+        {
+          type: 'taskList',
+          content: [{type: 'taskItem', attrs: {checked: false}, content: [para('A')]}]
+        }
+      ]
+    })
+    const tr = moveListIntoItem(
+      state,
+      posOfType(state.doc, 'orderedList'),
+      posOfType(state.doc, 'taskItem')
+    )
+    const result = state.apply(tr)
+    expect(() => result.doc.check()).not.toThrow()
+    expect(result.doc.childCount).toBe(1)
+    const ti = result.doc.child(0).child(0)
+    expect(ti.childCount).toBe(2)
+    expect(ti.child(1).type.name).toBe('orderedList')
+  })
+})

--- a/packages/client/tiptap/extensions/listNestingCommands.ts
+++ b/packages/client/tiptap/extensions/listNestingCommands.ts
@@ -1,0 +1,81 @@
+import type {NodeType} from '@tiptap/pm/model'
+import type {EditorState, Transaction} from '@tiptap/pm/state'
+
+const LIST_NODE_NAMES = new Set(['taskList', 'bulletList', 'orderedList'])
+const ITEM_NODE_NAMES = new Set(['listItem', 'taskItem'])
+
+// The item type a given list contains.
+const itemTypeForList = (state: EditorState, listName: string): NodeType | null => {
+  const name = listName === 'taskList' ? 'taskItem' : 'listItem'
+  return state.schema.nodes[name] ?? null
+}
+
+const makeItem = (type: NodeType, content: Parameters<NodeType['create']>[1]) => {
+  const attrs = type.name === 'taskItem' ? {checked: false} : null
+  return type.create(attrs, content)
+}
+
+/**
+ * Indent (Tab): if the previous sibling item has a trailing sublist, move the
+ * current item into it, converting to that sublist's item type ("adopt the list
+ * you land in"). Returns null when there is no previous sibling or it has no
+ * trailing sublist — the caller should fall back to stock `sinkListItem`, which
+ * creates a same-type sublist.
+ */
+export const indentItem = (state: EditorState, itemPos: number): Transaction | null => {
+  const {doc} = state
+  const $item = doc.resolve(itemPos)
+  const item = $item.nodeAfter
+  if (!item || !ITEM_NODE_NAMES.has(item.type.name)) return null
+  const list = $item.parent
+  const idx = $item.index()
+  if (idx === 0) return null
+  const prevItem = list.child(idx - 1)
+  const prevItemPos = itemPos - prevItem.nodeSize
+  const sublist = prevItem.lastChild
+  if (!sublist || !LIST_NODE_NAMES.has(sublist.type.name)) return null
+  const newItemType = itemTypeForList(state, sublist.type.name)
+  if (!newItemType) return null
+  const newItem = makeItem(newItemType, item.content)
+  // insertion point = end of prevItem's content (its trailing sublist's tail)
+  const sublistContentEnd = prevItemPos + prevItem.content.size
+  const {tr} = state
+  tr.delete(itemPos, itemPos + item.nodeSize)
+  tr.insert(tr.mapping.map(sublistContentEnd), newItem)
+  return tr
+}
+
+/**
+ * Outdent (Shift-Tab): lift the item out of its list to become a sibling in the
+ * ancestor list, converting to that list's item type ("adopt the list you land
+ * in"). Returns null when the item's list is not nested inside another list's
+ * item — the caller should fall back to stock `liftListItem`.
+ */
+export const outdentItem = (state: EditorState, itemPos: number): Transaction | null => {
+  const {doc} = state
+  const $item = doc.resolve(itemPos)
+  const item = $item.nodeAfter
+  if (!item || !ITEM_NODE_NAMES.has(item.type.name)) return null
+  const listDepth = $item.depth
+  if (listDepth < 2) return null
+  const grandItem = $item.node(listDepth - 1)
+  if (!ITEM_NODE_NAMES.has(grandItem.type.name)) return null
+  const ancestorList = $item.node(listDepth - 2)
+  if (!LIST_NODE_NAMES.has(ancestorList.type.name)) return null
+
+  const newItemType = itemTypeForList(state, ancestorList.type.name)
+  if (!newItemType) return null
+  const newItem = makeItem(newItemType, item.content)
+
+  const list = $item.parent
+  const afterGrandItem = $item.after(listDepth - 1)
+  const {tr} = state
+  if (list.childCount === 1) {
+    // removing the item empties its list — drop the whole list
+    tr.delete($item.before(listDepth), $item.after(listDepth))
+  } else {
+    tr.delete(itemPos, itemPos + item.nodeSize)
+  }
+  tr.insert(tr.mapping.map(afterGrandItem), newItem)
+  return tr
+}

--- a/packages/client/tiptap/extensions/nestListDrop.ts
+++ b/packages/client/tiptap/extensions/nestListDrop.ts
@@ -1,0 +1,86 @@
+import type {Node as PMNode} from '@tiptap/pm/model'
+import type {EditorState, Transaction} from '@tiptap/pm/state'
+import type {EditorView} from '@tiptap/pm/view'
+
+const LIST_NODE_NAMES = new Set(['taskList', 'bulletList', 'orderedList'])
+const ITEM_NODE_NAMES = new Set(['listItem', 'taskItem'])
+
+export const isListNode = (node: PMNode): boolean => LIST_NODE_NAMES.has(node.type.name)
+
+const isItemNode = (node: PMNode): boolean => ITEM_NODE_NAMES.has(node.type.name)
+
+/**
+ * Move the whole list node at `sourceListPos` so it becomes the last block
+ * child of the item (listItem/taskItem) at `targetItemPos`. The source node is
+ * relocated intact, so its type (e.g. taskList) is preserved. Order of
+ * delete/insert is chosen by relative position to avoid coordinate drift.
+ */
+export const moveListIntoItem = (
+  state: EditorState,
+  sourceListPos: number,
+  targetItemPos: number
+): Transaction => {
+  const {doc, tr} = state
+  const sourceNode = doc.nodeAt(sourceListPos)
+  if (!sourceNode) throw new Error('nestListDrop: no source node at position')
+  const targetItem = doc.nodeAt(targetItemPos)
+  if (!targetItem) throw new Error('nestListDrop: no target item at position')
+
+  const sourceFrom = sourceListPos
+  const sourceTo = sourceListPos + sourceNode.nodeSize
+  const insertPos = targetItemPos + 1 + targetItem.content.size
+
+  if (insertPos <= sourceFrom) {
+    tr.insert(insertPos, sourceNode)
+    const shift = sourceNode.nodeSize
+    tr.delete(sourceFrom + shift, sourceTo + shift)
+  } else {
+    tr.delete(sourceFrom, sourceTo)
+    const shift = sourceNode.nodeSize
+    tr.insert(insertPos - shift, sourceNode)
+  }
+  return tr
+}
+
+export interface NestDropTarget {
+  targetItemPos: number
+}
+
+/**
+ * Given a drop event, decide whether the gesture is a "nest" and, if so, which
+ * item to nest into. Returns null to fall back to ProseMirror's default
+ * (sibling) placement.
+ *
+ * The reference edge is the candidate item's *containing list* left edge — i.e.
+ * the column where a top-level sibling sits. Nesting requires pushing the cursor
+ * `indentPx` to the right of that column. Measuring against the item's own left
+ * edge would over-trigger, since list text is already indented from the list by
+ * the marker/padding width.
+ *
+ * NOTE: DOM-coordinate logic — verified in the browser, not unit tests.
+ */
+export const findNestDropTarget = (
+  view: EditorView,
+  event: DragEvent,
+  indentPx: number
+): NestDropTarget | null => {
+  const coords = view.posAtCoords({left: event.clientX, top: event.clientY})
+  if (!coords) return null
+  const $pos = view.state.doc.resolve(coords.pos)
+
+  for (let depth = $pos.depth; depth >= 1; depth--) {
+    const node = $pos.node(depth)
+    if (isItemNode(node)) {
+      const itemPos = $pos.before(depth)
+      // The item's parent is its list (depth - 1); use the list's left edge as
+      // the sibling-indent reference.
+      const listPos = $pos.before(depth - 1)
+      const listDom = view.nodeDOM(listPos)
+      if (!(listDom instanceof HTMLElement)) return null
+      const listLeft = listDom.getBoundingClientRect().left
+      if (event.clientX - listLeft > indentPx) return {targetItemPos: itemPos}
+      return null
+    }
+  }
+  return null
+}


### PR DESCRIPTION
# Description

Before these changes, you couldn't have a check list nested under an ordered list. Now you can!

## Demo

<img width="1520" height="907" alt="image" src="https://github.com/user-attachments/assets/d8646ec6-0211-4c4c-9146-d409756121a7" />


## Testing scenarios

[Please list all the testing scenarios a reviewer has to check before approving the PR]

- [ ] Make a checklist
- [ ] Make an ordered list
- [ ] Drag the checklist onto an ordered list item. Voila!
- [ ] Outdent (shift-tab) the checklist item, now it in ordered list item
- [ ] Repeat with indent, it is still an ordered list item

## Final checklist

- [ ] I checked the [code review guidelines](../docs/codeReview.md)
- [ ] I have added [Metrics Representative](../docs/codeReview.md#metrics-representative) as reviewer(s) if my PR invovles metrics/data/analytics related changes
- [ ] I have performed a self-review of my code, the same way I'd do it for any other team member
- [ ] I have tested all cases I listed in the testing scenarios and I haven't found any issues or regressions
- [ ] Whenever I took a non-obvious choice I added a comment explaining why I did it this way
- [ ] I added the label https://github.com/ParabolInc/parabol/labels/Skip%20Maintainer%20Review if the PR introduces only minor changes, does not contain any architectural changes or does not introduce any new patterns and I think one review is sufficient'
- [ ] PR title is human readable and could be used in changelog
