### PR TITLE
fix: page kebab menu triggers full page reload

### DIFF
--- a/packages/client/components/DashNavList/LeftNavItemButtons.tsx
+++ b/packages/client/components/DashNavList/LeftNavItemButtons.tsx
@@ -11,6 +11,7 @@ export const LeftNavItemButtons = (props: Props) => {
       className='flex w-0 items-center justify-end pr-1 opacity-0 group-hover:w-auto group-hover:opacity-100'
       onClick={(e) => {
         // Any clicks here should not propagate up to the parent anchor tag
+        e.preventDefault()
         e.stopPropagation()
       }}
     >


### PR DESCRIPTION
# Description

LeftNavItemButtons stopped React propagation, which skipped Link's preventDefault while the native click still bubbled to the anchor.

Prevent default in the wrapper so no child control can navigate.

Fixes #13413

