### PR TITLE
fix: various style fixes

### DIFF
--- a/packages/client/components/BottomControlBarMusic.tsx
+++ b/packages/client/components/BottomControlBarMusic.tsx
@@ -55,7 +55,7 @@ const BottomControlBarMusic = ({meetingId}: Props) => {
                 isPlaying ? 'animate-pulse text-fg-primary' : 'text-fg-primary'
               )}
             />
-            <span className='mt-0.5 font-medium text-fg-primary text-xs'>Music</span>
+            <span className='mt-0.5 font-medium text-fg-secondary text-xs'>Music</span>
           </span>
         </BottomNavControl>
       </RadixPopover.Trigger>

--- a/packages/client/components/BottomControlBarReady.tsx
+++ b/packages/client/components/BottomControlBarReady.tsx
@@ -151,11 +151,7 @@ const BottomControlBarReady = (props: Props) => {
         {isNext && <BottomControlBarProgress isNext={isNext} progress={progress} />}
         <BottomNavIconLabel className='px-2' label={label} ref={originRef}>
           <div
-            className={cn(
-              'h-6 w-6 origin-top-left',
-              iconColor,
-              '[&_svg]:fill-current [&_svg]:stroke-current'
-            )}
+            className={cn('h-6 w-6 origin-top-left', iconColor)}
             style={{
               transform: isNext
                 ? progress > 0
@@ -166,7 +162,7 @@ const BottomControlBarReady = (props: Props) => {
             }}
           >
             {isNext ? (
-              <ArrowForward style={{strokeWidth: 1}} />
+              <ArrowForward className='stroke-1 stroke-current' />
             ) : isViewerReady ? (
               <CheckCircle />
             ) : (

--- a/packages/client/components/EditableText.tsx
+++ b/packages/client/components/EditableText.tsx
@@ -1,5 +1,5 @@
 import type * as React from 'react'
-import {forwardRef, useEffect, useRef, useState} from 'react'
+import {forwardRef, useEffect, useLayoutEffect, useRef, useState} from 'react'
 import TextAreaAutoSize from 'react-textarea-autosize'
 import {Edit} from '~/ui/icons'
 import {cn} from '../ui/cn'
@@ -51,10 +51,6 @@ const EditableText = forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) =
 
   const setEditing = (isEditing: boolean) => {
     setIsEditing(isEditing)
-    if (isEditing) {
-      // Pre-calculate width when entering edit mode
-      setTimeout(calculateWidth, 0)
-    }
     setAutoFocus(false)
     onEditingChange?.(isEditing)
   }
@@ -64,9 +60,11 @@ const EditableText = forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) =
     setValue(initialValue)
   }, [initialValue])
 
-  useEffect(() => {
+  const showEditing = (error || isEditing || autoFocus) && !disabled
+
+  useLayoutEffect(() => {
     calculateWidth()
-  }, [value])
+  }, [value, showEditing])
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const nextValue = e.target.value || ''
@@ -111,7 +109,6 @@ const EditableText = forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) =
     }
   }
 
-  const showEditing = (error || isEditing || autoFocus) && !disabled
   if (showEditing) {
     const commonProps = {
       autoFocus: true,

--- a/packages/client/hooks/useResizeFontForElement.ts
+++ b/packages/client/hooks/useResizeFontForElement.ts
@@ -1,4 +1,4 @@
-import {type RefObject, useEffect} from 'react'
+import {type RefObject, useLayoutEffect} from 'react'
 import useForceUpdate from './useForceUpdate'
 
 const useResizeFontForElement = <T extends HTMLElement = HTMLInputElement>(
@@ -9,7 +9,7 @@ const useResizeFontForElement = <T extends HTMLElement = HTMLInputElement>(
   reduceBy = 0
 ) => {
   const forceUpdate = useForceUpdate()
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current
     if (!el) {
       forceUpdate()


### PR DESCRIPTION
- Scope the SVG stroke in BottomControlBarReady to the Next arrow; the Emotion→Tailwind port applied stroke-current to every state, thickening the check icons (April set strokeWidth 0 for them)

- Restore the Music label to text-fg-secondary (April's slate-600)

- Measure EditableText's auto-width in useLayoutEffect so the input is resized before paint instead of one frame after, which was letting the input scroll to the caret and then snap back on every keystroke; also covers entering edit mode, replacing the setTimeout pre-measure

- Same fix in useResizeFontForElement (Poker score input)
