### PR TITLE
feat: pages embed block (PR 1 of 4)

### DIFF
--- a/packages/client/hooks/useTipTapPageEditor.ts
+++ b/packages/client/hooks/useTipTapPageEditor.ts
@@ -24,6 +24,7 @@ import {LoomExtension} from '../components/TipTapEditor/LoomExtension'
 import {TiptapLinkExtension} from '../components/TipTapEditor/TiptapLinkExtension'
 import {useUploadUserAsset} from '../mutations/useUploadUserAsset'
 import {themeBackgroundColors} from '../shared/themeBackgroundColors'
+import {EmbedBlock} from '../tiptap/extensions/embedBlock/EmbedBlock'
 import FileBlock from '../tiptap/extensions/fileBlock/FileBlock'
 import {FileUpload} from '../tiptap/extensions/fileUpload/FileUpload'
 import {IndentHandler} from '../tiptap/extensions/IndentHandler'
@@ -127,6 +128,7 @@ export const useTipTapPageEditor = (
           commit,
           highestTier: user?.highestTier
         }),
+        EmbedBlock,
         ImageBlock.configure({
           editorWidth: 720,
           editorHeight: 400

--- a/packages/client/shared/embed/__tests__/curatedEmbedProviders.test.ts
+++ b/packages/client/shared/embed/__tests__/curatedEmbedProviders.test.ts
@@ -1,0 +1,208 @@
+import {isAllowedEmbedHost, resolveCuratedEmbed} from '../curatedEmbedProviders'
+
+describe('resolveCuratedEmbed', () => {
+  it('returns null for an unknown provider', () => {
+    expect(resolveCuratedEmbed('https://example.com/blog/post')).toBe(null)
+  })
+
+  it('returns null for a non-http url', () => {
+    expect(resolveCuratedEmbed('javascript:alert(1)')).toBe(null)
+  })
+
+  describe('youtube', () => {
+    it('handles a watch url', () => {
+      expect(resolveCuratedEmbed('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toMatchObject({
+        embedSrc: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+        providerName: 'YouTube',
+        aspectRatio: '16:9'
+      })
+    })
+
+    it('handles a youtu.be short url', () => {
+      expect(resolveCuratedEmbed('https://youtu.be/dQw4w9WgXcQ')?.embedSrc).toBe(
+        'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ'
+      )
+    })
+
+    it('handles a shorts url', () => {
+      expect(resolveCuratedEmbed('https://www.youtube.com/shorts/abc123XYZ_-')?.embedSrc).toBe(
+        'https://www.youtube-nocookie.com/embed/abc123XYZ_-'
+      )
+    })
+
+    it('handles a live url', () => {
+      expect(resolveCuratedEmbed('https://www.youtube.com/live/abc123XYZ_-')?.embedSrc).toBe(
+        'https://www.youtube-nocookie.com/embed/abc123XYZ_-'
+      )
+    })
+
+    it('carries a start time through as a query param', () => {
+      expect(
+        resolveCuratedEmbed('https://www.youtube.com/watch?v=abc123XYZ_-&t=90')?.embedSrc
+      ).toBe('https://www.youtube-nocookie.com/embed/abc123XYZ_-?start=90')
+    })
+
+    it('rejects a watch url with no video id', () => {
+      expect(resolveCuratedEmbed('https://www.youtube.com/watch')).toBe(null)
+    })
+
+    it('rejects a video id with unexpected characters', () => {
+      expect(resolveCuratedEmbed('https://www.youtube.com/watch?v=../../evil')).toBe(null)
+    })
+  })
+
+  describe('loom', () => {
+    it('handles a share url', () => {
+      expect(resolveCuratedEmbed('https://www.loom.com/share/abc123def456')).toMatchObject({
+        embedSrc: 'https://www.loom.com/embed/abc123def456',
+        providerName: 'Loom'
+      })
+    })
+
+    it('handles a share url with query noise', () => {
+      expect(resolveCuratedEmbed('https://loom.com/share/abc123def456?sid=xyz')?.embedSrc).toBe(
+        'https://www.loom.com/embed/abc123def456'
+      )
+    })
+  })
+
+  describe('vimeo', () => {
+    it('handles a numeric video url', () => {
+      expect(resolveCuratedEmbed('https://vimeo.com/123456789')?.embedSrc).toBe(
+        'https://player.vimeo.com/video/123456789'
+      )
+    })
+
+    it('ignores a non-numeric path', () => {
+      expect(resolveCuratedEmbed('https://vimeo.com/channels/staffpicks')).toBe(null)
+    })
+  })
+
+  describe('google', () => {
+    it('maps a doc edit url to preview', () => {
+      expect(
+        resolveCuratedEmbed('https://docs.google.com/document/d/ABC_123/edit?usp=sharing')
+      ).toMatchObject({
+        embedSrc: 'https://docs.google.com/document/d/ABC_123/preview',
+        providerName: 'Google Docs',
+        aspectRatio: '4:3'
+      })
+    })
+
+    it('maps a sheet to preview', () => {
+      expect(
+        resolveCuratedEmbed('https://docs.google.com/spreadsheets/d/ABC_123/edit#gid=0')?.embedSrc
+      ).toBe('https://docs.google.com/spreadsheets/d/ABC_123/preview')
+    })
+
+    it('maps slides to embed', () => {
+      expect(
+        resolveCuratedEmbed('https://docs.google.com/presentation/d/ABC_123/edit')?.embedSrc
+      ).toBe('https://docs.google.com/presentation/d/ABC_123/embed')
+    })
+
+    it('maps a form to an embedded viewform', () => {
+      expect(
+        resolveCuratedEmbed('https://docs.google.com/forms/d/e/ABC_123/viewform')?.embedSrc
+      ).toBe('https://docs.google.com/forms/d/e/ABC_123/viewform?embedded=true')
+    })
+
+    it('ignores a google url that is not a document', () => {
+      expect(resolveCuratedEmbed('https://docs.google.com/')).toBe(null)
+    })
+  })
+
+  describe('figma', () => {
+    it('wraps a design url in the embed endpoint', () => {
+      const result = resolveCuratedEmbed('https://www.figma.com/design/AbC123/My-File')
+      expect(result?.embedSrc).toBe(
+        'https://www.figma.com/embed?embed_host=parabol&url=https%3A%2F%2Fwww.figma.com%2Fdesign%2FAbC123%2FMy-File'
+      )
+      expect(result?.providerName).toBe('Figma')
+    })
+  })
+
+  describe('miro', () => {
+    it('maps a board to the live embed', () => {
+      expect(resolveCuratedEmbed('https://miro.com/app/board/uXjVK123=/')?.embedSrc).toBe(
+        'https://miro.com/app/live-embed/uXjVK123='
+      )
+    })
+  })
+
+  describe('codepen', () => {
+    it('maps a pen to the embed path', () => {
+      expect(resolveCuratedEmbed('https://codepen.io/someuser/pen/abcXYZ')?.embedSrc).toBe(
+        'https://codepen.io/someuser/embed/abcXYZ'
+      )
+    })
+  })
+
+  describe('spotify', () => {
+    it('maps a track', () => {
+      expect(resolveCuratedEmbed('https://open.spotify.com/track/abc123')?.embedSrc).toBe(
+        'https://open.spotify.com/embed/track/abc123'
+      )
+    })
+
+    it('maps a playlist', () => {
+      expect(resolveCuratedEmbed('https://open.spotify.com/playlist/abc123')?.embedSrc).toBe(
+        'https://open.spotify.com/embed/playlist/abc123'
+      )
+    })
+
+    it('ignores an unsupported spotify path', () => {
+      expect(resolveCuratedEmbed('https://open.spotify.com/user/someone')).toBe(null)
+    })
+  })
+})
+
+describe('isAllowedEmbedHost', () => {
+  it('accepts an exact allowlisted host', () => {
+    expect(isAllowedEmbedHost('https://www.loom.com/embed/abc')).toBe(true)
+  })
+
+  it('accepts a subdomain of an allowlisted host', () => {
+    expect(isAllowedEmbedHost('https://player.vimeo.com/video/1')).toBe(true)
+  })
+
+  it('rejects an arbitrary host', () => {
+    expect(isAllowedEmbedHost('https://evil.example.com/x')).toBe(false)
+  })
+
+  it('rejects a lookalike suffix attack', () => {
+    expect(isAllowedEmbedHost('https://notloom.com/embed/abc')).toBe(false)
+    expect(isAllowedEmbedHost('https://www.loom.com.evil.co/embed/abc')).toBe(false)
+  })
+
+  it('rejects http even on an allowlisted host', () => {
+    expect(isAllowedEmbedHost('http://www.loom.com/embed/abc')).toBe(false)
+  })
+
+  it('rejects javascript urls', () => {
+    expect(isAllowedEmbedHost('javascript:alert(1)')).toBe(false)
+  })
+
+  it('rejects unparseable input', () => {
+    expect(isAllowedEmbedHost('')).toBe(false)
+    expect(isAllowedEmbedHost('not a url')).toBe(false)
+  })
+
+  it('accepts every embedSrc the curated table can produce', () => {
+    const samples = [
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://www.loom.com/share/abc123def456',
+      'https://vimeo.com/123456789',
+      'https://docs.google.com/document/d/ABC_123/edit',
+      'https://www.figma.com/design/AbC123/My-File',
+      'https://miro.com/app/board/uXjVK123=/',
+      'https://codepen.io/someuser/pen/abcXYZ',
+      'https://open.spotify.com/track/abc123'
+    ]
+    for (const sample of samples) {
+      const result = resolveCuratedEmbed(sample)
+      expect(result).not.toBe(null)
+      expect(isAllowedEmbedHost(result!.embedSrc)).toBe(true)
+    }
+  })
+})

--- a/packages/client/shared/embed/__tests__/normalizeEmbedUrl.test.ts
+++ b/packages/client/shared/embed/__tests__/normalizeEmbedUrl.test.ts
@@ -1,0 +1,78 @@
+import {normalizeEmbedUrl} from '../normalizeEmbedUrl'
+
+describe('normalizeEmbedUrl', () => {
+  it('rejects non-http protocols', () => {
+    expect(normalizeEmbedUrl('javascript:alert(1)')).toBe(null)
+    expect(normalizeEmbedUrl('data:text/html,<h1>hi</h1>')).toBe(null)
+    expect(normalizeEmbedUrl('file:///etc/passwd')).toBe(null)
+    expect(normalizeEmbedUrl('ftp://example.com/a')).toBe(null)
+  })
+
+  it('rejects unparseable input', () => {
+    expect(normalizeEmbedUrl('')).toBe(null)
+    expect(normalizeEmbedUrl('not a url')).toBe(null)
+    expect(normalizeEmbedUrl('   ')).toBe(null)
+  })
+
+  it('accepts http and https', () => {
+    expect(normalizeEmbedUrl('https://example.com/post')).toBe('https://example.com/post')
+    expect(normalizeEmbedUrl('http://example.com/post')).toBe('http://example.com/post')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeEmbedUrl('  https://example.com/post  ')).toBe('https://example.com/post')
+  })
+
+  it('lowercases the host but preserves path case', () => {
+    expect(normalizeEmbedUrl('https://EXAMPLE.com/MyPost')).toBe('https://example.com/MyPost')
+  })
+
+  it('drops the fragment', () => {
+    expect(normalizeEmbedUrl('https://example.com/post#section-2')).toBe('https://example.com/post')
+  })
+
+  it('strips utm_* tracking params', () => {
+    expect(normalizeEmbedUrl('https://example.com/p?utm_source=x&utm_medium=y')).toBe(
+      'https://example.com/p'
+    )
+  })
+
+  it('strips known click identifiers', () => {
+    expect(normalizeEmbedUrl('https://example.com/p?fbclid=abc&gclid=def&igshid=ghi')).toBe(
+      'https://example.com/p'
+    )
+  })
+
+  it('strips the si share token used by YouTube and Spotify', () => {
+    expect(normalizeEmbedUrl('https://youtu.be/dQw4w9WgXcQ?si=AbCdEf')).toBe(
+      'https://youtu.be/dQw4w9WgXcQ'
+    )
+  })
+
+  it('preserves semantic params', () => {
+    expect(normalizeEmbedUrl('https://www.youtube.com/watch?v=abc123&t=42')).toBe(
+      'https://www.youtube.com/watch?t=42&v=abc123'
+    )
+  })
+
+  it('preserves semantic params while removing tracking ones', () => {
+    expect(normalizeEmbedUrl('https://www.youtube.com/watch?v=abc123&utm_source=slack&t=9')).toBe(
+      'https://www.youtube.com/watch?t=9&v=abc123'
+    )
+  })
+
+  it('sorts remaining params so key order does not fragment the cache', () => {
+    expect(normalizeEmbedUrl('https://example.com/p?b=2&a=1')).toBe('https://example.com/p?a=1&b=2')
+  })
+
+  it('normalizes two links differing only by tracking to one cache key', () => {
+    const a = normalizeEmbedUrl('https://example.com/post?utm_campaign=jan')
+    const b = normalizeEmbedUrl('https://example.com/post#intro')
+    expect(a).toBe(b)
+  })
+
+  it('strips a trailing slash on the root path only', () => {
+    expect(normalizeEmbedUrl('https://example.com/')).toBe('https://example.com')
+    expect(normalizeEmbedUrl('https://example.com/dir/')).toBe('https://example.com/dir/')
+  })
+})

--- a/packages/client/shared/embed/curatedEmbedProviders.ts
+++ b/packages/client/shared/embed/curatedEmbedProviders.ts
@@ -1,0 +1,213 @@
+import type {EmbedAspectRatio} from './embedTypes'
+
+export type CuratedEmbedResult = {
+  embedSrc: string
+  providerName: string
+  aspectRatio: EmbedAspectRatio
+}
+
+/**
+ * Hosts we are willing to put inside an iframe. This is a security boundary, not a
+ * convenience list: `embedSrc` lives in a Yjs document, so any collaborator with edit
+ * access can write it straight over the websocket, bypassing the server resolver.
+ * The node view re-checks against this list before rendering.
+ */
+export const EMBED_HOST_ALLOWLIST = [
+  'youtube.com',
+  'youtube-nocookie.com',
+  'loom.com',
+  'vimeo.com',
+  'docs.google.com',
+  'figma.com',
+  'miro.com',
+  'codepen.io',
+  'spotify.com',
+  'soundcloud.com',
+  'twitch.tv',
+  'whimsical.com',
+  'wistia.net',
+  'canva.com',
+  'replit.com',
+  'observablehq.com',
+  'tiktok.com',
+  'speakerdeck.com',
+  'dwcdn.net'
+]
+
+export const isAllowedEmbedHost = (src: string | null | undefined): boolean => {
+  if (!src) return false
+  let url: URL
+  try {
+    url = new URL(src)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'https:') return false
+  const host = url.hostname.toLowerCase()
+  return EMBED_HOST_ALLOWLIST.some((allowed) => host === allowed || host.endsWith(`.${allowed}`))
+}
+
+const YOUTUBE_ID = /^[\w-]{6,20}$/
+// The share dialog emits 1m30s past the first minute; plain seconds is the older form
+const YOUTUBE_DURATION = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/
+const parseYouTubeSeconds = (raw: string | null) => {
+  if (!raw) return 0
+  if (/^\d+$/.test(raw)) return Number.parseInt(raw, 10)
+  const match = YOUTUBE_DURATION.exec(raw)
+  if (!match || raw === '') return 0
+  const [, h, m, sec] = match
+  return Number(h ?? 0) * 3600 + Number(m ?? 0) * 60 + Number(sec ?? 0)
+}
+const parseYouTube = (url: URL): CuratedEmbedResult | null => {
+  const host = url.hostname.replace(/^www\./, '')
+  let id: string | undefined
+  if (host === 'youtu.be') {
+    id = url.pathname.slice(1).split('/')[0]
+  } else if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+    const [, segment, pathId] = url.pathname.split('/')
+    if (segment === 'watch') {
+      id = url.searchParams.get('v') ?? undefined
+    } else if (segment === 'shorts' || segment === 'live' || segment === 'embed') {
+      id = pathId
+    }
+  }
+  if (!id || !YOUTUBE_ID.test(id)) return null
+  const start = url.searchParams.get('t') ?? url.searchParams.get('start')
+  const seconds = parseYouTubeSeconds(start)
+  const query = seconds > 0 ? `?start=${seconds}` : ''
+  return {
+    embedSrc: `https://www.youtube-nocookie.com/embed/${id}${query}`,
+    providerName: 'YouTube',
+    aspectRatio: '16:9'
+  }
+}
+
+const LOOM_ID = /^[a-zA-Z0-9]{8,}$/
+const parseLoom = (url: URL): CuratedEmbedResult | null => {
+  const [, segment, id] = url.pathname.split('/')
+  if (segment !== 'share' || !id || !LOOM_ID.test(id)) return null
+  return {
+    embedSrc: `https://www.loom.com/embed/${id}`,
+    providerName: 'Loom',
+    aspectRatio: '16:9'
+  }
+}
+
+const parseVimeo = (url: URL): CuratedEmbedResult | null => {
+  const [, id] = url.pathname.split('/')
+  if (!id || !/^\d+$/.test(id)) return null
+  return {
+    embedSrc: `https://player.vimeo.com/video/${id}`,
+    providerName: 'Vimeo',
+    aspectRatio: '16:9'
+  }
+}
+
+const GOOGLE_DOC_ID = /^[\w-]+$/
+type GoogleKind = {
+  provider: string
+  aspectRatio: EmbedAspectRatio
+  suffix: 'preview' | 'embed'
+}
+const GOOGLE_KINDS: Record<string, GoogleKind> = {
+  document: {provider: 'Google Docs', aspectRatio: '4:3', suffix: 'preview'},
+  spreadsheets: {provider: 'Google Sheets', aspectRatio: '4:3', suffix: 'preview'},
+  presentation: {provider: 'Google Slides', aspectRatio: '16:9', suffix: 'embed'}
+}
+const parseGoogle = (url: URL): CuratedEmbedResult | null => {
+  const [, kind, d, first, second] = url.pathname.split('/')
+  if (!kind || d !== 'd') return null
+  if (kind === 'forms') {
+    // forms use /forms/d/e/<id>/viewform
+    const id = first === 'e' ? second : first
+    if (!id || !GOOGLE_DOC_ID.test(id)) return null
+    const path = first === 'e' ? `d/e/${id}` : `d/${id}`
+    return {
+      embedSrc: `https://docs.google.com/forms/${path}/viewform?embedded=true`,
+      providerName: 'Google Forms',
+      aspectRatio: '4:3'
+    }
+  }
+  const config = GOOGLE_KINDS[kind]
+  if (!config || !first || !GOOGLE_DOC_ID.test(first)) return null
+  return {
+    embedSrc: `https://docs.google.com/${kind}/d/${first}/${config.suffix}`,
+    providerName: config.provider,
+    aspectRatio: config.aspectRatio
+  }
+}
+
+const FIGMA_KINDS = new Set(['file', 'design', 'board', 'slides', 'proto', 'deck'])
+const parseFigma = (url: URL): CuratedEmbedResult | null => {
+  const [, kind] = url.pathname.split('/')
+  if (!kind || !FIGMA_KINDS.has(kind)) return null
+  return {
+    embedSrc: `https://www.figma.com/embed?embed_host=parabol&url=${encodeURIComponent(url.href)}`,
+    providerName: 'Figma',
+    aspectRatio: '16:9'
+  }
+}
+
+const parseMiro = (url: URL): CuratedEmbedResult | null => {
+  const [, app, board, id] = url.pathname.split('/')
+  if (app !== 'app' || board !== 'board' || !id) return null
+  return {
+    embedSrc: `https://miro.com/app/live-embed/${id}`,
+    providerName: 'Miro',
+    aspectRatio: '16:9'
+  }
+}
+
+const parseCodePen = (url: URL): CuratedEmbedResult | null => {
+  const [, user, pen, id] = url.pathname.split('/')
+  if (!user || pen !== 'pen' || !id) return null
+  return {
+    embedSrc: `https://codepen.io/${user}/embed/${id}`,
+    providerName: 'CodePen',
+    aspectRatio: '4:3'
+  }
+}
+
+const SPOTIFY_KINDS = new Set(['track', 'album', 'playlist', 'episode', 'show', 'artist'])
+const parseSpotify = (url: URL): CuratedEmbedResult | null => {
+  const [, kind, id] = url.pathname.split('/')
+  if (!kind || !SPOTIFY_KINDS.has(kind) || !id) return null
+  return {
+    embedSrc: `https://open.spotify.com/embed/${kind}/${id}`,
+    providerName: 'Spotify',
+    aspectRatio: 'tall'
+  }
+}
+
+const PARSERS: Record<string, (url: URL) => CuratedEmbedResult | null> = {
+  'youtube.com': parseYouTube,
+  'm.youtube.com': parseYouTube,
+  'music.youtube.com': parseYouTube,
+  'youtu.be': parseYouTube,
+  'loom.com': parseLoom,
+  'vimeo.com': parseVimeo,
+  'docs.google.com': parseGoogle,
+  'figma.com': parseFigma,
+  'miro.com': parseMiro,
+  'codepen.io': parseCodePen,
+  'open.spotify.com': parseSpotify
+}
+
+/**
+ * Deterministic URL to embed-src transforms for providers we care about.
+ * Runs before any network call, so the client can render these instantly on paste,
+ * and wins over the oEmbed registry (which does not cover Google Docs at all).
+ */
+export const resolveCuratedEmbed = (rawUrl: string): CuratedEmbedResult | null => {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+  const host = url.hostname.toLowerCase().replace(/^www\./, '')
+  const parser = PARSERS[host] ?? PARSERS[url.hostname.toLowerCase()]
+  if (!parser) return null
+  return parser(url)
+}

