### PR TITLE
fix: truncate long Page titles with ellipsis

### DIFF
--- a/packages/client/components/DashNavList/LeftNavItem.tsx
+++ b/packages/client/components/DashNavList/LeftNavItem.tsx
@@ -5,13 +5,5 @@ interface Props {
 }
 export const LeftNavItem = (props: Props) => {
   const {children} = props
-  return (
-    <div
-      className={
-        'flex flex-1 flex-col overflow-hidden text-clip whitespace-nowrap font-medium text-sm'
-      }
-    >
-      {children}
-    </div>
-  )
+  return <div className='flex-1 truncate font-medium text-sm'>{children}</div>
 }


### PR DESCRIPTION
# Description

This was a feature we wanted implemented early in Pages. It bugged me, so I went ahead and did it.

## Demo

<img width="258" height="237" alt="image" src="https://github.com/user-attachments/assets/4fe17d2d-3b8d-4a21-a333-63f3cbc535e9" />
