### PR TITLE
fix: deliver @defer payloads over WebSocket to relay

### DIFF
--- a/packages/client/Atmosphere.ts
+++ b/packages/client/Atmosphere.ts
@@ -33,6 +33,9 @@ import {AuthToken} from './types/AuthToken'
 import type {NavigateFn} from './types/relayMutations'
 import {getAuthCookie, onAuthCookieChange} from './utils/authCookie'
 import {createWSClient} from './utils/createWSClient'
+import flattenIncrementalResponse, {
+  type IncrementalFrame
+} from './utils/relay/flattenIncrementalResponse'
 import handlerProvider from './utils/relay/handlerProvider'
 import sleep from './utils/sleep'
 
@@ -230,13 +233,10 @@ export default class Atmosphere extends Environment {
                     const body = part.slice(sepIdx + 4).trim()
                     if (!body) continue
                     try {
-                      const parsed = JSON.parse(body)
-                      if (Array.isArray(parsed.incremental)) {
-                        for (const item of parsed.incremental) {
-                          sink.next({...item, hasNext: parsed.hasNext})
-                        }
-                      } else {
-                        sink.next(parsed)
+                      const parsed: IncrementalFrame = JSON.parse(body)
+                      const responses = flattenIncrementalResponse(parsed)
+                      if (responses.length > 0) {
+                        sink.next(responses.length === 1 ? responses[0]! : responses)
                       }
                       if (!parsed.hasNext) {
                         sink.complete()
@@ -292,7 +292,7 @@ export default class Atmosphere extends Environment {
           _error(error)
         }
       }
-      sink.next = (value: any) => {
+      const toRelayResponse = (value: any) => {
         const {data, errors} = value
         if (!data) {
           if (errors) {
@@ -301,25 +301,27 @@ export default class Atmosphere extends Environment {
           // if a mutation throws a GraphQLError, this will result in
           // `Warning: RelayResponseNormalizer: Payload did not contain a value for field`
           // but without it, it's a hard error
-          _next({...value, data: {}})
-          return
+          return {...value, data: {}}
         }
         const subscriptionName = data ? Object.keys(data)[0] : undefined
         const nullObj = this.subscriptionInterfaces[subscriptionName!]
-        const nextObj =
-          nullObj && subscriptionName
-            ? {
-                ...value,
-                data: {
-                  ...data,
-                  [subscriptionName]: {
-                    ...nullObj,
-                    ...data[subscriptionName]
-                  }
+        return nullObj && subscriptionName
+          ? {
+              ...value,
+              data: {
+                ...data,
+                [subscriptionName]: {
+                  ...nullObj,
+                  ...data[subscriptionName]
                 }
               }
-            : value
-        _next(nextObj)
+            }
+          : value
+      }
+      sink.next = (value: any) => {
+        const responses = flattenIncrementalResponse(value).map(toRelayResponse)
+        if (responses.length === 0) return
+        _next(responses.length === 1 ? responses[0] : responses)
       }
       ;(async () => {
         // waiting a tick prevents `client.subscribe` from creating 2 websocket instances

--- a/packages/client/utils/relay/__tests__/flattenIncrementalResponse.test.ts
+++ b/packages/client/utils/relay/__tests__/flattenIncrementalResponse.test.ts
@@ -1,0 +1,191 @@
+import {
+  type ConcreteRequest,
+  createOperationDescriptor,
+  createReaderSelector,
+  Environment,
+  type GraphQLSingularResponse,
+  Network,
+  Observable,
+  type ReaderFragment,
+  RecordSource,
+  Store
+} from 'relay-runtime'
+import flattenIncrementalResponse, {type IncrementalFrame} from '../flattenIncrementalResponse'
+
+const DEFER_LABEL = 'DeferTestQuery$defer$DeferTest_viewer'
+
+const idField = {
+  alias: null,
+  args: null,
+  kind: 'ScalarField',
+  name: 'id',
+  storageKey: null
+} as const
+const preferredNameField = {
+  alias: null,
+  args: null,
+  kind: 'ScalarField',
+  name: 'preferredName',
+  storageKey: null
+} as const
+
+const deferredFragment: ReaderFragment = {
+  argumentDefinitions: [],
+  kind: 'Fragment',
+  metadata: null,
+  name: 'DeferTest_viewer',
+  selections: [preferredNameField],
+  type: 'User',
+  abstractKey: null
+}
+
+const request: ConcreteRequest = {
+  fragment: {
+    argumentDefinitions: [],
+    kind: 'Fragment',
+    metadata: null,
+    name: 'DeferTestQuery',
+    selections: [
+      {
+        alias: null,
+        args: null,
+        concreteType: 'User',
+        kind: 'LinkedField',
+        name: 'viewer',
+        plural: false,
+        selections: [idField, {args: null, kind: 'FragmentSpread', name: 'DeferTest_viewer'}],
+        storageKey: null
+      }
+    ],
+    type: 'Query',
+    abstractKey: null
+  },
+  kind: 'Request',
+  operation: {
+    argumentDefinitions: [],
+    kind: 'Operation',
+    name: 'DeferTestQuery',
+    selections: [
+      {
+        alias: null,
+        args: null,
+        concreteType: 'User',
+        kind: 'LinkedField',
+        name: 'viewer',
+        plural: false,
+        selections: [
+          idField,
+          {if: null, kind: 'Defer', label: DEFER_LABEL, selections: [preferredNameField]}
+        ],
+        storageKey: null
+      }
+    ]
+  },
+  params: {
+    id: 'DeferTestQuery',
+    metadata: {},
+    name: 'DeferTestQuery',
+    operationKind: 'query',
+    text: null
+  }
+}
+
+const initialFrame: IncrementalFrame = {data: {viewer: {id: 'u1'}}, hasNext: true}
+const deferredFrame: IncrementalFrame = {
+  incremental: [{data: {preferredName: 'Jordan'}, path: ['viewer'], label: DEFER_LABEL}],
+  hasNext: false
+}
+
+const legacyRewrite = (frame: IncrementalFrame): GraphQLSingularResponse[] => [
+  {...frame, data: frame.data ?? {}}
+]
+
+const replayThroughRelay = async (
+  frames: IncrementalFrame[],
+  toResponses: (frame: IncrementalFrame) => GraphQLSingularResponse[] = flattenIncrementalResponse
+) => {
+  const network = Network.create(() =>
+    Observable.create((sink) => {
+      frames.forEach((frame) => {
+        const responses = toResponses(frame)
+        if (responses.length > 0) sink.next(responses)
+      })
+      sink.complete()
+    })
+  )
+  const environment = new Environment({network, store: new Store(new RecordSource())})
+  const operation = createOperationDescriptor(request, {})
+  await new Promise<void>((resolve, reject) => {
+    environment.execute({operation}).subscribe({complete: resolve, error: reject})
+  })
+  return environment.lookup(createReaderSelector(deferredFragment, 'u1', {}, operation.request))
+}
+
+describe('flattenIncrementalResponse', () => {
+  it('passes a plain response through untouched', () => {
+    const response = {data: {viewer: {id: 'u1'}}}
+    expect(flattenIncrementalResponse(response)).toEqual([response])
+  })
+
+  it('passes an error-only response through untouched', () => {
+    const response = {data: null, errors: [{name: 'GraphQLError', message: 'boom'}]}
+    expect(flattenIncrementalResponse(response)).toEqual([response])
+  })
+
+  it('keeps the initial frame of an incremental response', () => {
+    expect(flattenIncrementalResponse(initialFrame)).toEqual([{data: {viewer: {id: 'u1'}}}])
+  })
+
+  it('unwraps incremental entries into path/label responses', () => {
+    expect(flattenIncrementalResponse(deferredFrame)).toEqual([
+      {data: {preferredName: 'Jordan'}, path: ['viewer'], label: DEFER_LABEL}
+    ])
+  })
+
+  it('emits initial data ahead of incremental entries carried on the same frame', () => {
+    const frame: IncrementalFrame = {
+      data: {viewer: {id: 'u1'}},
+      incremental: [{data: {preferredName: 'Jordan'}, path: ['viewer'], label: DEFER_LABEL}],
+      hasNext: false
+    }
+    expect(flattenIncrementalResponse(frame)).toEqual([
+      {data: {viewer: {id: 'u1'}}},
+      {data: {preferredName: 'Jordan'}, path: ['viewer'], label: DEFER_LABEL}
+    ])
+  })
+
+  it('drops a bare terminator frame', () => {
+    expect(flattenIncrementalResponse({hasNext: false})).toEqual([])
+  })
+
+  it('keeps an incremental entry whose deferred resolver errored', () => {
+    const entry = {
+      data: null,
+      errors: [{name: 'GraphQLError', message: 'token expired'}],
+      path: ['viewer'],
+      label: DEFER_LABEL
+    }
+    expect(flattenIncrementalResponse({incremental: [entry], hasNext: false})).toEqual([entry])
+  })
+
+  it('leaves the @defer fragment missing when the envelope is passed through as root data', async () => {
+    const snapshot = await replayThroughRelay([initialFrame, deferredFrame], legacyRewrite)
+    expect(snapshot.isMissingData).toBe(true)
+  })
+
+  it('lets relay resolve a @defer fragment from flattened frames', async () => {
+    const snapshot = await replayThroughRelay([initialFrame, deferredFrame])
+    expect(snapshot.isMissingData).toBe(false)
+    expect(snapshot.data).toEqual({preferredName: 'Jordan'})
+  })
+
+  it('lets relay resolve a @defer fragment when a terminator frame trails the data', async () => {
+    const snapshot = await replayThroughRelay([
+      initialFrame,
+      {...deferredFrame, hasNext: true},
+      {hasNext: false}
+    ])
+    expect(snapshot.isMissingData).toBe(false)
+    expect(snapshot.data).toEqual({preferredName: 'Jordan'})
+  })
+})

--- a/packages/client/utils/relay/flattenIncrementalResponse.ts
+++ b/packages/client/utils/relay/flattenIncrementalResponse.ts
@@ -1,0 +1,30 @@
+import type {
+  GraphQLResponseWithData,
+  GraphQLSingularResponse,
+  PayloadData,
+  PayloadError
+} from 'relay-runtime'
+
+interface WireResponse {
+  data?: PayloadData | null
+  errors?: PayloadError[]
+  extensions?: GraphQLResponseWithData['extensions']
+  label?: string
+  path?: Array<string | number>
+}
+
+export interface IncrementalFrame extends WireResponse {
+  hasNext?: boolean
+  incremental?: WireResponse[]
+}
+
+const isGraphQLResponse = (response: WireResponse): response is GraphQLSingularResponse =>
+  'data' in response || 'errors' in response || 'extensions' in response
+
+// relay-runtime reads top-level {data, path, label}; it does not understand the spec's {incremental: [...], hasNext} envelope
+const flattenIncrementalResponse = (frame: IncrementalFrame): GraphQLSingularResponse[] => {
+  const {incremental = [], hasNext: _hasNext, ...initial} = frame
+  return [initial, ...incremental].filter(isGraphQLResponse)
+}
+
+export default flattenIncrementalResponse


### PR DESCRIPTION
- Yoga streams @defer as {data, hasNext} then {incremental: [{data, path, label}], hasNext}; relay-runtime 21 only reads top-level path/label and has no envelope handling

  Atmosphere's WS sink rewrote the envelope frame to {data: {}}, so deferred fragments never populated (GitHubRepoSearchFilterMenu "No repos found!", JiraScopingSearchBarLabel, LinearProjectFilterBar)

  I added flattenIncrementalResponse to unwrap incremental entries into {data, path, label, errors}, drop bare {hasNext: false} terminator frames, emit multi-entry frames as a batch

- Use it on both the WS and HTTP multipart paths; non-defer payloads are unchanged
- Add unit tests plus a relay-runtime replay test with a negative control

To test:

Open the Scope page, click the filter once (so the lazy chunk loads), then in DevTools console:

- [x] grab webpack's module cache

```ts
let req; window[Object.keys(window).find(k => k.startsWith('webpackChunk'))]
  .push([['probe'], {}, r => { req = r }])
const mods = Object.values(req.c).map(m => m.exports).filter(Boolean)
const pick = p => { for (const ex of mods) { const d = ex.default || ex; try { if (p(d)) return d } catch {} } }
const request  = pick(d => d?.kind === 'Request' && d.params?.name === 'GitHubScopingSearchFilterMenuQuery')
const fragment = pick(d => d?.kind === 'Fragment' && d.name === 'useGetRepoContributions_teamMember')
const relay    = mods.find(ex => ex?.createOperationDescriptor && ex.Environment && ex.RecordSource)
```

- [x] live Atmosphere from the React tree

```ts
let fiber = document.querySelector('button')[Object.keys(document.querySelector('button')).find(k => k.startsWith('__reactFiber$'))], env
while (fiber && !env) { if (fiber.memoizedProps?.environment?.commitUpdate) env = fiber.memoizedProps.environment; fiber = fiber.return }
```

- [x] same network, EMPTY store → no masking

```ts
const e2 = new relay.Environment({network: env.getNetwork(), store: new relay.Store(new relay.RecordSource())})
const op = relay.createOperationDescriptor(request, {meetingId: '<meetingId>', teamId: '<teamId>'})
const frames = []
await new Promise(res => e2.execute({operation: op}).subscribe({
  next: v => frames.push(Array.isArray(v) ? v.map(x => Object.keys(x)) : Object.keys(v)), complete: res, error: res}))
const snap = e2.lookup(relay.createReaderSelector(fragment, '<userId>::<teamId>', {}, op.request))
console.log({frames, isMissingData: snap.isMissingData})
```