--- a/packages/client/shared/embed/embedTypes.ts
+++ b/packages/client/shared/embed/embedTypes.ts
@@ -1,0 +1,58 @@
+export type EmbedDisplayMode = 'embed' | 'card'
+
+export type EmbedAspectRatio = '16:9' | '4:3' | '1:1' | 'tall'
+
+export type EmbedAlign = 'left' | 'center' | 'right'
+
+/** Everything a resolver can learn about a URL. All fields beyond `url` are provider-derived. */
+export type EmbedMetadata = {
+  url: string
+  embedSrc?: string | null
+  title?: string | null
+  description?: string | null
+  thumbnailUrl?: string | null
+  faviconUrl?: string | null
+  providerName?: string | null
+  authorName?: string | null
+  aspectRatio?: EmbedAspectRatio | null
+  fetchedAt?: string | null
+}
+
+/**
+ * Attributes written onto the node. Split into two classes that never mix:
+ * user intent is only ever written by the person editing, provider-derived
+ * is only ever written by the server. Background revalidation cannot fight a
+ * formatting choice because it cannot address those fields.
+ */
+export type EmbedBlockUserAttrs = {
+  url: string
+  displayMode: EmbedDisplayMode
+  align: EmbedAlign
+  width?: number
+  isFullWidth: boolean
+  aspectRatio: EmbedAspectRatio
+}
+
+export type EmbedBlockProviderAttrs = {
+  embedSrc?: string
+  title?: string
+  description?: string
+  thumbnailUrl?: string
+  faviconUrl?: string
+  providerName?: string
+  authorName?: string
+  fetchedAt?: string
+}
+
+export type EmbedBlockAttrs = EmbedBlockUserAttrs & EmbedBlockProviderAttrs
+
+export const PROVIDER_ATTR_KEYS = [
+  'embedSrc',
+  'title',
+  'description',
+  'thumbnailUrl',
+  'faviconUrl',
+  'providerName',
+  'authorName',
+  'fetchedAt'
+] as const satisfies readonly (keyof EmbedBlockProviderAttrs)[]

