### PR TITLE
fix: persistedquerynotfound error

### DIFF
--- a/packages/server/yoga.ts
+++ b/packages/server/yoga.ts
@@ -61,9 +61,16 @@ export const extractPersistedOperationId = (
 const queryMap = {} as Record<string, string | undefined>
 const primeQueryMap = () => {
   if (__PRODUCTION__) return
-  const primed = require('../../queryMap.json')
+  let primed: Record<string, string>
+  try {
+    // resolved off disk at boot, see the externals in dev.servers.config.js
+    primed = require('../../queryMap.json')
+  } catch {
+    Logger.warn('queryMap.json not found. Run `pnpm relay:build`')
+    return
+  }
   Object.keys(primed).forEach((key) => {
-    queryMap[key] = primed[key].replace('@stream_HACK', '@stream')
+    queryMap[key] = primed[key]!.replace('@stream_HACK', '@stream')
   })
 }
 primeQueryMap()

--- a/pm2.dev.config.js
+++ b/pm2.dev.config.js
@@ -1,3 +1,8 @@
+const killOrphanedDevProcesses = require('./scripts/killOrphanedDevProcesses')
+
+// leftovers from a previous stack still hold their ports, see the note in the required module
+killOrphanedDevProcesses()
+
 const {DEV_RUN_ONLY} = process.env
 // const DEV_RUN_ONLY = 'Webpack Servers,Socket Server,Dev Server'
 const runOnly = DEV_RUN_ONLY ? DEV_RUN_ONLY.split(',') : []

--- a/scripts/killOrphanedDevProcesses.js
+++ b/scripts/killOrphanedDevProcesses.js
@@ -1,0 +1,62 @@
+/*
+  pm2 does not reap its children when the daemon itself dies (a Ctrl-C on `pm2 --no-daemon`
+  leaves them running and the OS reparents them to init). The next `pnpm dev` starts a daemon
+  that knows nothing about them, so they keep their ports: uWS binds with SO_REUSEPORT, which
+  lets an orphaned socket server keep serving stale bundles alongside the live one while the
+  kernel round-robins between them. Sweep them before pm2 boots the new stack.
+
+  Only processes reparented to init are killed, so a second `pnpm dev` running in another
+  terminal keeps its own children (they still belong to a live daemon)
+*/
+const cp = require('child_process')
+
+const DEV_SCRIPTS = [
+  'scripts/runSocketServer.js',
+  'scripts/runEmbedder.js',
+  'scripts/buildServers.js',
+  'scripts/hmrServer.js',
+  'scripts/relayWatch.js'
+]
+
+const getOrphans = (pattern) => {
+  let pids = []
+  try {
+    // execFileSync avoids a shell, so no `sh -c` process matches our own pattern
+    pids = cp
+      .execFileSync('pgrep', ['-f', pattern], {encoding: 'utf8'})
+      .split('\n')
+      .map((pid) => Number(pid.trim()))
+      .filter((pid) => pid && pid !== process.pid)
+  } catch {
+    // pgrep exits 1 when nothing matches
+    return []
+  }
+  if (pids.length === 0) return []
+  try {
+    return cp
+      .execFileSync('ps', ['-o', 'pid=,ppid=', '-p', pids.join(',')], {encoding: 'utf8'})
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/).map(Number))
+      .filter(([pid, ppid]) => pid && ppid === 1)
+      .map(([pid]) => pid)
+  } catch {
+    // every match exited between the pgrep and the ps
+    return []
+  }
+}
+
+const killOrphanedDevProcesses = () => {
+  const orphans = [...new Set(DEV_SCRIPTS.flatMap(getOrphans))]
+  orphans.forEach((pid) => {
+    try {
+      process.kill(pid, 'SIGTERM')
+    } catch {
+      // already gone
+    }
+  })
+  if (orphans.length > 0) {
+    console.log(`Killed ${orphans.length} orphaned dev process(es): ${orphans.join(', ')}`)
+  }
+}
+
+module.exports = killOrphanedDevProcesses


### PR DESCRIPTION
# Description

when claude does a bunch of writes when the dev server is still running i think pm2 can't keep up & it keeps multiple children open, which results in a "PersistedQueryNotFound" error that comes back from the server. I can't find those children processes, but claude wrote this fix & it worked locally for me. worth trying out for a bit & seeing if the error comes back