### PR TITLE
fix: reject updatePersonalAccessToken with no fields

### DIFF
--- a/packages/server/__tests__/updatePersonalAccessToken.test.ts
+++ b/packages/server/__tests__/updatePersonalAccessToken.test.ts
@@ -1,0 +1,94 @@
+import {sendPublic, signUp} from './common'
+
+const CREATE_PERSONAL_ACCESS_TOKEN = `
+  mutation CreatePersonalAccessTokenMutation(
+    $name: String!
+    $scopes: [OAuthScopeEnum!]!
+    $expiresAt: DateTime!
+  ) {
+    createPersonalAccessToken(name: $name, scopes: $scopes, expiresAt: $expiresAt) {
+      personalAccessToken {
+        id
+      }
+    }
+  }
+`
+
+const UPDATE_PERSONAL_ACCESS_TOKEN = `
+  mutation UpdatePersonalAccessTokenMutation($tokenId: ID!, $name: String, $revoke: Boolean) {
+    updatePersonalAccessToken(tokenId: $tokenId, name: $name, revoke: $revoke) {
+      personalAccessToken {
+        id
+        name
+        revokedAt
+      }
+    }
+  }
+`
+
+const createToken = async (cookie: string) => {
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
+  const created = await sendPublic({
+    query: CREATE_PERSONAL_ACCESS_TOKEN,
+    variables: {name: 'test token', scopes: ['USERS_WRITE'], expiresAt},
+    cookie
+  })
+  expect(created).toMatchObject({
+    data: {createPersonalAccessToken: {personalAccessToken: {id: expect.any(String)}}}
+  })
+  return created.data.createPersonalAccessToken.personalAccessToken.id as string
+}
+
+test('rejects an update that supplies no fields', async () => {
+  const {cookie} = await signUp()
+  const tokenId = await createToken(cookie)
+
+  const updated = await sendPublic({
+    query: UPDATE_PERSONAL_ACCESS_TOKEN,
+    variables: {tokenId},
+    cookie
+  })
+
+  expect(updated).toMatchObject({
+    data: null,
+    errors: [{message: 'No fields to update'}]
+  })
+})
+
+test('updates the name', async () => {
+  const {cookie} = await signUp()
+  const tokenId = await createToken(cookie)
+
+  const updated = await sendPublic({
+    query: UPDATE_PERSONAL_ACCESS_TOKEN,
+    variables: {tokenId, name: 'renamed token'},
+    cookie
+  })
+
+  expect(updated).toMatchObject({
+    data: {
+      updatePersonalAccessToken: {
+        personalAccessToken: {id: tokenId, name: 'renamed token', revokedAt: null}
+      }
+    }
+  })
+})
+
+test('revokes the token', async () => {
+  const {cookie} = await signUp()
+  const tokenId = await createToken(cookie)
+
+  const revoked = await sendPublic({
+    query: UPDATE_PERSONAL_ACCESS_TOKEN,
+    variables: {tokenId, revoke: true},
+    cookie
+  })
+
+  expect(revoked).toMatchObject({
+    data: {
+      updatePersonalAccessToken: {
+        personalAccessToken: {id: tokenId, revokedAt: expect.any(String)}
+      }
+    }
+  })
+})

--- a/packages/server/graphql/public/mutations/updatePersonalAccessToken.ts
+++ b/packages/server/graphql/public/mutations/updatePersonalAccessToken.ts
@@ -55,20 +55,18 @@ export const updatePersonalAccessToken: MutationResolvers['updatePersonalAccessT
   if (expiresAt && expiresAt > maxExpiry) {
     throw new GraphQLError('Expiration date cannot be more than 1 year in the future')
   }
+  const updates = {
+    ...(tokenName !== undefined && tokenName !== null ? {name: tokenName} : {}),
+    ...(scopes !== undefined && scopes !== null ? {scopes} : {}),
+    ...(grantedOrgIds !== undefined ? {grantedOrgIds} : {}),
+    ...(grantedTeamIds !== undefined ? {grantedTeamIds} : {}),
+    ...(grantedPageIds !== undefined ? {grantedPageIds} : {}),
+    ...(expiresAt !== undefined && expiresAt !== null ? {expiresAt} : {}),
+    ...(revoke ? {revokedAt: new Date()} : {})
+  }
+  if (Object.keys(updates).length === 0) throw new GraphQLError('No fields to update')
   const pg = getKysely()
-  await pg
-    .updateTable('PersonalAccessToken')
-    .set({
-      ...(tokenName !== undefined && tokenName !== null ? {name: tokenName} : {}),
-      ...(scopes !== undefined && scopes !== null ? {scopes} : {}),
-      ...(grantedOrgIds !== undefined ? {grantedOrgIds} : {}),
-      ...(grantedTeamIds !== undefined ? {grantedTeamIds} : {}),
-      ...(grantedPageIds !== undefined ? {grantedPageIds} : {}),
-      ...(expiresAt !== undefined && expiresAt !== null ? {expiresAt} : {}),
-      ...(revoke ? {revokedAt: new Date()} : {})
-    })
-    .where('id', '=', token.id)
-    .execute()
+  await pg.updateTable('PersonalAccessToken').set(updates).where('id', '=', token.id).execute()
 
   return {patId: token.id}
 }


### PR DESCRIPTION
An update with only tokenId compiled to an empty SET clause and surfaced a pg syntax error. Throw a GraphQL error before the query instead. Fixes #13435.