--- a/packages/client/shared/embed/normalizeEmbedUrl.ts
+++ b/packages/client/shared/embed/normalizeEmbedUrl.ts
@@ -1,0 +1,64 @@
+const TRACKING_PARAMS = new Set([
+  'fbclid',
+  'gclid',
+  'mc_cid',
+  'mc_eid',
+  'ref',
+  'ref_src',
+  '_hsenc',
+  '_hsmi',
+  'igshid',
+  // YouTube and Spotify append `si` as a per-share token, so two people sharing
+  // the same video would otherwise occupy two cache entries
+  'si'
+])
+
+const isTrackingParam = (key: string) => key.startsWith('utm_') || TRACKING_PARAMS.has(key)
+
+/**
+ * Canonical form of a URL, used as the cache key and to de-duplicate links that
+ * differ only by tracking noise. Returns null for anything we must never fetch.
+ */
+export const normalizeEmbedUrl = (raw: string): string | null => {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  let url: URL
+  try {
+    url = new URL(trimmed)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+
+  url.hash = ''
+  url.hostname = url.hostname.toLowerCase()
+
+  const params = [...url.searchParams.entries()].filter(([key]) => !isTrackingParam(key))
+  params.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+  url.search = ''
+  for (const [key, value] of params) {
+    url.searchParams.append(key, value)
+  }
+
+  const href = url.href
+  // URL always renders the root as a trailing slash; drop it so `example.com` and
+  // `example.com/` share a cache entry. Deeper paths keep their slash, since a
+  // trailing slash can be semantically distinct.
+  return url.pathname === '/' && !url.search ? href.slice(0, -1) : href
+}
+
+/**
+ * `url` lives in a Yjs document just like `embedSrc`, so a collaborator with edit access
+ * can write any scheme straight over the websocket. Every sink that renders it as an
+ * href or hands it to window.open has to re-check it here.
+ */
+export const toSafeHref = (raw: string | null | undefined): string | null => {
+  if (!raw) return null
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return null
+  }
+  return url.protocol === 'http:' || url.protocol === 'https:' ? raw : null
+}

