### PR TITLE
fix: support multiple insights blocks on a Page (#12465)

### DIFF
--- a/packages/client/tiptap/extensions/insightsBlock/InsightsBlock.ts
+++ b/packages/client/tiptap/extensions/insightsBlock/InsightsBlock.ts
@@ -1,5 +1,6 @@
 import {TextSelection} from '@tiptap/pm/state'
-import {ReactNodeViewRenderer} from '@tiptap/react'
+import {type JSONContent, ReactNodeViewRenderer} from '@tiptap/react'
+import ms from 'ms'
 import type {MeetingTypeEnum} from '../../../__generated__/ExportToCSVQuery.graphql'
 import {InsightsBlockBase} from '../../../shared/tiptap/extensions/InsightsBlockBase'
 import {InsightsBlockView} from './InsightsBlockView'
@@ -34,7 +35,12 @@ export const InsightsBlock = InsightsBlockBase.extend<any, {}>({
         ({editor, commands}) => {
           const {to} = editor.state.selection
           const size = editor.state.doc.content.size
-          const content = [{type: 'insightsBlock'}]
+          const attrs = {
+            id: crypto.randomUUID(),
+            after: new Date(Date.now() - ms('12w')).toISOString(),
+            before: new Date().toISOString()
+          }
+          const content: JSONContent[] = [{type: 'insightsBlock', attrs}]
           if (size - to <= 1) {
             content.push({type: 'paragraph'})
           }

--- a/packages/client/tiptap/extensions/insightsBlock/InsightsBlockEditing.tsx
+++ b/packages/client/tiptap/extensions/insightsBlock/InsightsBlockEditing.tsx
@@ -51,9 +51,9 @@ const queryNode = graphql`
 `
 
 export const InsightsBlockEditing = (props: NodeViewProps) => {
-  const {editor, node, updateAttributes} = props
+  const {editor, getPos, node, updateAttributes} = props
   const attrs = node.attrs as InsightsBlockAttrs
-  const {id: blockId, after, before, meetingTypes, teamIds, meetingIds, hash, title, prompt} = attrs
+  const {after, before, meetingTypes, teamIds, meetingIds, hash, title, prompt} = attrs
   const atmosphere = useAtmosphere()
   const canQueryMeetings = teamIds.length > 0 && meetingTypes.length > 0 && after && before
   const {submitting, submitMutation, onCompleted} = useMutationProps()
@@ -92,18 +92,18 @@ export const InsightsBlockEditing = (props: NodeViewProps) => {
             }
             return
           }
-          const freshInsightsNode = editor.$node('insightsBlock', {
-            id: blockId
-          })
-          if (!freshInsightsNode) return
+          buffer += chunk
+          const pos = getPos()
+          if (pos === undefined) return
+          const freshNode = editor.state.doc.nodeAt(pos)
+          if (freshNode?.type.name !== 'insightsBlock') return
           if (first) {
             first = false
             updateAttributes({editing: false, hash: resultsHash})
           }
-          buffer += chunk
           const bufferFragment = marked.parse(buffer)
           editor.commands.insertContentAt(
-            {from: freshInsightsNode.from, to: freshInsightsNode.to - 1},
+            {from: pos + 1, to: pos + freshNode.nodeSize - 1},
             bufferFragment
           )
         } catch (e) {

--- a/packages/client/tiptap/extensions/insightsBlock/InsightsBlockResult.tsx
+++ b/packages/client/tiptap/extensions/insightsBlock/InsightsBlockResult.tsx
@@ -5,11 +5,8 @@ import {ContentCopy as ContentCopyIcon, Edit as EditIcon} from '~/ui/icons'
 import {Tooltip} from '../../../ui/Tooltip/Tooltip'
 import {TooltipContent} from '../../../ui/Tooltip/TooltipContent'
 import {TooltipTrigger} from '../../../ui/Tooltip/TooltipTrigger'
-import type {InsightsBlockAttrs} from './InsightsBlock'
 export const InsightsBlockResult = (props: NodeViewProps) => {
   const {editor, node, updateAttributes} = props
-  const attrs = node.attrs as InsightsBlockAttrs
-  const {id} = attrs
   return (
     <>
       <div className='flex justify-end space-x-2'>
@@ -18,15 +15,10 @@ export const InsightsBlockResult = (props: NodeViewProps) => {
             <button
               className='cursor-pointer text-fg-secondary hover:text-fg-primary'
               onClick={async () => {
-                // Leaving the comment here in case we want to switch back to plain text
-                // const plainText = editor.state.doc.textBetween(nodePos.from, nodePos.to, '\n')
-                // Important: get HTML from schema so we get attributes
-                const nodePos = editor.$node('insightsBlock', {id})!
-                // const fragment = Fragment.from(nodePos.node)
-                const htmlFragment = Fragment.from(nodePos.node)
+                const htmlFragment = Fragment.from(node)
                 const htmlText = getHTMLFromFragment(htmlFragment, editor.schema)
 
-                const innerFragment = nodePos.node.content
+                const innerFragment = node.content
                 const innerText = getHTMLFromFragment(innerFragment, editor.schema)
                 const tmpEditor = new Editor({
                   contentType: 'html',

--- a/packages/client/tiptap/extensions/insightsBlock/__tests__/InsightsBlock.test.ts
+++ b/packages/client/tiptap/extensions/insightsBlock/__tests__/InsightsBlock.test.ts
@@ -1,0 +1,96 @@
+import {Editor} from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import ms from 'ms'
+import {InsightsBlock} from '../InsightsBlock'
+
+jest.mock('../InsightsBlockView', () => ({InsightsBlockView: () => null}))
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+const createEditor = () =>
+  new Editor({
+    extensions: [StarterKit, InsightsBlock],
+    content: {type: 'doc', content: [{type: 'paragraph'}]}
+  })
+
+const getInsightsBlocks = (editor: Editor) => {
+  const blocks: Array<{id: string; after: string; before: string}> = []
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === 'insightsBlock') {
+      blocks.push(node.attrs as {id: string; after: string; before: string})
+    }
+  })
+  return blocks
+}
+
+const insertTwoInsightsBlocks = (editor: Editor) => {
+  editor.commands.setInsights()
+  editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+  editor.commands.setInsights()
+  return getInsightsBlocks(editor)
+}
+
+describe('InsightsBlock setInsights', () => {
+  it('assigns each inserted block a unique, non-empty id', () => {
+    const editor = createEditor()
+    const blocks = insertTwoInsightsBlocks(editor)
+
+    expect(blocks).toHaveLength(2)
+    const [first, second] = blocks
+    expect(first!.id).toBeTruthy()
+    expect(second!.id).toBeTruthy()
+    expect(first!.id).not.toBe(second!.id)
+  })
+
+  it('stamps the block with the current time, not a frozen schema default', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    const editor = createEditor()
+
+    jest.setSystemTime(new Date('2026-01-01T06:00:00.000Z'))
+    editor.commands.setInsights()
+
+    const [block] = getInsightsBlocks(editor)
+    expect(block!.before).toBe('2026-01-01T06:00:00.000Z')
+    expect(block!.after).toBe(
+      new Date(new Date('2026-01-01T06:00:00.000Z').getTime() - ms('12w')).toISOString()
+    )
+  })
+})
+
+describe('InsightsBlock content isolation across multiple blocks', () => {
+  const findBlockPos = (editor: Editor, index: number) => {
+    const matches: number[] = []
+    editor.state.doc.descendants((node, pos) => {
+      if (node.type.name === 'insightsBlock') {
+        matches.push(pos)
+      }
+    })
+    return matches[index]!
+  }
+
+  const writeToBlock = (editor: Editor, index: number, text: string) => {
+    const pos = findBlockPos(editor, index)
+    const node = editor.state.doc.nodeAt(pos)!
+    editor.commands.insertContentAt(
+      {from: pos + 1, to: pos + node.nodeSize - 1},
+      {type: 'paragraph', content: [{type: 'text', text}]}
+    )
+  }
+
+  it('writes streamed content into the correct block by position, not by id', () => {
+    const editor = createEditor()
+    insertTwoInsightsBlocks(editor)
+
+    writeToBlock(editor, 0, 'first result')
+    writeToBlock(editor, 1, 'second result')
+
+    const firstNode = editor.state.doc.nodeAt(findBlockPos(editor, 0))!
+    const secondNode = editor.state.doc.nodeAt(findBlockPos(editor, 1))!
+    expect(firstNode.textContent).toBe('first result')
+    expect(secondNode.textContent).toBe('second result')
+    expect(editor.state.doc.lastChild?.type.name).toBe('paragraph')
+  })
+})


### PR DESCRIPTION
Fixes #12465

- Give each /insights block a fresh id and date window on insert
- Target the block by position, not id, when streaming and copying
- Add headless tests for unique ids, insert-time dates, and block isolation
