### PR TITLE
feat: update AI model to luna

### DIFF
--- a/packages/server/dataloader/aiLoaderMakers.ts
+++ b/packages/server/dataloader/aiLoaderMakers.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader'
 import yaml from 'js-yaml'
+import {AI_MODEL} from '../utils/aiModel'
 import logError from '../utils/logError'
 import {makeMeetingInsightInput} from '../utils/makeMeetingInsightInput'
 import OpenAIServerManager from '../utils/OpenAIServerManager'
@@ -66,7 +67,7 @@ export const meetingInsightsContent = (parent: RootDataLoader) => {
           try {
             const openAI = new OpenAIServerManager()
             const response = await openAI.openAIApi!.chat.completions.create({
-              model: 'o3-mini',
+              model: AI_MODEL,
               messages: [
                 {
                   role: 'system',

--- a/packages/server/graphql/public/fields/pageInsights.ts
+++ b/packages/server/graphql/public/fields/pageInsights.ts
@@ -4,6 +4,7 @@ import {sql} from 'kysely'
 import TeamMemberId from '../../../../client/shared/gqlIds/TeamMemberId'
 import {USER_AI_TOKENS_MONTHLY_LIMIT} from '../../../postgres/constants'
 import getKysely from '../../../postgres/getKysely'
+import {AI_MODEL} from '../../../utils/aiModel'
 import {analytics} from '../../../utils/analytics/analytics'
 import {getUserId, isSuperUser} from '../../../utils/authorization'
 import {makeMeetingInsightInput} from '../../../utils/makeMeetingInsightInput'
@@ -97,7 +98,8 @@ export const pageInsights: NonNullable<UserResolvers['pageInsights']> = async (
   } else {
     // make a title for the prompt
     const promptValidation = await openAI.openAIApi!.chat.completions.create({
-      model: 'o3-mini',
+      model: AI_MODEL,
+      reasoning_effort: 'low',
       messages: [
         {
           role: 'system',
@@ -127,7 +129,7 @@ If not, respond with "Invalid prompt"`
   }
   try {
     const rawInsightResponseStream = await openAI.openAIApi!.chat.completions.create({
-      model: 'o3-mini',
+      model: AI_MODEL,
       stream: true,
       stream_options: {
         include_usage: true

--- a/packages/server/postgres/constants.ts
+++ b/packages/server/postgres/constants.ts
@@ -5,4 +5,4 @@ export const USER_REASON_REMOVED_LIMIT = 2000
 
 export const TEAM_NAME_LIMIT = 100
 
-export const USER_AI_TOKENS_MONTHLY_LIMIT = 500_000 // One BIG request every day
+export const USER_AI_TOKENS_MONTHLY_LIMIT = 600_000 // One BIG request every day

--- a/packages/server/postgres/migrations/2026-08-24T00:00:00.000Z_modernizeDefaultAIPrompts.ts
+++ b/packages/server/postgres/migrations/2026-08-24T00:00:00.000Z_modernizeDefaultAIPrompts.ts
@@ -1,0 +1,70 @@
+import type {Kysely} from 'kysely'
+
+// The seeded prompts were written for gpt-4-era models, so they leaned on persona priming
+// ("You are an expert in...") and anti-preamble hacks ("No yapping", "Try for about 300 words").
+// A reasoning model needs none of that; what it can act on is a hard scope, a firm word budget,
+// and permission to say the data is too thin rather than inventing a finding.
+const PROMPTS = [
+  {
+    title: 'Wins, Challenges, and Recommendations',
+    content: `Report on this data under three headings: **Wins**, **Challenges**, and **Recommendations**.
+
+Cover the most significant completed work, the biggest obstacles the team hit, and any pattern that recurs across meetings — repeated blockers, shared frustrations, or strategies that worked. Ground every point in specific evidence from the data. Make each recommendation a concrete next step, not a general principle.
+
+Start with the first heading.`,
+    previousContent: `You are an expert in agile retrospectives and project management.
+
+Analyze this data and provide key insights on:
+- The most significant **wins** in terms of completed work, team collaboration, or project improvements.
+- The biggest **challenges** faced by the team.
+- Any **trends** in the conversations (e.g., recurring blockers, common frustrations, or successful strategies).
+- Suggestions for improving efficiency based on the data.
+
+Use a structured response format with **Wins**, **Challenges**, and **Recommendations**. No yapping. No introductory sentence.`
+  },
+  {
+    title: 'Psychological Safety & Team Dynamics',
+    content: `Assess psychological safety across these meetings. Look for whether concerns get raised directly or hedged, whose voices dominate, and who stays quiet. Say so plainly where the data is too thin to judge.
+
+Explain how those dynamics are shaping the team's decisions, then give specific steps to widen participation. Under 300 words.`,
+    previousContent: `Analyze the retrospective discussions, sprint poker meetings, and daily standups to assess the level of psychological safety within the teams. Identify signs of open communication, hesitancy in raising concerns, and patterns of dominant voices versus silent participants. Provide insights on how team dynamics influence decision-making and suggest actionable steps to improve collaboration and inclusivity. No yapping. Try for about 300 words.`
+  },
+  {
+    title: 'Sprint Predictability & Estimation Accuracy',
+    content: `Compare the team's poker estimates against what actually got completed. Identify where they consistently under- or over-estimate, and judge whether spillover points to scope creep, bottlenecks, or blockers. Separate real patterns from one-off sprints.
+
+Recommend specific changes to improve predictability. Under 300 words.`,
+    previousContent: `Evaluate how well our sprint planning aligns with actual execution by analyzing the consistency of our sprint poker estimates versus completed work. Identify patterns where underestimation or overestimation is common, and assess whether work spillover trends indicate scope creep, bottlenecks, or blockers. Provide recommendations to improve sprint predictability and estimation accuracy. No yapping. Try for about 300 words.`
+  },
+  {
+    title: 'Sentiment & Morale Trends Over Time',
+    content: `Track how the team's morale and stress levels shift across these meetings, quoting the language that signals each shift. Correlate any change with workload, sprint outcomes, or events visible in the data, and say when a correlation is too weak to call.
+
+Close with specific ways to improve engagement. Under 300 words.`,
+    previousContent: `Perform a sentiment analysis of the team's discussions during retrospectives, standups, and sprint poker meetings. Identify changes in morale, motivation, and stress levels over the past three months. Highlight any correlations between team sentiment and sprint outcomes, workload, or external factors. Provide insights on how to boost team morale and engagement. No yapping. Try for about 300 words.`
+  }
+]
+
+const setContent = async (db: Kysely<any>, prompts: {title: string; content: string}[]) => {
+  await Promise.all(
+    prompts.map(({title, content}) =>
+      db
+        .updateTable('AIPrompt')
+        .set({content})
+        .where('userId', '=', 'aGhostUser')
+        .where('title', '=', title)
+        .execute()
+    )
+  )
+}
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await setContent(db, PROMPTS)
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await setContent(
+    db,
+    PROMPTS.map(({title, previousContent}) => ({title, content: previousContent}))
+  )
+}

--- a/packages/server/utils/OpenAIServerManager.ts
+++ b/packages/server/utils/OpenAIServerManager.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai'
 import type {ModifyType} from '../graphql/public/resolverTypes'
 import type {RetroReflection} from '../postgres/types'
+import {AI_MODEL} from './aiModel'
 import groupReflections from './groupReflections/groupReflectionsStructured'
 import type {GroupReflectionsInput, GroupReflectionsOptions} from './groupReflections/types'
 import logError from './logError'
@@ -24,7 +25,7 @@ class OpenAIServerManager {
       {
         label: 'openai',
         client: this.openAIApi,
-        model: 'gpt-5.6-luna',
+        model: AI_MODEL,
         // Hidden reasoning dominated grouping latency, and holding the effort down is only safe
         // because repairGroups patches a forgotten card instead of discarding the whole batch
         params: {reasoning_effort: 'low'}
@@ -53,18 +54,15 @@ class OpenAIServerManager {
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
             content: prompt
           }
         ],
-        temperature: 0.7,
-        max_tokens: 500,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+        reasoning_effort: 'low',
+        max_completion_tokens: 4000
       })
       return (response.choices[0]?.message?.content?.trim() as string) ?? null
     } catch (e) {
@@ -103,15 +101,15 @@ class OpenAIServerManager {
       .join('\n')}`
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
             content: prompt
           }
         ],
-        temperature: 0.3,
-        max_tokens: 80
+        reasoning_effort: 'low',
+        max_completion_tokens: 2000
       })
       const question =
         (response.choices[0]?.message?.content?.trim() as string).replace(
@@ -161,13 +159,14 @@ Compare the scope and complexity of the issue to estimate against the reference 
 Respond in GitHub-flavored markdown. The first line MUST be exactly "**Estimate: <value>**" where <value> is the chosen allowed value. After a blank line, justify the estimate in 2-3 sentences. When you cite a reference issue, refer to it by its bare issue key only (e.g. ${references[0]?.issueKey ?? 'PROJ-123'}) — do not include its title or a link.`
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-5.4-mini',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
             content: prompt
           }
-        ]
+        ],
+        reasoning_effort: 'low'
       })
       const estimate = response.choices[0]?.message?.content?.trim()
       return estimate || null
@@ -198,18 +197,15 @@ Respond in GitHub-flavored markdown. The first line MUST be exactly "**Estimate:
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
             content: prompt[modifyType]
           }
         ],