--- a/packages/client/shared/tiptap/__tests__/embedBlockMarkdown.test.ts
+++ b/packages/client/shared/tiptap/__tests__/embedBlockMarkdown.test.ts
@@ -1,0 +1,67 @@
+import {Editor} from '@tiptap/core'
+import {serverTipTapExtensions} from '../serverTipTapExtensions'
+
+const embedDoc = (attrs: Record<string, unknown>) => ({
+  type: 'doc',
+  content: [{type: 'embedBlock', attrs}]
+})
+
+const roundTrip = (attrs: Record<string, unknown>) => {
+  const editor = new Editor({
+    element: undefined,
+    content: embedDoc(attrs),
+    extensions: serverTipTapExtensions
+  })
+  const markdown = editor.getMarkdown()
+  const reparsed = new Editor({
+    element: undefined,
+    content: markdown,
+    contentType: 'markdown',
+    extensions: serverTipTapExtensions
+  })
+  return {markdown, node: reparsed.getJSON().content?.find((node) => node.type === 'embedBlock')}
+}
+
+describe('embedBlock markdown round trip', () => {
+  it('preserves url and formatting attrs through a serialize/parse round trip', () => {
+    const url = 'https://www.loom.com/share/abc123def456'
+    const {node} = roundTrip({
+      url,
+      displayMode: 'embed',
+      align: 'center',
+      aspectRatio: '16:9',
+      providerName: 'Loom'
+    })
+
+    expect(node?.attrs?.url).toBe(url)
+    expect(node?.attrs?.aspectRatio).toBe('16:9')
+    expect(node?.attrs?.providerName).toBe('Loom')
+  })
+
+  it('does not serialize free-text provider fields that can break Pandoc attribute syntax', () => {
+    const url = 'https://www.loom.com/share/abc123def456'
+    const {markdown} = roundTrip({
+      url,
+      title: 'JSON {a} tips',
+      description: 'She said "hi" to Bob',
+      authorName: "Bob's channel"
+    })
+
+    expect(markdown).not.toMatch(/title=/)
+    expect(markdown).not.toMatch(/description=/)
+    expect(markdown).not.toMatch(/authorName=/)
+  })
+
+  it('survives a round trip as a real embedBlock even when free-text fields contain unsafe characters', () => {
+    const url = 'https://www.loom.com/share/abc123def456'
+    const {node} = roundTrip({
+      url,
+      title: 'JSON {a} tips',
+      description: 'She said "hi" to Bob',
+      authorName: "Bob's channel"
+    })
+
+    expect(node?.type).toBe('embedBlock')
+    expect(node?.attrs?.url).toBe(url)
+  })
+})

