### PR TITLE
fix: add entropy to server test dummy data

### DIFF
--- a/packages/server/__tests__/SCIM.test.ts
+++ b/packages/server/__tests__/SCIM.test.ts
@@ -3,7 +3,15 @@ import fs from 'fs'
 import {InvoiceItemType} from '../../client/types/constEnums'
 import adjustUserCount from '../billing/helpers/adjustUserCount'
 import {getNewDataLoader} from '../dataloader/getNewDataLoader'
-import {HOST, PROTOCOL, sendIntranet, sendPublic, signUpWithEmail} from './common'
+import {
+  getTestDomain,
+  getTestEmail,
+  HOST,
+  PROTOCOL,
+  sendIntranet,
+  sendPublic,
+  signUpWithEmail
+} from './common'
 
 const SCIM_URL = `${PROTOCOL}://${HOST}/scim`
 
@@ -313,7 +321,7 @@ const enableSCIM = async (orgId: string, cookie: string) => {
 
 describe('Okta SCIM 2.0', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
 
   beforeAll(async () => {
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
@@ -335,7 +343,7 @@ describe('Okta SCIM 2.0', () => {
         randomUsernameCaps: randomUsername.toUpperCase(),
         randomGivenName: faker.name.firstName(),
         randomFamilyName: faker.name.lastName(),
-        randomEmail: faker.internet.email()
+        randomEmail: getTestEmail()
       })
     })
 
@@ -362,7 +370,7 @@ describe('Okta SCIM 2.0', () => {
     const userName = faker.internet.userName().toLowerCase()
     const givenName = faker.name.firstName()
     const familyName = faker.name.lastName()
-    const testEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const testEmail = getTestEmail(domain)
     const displayName = faker.name.firstName()
     const externalId = faker.datatype.uuid()
 
@@ -483,7 +491,7 @@ describe('Okta SCIM 2.0', () => {
       })
     })
 
-    const newEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const newEmail = getTestEmail(domain)
     const newUserName = faker.internet.userName().toLowerCase()
 
     test('PUT /Users/{id} - Update User with the latest email and username', async () => {
@@ -534,7 +542,7 @@ describe('Microsoft Entra SCIM 2.0', () => {
   // see https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups#user-operations
 
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
   beforeAll(async () => {
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
     await verifyDomain(domain, orgId)
@@ -543,7 +551,7 @@ describe('Microsoft Entra SCIM 2.0', () => {
 
   describe('Create New User', () => {
     const userName = faker.internet.userName().toLowerCase()
-    const testEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const testEmail = getTestEmail(domain)
     const externalId = faker.datatype.uuid()
     const givenName = faker.name.firstName()
     const familyName = faker.name.lastName()
@@ -701,7 +709,7 @@ describe('Microsoft Entra SCIM 2.0', () => {
 
   test('Create Duplicate User', async () => {
     const userName = faker.internet.userName().toLowerCase()
-    const testEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const testEmail = getTestEmail(domain)
 
     const post1 = await fetch(`${SCIM_URL}/Users`, {
       method: 'POST',
@@ -724,7 +732,7 @@ describe('Microsoft Entra SCIM 2.0', () => {
     })
     expect(post1.status).toBe(201)
 
-    const otherEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const otherEmail = getTestEmail(domain)
     const post2 = await fetch(`${SCIM_URL}/Users`, {
       method: 'POST',
       headers: {
@@ -775,7 +783,7 @@ describe('Microsoft Entra SCIM 2.0', () => {
 
   describe('Update User', () => {
     const userName = faker.internet.userName().toLowerCase()
-    const testEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const testEmail = getTestEmail(domain)
     const givenName = faker.name.firstName()
     const familyName = faker.name.lastName()
 
@@ -885,7 +893,7 @@ describe('Microsoft Entra SCIM 2.0', () => {
       })
     })
 
-    const newEmail = faker.internet.email().toLowerCase()
+    const newEmail = getTestEmail()
     const newFamilyName = faker.name.lastName()
     test('PATCH /Users/{id} Replace multi-valued properties', async () => {
       const res = await fetch(`${SCIM_URL}/Users/${id}`, {
@@ -1172,7 +1180,7 @@ test('Invalid endpoint returns 404', async () => {
 
 describe('Org membership is reflected in SCIM', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
   let orgId: string
 
   beforeAll(async () => {
@@ -1243,7 +1251,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('External user in org shows up', async () => {
-    const email = faker.internet.email().toLowerCase()
+    const email = getTestEmail()
     const {userId} = await signUpWithEmail(email)
     const dataLoader = getNewDataLoader('test-loader')
     await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
@@ -1277,7 +1285,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('PATCH active=false deletes managed user from org', async () => {
-    const email = faker.internet.userName().toLowerCase() + '@' + domain
+    const email = getTestEmail(domain)
     const {userId} = await signUpWithEmail(email)
     const dataLoader = getNewDataLoader('test-loader')
     await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
@@ -1329,7 +1337,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('PATCH active=false invalidates the managed user JWT', async () => {
-    const email = faker.internet.userName().toLowerCase() + '@' + domain
+    const email = getTestEmail(domain)
     const {userId, cookie} = await signUpWithEmail(email)
     const dataLoader = getNewDataLoader('test-loader')
     await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
@@ -1362,7 +1370,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('PATCH active=false removes external user from org', async () => {
-    const email = faker.internet.email().toLowerCase()
+    const email = getTestEmail()
     const {userId} = await signUpWithEmail(email)
     const dataLoader = getNewDataLoader('test-loader')
     await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
@@ -1414,7 +1422,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('DELETE hard deletes managed user', async () => {
-    const email = faker.internet.userName().toLowerCase() + '@' + domain
+    const email = getTestEmail(domain)
     const {userId} = await signUpWithEmail(email)
 
     const res = await fetch(`${SCIM_URL}/Users/${userId}`, {
@@ -1432,7 +1440,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('DELETE external user just removes from org', async () => {
-    const email = faker.internet.email().toLowerCase()
+    const email = getTestEmail()
     const {userId} = await signUpWithEmail(email)
     const dataLoader = getNewDataLoader('test-loader')
     await adjustUserCount(userId, orgId, InvoiceItemType.ADD_USER, dataLoader)
@@ -1464,7 +1472,7 @@ describe('Org membership is reflected in SCIM', () => {
   })
 
   test('PATCH on managed user outside org adds user to org', async () => {
-    const email = faker.internet.userName().toLowerCase() + '@' + domain
+    const email = getTestEmail(domain)
     const {userId} = await signUpWithEmail(email)
 
     const res = await fetch(`${SCIM_URL}/Users/${userId}`, {
@@ -1506,7 +1514,7 @@ describe('Org membership is reflected in SCIM', () => {
 
 describe('Unrelated users are inaccessible', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
 
   let userId: string
   let email: string
@@ -1516,7 +1524,7 @@ describe('Unrelated users are inaccessible', () => {
     await verifyDomain(domain, orgId)
     bearerToken = await enableSCIM(orgId, cookie)
 
-    email = faker.internet.email().toLowerCase()
+    email = getTestEmail()
     const user = await signUpWithEmail(email)
     userId = user.userId
   })
@@ -1591,7 +1599,7 @@ describe('Unrelated users are inaccessible', () => {
         emails: [
           {
             type: 'work',
-            value: faker.internet.email().toLowerCase()
+            value: getTestEmail()
           }
         ]
       })
@@ -1600,7 +1608,7 @@ describe('Unrelated users are inaccessible', () => {
   })
 
   test('DELETE unrelated user returns 404', async () => {
-    const email = faker.internet.email().toLowerCase()
+    const email = getTestEmail()
     const {userId} = await signUpWithEmail(email)
 
     const res = await fetch(`${SCIM_URL}/Users/${userId}`, {
@@ -1624,7 +1632,7 @@ describe('Unrelated users are inaccessible', () => {
 
 describe('External Users cannot be modified', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
   let userId: string
   let email: string
 
@@ -1633,7 +1641,7 @@ describe('External Users cannot be modified', () => {
     await verifyDomain(domain, orgId)
     bearerToken = await enableSCIM(orgId, cookie)
 
-    email = faker.internet.email().toLowerCase()
+    email = getTestEmail()
     const user = await signUpWithEmail(email)
     userId = user.userId
 
@@ -1654,7 +1662,7 @@ describe('External Users cannot be modified', () => {
           {
             op: 'Replace',
             path: 'emails[type eq "work"].value',
-            value: faker.internet.email().toLowerCase()
+            value: getTestEmail()
           }
         ]
       })
@@ -1685,7 +1693,7 @@ describe('External Users cannot be modified', () => {
         emails: [
           {
             type: 'work',
-            value: faker.internet.email().toLowerCase()
+            value: getTestEmail()
           }
         ]
       })
@@ -1704,7 +1712,7 @@ describe('External Users cannot be modified', () => {
 
 describe('Provisioned Users with external emails can be managed', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
   let email: string
 
   let userId: string
@@ -1714,7 +1722,7 @@ describe('Provisioned Users with external emails can be managed', () => {
     await verifyDomain(domain, orgId)
     bearerToken = await enableSCIM(orgId, cookie)
 
-    email = faker.internet.email().toLowerCase()
+    email = getTestEmail()
   })
 
   test('POST new user with external email', async () => {
@@ -1762,7 +1770,7 @@ describe('Provisioned Users with external emails can be managed', () => {
   })
 
   test('PATCH user with external email', async () => {
-    const newEmail = faker.internet.email().toLowerCase()
+    const newEmail = getTestEmail()
     const res = await fetch(`${SCIM_URL}/Users/${userId}`, {
       method: 'PATCH',
       headers: {
@@ -1862,8 +1870,8 @@ describe('Managed User can be taken over by SCIM with matched domain', () => {
   // user is first provisioned by company A but domain matches with B, so B can take over
   let bearerTokenA: string
   let bearerTokenB: string
-  const domainA = faker.internet.domainName()
-  const domainB = faker.internet.domainName()
+  const domainA = getTestDomain()
+  const domainB = getTestDomain()
   let email: string
 
   let userId: string
@@ -1877,7 +1885,7 @@ describe('Managed User can be taken over by SCIM with matched domain', () => {
     await verifyDomain(domainB, orgIdB)
     bearerTokenB = await enableSCIM(orgIdB, cookieB)
 
-    email = faker.internet.userName().toLowerCase() + '@' + domainB
+    email = getTestEmail(domainB)
   })
 
   test('POST new user with domainB email under orgA', async () => {
@@ -1970,7 +1978,7 @@ describe('Managed User can be taken over by SCIM with matched domain', () => {
           {
             op: 'Replace',
             path: 'emails[type eq "work"].value',
-            value: faker.internet.email().toLowerCase()
+            value: getTestEmail()
           }
         ]
       })
@@ -1988,7 +1996,7 @@ describe('Managed User can be taken over by SCIM with matched domain', () => {
 
 describe('Groups', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
 
   beforeAll(async () => {
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
@@ -2152,12 +2160,12 @@ describe('Groups', () => {
         },
         body: JSON.stringify({
           schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
-          userName: faker.internet.email().toLowerCase(),
+          userName: getTestEmail(),
           active: true,
           emails: [
             {
               type: 'work',
-              value: faker.internet.email().toLowerCase()
+              value: getTestEmail()
             }
           ]
         })
@@ -2178,12 +2186,12 @@ describe('Groups', () => {
         },
         body: JSON.stringify({
           schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
-          userName: faker.internet.email().toLowerCase(),
+          userName: getTestEmail(),
           active: true,
           emails: [
             {
               type: 'work',
-              value: faker.internet.email().toLowerCase()
+              value: getTestEmail()
             }
           ]
         })
@@ -2297,7 +2305,7 @@ describe('Groups', () => {
   })
 
   describe('Empty teams are archived', () => {
-    const userEmail = faker.internet.userName().toLowerCase() + '@' + domain
+    const userEmail = getTestEmail(domain)
     let userId: string
     let groupId: string
 
@@ -2399,7 +2407,7 @@ describe('Groups', () => {
     let groupId: string
 
     test('Create group with one member', async () => {
-      const userEmail = faker.internet.userName().toLowerCase() + '@' + domain
+      const userEmail = getTestEmail(domain)
       const user = await signUpWithEmail(userEmail)
       const userId = user.userId
 
@@ -2486,7 +2494,7 @@ describe('Groups', () => {
     })
 
     test('Add new member and check if they are lead', async () => {
-      const userEmail = faker.internet.userName().toLowerCase() + '@' + domain
+      const userEmail = getTestEmail(domain)
       const user = await signUpWithEmail(userEmail)
       const userId = user.userId
 
@@ -2545,7 +2553,7 @@ describe('Groups', () => {
 
 describe('Pagination', () => {
   let bearerToken: string
-  const domain = faker.internet.domainName()
+  const domain = getTestDomain()
   const PAGE_SIZE = 10
 
   beforeAll(async () => {
@@ -2820,7 +2828,7 @@ describe('SCIM OAuth Client Credentials authentication', () => {
   }
 
   test('can obtain access token and use it for SCIM requests', async () => {
-    const domain = faker.internet.domainName()
+    const domain = getTestDomain()
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
     await verifyDomain(domain, orgId)
     const {scimOAuthClientId, scimOAuthClientSecret} = await enableSCIMOAuth(orgId, cookie)
@@ -2857,7 +2865,7 @@ describe('SCIM OAuth Client Credentials authentication', () => {
   })
 
   test('wrong client_secret returns 401', async () => {
-    const domain = faker.internet.domainName()
+    const domain = getTestDomain()
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
     await verifyDomain(domain, orgId)
     const {scimOAuthClientId} = await enableSCIMOAuth(orgId, cookie)
@@ -2879,7 +2887,7 @@ describe('SCIM OAuth Client Credentials authentication', () => {
 
 describe('SCIM Bearer Token authentication', () => {
   test('Refreshing creates a new token', async () => {
-    const domain = faker.internet.domainName()
+    const domain = getTestDomain()
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
     await verifyDomain(domain, orgId)
     const bearerToken = await enableSCIM(orgId, cookie)
@@ -2897,7 +2905,7 @@ describe('SCIM Bearer Token authentication', () => {
   })
 
   test('Refreshing invalidates the old one', async () => {
-    const domain = faker.internet.domainName()
+    const domain = getTestDomain()
     const {orgId, cookie} = await createOrgAdmin(`admin@${domain}`)
     await verifyDomain(domain, orgId)
     const oldBearerToken = await enableSCIM(orgId, cookie)

--- a/packages/server/__tests__/abandonedSSOAccountRecovery.test.ts
+++ b/packages/server/__tests__/abandonedSSOAccountRecovery.test.ts
@@ -1,6 +1,5 @@
-import faker from 'faker'
 import getKysely from '../postgres/getKysely'
-import {sendIntranet, sendPublic, signUpWithEmail} from './common'
+import {getTestDomain, getTestEmail, sendIntranet, sendPublic, signUpWithEmail} from './common'
 
 const REMOVE_AUTH_IDENTITY_MUTATION = `
   mutation RemoveAuthIdentity(
@@ -34,7 +33,7 @@ const REMOVE_AUTH_IDENTITY_MUTATION = `
 `
 
 test('emailPasswordReset succeeds for abandoned SSO user with no local identity', async () => {
-  const domain = `abandoned-sso-${Date.now()}.example`
+  const domain = getTestDomain()
   const email = `user@${domain}`
   const {userId} = await signUpWithEmail(email)
 
@@ -91,7 +90,7 @@ test('emailPasswordReset succeeds for abandoned SSO user with no local identity'
 })
 
 test('removeAuthIdentity accepts emails parameter', async () => {
-  const email = faker.internet.email().toLowerCase()
+  const email = getTestEmail()
   const {userId} = await signUpWithEmail(email)
 
   const result = await sendIntranet({
@@ -114,7 +113,7 @@ test('removeAuthIdentity accepts emails parameter', async () => {
 })
 
 test('removeAuthIdentity accepts userIds parameter', async () => {
-  const email = faker.internet.email().toLowerCase()
+  const email = getTestEmail()
   const {userId} = await signUpWithEmail(email)
 
   const result = await sendIntranet({

--- a/packages/server/__tests__/autoJoin.test.ts
+++ b/packages/server/__tests__/autoJoin.test.ts
@@ -1,7 +1,7 @@
 import faker from 'faker'
 import createEmailVerification from '../email/createEmailVerification'
 import getKysely from '../postgres/getKysely'
-import {getUserTeams, sendIntranet, sendPublic} from './common'
+import {getTestDomain, getTestEmail, getUserTeams, sendIntranet, sendPublic} from './common'
 
 const signUpVerified = async (email: string) => {
   const password = faker.internet.password()
@@ -74,9 +74,9 @@ const signUpVerified = async (email: string) => {
 }
 
 test('autoJoin on multiple teams does not create duplicate `OrganizationUser`s', async () => {
-  const domain = `${faker.internet.domainWord()}.parabol.fun`
+  const domain = getTestDomain('parabol.fun')
 
-  const email = `${faker.internet.userName()}@${domain}`.toLowerCase()
+  const email = getTestEmail(domain)
   const {cookie, user, userId} = await signUpVerified(email)
   const orgId = user.organizations[0].id
 
@@ -151,7 +151,7 @@ test('autoJoin on multiple teams does not create duplicate `OrganizationUser`s',
   })
 
   // sign up a new user with same domain and check number of `OrganizationUser`s
-  const newEmail = `${faker.internet.userName()}@${domain}`.toLowerCase()
+  const newEmail = getTestEmail(domain)
   const {user: newUser} = await signUpVerified(newEmail)
 
   expect(newUser.tms).toEqual(expect.arrayContaining(teamIds))

--- a/packages/server/__tests__/common.ts
+++ b/packages/server/__tests__/common.ts
@@ -163,6 +163,19 @@ export const SIGNUP_WITH_PASSWORD_MUTATION = `
   }
 `
 
+// Test DBs are never truncated between runs, so every generated email/domain must be unique
+// across all runs & parallel workers, or signUp fails with "User already exists"
+const uniqueToken = () => crypto.randomBytes(8).toString('hex')
+
+export const getTestDomain = (suffix = faker.internet.domainSuffix()) =>
+  `${faker.internet.domainWord()}-${uniqueToken()}.${suffix}`.toLowerCase()
+
+export const getTestEmail = (domain?: string) => {
+  const base = domain ? `${faker.internet.userName()}@${domain}` : faker.internet.email()
+  const [localPart, emailDomain] = base.toLowerCase().split('@')
+  return `${localPart}-${uniqueToken()}@${emailDomain}`
+}
+
 export const signUpWithEmail = async (emailInput: string) => {
   //FIXME #1402 email addresses are case sensitive
   const email = emailInput.toLowerCase()
@@ -259,8 +272,7 @@ export const signUpWithEmail = async (emailInput: string) => {
 }
 
 export const signUp = async () => {
-  const email = faker.internet.email()
-  return signUpWithEmail(email)
+  return signUpWithEmail(getTestEmail())
 }
 
 export const getUserTeams = async (userId: string) => {

--- a/packages/server/__tests__/inviteToTeam.test.ts
+++ b/packages/server/__tests__/inviteToTeam.test.ts
@@ -1,6 +1,6 @@
 import faker from 'faker'
 import getKysely from '../postgres/getKysely'
-import {SIGNUP_WITH_PASSWORD_MUTATION, sendPublic, signUp} from './common'
+import {getTestEmail, SIGNUP_WITH_PASSWORD_MUTATION, sendPublic, signUp} from './common'
 
 test('Invite to team, works for ordinary email domain', async () => {
   const [user1, user2] = await Promise.all([signUp(), signUp()])
@@ -73,7 +73,7 @@ test('Team invite to an email acts as email verification', async () => {
   const user1 = await signUp()
   const {cookie, teamId} = user1
 
-  const email = faker.internet.email().toLowerCase()
+  const email = getTestEmail()
 
   const inviteToTeam = await sendPublic({
     query: `
@@ -142,7 +142,7 @@ test('Existing user cannot accept a team invitation sent to a different email', 
   const {cookie: user1Cookie, teamId} = user1
   const {cookie: user2Cookie} = user2
 
-  const invitedEmail = faker.internet.email().toLowerCase()
+  const invitedEmail = getTestEmail()
 
   await sendPublic({
     query: `
@@ -201,7 +201,7 @@ test('Team invite to an email acts as email verification only if the email match
   const user1 = await signUp()
   const {cookie, teamId} = user1
 
-  const email = faker.internet.email().toLowerCase()
+  const email = getTestEmail()
 
   const inviteToTeam = await sendPublic({
     query: `

--- a/packages/server/__tests__/pageAccess.test.ts
+++ b/packages/server/__tests__/pageAccess.test.ts
@@ -1,8 +1,7 @@
-import faker from 'faker'
 import type {Doc, YXmlEvent} from 'yjs'
 import {createPageLinkElement} from '../../client/shared/tiptap/createPageLinkElement'
 import getKysely from '../postgres/getKysely'
-import {sendPublic, sendTipTap, signUp, signUpWithEmail} from './common'
+import {getTestEmail, sendPublic, sendTipTap, signUp, signUpWithEmail} from './common'
 
 afterAll(async () => {
   await getKysely().destroy()
@@ -466,7 +465,7 @@ test('Revoking access unlinks children', async () => {
 
 test('New User adopts external access', async () => {
   const owner = await signUp()
-  const inviteeEmail = faker.internet.email().toLowerCase()
+  const inviteeEmail = getTestEmail()
   const {cookie} = owner
 
   const page = await sendPublic({

--- a/packages/server/__tests__/updateEmail.test.ts
+++ b/packages/server/__tests__/updateEmail.test.ts
@@ -1,9 +1,8 @@
-import faker from 'faker'
-import {sendIntranet, signUp} from './common'
+import {getTestEmail, sendIntranet, signUp} from './common'
 
 test('Update user email with unknown email fails', async () => {
-  const email = faker.internet.email().toLowerCase()
-  const newEmail = faker.internet.email().toLowerCase()
+  const email = getTestEmail()
+  const newEmail = getTestEmail()
 
   const updateEmail = await sendIntranet({
     query: `
@@ -24,7 +23,7 @@ test('Update user email with unknown email fails', async () => {
 
 test('Update user email', async () => {
   const {email, userId} = await signUp()
-  const newEmail = faker.internet.email().toLowerCase()
+  const newEmail = getTestEmail()
 
   const updateEmail = await sendIntranet({
     query: `

--- a/packages/server/__tests__/user.test.ts
+++ b/packages/server/__tests__/user.test.ts
@@ -1,6 +1,12 @@
-import faker from 'faker'
 import getKysely from '../postgres/getKysely'
-import {sendIntranet, sendPublic, signUp, signUpWithEmail} from './common'
+import {
+  getTestDomain,
+  getTestEmail,
+  sendIntranet,
+  sendPublic,
+  signUp,
+  signUpWithEmail
+} from './common'
 
 test('Get user by id', async () => {
   const {email, userId} = await signUp()
@@ -73,9 +79,9 @@ test('Get user by email', async () => {
 })
 
 test('First user is patientZero', async () => {
-  const domain = faker.internet.domainName()
-  const email1 = `${faker.internet.userName()}@${domain}`
-  const email2 = `${faker.internet.userName()}@${domain}`
+  const domain = getTestDomain()
+  const email1 = getTestEmail(domain)
+  const email2 = getTestEmail(domain)
 
   const {userId: user1Id} = await signUpWithEmail(email1)
   const {userId: user2Id} = await signUpWithEmail(email2)


### PR DESCRIPTION
# Description

server tests can fail in CI sometimes because there's not enough entropy using faker. now there is