-        temperature: 0.8,
-        max_tokens: 256,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+        reasoning_effort: 'low',
+        max_completion_tokens: 2000
       })
 
       return (response.choices[0]?.message?.content?.trim() as string).replaceAll(`"`, '') ?? null
@@ -266,7 +262,7 @@ Return JSON of the form: { "items": [{ "title": "<short heading, or null>", "con
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
@@ -274,10 +270,7 @@ Return JSON of the form: { "items": [{ "title": "<short heading, or null>", "con
           }
         ],
         response_format: {type: 'json_object'},
-        temperature: 0.7,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+        reasoning_effort: 'low'
       })
 
       const content = response.choices[0]?.message?.content
@@ -356,7 +349,7 @@ Return JSON of the form: { "items": [{ "title": "<short heading, or null>", "con
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
@@ -364,10 +357,7 @@ Return JSON of the form: { "items": [{ "title": "<short heading, or null>", "con
           }
         ],
         response_format: {type: 'json_object'},
-        temperature: 0.7,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+        reasoning_effort: 'low'
       })
 
       const content = response.choices[0]?.message?.content
@@ -422,18 +412,14 @@ Return JSON of the form: { "items": [{ "title": "<short heading, or null>", "con
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
             content: `${prompt}\n\n${yamlData}`
           }
         ],
-
-        temperature: 0.7,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+        reasoning_effort: 'low'
       })
 
       const content = response.choices[0]?.message.content as string
@@ -455,18 +441,15 @@ Important: Respond with ONLY the title itself. Do not include any prefixes like 
 
     try {
       const response = await this.openAIApi.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: AI_MODEL,
         messages: [
           {
             role: 'user',
             content: prompt
           }
         ],
-        temperature: 0.3,
-        max_tokens: 20,
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0
+        reasoning_effort: 'low',
+        max_completion_tokens: 1000
       })
       const title =
         (response.choices[0]?.message?.content?.trim() as string)

--- a/packages/server/utils/aiModel.ts
+++ b/packages/server/utils/aiModel.ts
@@ -1,0 +1,14 @@
+/**
+ * The one model every OpenAI call in the app uses, so swapping it is a single edit.
+ *
+ * It is a reasoning model: it rejects `temperature`, `top_p`, `frequency_penalty`, and
+ * `presence_penalty`, and it spends hidden reasoning tokens against `max_completion_tokens`
+ * before emitting a visible one. Cap output generously enough to leave room for that and control
+ * length in the prompt instead.
+ *
+ * Callers separate themselves by `reasoning_effort`, not by model. Pass 'low' whenever a user is
+ * waiting on the answer; leave it at the default only where the analysis is itself the feature.
+ * Effort is the cost knob too, since AIRequest.tokenCost bills reasoning tokens against the
+ * caller's 500k monthly quota.
+ */
+export const AI_MODEL = 'gpt-5.6-luna'


### PR DESCRIPTION
# Description

OpenAI just cut their pricing on the already cheap luna model & I'd like to reward their race-to-the-bottom behavior, while saving ourselves some money, I hope!

Bumping from gpt-4 to 5.6-luna will be faster, cheaper, and should yield better results.

fix #13345
fix #13343