--- a/packages/client/shared/tiptap/extensions/EmbedBlockBase.ts
+++ b/packages/client/shared/tiptap/extensions/EmbedBlockBase.ts
@@ -1,0 +1,152 @@
+import {createBlockMarkdownSpec, mergeAttributes, Node, type NodeConfig} from '@tiptap/core'
+import {isAllowedEmbedHost} from '../../embed/curatedEmbedProviders'
+import type {
+  EmbedAspectRatio,
+  EmbedBlockAttrs,
+  EmbedBlockProviderAttrs
+} from '../../embed/embedTypes'
+import {toSafeHref} from '../../embed/normalizeEmbedUrl'
+
+export type {EmbedBlockAttrs}
+
+export const ASPECT_RATIO_PADDING: Record<EmbedAspectRatio, string> = {
+  '16:9': '56.25%',
+  '4:3': '75%',
+  '1:1': '100%',
+  tall: '133.33%'
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    embedBlock: {
+      setEmbedBlock: (attributes?: {url?: string; pos?: number}) => ReturnType
+      setEmbedBlockAlign: (align: 'left' | 'center' | 'right') => ReturnType
+      setEmbedBlockWidth: (width: number) => ReturnType
+      setEmbedBlockFullWidth: (isFullWidth: boolean) => ReturnType
+      setEmbedBlockDisplayMode: (displayMode: 'embed' | 'card') => ReturnType
+      setEmbedBlockAspectRatio: (aspectRatio: EmbedAspectRatio) => ReturnType
+      setEmbedBlockMetadata: (metadata: EmbedBlockProviderAttrs) => ReturnType
+    }
+  }
+}
+
+const stringAttr = (name: string, dataName: string, fallback: unknown = undefined) => ({
+  default: fallback,
+  parseHTML: (element: HTMLElement) => element.getAttribute(dataName) ?? fallback,
+  renderHTML: (attributes: Record<string, any>) =>
+    attributes[name] ? {[dataName]: attributes[name]} : {}
+})
+
+export const EmbedBlockBase = Node.create({
+  name: 'embedBlock',
+
+  group: 'block',
+
+  atom: true,
+
+  defining: true,
+
+  isolating: true,
+
+  draggable: true,
+
+  selectable: true,
+
+  inline: false,
+
+  addAttributes() {
+    return {
+      url: stringAttr('url', 'data-url', ''),
+      displayMode: stringAttr('displayMode', 'data-display-mode', 'embed'),
+      align: stringAttr('align', 'data-align', 'center'),
+      aspectRatio: stringAttr('aspectRatio', 'data-aspect-ratio', '16:9'),
+      embedSrc: stringAttr('embedSrc', 'data-embed-src'),
+      title: stringAttr('title', 'data-title'),
+      description: stringAttr('description', 'data-description'),
+      thumbnailUrl: stringAttr('thumbnailUrl', 'data-thumbnail-url'),
+      faviconUrl: stringAttr('faviconUrl', 'data-favicon-url'),
+      providerName: stringAttr('providerName', 'data-provider-name'),
+      authorName: stringAttr('authorName', 'data-author-name'),
+      fetchedAt: stringAttr('fetchedAt', 'data-fetched-at'),
+      width: {
+        default: undefined,
+        parseHTML: (element: HTMLElement) => {
+          const raw = element.getAttribute('data-width')
+          const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN
+          return Number.isFinite(parsed) ? parsed : undefined
+        },
+        renderHTML: (attributes: Record<string, any>) =>
+          attributes.width ? {'data-width': String(attributes.width)} : {}
+      },
+      isFullWidth: {
+        default: false,
+        parseHTML: (element: HTMLElement) => element.getAttribute('data-full-width') === 'true',
+        renderHTML: (attributes: Record<string, any>) =>
+          attributes.isFullWidth ? {'data-full-width': 'true'} : {}
+      }
+    }
+  },
+
+  parseHTML() {
+    return [{tag: `div[data-type="${this.name}"]`}]
+  },
+
+  renderText({node}) {
+    const {title, url} = node.attrs as EmbedBlockAttrs
+    return `\n${title ? `${title}: ` : ''}${url}\n`
+  },
+
+  // Consumed by HTML, markdown and Confluence export, so it must always render
+  // something a reader can follow. An unresolved embed still yields a link.
+  renderHTML({HTMLAttributes, node}) {
+    const {url, title, embedSrc, displayMode, align, aspectRatio} = node.attrs as EmbedBlockAttrs
+    const justify = align === 'left' ? 'start' : align === 'right' ? 'end' : 'center'
+    const attrs = mergeAttributes(HTMLAttributes, {'data-type': 'embedBlock'})
+    const canFrame = displayMode === 'embed' && isAllowedEmbedHost(embedSrc)
+    if (!canFrame) {
+      const href = toSafeHref(url)
+      const label = title || url
+      if (!href) return ['div', attrs, label]
+      return ['div', attrs, ['a', {href, target: '_blank', rel: 'noopener noreferrer'}, label]]
+    }
+    const padding = ASPECT_RATIO_PADDING[aspectRatio] ?? ASPECT_RATIO_PADDING['16:9']
+    return [
+      'div',
+      mergeAttributes(attrs, {
+        style: `width: 100%; display: flex; justify-content: ${justify};`
+      }),
+      [
+        'div',
+        {style: `position: relative; width: 100%; padding-bottom: ${padding}; height: 0;`},
+        [
+          'iframe',
+          {
+            src: embedSrc!,
+            title: title || url,
+            style: 'position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;',
+            loading: 'lazy',
+            referrerpolicy: 'strict-origin-when-cross-origin',
+            sandbox: 'allow-scripts allow-same-origin allow-popups allow-presentation allow-forms',
+            allow: 'accelerometer; autoplay; clipboard-write; encrypted-media; picture-in-picture',
+            allowfullscreen: 'true'
+          }
+        ]
+      ]
+    ]
+  },
+  ...createBlockMarkdownSpec({
+    nodeName: 'embedBlock',
+    allowedAttributes: [
+      'url',
+      'displayMode',
+      'align',
+      'aspectRatio',
+      'isFullWidth',
+      'embedSrc',
+      'thumbnailUrl',
+      'faviconUrl',
+      'providerName'
+    ]
+  })
+  // TipTap v3 got some types wrong, this cast shouldn't be necessary
+} as NodeConfig)

--- a/packages/client/shared/tiptap/serverTipTapExtensions.ts
+++ b/packages/client/shared/tiptap/serverTipTapExtensions.ts
@@ -13,6 +13,7 @@ import {UniqueID} from '../../tiptap/extensions/docWithID/UniqueID'
 import {ImageBlockBase} from '../../tiptap/extensions/imageBlock/ImageBlockBase'
 import {PageUserMention} from '../../tiptap/extensions/pageUserMention/PageUserMention'
 import {MentionTaskTag} from '../../utils/MentionTaskTag'
+import {EmbedBlockBase} from './extensions/EmbedBlockBase'
 import {FileBlockBase} from './extensions/FileBlockBase'
 import {FileUploadBase} from './extensions/FileUploadBase'
 import {InsightsBlockBase} from './extensions/InsightsBlockBase'
@@ -65,6 +66,7 @@ export const serverTipTapExtensions: Extensions = [
   TaskItem.configure({
     nested: true
   }),
+  EmbedBlockBase,
   FileBlockBase,
   FileUploadBase,
   ImageBlockBase,

--- a/packages/client/tiptap/extensions/PageDragHandle.ts
+++ b/packages/client/tiptap/extensions/PageDragHandle.ts
@@ -27,6 +27,9 @@ const queryNode = graphql`
   }
 `
 
+// Approximates a text line so the handle sits at the top of a media block
+const DRAG_HANDLE_ANCHOR_HEIGHT = 24
+
 function isEmptyParagraph(node: Node) {
   return node.type.name === 'paragraph' && node.textContent.length === 0
 }
@@ -244,6 +247,27 @@ export const PageDragHandle = Extension.create<Options>({
             horizontalRef = horizontalRef.parentElement
           }
           const horizontalRect = horizontalRef.getBoundingClientRect()
+          // Media blocks carry no text to anchor to. Without this the walker below finds
+          // nothing and the handle never renders for an iframe embed, and anchors to the
+          // title line rather than the block top for a card.
+          const handleNode = editorRef.state.doc.nodeAt(dragHandleNodePos)
+          if (handleNode?.type.name === 'embedBlock') {
+            const blockRect = dom.getBoundingClientRect()
+            const anchorHeight = Math.min(blockRect.height, DRAG_HANDLE_ANCHOR_HEIGHT)
+            return {
+              getBoundingClientRect: () => ({
+                x: horizontalRect.x,
+                y: blockRect.y,
+                width: horizontalRect.width,
+                height: anchorHeight,
+                top: blockRect.top,
+                right: horizontalRect.right,
+                bottom: blockRect.top + anchorHeight,
+                left: horizontalRect.left
+              }),
+              contextElement: horizontalRef
+            }
+          }
           const walker = document.createTreeWalker(dom, NodeFilter.SHOW_TEXT, {
             acceptNode: (node) =>
               node.textContent?.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT

--- a/packages/client/tiptap/extensions/embedBlock/EmbedBlock.ts
+++ b/packages/client/tiptap/extensions/embedBlock/EmbedBlock.ts
@@ -1,0 +1,105 @@
+import {Plugin, PluginKey} from '@tiptap/pm/state'
+import {ReactNodeViewRenderer} from '@tiptap/react'
+import {resolveCuratedEmbed} from '../../../shared/embed/curatedEmbedProviders'
+import {normalizeEmbedUrl} from '../../../shared/embed/normalizeEmbedUrl'
+import {EmbedBlockBase} from '../../../shared/tiptap/extensions/EmbedBlockBase'
+import {EmbedBlockView} from './EmbedBlockView'
+
+export const EmbedBlock = EmbedBlockBase.extend({
+  addCommands() {
+    return {
+      setEmbedBlock:
+        (attributes) =>
+        ({commands}) => {
+          const {url, pos} = attributes ?? {}
+          const curated = url ? resolveCuratedEmbed(url) : null
+          const node = {
+            type: 'embedBlock',
+            attrs: {
+              url: url ?? '',
+              ...(curated && {
+                embedSrc: curated.embedSrc,
+                providerName: curated.providerName,
+                aspectRatio: curated.aspectRatio
+              })
+            }
+          }
+          if (pos !== undefined) return commands.insertContentAt(pos, node)
+          return commands.insertContent(node)
+        },
+      setEmbedBlockAlign:
+        (align) =>
+        ({commands}) =>
+          commands.updateAttributes('embedBlock', {align}),
+      setEmbedBlockWidth:
+        (width) =>
+        ({commands}) =>
+          commands.updateAttributes('embedBlock', {width, isFullWidth: false}),
+      setEmbedBlockFullWidth:
+        (isFullWidth) =>
+        ({commands}) =>
+          commands.updateAttributes('embedBlock', {isFullWidth}),
+      setEmbedBlockDisplayMode:
+        (displayMode) =>
+        ({commands}) =>
+          commands.updateAttributes('embedBlock', {displayMode}),
+      setEmbedBlockAspectRatio:
+        (aspectRatio) =>
+        ({commands}) =>
+          commands.updateAttributes('embedBlock', {aspectRatio}),
+      setEmbedBlockMetadata:
+        (metadata) =>
+        ({commands}) =>
+          commands.updateAttributes('embedBlock', metadata)
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('embedBlockPaste'),
+        props: {
+          handlePaste: (view, event) => {
+            const text = event.clipboardData?.getData('text/plain')?.trim()
+            if (!text) return false
+            const url = normalizeEmbedUrl(text)
+            if (!url) return false
+            const {selection, schema} = view.state
+            // Only claim the paste when it cannot be meant as a link: an empty
+            // selection sitting alone in an empty paragraph. Pasting over text
+            // must still produce a link mark.
+            if (!selection.empty) return false
+            const {$from} = selection
+            const parent = $from.parent
+            if (parent.type.name !== 'paragraph' || parent.content.size !== 0) return false
+            // Only a top-level paragraph. A paragraph nested in a table cell, list item
+            // or details block may not accept a block node, and replaceSelectionWith
+            // would then place it somewhere surprising.
+            if ($from.depth !== 1) return false
+            const nodeType = schema.nodes.embedBlock
+            if (!nodeType) return false
+            const curated = resolveCuratedEmbed(url)
+            const node = nodeType.create({
+              url,
+              ...(curated && {
+                embedSrc: curated.embedSrc,
+                providerName: curated.providerName,
+                aspectRatio: curated.aspectRatio
+              })
+            })
+            const tr = view.state.tr.replaceSelectionWith(node)
+            view.dispatch(tr.scrollIntoView())
+            return true
+          }
+        }
+      })
+    ]
+  },
+
+  addNodeView() {
+    // By convention, components rendered here are named with a *View suffix
+    return ReactNodeViewRenderer(EmbedBlockView, {className: 'group'})
+  }
+})
+
+export default EmbedBlock

--- a/packages/client/tiptap/extensions/embedBlock/EmbedBlockCard.tsx
+++ b/packages/client/tiptap/extensions/embedBlock/EmbedBlockCard.tsx
@@ -1,0 +1,58 @@
+import {Public as PublicIcon} from '~/ui/icons'
+import {toSafeHref} from '../../../shared/embed/normalizeEmbedUrl'
+import type {EmbedBlockAttrs} from '../../../shared/tiptap/extensions/EmbedBlockBase'
+
+interface Props {
+  attrs: EmbedBlockAttrs
+}
+
+export const EmbedBlockCard = (props: Props) => {
+  const {attrs} = props
+  const {url, title, description, thumbnailUrl, faviconUrl, providerName} = attrs
+  const href = toSafeHref(url)
+  let hostname = url
+  try {
+    hostname = new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    // a malformed url still deserves a rendered card
+  }
+
+  return (
+    <a
+      href={href ?? undefined}
+      target='_blank'
+      rel='noopener noreferrer'
+      className='flex w-full overflow-hidden rounded-md border border-hairline bg-surface-card no-underline transition-colors hover:bg-surface-hover'
+    >
+      <div className='flex min-w-0 flex-1 flex-col justify-center gap-1 p-3'>
+        <div className='truncate font-semibold text-fg-primary text-sm'>{title || hostname}</div>
+        {description ? (
+          <div className='line-clamp-2 text-fg-secondary text-xs'>{description}</div>
+        ) : null}
+        <div className='flex items-center gap-1.5 pt-1'>
+          {faviconUrl ? (
+            <img
+              src={faviconUrl}
+              alt=''
+              referrerPolicy='no-referrer'
+              loading='lazy'
+              className='size-4 rounded-xs'
+            />
+          ) : (
+            <PublicIcon className='size-4 text-fg-muted' />
+          )}
+          <span className='truncate text-fg-muted text-xs'>{providerName || hostname}</span>
+        </div>
+      </div>
+      {thumbnailUrl ? (
+        <img
+          src={thumbnailUrl}
+          alt=''
+          referrerPolicy='no-referrer'
+          loading='lazy'
+          className='hidden h-[120px] w-[200px] shrink-0 object-cover sm:block'
+        />
+      ) : null}
+    </a>
+  )
+}

--- a/packages/client/tiptap/extensions/embedBlock/EmbedBlockFrame.tsx
+++ b/packages/client/tiptap/extensions/embedBlock/EmbedBlockFrame.tsx
@@ -1,0 +1,77 @@
+import {useEffect, useRef, useState} from 'react'
+import type {EmbedAspectRatio} from '../../../shared/embed/embedTypes'
+import {ASPECT_RATIO_PADDING} from '../../../shared/tiptap/extensions/EmbedBlockBase'
+import {cn} from '../../../ui/cn'
+
+interface Props {
+  embedSrc: string
+  title: string
+  aspectRatio: EmbedAspectRatio
+  thumbnailUrl?: string
+  /** While true the frame ignores pointer events so hover reaches the editor */
+  isInert?: boolean
+}
+
+export const EmbedBlockFrame = (props: Props) => {
+  const {embedSrc, title, aspectRatio, thumbnailUrl, isInert} = props
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  // A page with twenty videos must not boot twenty players on load
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el || isVisible) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setIsVisible(true)
+          observer.disconnect()
+        }
+      },
+      {rootMargin: '200px'}
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [isVisible])
+
+  const paddingBottom = ASPECT_RATIO_PADDING[aspectRatio] ?? ASPECT_RATIO_PADDING['16:9']
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        'relative h-0 w-full overflow-hidden rounded-md bg-surface-well',
+        isInert && 'cursor-pointer'
+      )}
+      style={{paddingBottom}}
+    >
+      {isVisible ? (
+        <iframe
+          src={embedSrc}
+          title={title}
+          loading='lazy'
+          referrerPolicy='strict-origin-when-cross-origin'
+          sandbox='allow-scripts allow-same-origin allow-popups allow-presentation allow-forms'
+          allow='accelerometer; autoplay; clipboard-write; encrypted-media; picture-in-picture'
+          allowFullScreen
+          className={cn(
+            'absolute top-0 left-0 h-full w-full border-0',
+            isInert && 'pointer-events-none'
+          )}
+        />
+      ) : (
+        <div className='absolute top-0 left-0 flex h-full w-full items-center justify-center'>
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt=''
+              referrerPolicy='no-referrer'
+              loading='lazy'
+              className='h-full w-full object-cover'
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/client/tiptap/extensions/embedBlock/EmbedBlockUrlInput.tsx
+++ b/packages/client/tiptap/extensions/embedBlock/EmbedBlockUrlInput.tsx
@@ -1,0 +1,47 @@
+import {useState} from 'react'
+import {Link as LinkIcon} from '~/ui/icons'
+import {Button} from '../../../ui/Button/Button'
+
+interface Props {
+  isResolving: boolean
+  onSubmit: (url: string) => void
+}
+
+export const EmbedBlockUrlInput = (props: Props) => {
+  const {isResolving, onSubmit} = props
+  const [value, setValue] = useState('')
+
+  const submit = () => {
+    const trimmed = value.trim()
+    if (trimmed) onSubmit(trimmed)
+  }
+
+  return (
+    <div className='flex items-center gap-2 rounded-md border border-hairline border-dashed bg-surface-well p-3'>
+      <LinkIcon className='size-5 shrink-0 text-fg-muted' />
+      <input
+        autoFocus
+        type='url'
+        value={value}
+        placeholder='Paste a link to embed'
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            e.stopPropagation()
+            submit()
+          }
+        }}
+        className='min-w-0 flex-1 rounded-sm border border-hairline-field bg-surface-input px-2 py-1 text-sm outline-hidden focus:border-accent'
+      />
+      <Button
+        variant='secondary'
+        size='sm'
+        disabled={!value.trim() || isResolving}
+        onClick={submit}
+      >
+        {isResolving ? 'Loading…' : 'Embed'}
+      </Button>
+    </div>
+  )
+}

--- a/packages/client/tiptap/extensions/embedBlock/EmbedBlockView.tsx
+++ b/packages/client/tiptap/extensions/embedBlock/EmbedBlockView.tsx
@@ -1,0 +1,94 @@
+import {type NodeViewProps, NodeViewWrapper} from '@tiptap/react'
+import {useCallback} from 'react'
+import {isAllowedEmbedHost, resolveCuratedEmbed} from '../../../shared/embed/curatedEmbedProviders'
+import type {EmbedBlockAttrs} from '../../../shared/embed/embedTypes'
+import {normalizeEmbedUrl} from '../../../shared/embed/normalizeEmbedUrl'
+import {cn} from '../../../ui/cn'
+import {EmbedBlockCard} from './EmbedBlockCard'
+import {EmbedBlockFrame} from './EmbedBlockFrame'
+import {EmbedBlockUrlInput} from './EmbedBlockUrlInput'
+
+export const EmbedBlockView = (props: NodeViewProps) => {
+  const {editor, getPos, node, updateAttributes, selected} = props
+  const attrs = node.attrs as EmbedBlockAttrs
+  const {url, displayMode, align, width, isFullWidth, aspectRatio, embedSrc, title, thumbnailUrl} =
+    attrs
+
+  const onClick = useCallback(() => {
+    const pos = getPos()
+    if (pos === undefined) return
+    editor.commands.setNodeSelection(pos)
+  }, [getPos, editor])
+
+  const onSubmitUrl = useCallback(
+    (raw: string) => {
+      const normalized = normalizeEmbedUrl(raw)
+      if (!normalized) return
+      // Curated providers resolve with no round-trip, so the embed paints immediately
+      const curated = resolveCuratedEmbed(normalized)
+      if (curated) {
+        updateAttributes({
+          url: normalized,
+          embedSrc: curated.embedSrc,
+          providerName: curated.providerName,
+          aspectRatio: curated.aspectRatio,
+          displayMode: 'embed',
+          fetchedAt: new Date().toISOString()
+        })
+        return
+      }
+      // Nothing more can be learned about this URL yet, so the card renders from the
+      // URL alone and fetchedAt stays unset for a later resolver to pick up
+      updateAttributes({url: normalized, displayMode: 'card'})
+    },
+    [updateAttributes]
+  )
+
+  const alignClass =
+    align === 'left' ? 'justify-start' : align === 'right' ? 'justify-end' : 'justify-center'
+
+  if (!url) {
+    return (
+      <NodeViewWrapper>
+        <div contentEditable={false}>
+          <EmbedBlockUrlInput isResolving={false} onSubmit={onSubmitUrl} />
+        </div>
+      </NodeViewWrapper>
+    )
+  }
+
+  // embedSrc lives in a Yjs doc, so a collaborator can write it directly over the
+  // websocket. Re-check it here rather than trusting what the resolver stored.
+  const canFrame = displayMode === 'embed' && isAllowedEmbedHost(embedSrc)
+
+  return (
+    <NodeViewWrapper>
+      <div className={cn('flex', alignClass)}>
+        <div
+          contentEditable={false}
+          onClick={onClick}
+          className={cn('group relative', isFullWidth || !width ? 'w-full' : undefined)}
+          style={isFullWidth || !width ? undefined : {width}}
+        >
+          {canFrame ? (
+            <EmbedBlockFrame
+              embedSrc={embedSrc!}
+              title={title || url}
+              aspectRatio={aspectRatio}
+              thumbnailUrl={thumbnailUrl}
+              // A cross-origin iframe swallows mousemove, so while it is live the editor
+              // never learns the pointer is over this block and the drag handle stays
+              // hidden. Letting pointer events fall through to the in-flow container
+              // until the block is selected restores both the handle and click-to-select.
+              isInert={editor.isEditable && !selected}
+            />
+          ) : (
+            <EmbedBlockCard attrs={attrs} />
+          )}
+        </div>
+      </div>
+    </NodeViewWrapper>
+  )
+}
+
+export default EmbedBlockView

--- a/packages/client/tiptap/extensions/slashCommand/slashCommands.ts
+++ b/packages/client/tiptap/extensions/slashCommand/slashCommands.ts
@@ -254,9 +254,6 @@ export const slashCommands = [
         action: (editor: Editor) => {
           const {to} = editor.state.selection
           const size = editor.state.doc.content.size
-          // setTextSelection is load-bearing: embedBlock is an atom, so inserting it
-          // leaves a NodeSelection on the node, and a chained insertContent would
-          // replace it rather than append after it
           let command = editor
             .chain()
             .focus()

--- a/packages/client/tiptap/extensions/slashCommand/slashCommands.ts
+++ b/packages/client/tiptap/extensions/slashCommand/slashCommands.ts
@@ -16,7 +16,8 @@ import {
   GridOn as TableIcon,
   TextFields as TextFieldsIcon,
   Title as TitleIcon,
-  Toc as TocIcon
+  Toc as TocIcon,
+  WebAsset as WebAssetIcon
 } from '~/ui/icons'
 
 declare module '@tiptap/core' {
@@ -233,6 +234,40 @@ export const slashCommands = [
   {
     group: 'Media',
     commands: [
+      {
+        title: 'Embed',
+        description: 'Embed a video, doc, or link',
+        searchTerms: [
+          'embed',
+          'video',
+          'youtube',
+          'loom',
+          'vimeo',
+          'google docs',
+          'figma',
+          'miro',
+          'bookmark',
+          'link',
+          'url'
+        ],
+        icon: WebAssetIcon,
+        action: (editor: Editor) => {
+          const {to} = editor.state.selection
+          const size = editor.state.doc.content.size
+          // setTextSelection is load-bearing: embedBlock is an atom, so inserting it
+          // leaves a NodeSelection on the node, and a chained insertContent would
+          // replace it rather than append after it
+          let command = editor
+            .chain()
+            .focus()
+            .setEmbedBlock()
+            .setTextSelection(to + 1)
+          if (size - to <= 1) {
+            command = command.insertContent('<p></p>').setTextSelection(to + 1)
+          }
+          return command.scrollIntoView().run()
+        }
+      },
       {
         title: 'Image',
         description: 'Upload any image from your device',

--- a/packages/client/tiptap/isCustomNodeSelected.ts
+++ b/packages/client/tiptap/isCustomNodeSelected.ts
@@ -1,5 +1,6 @@
 import type {Editor} from '@tiptap/core'
 import {TiptapLinkExtension} from '../components/TipTapEditor/TiptapLinkExtension'
+import {EmbedBlock} from './extensions/embedBlock/EmbedBlock'
 import FileBlock from './extensions/fileBlock/FileBlock'
 import {FileUpload} from './extensions/fileUpload/FileUpload'
 import {ImageBlock} from './extensions/imageBlock/ImageBlock'
@@ -16,6 +17,7 @@ const customNodes = [
   FileBlock.name,
   ResponseBlock.name,
   InsightsBlock.name,
+  EmbedBlock.name,
   ImageBlock.name,
   TaskBlock.name,
   TableOfContents.name

--- a/packages/server/utils/confluence/__tests__/serializerCoverage.test.ts
+++ b/packages/server/utils/confluence/__tests__/serializerCoverage.test.ts
@@ -32,6 +32,7 @@ const HANDLED_NODES = new Set([
   'fileBlock',
   'fileUpload',
   'loom',
+  'embedBlock',
   'pageLinkBlock',
   'tableOfContents',
   'insightsBlock',

--- a/packages/server/utils/confluence/convertTipTapToConfluenceStorage.ts
+++ b/packages/server/utils/confluence/convertTipTapToConfluenceStorage.ts
@@ -1,4 +1,5 @@
 import type {JSONContent} from '@tiptap/core'
+import {toSafeHref} from 'parabol-client/shared/embed/normalizeEmbedUrl'
 import {escapeHtml} from '../escapeHtml'
 import {escapeCdata} from './escapeXhtml'
 import type {ExportAsset, StorageConversionCtx, StorageConversionResult} from './types'
@@ -264,6 +265,14 @@ const emitBlock = (node: JSONContent, state: EmitState): string => {
     case 'loom': {
       const src = escapeHtml(String(attrs?.src ?? ''))
       return src ? `<p><a href="${src}" data-card-appearance="embed">${src}</a></p>` : ''
+    }
+    case 'embedBlock': {
+      const href = toSafeHref(attrs?.url as string | undefined)
+      if (!href) return ''
+      const src = escapeHtml(href)
+      const appearance = attrs?.displayMode === 'card' ? 'block' : 'embed'
+      const label = escapeHtml(String(attrs?.title ?? href))
+      return `<p><a href="${src}" data-card-appearance="${appearance}">${label}</a></p>`
     }
     case 'pageLinkBlock':
       return emitPageLink(node, state)


### PR DESCRIPTION
# Description

Implements a nice little block for embedding content in a Parabol Page.

Note: merges back to feat/pages-embed-block, not master. This is to keep the reviews light and tidy.

## Demo

https://www.loom.com/share/88ced169c3504f2c985d86205d329b83
