### PR TITLE
feat: pages embed block (PR 2 of 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
+    "@extractus/oembed-extractor": "^6.0.0",
     "@floating-ui/dom": "^1.6.13",
     "@graphql-yoga/plugin-prometheus": "^6.8.5",
     "@hocuspocus/provider": "^4.1.0",
@@ -194,6 +195,12 @@
     "kysely": "0.30.0-beta.1",
     "magic-bytes.js": "^1.13.0",
     "markdown-it": "^14.3.0",
+    "metascraper": "^5.56.2",
+    "metascraper-description": "^5.56.2",
+    "metascraper-image": "^5.56.2",
+    "metascraper-logo": "^5.56.2",
+    "metascraper-publisher": "^5.56.2",
+    "metascraper-title": "^5.56.2",
     "ms": "^2.0.0",
     "msgpackr": "^1.11.8",
     "openai": "^6.9.1",

--- a/packages/client/tiptap/extensions/embedBlock/EmbedBlockView.tsx
+++ b/packages/client/tiptap/extensions/embedBlock/EmbedBlockView.tsx
@@ -1,5 +1,5 @@
 import {type NodeViewProps, NodeViewWrapper} from '@tiptap/react'
-import {useCallback} from 'react'
+import {useCallback, useEffect, useRef} from 'react'
 import {isAllowedEmbedHost, resolveCuratedEmbed} from '../../../shared/embed/curatedEmbedProviders'
 import type {EmbedBlockAttrs} from '../../../shared/embed/embedTypes'
 import {normalizeEmbedUrl} from '../../../shared/embed/normalizeEmbedUrl'
@@ -7,12 +7,26 @@ import {cn} from '../../../ui/cn'
 import {EmbedBlockCard} from './EmbedBlockCard'
 import {EmbedBlockFrame} from './EmbedBlockFrame'
 import {EmbedBlockUrlInput} from './EmbedBlockUrlInput'
+import {useResolveEmbedUrl} from './useResolveEmbedUrl'
 
 export const EmbedBlockView = (props: NodeViewProps) => {
   const {editor, getPos, node, updateAttributes, selected} = props
   const attrs = node.attrs as EmbedBlockAttrs
-  const {url, displayMode, align, width, isFullWidth, aspectRatio, embedSrc, title, thumbnailUrl} =
-    attrs
+  const {
+    url,
+    displayMode,
+    align,
+    width,
+    isFullWidth,
+    aspectRatio,
+    embedSrc,
+    title,
+    thumbnailUrl,
+    fetchedAt
+  } = attrs
+
+  const [resolve, isResolving] = useResolveEmbedUrl()
+  const resolvedUrlRef = useRef<string | null>(null)
 
   const onClick = useCallback(() => {
     const pos = getPos()
@@ -20,8 +34,24 @@ export const EmbedBlockView = (props: NodeViewProps) => {
     editor.commands.setNodeSelection(pos)
   }, [getPos, editor])
 
-  const onSubmitUrl = useCallback(
-    (raw: string) => {
+  const applyResolvedMetadata = useCallback(
+    (resolved: Awaited<ReturnType<typeof resolve>>) => {
+      if (!resolved) {
+        updateAttributes({displayMode: 'card', fetchedAt: new Date().toISOString()})
+        return
+      }
+      const {aspectRatio: resolvedAspect, url: _url, ...metadata} = resolved
+      updateAttributes({
+        ...metadata,
+        ...(resolvedAspect && {aspectRatio: resolvedAspect}),
+        ...(!resolved.embedSrc && {displayMode: 'card'})
+      })
+    },
+    [updateAttributes]
+  )
+
+  const applyUrl = useCallback(
+    async (raw: string) => {
       const normalized = normalizeEmbedUrl(raw)
       if (!normalized) return
       // Curated providers resolve with no round-trip, so the embed paints immediately
@@ -37,12 +67,53 @@ export const EmbedBlockView = (props: NodeViewProps) => {
         })
         return
       }
-      // Nothing more can be learned about this URL yet, so the card renders from the
-      // URL alone and fetchedAt stays unset for a later resolver to pick up
-      updateAttributes({url: normalized, displayMode: 'card'})
+      // Clear the previous provider's metadata up front, so a failed resolve cannot
+      // leave the old title and thumbnail sitting next to the new URL
+      updateAttributes({
+        url: normalized,
+        embedSrc: undefined,
+        title: undefined,
+        description: undefined,
+        thumbnailUrl: undefined,
+        faviconUrl: undefined,
+        providerName: undefined,
+        authorName: undefined
+      })
+      const resolved = await resolve(normalized)
+      applyResolvedMetadata(resolved)
     },
-    [updateAttributes]
+    [updateAttributes, resolve, applyResolvedMetadata]
   )
+
+  // A URL can arrive already on the node, from a paste or a collaborator, without
+  // ever passing through applyUrl. An unstamped fetchedAt is the signal it was
+  // never resolved.
+  useEffect(() => {
+    if (!url || fetchedAt) return
+    if (!editor.isEditable) return
+    if (resolvedUrlRef.current === url) return
+    resolvedUrlRef.current = url
+
+    const curated = resolveCuratedEmbed(url)
+    if (curated) {
+      updateAttributes({
+        embedSrc: curated.embedSrc,
+        providerName: curated.providerName,
+        aspectRatio: curated.aspectRatio,
+        displayMode: 'embed',
+        fetchedAt: new Date().toISOString()
+      })
+      return
+    }
+
+    let cancelled = false
+    resolve(url).then((resolved) => {
+      if (!cancelled) applyResolvedMetadata(resolved)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [url, fetchedAt, editor.isEditable, resolve, applyResolvedMetadata, updateAttributes])
 
   const alignClass =
     align === 'left' ? 'justify-start' : align === 'right' ? 'justify-end' : 'justify-center'
@@ -51,7 +122,7 @@ export const EmbedBlockView = (props: NodeViewProps) => {
     return (
       <NodeViewWrapper>
         <div contentEditable={false}>
-          <EmbedBlockUrlInput isResolving={false} onSubmit={onSubmitUrl} />
+          <EmbedBlockUrlInput isResolving={isResolving} onSubmit={applyUrl} />
         </div>
       </NodeViewWrapper>
     )

--- a/packages/client/tiptap/extensions/embedBlock/useResolveEmbedUrl.ts
+++ b/packages/client/tiptap/extensions/embedBlock/useResolveEmbedUrl.ts
@@ -1,0 +1,64 @@
+import graphql from 'babel-plugin-relay/macro'
+import {useCallback, useState} from 'react'
+import {fetchQuery} from 'relay-runtime'
+import type {useResolveEmbedUrlQuery} from '../../../__generated__/useResolveEmbedUrlQuery.graphql'
+import useAtmosphere from '../../../hooks/useAtmosphere'
+import type {EmbedBlockProviderAttrs} from '../../../shared/embed/embedTypes'
+
+const query = graphql`
+  query useResolveEmbedUrlQuery($url: String!, $refresh: Boolean) {
+    resolveEmbedUrl(url: $url, refresh: $refresh) {
+      url
+      embedSrc
+      title
+      description
+      thumbnailUrl
+      faviconUrl
+      providerName
+      authorName
+      aspectRatio
+      fetchedAt
+    }
+  }
+`
+
+type Resolved = EmbedBlockProviderAttrs & {url: string; aspectRatio?: string}
+
+export const useResolveEmbedUrl = () => {
+  const atmosphere = useAtmosphere()
+  const [isResolving, setIsResolving] = useState(false)
+
+  const resolve = useCallback(
+    async (url: string, refresh?: boolean): Promise<Resolved | null> => {
+      setIsResolving(true)
+      try {
+        const data = await fetchQuery<useResolveEmbedUrlQuery>(atmosphere, query, {
+          url,
+          refresh
+        }).toPromise()
+        const result = data?.resolveEmbedUrl
+        if (!result) return null
+        return {
+          url: result.url,
+          embedSrc: result.embedSrc ?? undefined,
+          title: result.title ?? undefined,
+          description: result.description ?? undefined,
+          thumbnailUrl: result.thumbnailUrl ?? undefined,
+          faviconUrl: result.faviconUrl ?? undefined,
+          providerName: result.providerName ?? undefined,
+          authorName: result.authorName ?? undefined,
+          aspectRatio: result.aspectRatio ?? undefined,
+          fetchedAt: result.fetchedAt ?? new Date().toISOString()
+        }
+      } catch {
+        // a transport failure leaves the caller to fall back to a bare card
+        return null
+      } finally {
+        setIsResolving(false)
+      }
+    },
+    [atmosphere]
+  )
+
+  return [resolve, isResolving] as const
+}

--- a/packages/server/graphql/public/permissions.ts
+++ b/packages/server/graphql/public/permissions.ts
@@ -469,8 +469,6 @@ const permissionMap: PermissionMap<Resolvers> = {
     getDemoGroupTitle: rateLimit({perMinute: 15, perHour: 150}),
     massInvitation: rateLimit({perMinute: 60, perHour: 1800}),
     public: rateLimit({perMinute: 20, perHour: 100}),
-    // a named rule replaces the '*' wildcard rather than composing with it, so
-    // isAuthenticated has to be spelled out alongside the limiter
     resolveEmbedUrl: and(isAuthenticated, rateLimit({perMinute: 30, perHour: 300})),
     SAMLIdP: rateLimit({perMinute: 120, perHour: 3600}),
     verifiedInvitation: rateLimit({perMinute: 60, perHour: 1800})

--- a/packages/server/graphql/public/permissions.ts
+++ b/packages/server/graphql/public/permissions.ts
@@ -469,6 +469,9 @@ const permissionMap: PermissionMap<Resolvers> = {
     getDemoGroupTitle: rateLimit({perMinute: 15, perHour: 150}),
     massInvitation: rateLimit({perMinute: 60, perHour: 1800}),
     public: rateLimit({perMinute: 20, perHour: 100}),
+    // a named rule replaces the '*' wildcard rather than composing with it, so
+    // isAuthenticated has to be spelled out alongside the limiter
+    resolveEmbedUrl: and(isAuthenticated, rateLimit({perMinute: 30, perHour: 300})),
     SAMLIdP: rateLimit({perMinute: 120, perHour: 3600}),
     verifiedInvitation: rateLimit({perMinute: 60, perHour: 1800})
   },

--- a/packages/server/graphql/public/queries/resolveEmbedUrl.ts
+++ b/packages/server/graphql/public/queries/resolveEmbedUrl.ts
@@ -1,0 +1,14 @@
+import {resolveEmbed} from '../../../utils/embed/resolveEmbed'
+import type {QueryResolvers} from '../resolverTypes'
+
+const resolveEmbedUrl: QueryResolvers['resolveEmbedUrl'] = async (_source, {url, refresh}) => {
+  const result = await resolveEmbed(url, refresh ?? false)
+  if (!result) return null
+  const {metadata} = result
+  return {
+    ...metadata,
+    fetchedAt: metadata.fetchedAt ? new Date(metadata.fetchedAt) : null
+  }
+}
+
+export default resolveEmbedUrl

--- a/packages/server/graphql/public/typeDefs/EmbedMetadata.graphql
+++ b/packages/server/graphql/public/typeDefs/EmbedMetadata.graphql
@@ -1,0 +1,45 @@
+"""
+Metadata resolved from an external URL, used to render an embed block
+"""
+type EmbedMetadata {
+  """
+  The normalized URL this metadata describes
+  """
+  url: String!
+  """
+  The https iframe source, or null when the provider cannot be framed
+  """
+  embedSrc: String
+  """
+  The title of the resource
+  """
+  title: String
+  """
+  A short summary of the resource
+  """
+  description: String
+  """
+  A preview image for the resource
+  """
+  thumbnailUrl: String
+  """
+  The site icon for the resource
+  """
+  faviconUrl: String
+  """
+  The human readable name of the provider, e.g. YouTube
+  """
+  providerName: String
+  """
+  The author or owner of the resource
+  """
+  authorName: String
+  """
+  The suggested aspect ratio for the frame: 16:9, 4:3, 1:1, or tall
+  """
+  aspectRatio: String
+  """
+  When this metadata was resolved
+  """
+  fetchedAt: DateTime
+}

--- a/packages/server/graphql/public/typeDefs/Query.graphql
+++ b/packages/server/graphql/public/typeDefs/Query.graphql
@@ -16,6 +16,19 @@ type Query {
     token: ID!
   ): MassInvitationPayload! @scope(name: TEAMS_READ)
   """
+  Resolve an external URL into embeddable metadata
+  """
+  resolveEmbedUrl(
+    """
+    The URL to resolve
+    """
+    url: String!
+    """
+    Bypass the cache and force a fresh fetch
+    """
+    refresh: Boolean
+  ): EmbedMetadata @scope(name: USERS_READ)
+  """
   Search for GIFs using Giphy
   """
   searchGifs(

--- a/packages/server/utils/__tests__/redisStaleWhileRevalidate.test.ts
+++ b/packages/server/utils/__tests__/redisStaleWhileRevalidate.test.ts
@@ -1,0 +1,88 @@
+import type Redis from 'ioredis'
+
+jest.mock('../getRedis')
+
+import getRedis from '../getRedis'
+import {redisStaleWhileRevalidate} from '../redisStaleWhileRevalidate'
+
+const mockedGetRedis = getRedis as jest.MockedFunction<typeof getRedis>
+
+type FakeRedis = {
+  get: jest.Mock<Promise<string | null>, [string]>
+  set: jest.Mock<Promise<'OK'>, [string, string, ...unknown[]]>
+  del: jest.Mock<Promise<number>, [string]>
+}
+
+const makeFakeRedis = (store: Map<string, string>): FakeRedis => ({
+  get: jest.fn(async (key: string) => store.get(key) ?? null),
+  set: jest.fn(async (key: string, value: string, ..._rest: unknown[]) => {
+    store.set(key, value)
+    return 'OK' as const
+  }),
+  del: jest.fn(async (key: string) => {
+    store.delete(key)
+    return 1
+  })
+})
+
+describe('redisStaleWhileRevalidate', () => {
+  let store: Map<string, string>
+  let redis: FakeRedis
+
+  beforeEach(() => {
+    store = new Map()
+    redis = makeFakeRedis(store)
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis)
+  })
+
+  it('returns the cached value without calling the thunk on a hit', async () => {
+    store.set('embed:foo', JSON.stringify({title: 'cached'}))
+    const thunk = jest.fn(async () => ({title: 'fresh'}))
+
+    const result = await redisStaleWhileRevalidate('embed:foo', thunk, 1000)
+
+    expect(result).toEqual({title: 'cached'})
+    expect(thunk).not.toHaveBeenCalled()
+  })
+
+  it('selects the TTL from the resolved value when ttlMs is a function', async () => {
+    const thunk = jest.fn(async () => ({isFallback: true}))
+    const ttlSelector = jest.fn((value: {isFallback: boolean}) =>
+      value.isFallback ? 300_000 : 604_800_000
+    )
+
+    await redisStaleWhileRevalidate('embed:bar', thunk, ttlSelector)
+
+    expect(ttlSelector).toHaveBeenCalledWith({isFallback: true})
+    const call = redis.set.mock.calls.find(([key]) => key === 'embed:bar')!
+    const ttlArg = call[3] as number
+    // jitterTTL applies +/-20%, so assert the jittered value stays in that band
+    expect(ttlArg).toBeGreaterThanOrEqual(240_000)
+    expect(ttlArg).toBeLessThanOrEqual(360_000)
+  })
+
+  it('reads the cache both before and after the lock when refresh is not set', async () => {
+    const thunk = jest.fn(async () => ({title: 'fresh'}))
+
+    await redisStaleWhileRevalidate('embed:quux', thunk, 1000)
+
+    expect(thunk).toHaveBeenCalledTimes(1)
+    expect(redis.get.mock.calls.filter(([key]) => key === 'embed:quux')).toHaveLength(2)
+  })
+
+  it('never reads the cache and always refetches when refresh is true, even on a hit', async () => {
+    // A value present before the call stands in for either a normal cache hit (the
+    // initial read) or another holder populating the key while this caller waited
+    // for the lock (the post-lock read) - refresh must skip both.
+    store.set('embed:baz', JSON.stringify({title: 'stale'}))
+    const thunk = jest.fn(async () => ({title: 'fresh'}))
+
+    const result = await redisStaleWhileRevalidate('embed:baz', thunk, 1000, {refresh: true})
+
+    expect(thunk).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({title: 'fresh'})
+    expect(redis.get).not.toHaveBeenCalledWith('embed:baz')
+    // The fresh value overwrites the stale one, so a later non-refresh read gets it
+    expect(JSON.parse(store.get('embed:baz')!)).toEqual({title: 'fresh'})
+  })
+})

--- a/packages/server/utils/embed/__tests__/extractIframeSrc.test.ts
+++ b/packages/server/utils/embed/__tests__/extractIframeSrc.test.ts
@@ -1,0 +1,63 @@
+import {extractIframeSrc} from '../extractIframeSrc'
+
+describe('extractIframeSrc', () => {
+  it('pulls the src out of a youtube style embed', () => {
+    const html =
+      '<iframe width="480" height="270" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allowfullscreen></iframe>'
+    expect(extractIframeSrc(html)).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed')
+  })
+
+  it('handles single quoted attributes', () => {
+    const html = "<iframe src='https://player.vimeo.com/video/123'></iframe>"
+    expect(extractIframeSrc(html)).toBe('https://player.vimeo.com/video/123')
+  })
+
+  it('handles attributes before src', () => {
+    const html =
+      '<iframe class="x" data-a="b" src="https://www.loom.com/embed/abc" allowfullscreen></iframe>'
+    expect(extractIframeSrc(html)).toBe('https://www.loom.com/embed/abc')
+  })
+
+  it('decodes html entities in the src', () => {
+    const html = '<iframe src="https://open.spotify.com/embed/track/1?a=1&amp;b=2"></iframe>'
+    expect(extractIframeSrc(html)).toBe('https://open.spotify.com/embed/track/1?a=1&b=2')
+  })
+
+  it('returns null when there is no iframe', () => {
+    const html =
+      '<blockquote class="twitter-tweet"><p>hi</p></blockquote><script src="https://platform.twitter.com/widgets.js"></script>'
+    expect(extractIframeSrc(html)).toBe(null)
+  })
+
+  it('returns null for an http src', () => {
+    expect(extractIframeSrc('<iframe src="http://www.loom.com/embed/abc"></iframe>')).toBe(null)
+  })
+
+  it('returns null for a src on a host that is not allowlisted', () => {
+    expect(extractIframeSrc('<iframe src="https://evil.example.com/x"></iframe>')).toBe(null)
+  })
+
+  it('returns null for a javascript src', () => {
+    expect(extractIframeSrc('<iframe src="javascript:alert(1)"></iframe>')).toBe(null)
+  })
+
+  it('returns null for a protocol-relative src', () => {
+    expect(extractIframeSrc('<iframe src="//www.loom.com/embed/abc"></iframe>')).toBe(null)
+  })
+
+  it('returns null for a data uri src', () => {
+    expect(extractIframeSrc('<iframe src="data:text/html;base64,PHNjcmlwdD4="></iframe>')).toBe(
+      null
+    )
+  })
+
+  it('returns null on empty input', () => {
+    expect(extractIframeSrc('')).toBe(null)
+    expect(extractIframeSrc('   ')).toBe(null)
+  })
+
+  it('ignores a script tag that precedes the iframe', () => {
+    const html = '<script>window.x=1</script><iframe src="https://www.loom.com/embed/abc"></iframe>'
+    expect(extractIframeSrc(html)).toBe('https://www.loom.com/embed/abc')
+  })
+})

--- a/packages/server/utils/embed/__tests__/resolveEmbed.test.ts
+++ b/packages/server/utils/embed/__tests__/resolveEmbed.test.ts
@@ -1,0 +1,124 @@
+import type Redis from 'ioredis'
+
+jest.mock('../oEmbedResolver', () => ({resolveOEmbed: jest.fn()}))
+jest.mock('../openGraphResolver', () => ({resolveOpenGraph: jest.fn()}))
+jest.mock('../../getRedis')
+
+import getRedis from '../../getRedis'
+import {resolveOEmbed} from '../oEmbedResolver'
+import {resolveOpenGraph} from '../openGraphResolver'
+import {EMBED_CACHE_TTL_MS, EMBED_UNRESOLVED_CACHE_TTL_MS, resolveEmbed} from '../resolveEmbed'
+
+const mockedResolveOEmbed = resolveOEmbed as jest.MockedFunction<typeof resolveOEmbed>
+const mockedResolveOpenGraph = resolveOpenGraph as jest.MockedFunction<typeof resolveOpenGraph>
+const mockedGetRedis = getRedis as jest.MockedFunction<typeof getRedis>
+
+type FakeRedis = {
+  get: jest.Mock<Promise<string | null>, [string]>
+  set: jest.Mock<Promise<'OK'>, [string, string, ...unknown[]]>
+  del: jest.Mock<Promise<number>, [string]>
+}
+
+const makeFakeRedis = (store: Map<string, string>): FakeRedis => ({
+  get: jest.fn(async (key: string) => store.get(key) ?? null),
+  set: jest.fn(async (key: string, value: string, ..._rest: unknown[]) => {
+    store.set(key, value)
+    return 'OK' as const
+  }),
+  del: jest.fn(async (key: string) => {
+    store.delete(key)
+    return 1
+  })
+})
+
+const ttlWrittenFor = (redis: FakeRedis, key: string, callIndex = 0): number => {
+  const calls = redis.set.mock.calls.filter(([k]) => k === key)
+  return calls[callIndex]![3] as number
+}
+
+// Not the exact TTL: jitterTTL applies +/-20%, so assert the written value lands in that band
+const expectTtlNear = (ttlArg: number, ttlMs: number) => {
+  expect(ttlArg).toBeGreaterThanOrEqual(ttlMs * 0.8)
+  expect(ttlArg).toBeLessThanOrEqual(ttlMs * 1.2)
+}
+
+describe('resolveEmbed short-TTL decision', () => {
+  const url = 'https://someblog.example.com/post'
+  let store: Map<string, string>
+  let redis: FakeRedis
+
+  beforeEach(() => {
+    store = new Map()
+    redis = makeFakeRedis(store)
+    mockedGetRedis.mockReturnValue(redis as unknown as Redis)
+    mockedResolveOEmbed.mockReset()
+    mockedResolveOpenGraph.mockReset()
+  })
+
+  it('caches a real oEmbed resolution for the full week-long TTL', async () => {
+    mockedResolveOEmbed.mockResolvedValue({
+      embedSrc: 'https://player.example.com/embed/1',
+      title: 'A Real Post'
+    })
+    mockedResolveOpenGraph.mockResolvedValue(null)
+
+    await resolveEmbed(url)
+
+    expectTtlNear(ttlWrittenFor(redis, `embed:v2:${url}`), EMBED_CACHE_TTL_MS)
+  })
+
+  it('caches a real Open Graph resolution for the full week-long TTL', async () => {
+    mockedResolveOEmbed.mockResolvedValue(null)
+    mockedResolveOpenGraph.mockResolvedValue({
+      embedSrc: null,
+      title: 'A Real Post Title',
+      description: 'a real description'
+    })
+
+    await resolveEmbed(url)
+
+    expectTtlNear(ttlWrittenFor(redis, `embed:v2:${url}`), EMBED_CACHE_TTL_MS)
+  })
+
+  it('caches the hostname-only fallback (both resolvers found nothing) for a short TTL', async () => {
+    mockedResolveOEmbed.mockResolvedValue(null)
+    mockedResolveOpenGraph.mockResolvedValue(null)
+
+    await resolveEmbed(url)
+
+    expectTtlNear(ttlWrittenFor(redis, `embed:v2:${url}`), EMBED_UNRESOLVED_CACHE_TTL_MS)
+  })
+
+  it('caches a soft-404/login-wall scrape (Open Graph resolves but every field is null) for a short TTL', async () => {
+    // This is the shape metascraper returns when it fetched a page but found nothing -
+    // the exact case a naive title-vs-hostname check misses, since title here is
+    // simply absent rather than equal to the synthesized hostname fallback.
+    mockedResolveOEmbed.mockResolvedValue(null)
+    mockedResolveOpenGraph.mockResolvedValue({
+      embedSrc: null,
+      title: null,
+      description: null,
+      thumbnailUrl: null,
+      faviconUrl: null,
+      providerName: null
+    })
+
+    await resolveEmbed(url)
+
+    expectTtlNear(ttlWrittenFor(redis, `embed:v2:${url}`), EMBED_UNRESOLVED_CACHE_TTL_MS)
+  })
+
+  it('bypasses the cache and re-resolves when refresh is true', async () => {
+    mockedResolveOEmbed.mockResolvedValue(null)
+    mockedResolveOpenGraph.mockResolvedValue(null)
+    await resolveEmbed(url)
+    expect(mockedResolveOpenGraph).toHaveBeenCalledTimes(1)
+
+    mockedResolveOpenGraph.mockResolvedValue({embedSrc: null, title: 'Now Reachable'})
+    const result = await resolveEmbed(url, true)
+
+    expect(mockedResolveOpenGraph).toHaveBeenCalledTimes(2)
+    expect(result?.metadata.title).toBe('Now Reachable')
+    expectTtlNear(ttlWrittenFor(redis, `embed:v2:${url}`, 1), EMBED_CACHE_TTL_MS)
+  })
+})

--- a/packages/server/utils/embed/extractIframeSrc.ts
+++ b/packages/server/utils/embed/extractIframeSrc.ts
@@ -1,0 +1,26 @@
+import {isAllowedEmbedHost} from '../../../client/shared/embed/curatedEmbedProviders'
+
+const IFRAME_SRC = /<iframe\b[^>]*?\ssrc\s*=\s*("([^"]*)"|'([^']*)')/i
+
+const decodeEntities = (value: string) =>
+  value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+
+/**
+ * oEmbed responses hand back arbitrary provider HTML. We never inject it: many
+ * providers ship script-based embeds that cannot work in a sandbox anyway, and
+ * owning the sizing is what makes the presentation modes possible. Pull out the
+ * single iframe src, verify it, and store only that.
+ */
+export const extractIframeSrc = (html: string | undefined | null): string | null => {
+  if (!html) return null
+  const match = IFRAME_SRC.exec(html)
+  const raw = match?.[2] ?? match?.[3]
+  if (!raw) return null
+  const src = decodeEntities(raw.trim())
+  return isAllowedEmbedHost(src) ? src : null
+}

--- a/packages/server/utils/embed/oEmbedResolver.ts
+++ b/packages/server/utils/embed/oEmbedResolver.ts
@@ -1,0 +1,53 @@
+import {extract, hasProvider, type OembedData} from '@extractus/oembed-extractor'
+import {Response} from '@whatwg-node/fetch'
+import type {EmbedAspectRatio, EmbedMetadata} from '../../../client/shared/embed/embedTypes'
+import {fetchUntrusted} from '../fetchUntrusted'
+import {Logger} from '../Logger'
+import {extractIframeSrc} from './extractIframeSrc'
+
+const MAX_OEMBED_BYTES = 256_000
+
+// The registry endpoint is still a user-influenced URL, so it goes through the
+// SSRF guard like everything else. oembed-extractor only needs a Response back.
+const untrustedFetcher = async (url: string) => {
+  const result = await fetchUntrusted(url, MAX_OEMBED_BYTES, {maxRedirects: 2})
+  if (!result) throw new Error('oEmbed fetch blocked or failed')
+  return new Response(new Uint8Array(result.buffer), {
+    status: 200,
+    headers: {'content-type': result.contentType}
+  })
+}
+
+const toAspectRatio = (data: OembedData): EmbedAspectRatio | undefined => {
+  const width = Number(data.width)
+  const height = Number(data.height)
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return undefined
+  }
+  const ratio = width / height
+  if (ratio >= 1.6) return '16:9'
+  if (ratio >= 1.2) return '4:3'
+  if (ratio >= 0.9) return '1:1'
+  return 'tall'
+}
+
+export const resolveOEmbed = async (url: string): Promise<Partial<EmbedMetadata> | null> => {
+  if (!hasProvider(url)) return null
+  let data: OembedData
+  try {
+    data = await extract(url, undefined, untrustedFetcher)
+  } catch (e) {
+    Logger.debug(`oEmbed lookup failed for ${new URL(url).hostname}`, e)
+    return null
+  }
+  const html = typeof data.html === 'string' ? data.html : undefined
+  const embedSrc = extractIframeSrc(html)
+  return {
+    embedSrc,
+    title: data.title ?? null,
+    thumbnailUrl: data.thumbnail_url ?? null,
+    providerName: data.provider_name ?? null,
+    authorName: data.author_name ?? null,
+    aspectRatio: toAspectRatio(data) ?? null
+  }
+}

--- a/packages/server/utils/embed/openGraphResolver.ts
+++ b/packages/server/utils/embed/openGraphResolver.ts
@@ -1,0 +1,40 @@
+import createMetascraper from 'metascraper'
+import metascraperDescription from 'metascraper-description'
+import metascraperImage from 'metascraper-image'
+import metascraperLogo from 'metascraper-logo'
+import metascraperPublisher from 'metascraper-publisher'
+import metascraperTitle from 'metascraper-title'
+import type {EmbedMetadata} from '../../../client/shared/embed/embedTypes'
+import {fetchUntrusted} from '../fetchUntrusted'
+import {Logger} from '../Logger'
+
+const MAX_HTML_BYTES = 512_000
+
+const scraper = createMetascraper([
+  metascraperTitle(),
+  metascraperDescription(),
+  metascraperImage(),
+  metascraperLogo(),
+  metascraperPublisher()
+])
+
+/** Never produces an embedSrc. A page we had to scrape is a page that would not frame. */
+export const resolveOpenGraph = async (url: string): Promise<Partial<EmbedMetadata> | null> => {
+  const result = await fetchUntrusted(url, MAX_HTML_BYTES, {maxRedirects: 3})
+  if (!result) return null
+  if (!result.contentType.startsWith('text/html')) return null
+  try {
+    const metadata = await scraper({url, html: result.buffer.toString('utf8')})
+    return {
+      embedSrc: null,
+      title: metadata.title ?? null,
+      description: metadata.description ?? null,
+      thumbnailUrl: metadata.image ?? null,
+      faviconUrl: metadata.logo ?? null,
+      providerName: metadata.publisher ?? null
+    }
+  } catch (e) {
+    Logger.debug(`Open Graph scrape failed for ${new URL(url).hostname}`, e)
+    return null
+  }
+}

--- a/packages/server/utils/embed/resolveEmbed.ts
+++ b/packages/server/utils/embed/resolveEmbed.ts
@@ -1,0 +1,102 @@
+import {resolveCuratedEmbed} from '../../../client/shared/embed/curatedEmbedProviders'
+import type {EmbedMetadata} from '../../../client/shared/embed/embedTypes'
+import {normalizeEmbedUrl} from '../../../client/shared/embed/normalizeEmbedUrl'
+import {redisStaleWhileRevalidate} from '../redisStaleWhileRevalidate'
+import {resolveOEmbed} from './oEmbedResolver'
+import {resolveOpenGraph} from './openGraphResolver'
+
+export const EMBED_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+export const EMBED_UNRESOLVED_CACHE_TTL_MS = 5 * 60 * 1000
+
+const hostnameOf = (url: string) => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+/** metascraper returns every key, nulled when it found nothing; those must not clobber oEmbed */
+const definedOnly = <T extends object>(value: T | null): Partial<T> =>
+  value ? (Object.fromEntries(Object.entries(value).filter(([, v]) => v != null)) as Partial<T>) : {}
+
+/** True when a scrape produced no embedSrc and none of the real, provider-authored fields */
+const hasRealMetadata = (metadata: Partial<EmbedMetadata>): boolean =>
+  !!metadata.embedSrc ||
+  !!metadata.title ||
+  !!metadata.description ||
+  !!metadata.thumbnailUrl ||
+  !!metadata.faviconUrl ||
+  !!metadata.authorName
+
+/**
+ * `isFallback` is decided here, at the point where we still know whether anything was
+ * actually found, rather than reconstructed later from the shape of the metadata
+ * (which cannot tell a synthesized hostname title apart from a page whose real title
+ * happens to equal its hostname, or a scrape that came back with every metascraper
+ * field nulled out - a login wall or soft-404 during an outage). Callers must treat a
+ * fallback resolve as a failed lookup, not an authoritative "this field is gone".
+ */
+export type ResolveResult = {metadata: EmbedMetadata; isFallback: boolean}
+
+const resolveUncached = async (url: string): Promise<ResolveResult> => {
+  const base: EmbedMetadata = {url, fetchedAt: new Date().toISOString()}
+
+  // Curated first: deterministic, no network, and it covers Google Docs, which the
+  // oEmbed registry does not list at all.
+  const curated = resolveCuratedEmbed(url)
+  if (curated) {
+    const enriched = await resolveOEmbed(url).catch(() => null)
+    // A failed or empty enrichment leaves these fields unset rather than null: null
+    // means the provider confirmed the field is gone, but a network error or timeout
+    // here has told us nothing at all.
+    return {
+      metadata: {
+        ...base,
+        embedSrc: curated.embedSrc,
+        providerName: curated.providerName,
+        aspectRatio: curated.aspectRatio,
+        ...definedOnly(enriched)
+      },
+      isFallback: false
+    }
+  }
+
+  const oEmbed = await resolveOEmbed(url).catch(() => null)
+  if (oEmbed?.embedSrc) {
+    return {metadata: {...base, ...oEmbed}, isFallback: false}
+  }
+
+  const openGraph = await resolveOpenGraph(url).catch(() => null)
+  // oEmbed may still have supplied a better title even when it gave us no iframe, so
+  // only let Open Graph override the fields it actually found
+  const scraped = {...definedOnly(oEmbed), ...definedOnly(openGraph)}
+  if (hasRealMetadata(scraped)) {
+    return {metadata: {...base, ...scraped, embedSrc: null}, isFallback: false}
+  }
+
+  return {
+    metadata: {...base, embedSrc: null, title: hostnameOf(url), providerName: hostnameOf(url)},
+    isFallback: true
+  }
+}
+
+/**
+ * Resolve a URL to embed metadata. Shared across every page that references the same
+ * link, so a hundred pages embedding one video make one upstream call.
+ */
+export const resolveEmbed = async (
+  rawUrl: string,
+  refresh = false
+): Promise<ResolveResult | null> => {
+  const url = normalizeEmbedUrl(rawUrl)
+  if (!url) return null
+  // v2: the cached value changed shape from bare EmbedMetadata to {metadata, isFallback}.
+  // Versioning the key avoids destructuring a pre-existing v1 entry as the new shape.
+  return redisStaleWhileRevalidate(
+    `embed:v2:${url}`,
+    () => resolveUncached(url),
+    (result) => (result.isFallback ? EMBED_UNRESOLVED_CACHE_TTL_MS : EMBED_CACHE_TTL_MS),
+    {refresh}
+  )
+}

--- a/packages/server/utils/embed/resolveEmbed.ts
+++ b/packages/server/utils/embed/resolveEmbed.ts
@@ -18,7 +18,9 @@ const hostnameOf = (url: string) => {
 
 /** metascraper returns every key, nulled when it found nothing; those must not clobber oEmbed */
 const definedOnly = <T extends object>(value: T | null): Partial<T> =>
-  value ? (Object.fromEntries(Object.entries(value).filter(([, v]) => v != null)) as Partial<T>) : {}
+  value
+    ? (Object.fromEntries(Object.entries(value).filter(([, v]) => v != null)) as Partial<T>)
+    : {}
 
 /** True when a scrape produced no embedSrc and none of the real, provider-authored fields */
 const hasRealMetadata = (metadata: Partial<EmbedMetadata>): boolean =>

--- a/packages/server/utils/redisStaleWhileRevalidate.ts
+++ b/packages/server/utils/redisStaleWhileRevalidate.ts
@@ -1,0 +1,68 @@
+import getRedis from './getRedis'
+import {Logger} from './Logger'
+import RedisLock from './RedisLock'
+
+const JITTER = 0.2
+
+// The thunk may make two sequential fetchUntrusted calls, each with a 15s timeout, so
+// the lock has to outlive the slowest realistic fetch or it expires mid-flight and
+// stops collapsing concurrent callers.
+const DEFAULT_LOCK_TTL_MS = 35_000
+const DEFAULT_MAX_WAIT_MS = 5_000
+
+/** Spread expiries so entries written together do not all expire in the same second. */
+const jitterTTL = (ttlMs: number) => Math.round(ttlMs * (1 + (Math.random() * 2 - 1) * JITTER))
+
+const readCached = async <T>(key: string): Promise<T | undefined> => {
+  const cached = await getRedis().get(key)
+  if (cached === null) return undefined
+  try {
+    return JSON.parse(cached) as T
+  } catch {
+    // A corrupt entry must not fail the request; fall through and refetch
+    Logger.debug(`discarding unparseable cache entry ${key}`)
+    return undefined
+  }
+}
+
+/**
+ * Like redisStoreOrNetwork, but adds the two things it lacks: a single-flight lock so
+ * concurrent misses collapse into one upstream call, and TTL jitter. Kept separate
+ * because existing redisStoreOrNetwork callers depend on its current behavior.
+ */
+export const redisStaleWhileRevalidate = async <T>(
+  key: string,
+  thunk: () => Promise<T>,
+  ttlMs: number | ((value: T) => number),
+  options?: {lockTtlMs?: number; maxWaitMs?: number; refresh?: boolean}
+): Promise<T> => {
+  const refresh = options?.refresh ?? false
+  if (!refresh) {
+    const cached = await readCached<T>(key)
+    if (cached !== undefined) return cached
+  }
+
+  const maxWaitMs = options?.maxWaitMs ?? DEFAULT_MAX_WAIT_MS
+  const lock = new RedisLock(`swr:${key}`, options?.lockTtlMs ?? DEFAULT_LOCK_TTL_MS)
+  let hasLock = true
+  try {
+    await lock.lock(maxWaitMs)
+  } catch {
+    // Someone else is fetching and is taking longer than we will wait. Fetch ourselves
+    // rather than failing, but do not release a lock we never acquired.
+    hasLock = false
+  }
+  try {
+    if (hasLock && !refresh) {
+      // The previous holder may have populated the key while we waited
+      const afterLock = await readCached<T>(key)
+      if (afterLock !== undefined) return afterLock
+    }
+    const value = await thunk()
+    const resolvedTtlMs = typeof ttlMs === 'function' ? ttlMs(value) : ttlMs
+    await getRedis().set(key, JSON.stringify(value), 'PX', jitterTTL(resolvedTtlMs))
+    return value
+  } finally {
+    if (hasLock) await lock.unlock()
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
 
   .:
     dependencies:
+      '@extractus/oembed-extractor':
+        specifier: ^6.0.0
+        version: 6.0.0
       '@floating-ui/dom':
         specifier: ^1.6.13
         version: 1.7.6
@@ -174,6 +177,24 @@ importers:
       markdown-it:
         specifier: ^14.3.0
         version: 14.3.0
+      metascraper:
+        specifier: ^5.56.2
+        version: 5.56.2(debug@4.4.3)
+      metascraper-description:
+        specifier: ^5.56.2
+        version: 5.56.2(debug@4.4.3)
+      metascraper-image:
+        specifier: ^5.56.2
+        version: 5.56.2(debug@4.4.3)
+      metascraper-logo:
+        specifier: ^5.56.2
+        version: 5.56.2(debug@4.4.3)
+      metascraper-publisher:
+        specifier: ^5.56.2
+        version: 5.56.2(debug@4.4.3)
+      metascraper-title:
+        specifier: ^5.56.2
+        version: 5.56.2(debug@4.4.3)
       ms:
         specifier: ^2.0.0
         version: 2.1.3
@@ -438,7 +459,7 @@ importers:
         version: 5.1.4(webpack-bundle-analyzer@5.3.1)(webpack-dev-server@5.2.6)(webpack@5.107.0)
       webpack-dev-server:
         specifier: ^5.2.6
-        version: 5.2.6(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
+        version: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
       webpack-hot-middleware:
         specifier: ^2.26.1
         version: 2.26.1
@@ -585,7 +606,7 @@ importers:
         version: 4.0.7
       fbjs:
         specifier: ^3.0.0
-        version: 3.0.5
+        version: 3.0.5(encoding@0.1.13)
       flatted:
         specifier: ^3.4.4
         version: 3.4.4
@@ -975,7 +996,7 @@ importers:
         version: 0.2.117
       mailgun.js:
         specifier: ^9.3.0
-        version: 9.4.1
+        version: 9.4.1(debug@4.4.3)
       mime-types:
         specifier: ^2.1.16
         version: 2.1.35
@@ -1123,6 +1144,14 @@ packages:
     resolution: {integrity: sha512-afG3YPwuSA0E5foouZusz5GlXKs74dObv4cuWyLyfKsYFj2r7oGRNB28v18HvwuLSQtQFCi+DpIe0TZkgQDYyg==}
     peerDependencies:
       graphql: '*'
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@authenio/xml-encryption@2.0.2':
     resolution: {integrity: sha512-cTlrKttbrRHEw3W+0/I609A2Matj5JQaRvfLtEIGZvlN0RaPi+3ANsMeqAyCAVlH/lUIW2tmtBlSMni74lcXeg==}
@@ -2114,6 +2143,46 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.1':
+    resolution: {integrity: sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9':
+    resolution: {integrity: sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@datadog/browser-core@6.33.0':
     resolution: {integrity: sha512-h/xuBuY4Xi32CbBHkChMMWlOQ4al/mFF08x3o0hqrderfJvX7VO5tD3OVNwF+pfMXOGlDtBCIhwazr9sn24h3g==}
 
@@ -2258,6 +2327,18 @@ packages:
   '@escape.tech/graphql-armor-types@0.7.0':
     resolution: {integrity: sha512-RHxyyp6PDgS6NAPnnmB6JdmUJ6oqhpSHFbsglGWeCcnNzceA5AkQFpir7VIDbVyS8LNC1xhipOtk7f9ycrIemQ==}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@extractus/oembed-extractor@6.0.0':
+    resolution: {integrity: sha512-CQz0BwCZ6cv9KqSVLacOpPT5h0FgkWFO3krddAjv2FOgkDiVSNK2iHjESXzqdu9ttHZ0dmI6KtuY80ivtzXucA==}
+
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
 
@@ -2281,6 +2362,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@graphiql/plugin-doc-explorer@0.4.2':
     resolution: {integrity: sha512-jqRUSaP9pq2JdoovKaiNQoV4ZVcDP5nn+QEa++vEYh0nCn76836SAde2/LkYMc9NnN8/PHMKqeUBnClZ+AUtVQ==}
@@ -3275,6 +3359,10 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  '@kikobeats/time-span@1.0.13':
+    resolution: {integrity: sha512-CfBK4/EZ73uN/6b5/wOfvWju1Ev/6H+uXqS2Vqd7/dEQTyOsvv4BdOHDqESp4Efa9YyrPPvN3IHU+C4z9FAo3Q==}
+    engines: {node: '>= 18'}
+
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
 
@@ -3306,6 +3394,10 @@ packages:
     engines: {node: '>=6.0.0'}
     peerDependencies:
       tslib: ^2.8.1
+
+  '@metascraper/helpers@5.56.2':
+    resolution: {integrity: sha512-a5D654n7GrWJk8nXtPA4N0g7ZpuGi8KzR/0HAe3NR7BZ6eyV8vW+e93uYyyZyk1pfnh0XCdvPbo1u/KyqV7V3Q==}
+    engines: {node: '>= 22.13'}
 
   '@module-federation/error-codes@0.22.0':
     resolution: {integrity: sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==}
@@ -3410,6 +3502,14 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@octokit/graphql-schema@10.74.2':
     resolution: {integrity: sha512-PG6zZvFyOi4aRsfWwBji8GjJRHF6U9gUjqonVa0N6kpGae6Uhc75GDXOLX0x+/b+Kws82pug3+17tmgZ/o7HfQ==}
@@ -5323,6 +5423,10 @@ packages:
       y-protocols: ^1.0.1
       yjs: ^13.5.38
 
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -5815,6 +5919,9 @@ packages:
   '@zxcvbn-ts/language-en@3.0.2':
     resolution: {integrity: sha512-Zp+zL+I6Un2Bj0tRXNs6VUBq3Djt+hwTwUz4dkt2qgsQz47U0/XthZ4ULrT/RxjwJRl5LwiaKOOZeOtmixHnjg==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -5849,6 +5956,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -5924,6 +6035,14 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -6003,6 +6122,10 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  audio-extensions@0.0.0:
+    resolution: {integrity: sha512-yj9C819u3ED3/OyRd9mLKMXGy8wsElaf6bkkv6OqZEKrNAT461TjiznS4IfPBy8Mmh6DWaXCQCVYSq3+VHkpjQ==}
+    engines: {node: '>=0.10.0'}
 
   auto-bind@4.0.0:
     resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
@@ -6115,6 +6238,9 @@ packages:
   bcryptjs@2.4.3:
     resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -6137,6 +6263,10 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -6181,6 +6311,10 @@ packages:
     peerDependenciesMeta:
       magicast:
         optional: true
+
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -6256,6 +6390,13 @@ packages:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
 
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -6264,9 +6405,17 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chrono-node@2.10.1:
+    resolution: {integrity: sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -6356,6 +6505,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -6415,6 +6568,10 @@ packages:
     engines: {node: ^14.13.0 || >=16.0.0}
     hasBin: true
 
+  condense-whitespace@3.0.0:
+    resolution: {integrity: sha512-Z186uLXZi/AMCd/9R0q3HEXgLZkT5fGFRe3dJqv0DsG5megM6QJ+N7t7KcVWxr3/dU8T0x++Uegq2NpIpW0zNQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
@@ -6425,6 +6582,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
@@ -6558,14 +6718,29 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -6577,9 +6752,21 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-uri-to-buffer@5.0.1:
+    resolution: {integrity: sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==}
+    engines: {node: '>= 14'}
+
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-uri-utils@1.0.15:
+    resolution: {integrity: sha512-on9aQ6gCke4GWBjWaKLsGG0q/ycibuureXXhMKdCd8iTCVwj3YItyaz36nhfKHTmdEjAEVizsRULEofZadNgzw==}
+    engines: {node: '>= 14'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -6624,6 +6811,12 @@ packages:
     resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
     engines: {node: '>=18'}
 
+  debug-logfmt@1.4.15:
+    resolution: {integrity: sha512-tMgdJRAlvf0sv3We8KpVlAnv0V9hnOoB3QqmvkXSGYnYMUJvJTGawqipROgh5WaPKXyt79cdPYx30jSu9aO7Rg==}
+    engines: {node: '>= 8'}
+    peerDependencies:
+      debug: '*'
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -6649,6 +6842,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -6703,6 +6899,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -6884,6 +7083,12 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -6900,6 +7105,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -6922,6 +7131,9 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -7124,6 +7336,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-extension@4.0.5:
+    resolution: {integrity: sha512-l0rOL3aKkoi6ea7MNZe6OHgqYYpn48Qfflr8Pe9G9JPPTx5A+sfboK91ZufzIs59/lPqh351l0eb6iKU9J5oGg==}
+    engines: {node: '>=4'}
+
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
@@ -7237,6 +7453,10 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -7259,6 +7479,11 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
@@ -7491,6 +7716,13 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  has-values@2.0.1:
+    resolution: {integrity: sha512-+QdH3jOmq9P8GfdjFg0eJudqx1FqU62NQJ4P16rOEHeRdl7ckgwn6uqQjzYE0ZoHVV/e5E2esuJ5Gl5+HUW19w==}
+    engines: {node: '>=6'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -7511,6 +7743,10 @@ packages:
 
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -7553,6 +7789,9 @@ packages:
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-deceiver@1.2.7:
     resolution: {integrity: sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==}
 
@@ -7569,6 +7808,10 @@ packages:
 
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -7606,6 +7849,9 @@ packages:
   humanize-duration@3.33.2:
     resolution: {integrity: sha512-K7Ny/ULO1hDm2nnhvAY+SJV1skxFb61fd073SG1IWJl+D44ULrruCuTyjHKjBVVcSuTlnY99DKtgEG39CM5QOQ==}
 
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
   husky@7.0.4:
     resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==}
     engines: {node: '>=12'}
@@ -7617,6 +7863,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
@@ -7642,6 +7892,10 @@ packages:
   ignore@7.0.6:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
+
+  image-extensions@1.1.0:
+    resolution: {integrity: sha512-P0t7ByhK8Jk9TU05ct/7+f7h8dNuXq5OY4m0IO/T+1aga/qHkpC0Wf472x3FLdq/zFDG17pgapCM3JDTxwZzow==}
+    engines: {node: '>=0.10.0'}
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -7683,12 +7937,20 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  install-artifact-from-github@1.8.0:
+    resolution: {integrity: sha512-EA861BGTOO91yuymA5V6Sx//J5471NBpMHnVZJetquqOYknm4zz25Y2tk/f74ggxerqtd8nfBrn9eaR0oxReEA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -7709,6 +7971,10 @@ packages:
     resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
+  ip-regex@4.3.0:
+    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
+    engines: {node: '>=8'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -7716,6 +7982,10 @@ packages:
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
     engines: {node: '>= 10'}
+
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-absolute@1.0.0:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
@@ -7802,6 +8072,9 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
+
   is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
 
@@ -7856,6 +8129,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-primitive@3.0.1:
     resolution: {integrity: sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==}
     engines: {node: '>=0.10.0'}
@@ -7867,6 +8143,10 @@ packages:
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
+
+  is-relative-url@4.1.0:
+    resolution: {integrity: sha512-vhIXKasjAuxS7n+sdv7pJQykEAgS+YU8VBQOENXwo/VZpOHDgBBsIbHo7zFKaWBjYWF4qxERdhbPRRtFAeJKfg==}
+    engines: {node: '>=14.16'}
 
   is-relative@1.0.0:
     resolution: {integrity: sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==}
@@ -7907,6 +8187,10 @@ packages:
   is-upper-case@2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
 
+  is-uri@1.2.14:
+    resolution: {integrity: sha512-YhTAOlejk4o85c3bPk9ayhr6VLm3e01mp4pBhtYOEXXlkK+Eoj/Nr3x+bqTwZvUI0z0L6TVk0HZViXdxUtsWDQ==}
+    engines: {node: '>= 4'}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -7936,6 +8220,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iso-639-3@3.0.1:
+    resolution: {integrity: sha512-SdljCYXOexv/JmbQ0tvigHN43yECoscVpe2y2hlEqy/CStXQlroPhZLj7zKLRiGqLJfw8k7B973UAMDoQczVgQ==}
+
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
@@ -7947,6 +8234,9 @@ packages:
 
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
+  isostring@0.0.1:
+    resolution: {integrity: sha512-wRcdJtXCe2LGtXnD14fXMkduWVdbeGkzBIKg8WcKeEOi6SIc+hRjYYw76WNx3v5FebhUWZrBTWB0NOl3/sagdQ==}
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
@@ -8166,6 +8456,15 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
 
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsep@1.4.0:
     resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
     engines: {node: '>= 10.16.0'}
@@ -8220,6 +8519,10 @@ packages:
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
+
+  jsonrepair@3.15.0:
+    resolution: {integrity: sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -8407,6 +8710,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkedom@0.18.13:
+    resolution: {integrity: sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
@@ -8532,8 +8844,16 @@ packages:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -8559,6 +8879,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -8603,6 +8927,9 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
@@ -8614,6 +8941,9 @@ packages:
     resolution: {integrity: sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==}
     peerDependencies:
       tslib: '2'
+
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -8634,6 +8964,30 @@ packages:
       '@types/node':
         optional: true
 
+  metascraper-description@5.56.2:
+    resolution: {integrity: sha512-mZuOtt9KwzWi2DdJspJf8rlUU1Xi/06gUOMng8EX6o9UAC0IUkCTKxl8ySs5pFpX1Uy6OYtxj8XrsnwGRD6saw==}
+    engines: {node: '>= 22'}
+
+  metascraper-image@5.56.2:
+    resolution: {integrity: sha512-N4DGdcylu6z1lcBxLD+S4ppEwfr1lHgQ5Xp3WVJ7opIBfUgJLkO0OUxM0xsvUbiXV/q/6aKCqE2Gp+11seccaQ==}
+    engines: {node: '>= 22'}
+
+  metascraper-logo@5.56.2:
+    resolution: {integrity: sha512-pLOTOGOyxZxfrKmqjtSmw4wXNGQRzGe7GQmQVqqx2jT7dLTDFXx4vjeQR6lHHnnHvvP7NdJVuntITGzWvYwEXw==}
+    engines: {node: '>= 22'}
+
+  metascraper-publisher@5.56.2:
+    resolution: {integrity: sha512-su9iopa4fQoD9WYKmJdvAOwRD/E36AvrgI/ZA6LbioAfuL+gaQBdS4cYFOfnZ6yWcNDgD9QQc8gesrQ+vrDKCg==}
+    engines: {node: '>= 22'}
+
+  metascraper-title@5.56.2:
+    resolution: {integrity: sha512-OzpBHL1k9S58L68hK/Y82kYF7OM56D8CJldztll2L4lxiie+49BqizMVR4/NILVvHuNZb64dE29bDoC91nPGAg==}
+    engines: {node: '>= 22'}
+
+  metascraper@5.56.2:
+    resolution: {integrity: sha512-3z+X+RdUgko2etdzjwhRtCUDNKv3FhB2UWHXZ76IwoqWbuYJ5aRDMPzqlOZ7s+XoyX8Bfc+txj52NPO0IC3DTg==}
+    engines: {node: '>= 22'}
+
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
@@ -8641,6 +8995,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  microsoft-capitalize@1.0.8:
+    resolution: {integrity: sha512-uSzg9VkW1+ZgNcJG0AcU/Ynje5xLnLuXoJCQBWKs7DeEzmgUTF5mLVbsmj0aYppN43MWI4RGUuRANLJAIaRfLw==}
+    engines: {node: '>= 10'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -8661,6 +9019,11 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
     hasBin: true
 
   mimic-fn@2.1.0:
@@ -8698,9 +9061,41 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
 
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -8786,6 +9181,9 @@ packages:
   n-gram@2.0.2:
     resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
 
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
   nanoclone@0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
 
@@ -8867,6 +9265,11 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
+
   node-html-markdown-cloudflare@1.3.0:
     resolution: {integrity: sha512-jJSply2eFaBCwpBgNgJaFmzFaIDZ4vzmEfmAW8Tq08Qz/k1QTXMDi15fhKS8fY+vX4G+e/huk5FPfNweAJdmKg==}
     engines: {node: '>=10.0.0'}
@@ -8896,6 +9299,11 @@ packages:
     resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   normalize-path@2.1.1:
     resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
     engines: {node: '>=0.10.0'}
@@ -8904,12 +9312,29 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@9.0.1:
+    resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
+    engines: {node: '>=20'}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
+
+  null-prototype-object@1.2.7:
+    resolution: {integrity: sha512-pSZWCUew0zed2gxCerA4zdXRGg8ezLiWwvE8RvncezTcROXL0uz3PjSZXl5NsI04Egz0Uu46o1wyX6qr3u/ZWA==}
+    engines: {node: '>= 20'}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -9086,8 +9511,25 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
+  parse-uri@2.0.6:
+    resolution: {integrity: sha512-sB5ONhkIMyztTX2trw4OVqHhUnHS8wDFHPRN+eaHxWQ+8cFlF7nUFIDpzFksQMntTts6SEgX/VOyeAowwLqQuw==}
+    engines: {node: '>= 0.10'}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -9368,12 +9810,28 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
 
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
@@ -9450,6 +9908,14 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
+  punycode2@1.0.1:
+    resolution: {integrity: sha512-+TXpd9YRW4YUZZPoRHJ3DILtWwootGc2DsgvfHmklQ8It1skINAuqSdqizt5nlTaBmwrYACHkHApCXjc9gHk2Q==}
+    engines: {node: '>=0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
@@ -9483,6 +9949,10 @@ packages:
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
+
+  re2@1.26.1:
+    resolution: {integrity: sha512-oi79a4h6EO3PAwNsDMWgeCcsRGQEUa52DIgOiFTZGDEZocEXG9h+oXy0qZqndo47huUeJuVWSoOJIEhOupqOcg==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   react-aria@3.48.0:
     resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
@@ -9769,6 +10239,10 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -9787,6 +10261,11 @@ packages:
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
@@ -9851,6 +10330,10 @@ packages:
 
   sanitizer@0.1.3:
     resolution: {integrity: sha512-j05vL56tR90rsYqm9ZD05v6K4HI7t4yMDEvvU0x4f+IADXM9Jx1x9mzatxOs5drJq6dGhugxDW99mcPvXVLl+Q==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -9921,6 +10404,9 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -10029,6 +10515,10 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
+  smartquotes@2.3.2:
+    resolution: {integrity: sha512-0R6YJ5hLpDH4mZR7N5eZ12oCMLspvGOHL9A9SEm2e3b/CQmQidekW4SWSKEmor/3x6m3NCBBEqLzikcZC9VJNQ==}
+    engines: {node: '>=4.0.0'}
+
   smob@1.6.2:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
@@ -10038,6 +10528,10 @@ packages:
 
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -10083,6 +10577,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -10225,6 +10723,9 @@ packages:
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   sync-fetch@0.6.0:
     resolution: {integrity: sha512-IELLEvzHuCfc1uTsshPK58ViSdNqXxlml1U+fmwJIKLYKOr/rAtBrorE2RYm5IHaMpDNlmC0fr1LAvdXvyheEQ==}
     engines: {node: '>=18'}
@@ -10241,6 +10742,11 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tayden-clusterfck@0.7.0:
     resolution: {integrity: sha512-1jw+Rz91yqwxqq8l2UMhTJ03JQZbWkDX20dmgAP/RQbBxN0mHLdDIH8bSm7z+Y7x+fnkgIWmB05t/EFabm2JPQ==}
@@ -10364,6 +10870,13 @@ packages:
     resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
     hasBin: true
 
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
   tlhunter-sorted-set@0.1.0:
     resolution: {integrity: sha512-eGYW4bjf1DtrHzUYxYfAcSytpOkA44zsr7G2n3PV7yOUR23vmkGe3LL4R+1jL9OsXtbsFOwe8XtbCrabeaEFnw==}
 
@@ -10388,8 +10901,16 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-dump@1.1.0:
     resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
@@ -10502,6 +11023,9 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -10515,6 +11039,14 @@ packages:
 
   undici-types@7.25.0:
     resolution: {integrity: sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -10531,6 +11063,12 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -10566,6 +11104,15 @@ packages:
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
+  url-regex-safe@4.0.0:
+    resolution: {integrity: sha512-BrnFCWKNFrFnRzKD66NtJqQepfJrUHNPvPxE5y5NSAhXBb4OlobQjt7907Jm4ItPiXaeX+dDWMkcnOd4jR9N8A==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      re2: ^1.20.1
+    peerDependenciesMeta:
+      re2:
+        optional: true
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
@@ -10661,6 +11208,10 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  video-extensions@2.0.0:
+    resolution: {integrity: sha512-qSXHIVmAVVKYk16x4keCwSqFuvF3D0K9KFuywWxd6ulpDfBHZ5QkGccMbT789IwSX9ykC88dL5kYGK3DZ59/ng==}
+    engines: {node: '>=18.20'}
+
   vscode-apollo-relay@1.5.2:
     resolution: {integrity: sha512-5OD2dtiuRWD+3d7Ewwws8hDjr24YAp1PUQxtuXcbMntPMHQLMZ7dIHbzBbL95BI6GIVK24g8SE7tRquRtrKF3w==}
     engines: {node: '>= 8'}
@@ -10673,6 +11224,10 @@ packages:
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -10690,6 +11245,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-bundle-analyzer@5.3.1:
     resolution: {integrity: sha512-wP2EusncRGL1tZyMHC/umLkjPdYMkTL9nPEKh8G8dkYCJ9TyF6xnXFqjhdqmv5J900irN/g0P5jMvLT22krEXQ==}
@@ -10771,6 +11330,11 @@ packages:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
@@ -10778,6 +11342,18 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -10802,6 +11378,13 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  whoops@5.1.4:
+    resolution: {integrity: sha512-qRfCp1x5MB0Fxuw0y91KqHawR9Cs4OBIyyxAemxVtCxlkCDLvjd1ti3NLVmutDMqU7jbgHKc9EX3i1Bppfif8w==}
+    engines: {node: '>= 8'}
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
@@ -10921,12 +11504,19 @@ packages:
   xml-escape@1.1.0:
     resolution: {integrity: sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xpath@0.0.32:
     resolution: {integrity: sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==}
@@ -10978,6 +11568,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
@@ -11111,6 +11704,21 @@ snapshots:
       graphql: 16.13.1
       immutable: 5.1.9
       invariant: 2.2.4
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -12647,6 +13255,34 @@ snapshots:
   '@biomejs/cli-win32-x64@2.3.5':
     optional: true
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@datadog/browser-core@6.33.0': {}
 
   '@datadog/browser-rum-core@6.33.0':
@@ -12811,6 +13447,14 @@ snapshots:
       graphql: 16.13.1
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
+  '@extractus/oembed-extractor@6.0.0':
+    dependencies:
+      linkedom: 0.18.13
+    transitivePeerDependencies:
+      - canvas
+
   '@fastify/busboy@3.2.0': {}
 
   '@floating-ui/core@1.7.5':
@@ -12837,6 +13481,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@gar/promisify@1.1.3': {}
 
   '@graphiql/plugin-doc-explorer@0.4.2(@graphiql/react@0.37.5(@types/node@22.19.19)(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(graphql-ws@6.2.1(graphql@16.13.1)(ws@8.21.3))(graphql@16.13.1)(immer@11.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))(@types/react@18.3.29)(graphql@16.13.1)(immer@11.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))':
     dependencies:
@@ -14136,6 +14782,8 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  '@kikobeats/time-span@1.0.13': {}
+
   '@kurkle/color@0.3.4': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
@@ -14155,6 +14803,40 @@ snapshots:
   '@mattkrick/sanitize-svg@0.4.1(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
+
+  '@metascraper/helpers@5.56.2(debug@4.4.3)':
+    dependencies:
+      audio-extensions: 0.0.0
+      chrono-node: 2.10.1
+      condense-whitespace: 3.0.0
+      data-uri-utils: 1.0.15
+      debug-logfmt: 1.4.15(debug@4.4.3)
+      entities: 8.0.0
+      file-extension: 4.0.5
+      has-values: 2.0.1
+      image-extensions: 1.1.0
+      is-relative-url: 4.1.0
+      is-uri: 1.2.14
+      iso-639-3: 3.0.1
+      isostring: 0.0.1
+      jsdom: 30.0.1
+      jsonrepair: 3.15.0
+      lodash: 4.18.1
+      memoize-one: 6.0.0
+      microsoft-capitalize: 1.0.8
+      mime: 4.1.0
+      normalize-url: 9.0.1
+      re2: 1.26.1
+      smartquotes: 2.3.2
+      tldts: 7.4.11
+      url-regex-safe: 4.0.0(re2@1.26.1)
+      video-extensions: 2.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
 
   '@module-federation/error-codes@0.22.0':
     optional: true
@@ -14259,6 +14941,16 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.8.5
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
 
   '@octokit/graphql-schema@10.74.2':
     dependencies:
@@ -14472,7 +15164,7 @@ snapshots:
       webpack: 5.107.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(html-minifier-terser@5.1.1)(postcss@8.5.26)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
+      webpack-dev-server: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
       webpack-hot-middleware: 2.26.1
 
   '@polka/url@1.0.0-next.29': {}
@@ -16110,6 +16802,8 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.30)
       yjs: 13.6.30
 
+  '@tootallnate/once@1.1.2': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
@@ -16537,7 +17231,7 @@ snapshots:
       webpack: 5.107.0(@swc/core@1.15.33(@swc/helpers@0.5.21))(html-minifier-terser@5.1.1)(postcss@8.5.26)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@5.3.1)(webpack-dev-server@5.2.6)(webpack@5.107.0)
     optionalDependencies:
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
+      webpack-dev-server: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
 
   '@whatwg-node/cookie-store@0.2.3':
     dependencies:
@@ -16599,6 +17293,8 @@ snapshots:
 
   '@zxcvbn-ts/language-en@3.0.2': {}
 
+  abbrev@1.1.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -16627,6 +17323,10 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   aggregate-error@3.1.0:
     dependencies:
@@ -16687,6 +17387,13 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  aproba@2.1.0: {}
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
 
   argparse@1.0.10:
     dependencies:
@@ -16765,6 +17472,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  audio-extensions@0.0.0: {}
+
   auto-bind@4.0.0: {}
 
   autoprefixer@10.5.0(postcss@8.5.26):
@@ -16780,9 +17489,9 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.19.0:
+  axios@1.19.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.3.7)
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -16918,6 +17627,10 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   big.js@5.2.2: {}
 
   bignumber.js@9.3.1: {}
@@ -16949,6 +17662,8 @@ snapshots:
       multicast-dns: 7.2.5
 
   boolbase@1.0.0: {}
+
+  boolbase@2.0.0: {}
 
   bowser@2.14.1: {}
 
@@ -16999,6 +17714,29 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       rc9: 3.0.1
+
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.3
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -17094,6 +17832,29 @@ snapshots:
     dependencies:
       '@kurkle/color': 0.3.4
 
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.29.0
+      whatwg-mimetype: 4.0.0
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -17110,7 +17871,11 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chownr@2.0.0: {}
+
   chrome-trace-event@1.0.4: {}
+
+  chrono-node@2.10.1: {}
 
   ci-info@3.9.0: {}
 
@@ -17185,6 +17950,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-support@1.1.3: {}
+
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -17241,11 +18008,15 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  condense-whitespace@3.0.0: {}
+
   confbox@0.2.4: {}
 
   connect-history-api-fallback@2.0.0: {}
 
   consola@3.4.2: {}
+
+  console-control-strings@1.1.0: {}
 
   constant-case@3.0.4:
     dependencies:
@@ -17351,9 +18122,9 @@ snapshots:
 
   croner@4.1.97: {}
 
-  cross-fetch@3.2.0:
+  cross-fetch@3.2.0(encoding@0.1.13):
     dependencies:
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -17407,9 +18178,26 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-select@7.0.0:
+    dependencies:
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
 
+  css-what@8.0.0: {}
+
   cssesc@3.0.0: {}
+
+  cssom@0.5.0: {}
 
   csstype@3.2.3: {}
 
@@ -17417,7 +18205,20 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-uri-to-buffer@5.0.1: {}
+
   data-uri-to-buffer@6.0.2: {}
+
+  data-uri-utils@1.0.15:
+    dependencies:
+      data-uri-to-buffer: 5.0.1
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -17492,6 +18293,13 @@ snapshots:
 
   debounce@2.2.0: {}
 
+  debug-logfmt@1.4.15(debug@4.4.3):
+    dependencies:
+      '@kikobeats/time-span': 1.0.13
+      debug: 4.4.3
+      null-prototype-object: 1.2.7
+      pretty-ms: 7.0.1
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -17503,6 +18311,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   dedent@0.7.0: {}
 
@@ -17554,6 +18364,8 @@ snapshots:
   delay@5.0.0: {}
 
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0: {}
 
   denque@2.1.0: {}
 
@@ -17709,6 +18521,16 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -17727,6 +18549,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   entities@7.0.1: {}
 
   entities@8.0.0: {}
@@ -17736,6 +18560,8 @@ snapshots:
   envinfo@7.21.0: {}
 
   environment@1.1.0: {}
+
+  err-code@2.0.3: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -18005,9 +18831,9 @@ snapshots:
 
   fbjs-css-vars@1.0.2: {}
 
-  fbjs@3.0.5:
+  fbjs@3.0.5(encoding@0.1.13):
     dependencies:
-      cross-fetch: 3.2.0
+      cross-fetch: 3.2.0(encoding@0.1.13)
       fbjs-css-vars: 1.0.2
       loose-envify: 1.4.0
       object-assign: 4.1.1
@@ -18025,6 +18851,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  file-extension@4.0.5: {}
 
   filelist@1.0.6:
     dependencies:
@@ -18080,6 +18908,10 @@ snapshots:
   follow-redirects@1.16.0(debug@4.3.7):
     optionalDependencies:
       debug: 4.3.7
+
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   for-each@0.3.5:
     dependencies:
@@ -18137,6 +18969,10 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -18157,6 +18993,17 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
 
   gaxios@7.1.4:
     dependencies:
@@ -18445,6 +19292,12 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  has-unicode@2.0.1: {}
+
+  has-values@2.0.1:
+    dependencies:
+      kind-of: 6.0.3
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
@@ -18470,6 +19323,12 @@ snapshots:
       obuf: 1.1.2
       readable-stream: 2.3.8
       wbuf: 1.7.3
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-entities@2.6.0: {}
 
@@ -18529,6 +19388,8 @@ snapshots:
       domutils: 2.8.0
       entities: 2.2.0
 
+  http-cache-semantics@4.2.0: {}
+
   http-deceiver@1.2.7: {}
 
   http-errors@1.8.1:
@@ -18553,6 +19414,14 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -18560,10 +19429,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.10(@types/express@4.17.25):
+  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -18572,10 +19441,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0(debug@4.3.7)
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -18600,11 +19469,19 @@ snapshots:
 
   humanize-duration@3.33.2: {}
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   husky@7.0.4: {}
 
   hyperdyperid@1.2.0: {}
 
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -18623,6 +19500,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
+
+  image-extensions@1.1.0: {}
 
   immediate@3.0.6: {}
 
@@ -18660,12 +19539,16 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  infer-owner@1.0.4: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  install-artifact-from-github@1.8.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -18695,9 +19578,13 @@ snapshots:
 
   ip-address@10.5.0: {}
 
+  ip-regex@4.3.0: {}
+
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.4.0: {}
+
+  is-absolute-url@4.0.1: {}
 
   is-absolute@1.0.0:
     dependencies:
@@ -18784,6 +19671,8 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-lambda@1.0.1: {}
+
   is-lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -18823,6 +19712,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-primitive@3.0.1: {}
 
   is-regex@1.2.1:
@@ -18833,6 +19724,10 @@ snapshots:
       hasown: 2.0.3
 
   is-regexp@1.0.0: {}
+
+  is-relative-url@4.1.0:
+    dependencies:
+      is-absolute-url: 4.0.1
 
   is-relative@1.0.0:
     dependencies:
@@ -18871,6 +19766,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  is-uri@1.2.14:
+    dependencies:
+      parse-uri: 2.0.6
+      punycode2: 1.0.1
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -18894,6 +19794,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iso-639-3@3.0.1: {}
+
   isobject@3.0.1: {}
 
   isomorphic-ws@5.0.0(ws@8.21.3):
@@ -18901,6 +19803,8 @@ snapshots:
       ws: 8.21.3
 
   isomorphic.js@0.2.5: {}
+
+  isostring@0.0.1: {}
 
   isows@1.0.7(ws@8.21.3):
     dependencies:
@@ -19331,6 +20235,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.9(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsep@1.4.0: {}
 
   jsesc@3.1.0: {}
@@ -19375,6 +20305,8 @@ snapshots:
       jsep: 1.4.0
 
   jsonpointer@5.0.1: {}
+
+  jsonrepair@3.15.0: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -19524,6 +20456,14 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkedom@0.18.13:
+    dependencies:
+      css-select: 7.0.0
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
@@ -19669,9 +20609,15 @@ snapshots:
 
   lru-cache@11.5.0: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lru-cache@7.18.3: {}
 
@@ -19683,9 +20629,9 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  mailgun.js@9.4.1:
+  mailgun.js@9.4.1(debug@4.4.3):
     dependencies:
-      axios: 1.19.0
+      axios: 1.19.0(debug@4.4.3)
       base-64: 1.0.0
       url-join: 4.0.1
     transitivePeerDependencies:
@@ -19700,6 +20646,28 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.0
+
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   makeerror@1.0.12:
     dependencies:
@@ -19745,6 +20713,8 @@ snapshots:
       marked: 7.0.4
       react: 18.3.1
 
+  mdn-data@2.27.1: {}
+
   mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
@@ -19766,6 +20736,8 @@ snapshots:
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
+  memoize-one@6.0.0: {}
+
   merge-descriptors@1.0.3: {}
 
   merge-stream@2.0.0: {}
@@ -19776,12 +20748,78 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
 
+  metascraper-description@5.56.2(debug@4.4.3):
+    dependencies:
+      '@metascraper/helpers': 5.56.2(debug@4.4.3)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
+
+  metascraper-image@5.56.2(debug@4.4.3):
+    dependencies:
+      '@metascraper/helpers': 5.56.2(debug@4.4.3)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
+
+  metascraper-logo@5.56.2(debug@4.4.3):
+    dependencies:
+      '@metascraper/helpers': 5.56.2(debug@4.4.3)
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
+
+  metascraper-publisher@5.56.2(debug@4.4.3):
+    dependencies:
+      '@metascraper/helpers': 5.56.2(debug@4.4.3)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
+
+  metascraper-title@5.56.2(debug@4.4.3):
+    dependencies:
+      '@metascraper/helpers': 5.56.2(debug@4.4.3)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
+
+  metascraper@5.56.2(debug@4.4.3):
+    dependencies:
+      '@metascraper/helpers': 5.56.2(debug@4.4.3)
+      cheerio: 1.2.0
+      debug-logfmt: 1.4.15(debug@4.4.3)
+      whoops: 5.1.4
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bluebird
+      - canvas
+      - debug
+      - supports-color
+
   methods@1.1.2: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  microsoft-capitalize@1.0.8: {}
 
   mime-db@1.52.0: {}
 
@@ -19796,6 +20834,8 @@ snapshots:
       mime-db: 1.54.0
 
   mime@1.6.0: {}
+
+  mime@4.1.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -19825,7 +20865,42 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
 
   mkdirp@1.0.4: {}
 
@@ -19908,6 +20983,8 @@ snapshots:
 
   n-gram@2.0.2: {}
 
+  nan@2.28.0: {}
+
   nanoclone@0.2.1: {}
 
   nanoid@3.3.18: {}
@@ -19953,9 +21030,11 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-fetch@3.3.2:
     dependencies:
@@ -19971,6 +21050,22 @@ snapshots:
   node-gyp-build@3.9.0: {}
 
   node-gyp-build@4.8.4: {}
+
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.8.5
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   node-html-markdown-cloudflare@1.3.0:
     dependencies:
@@ -20001,19 +21096,38 @@ snapshots:
 
   nodemailer@9.0.3: {}
 
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+
   normalize-path@2.1.1:
     dependencies:
       remove-trailing-separator: 1.1.0
 
   normalize-path@3.0.0: {}
 
+  normalize-url@9.0.1: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
 
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nth-check@3.0.1:
+    dependencies:
+      boolbase: 2.0.0
+
+  null-prototype-object@1.2.7: {}
 
   nullthrows@1.1.1: {}
 
@@ -20195,7 +21309,24 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-ms@2.1.0: {}
+
   parse-srcset@1.0.2: {}
+
+  parse-uri@2.0.6: {}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -20461,12 +21592,23 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  pretty-ms@7.0.1:
+    dependencies:
+      parse-ms: 2.1.0
+
   process-nextick-args@2.0.1: {}
 
   prom-client@15.1.3:
     dependencies:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
+
+  promise-inflight@1.0.1: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
 
   promise@7.3.1:
     dependencies:
@@ -20597,6 +21739,10 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
+  punycode2@1.0.1: {}
+
+  punycode@2.3.1: {}
+
   pure-rand@6.1.0: {}
 
   pvtsutils@1.3.6:
@@ -20628,6 +21774,15 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
+
+  re2@1.26.1:
+    dependencies:
+      install-artifact-from-github: 1.8.0
+      nan: 2.28.0
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   react-aria@3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -20696,7 +21851,7 @@ snapshots:
   react-relay@21.0.1(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
-      fbjs: 3.0.5
+      fbjs: 3.0.5(encoding@0.1.13)
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 18.3.1
@@ -20881,7 +22036,7 @@ snapshots:
   relay-runtime@21.0.1:
     dependencies:
       '@babel/runtime': 7.29.2
-      fbjs: 3.0.5
+      fbjs: 3.0.5(encoding@0.1.13)
       invariant: 2.2.4
     transitivePeerDependencies:
       - encoding
@@ -20941,6 +22096,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.12.0: {}
+
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
@@ -20952,6 +22109,10 @@ snapshots:
       glob: 7.2.3
 
   rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
+  rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
 
@@ -21072,6 +22233,10 @@ snapshots:
 
   sanitizer@0.1.3: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -21156,6 +22321,8 @@ snapshots:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -21303,6 +22470,8 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
+  smartquotes@2.3.2: {}
+
   smob@1.6.2: {}
 
   snake-case@3.0.4:
@@ -21315,6 +22484,14 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.5
+
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -21375,6 +22552,10 @@ snapshots:
       tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
 
   stack-utils@2.0.6:
     dependencies:
@@ -21531,6 +22712,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  symbol-tree@3.2.4: {}
+
   sync-fetch@0.6.0:
     dependencies:
       node-fetch: 3.3.2
@@ -21544,6 +22727,15 @@ snapshots:
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   tayden-clusterfck@0.7.0: {}
 
@@ -21633,6 +22825,12 @@ snapshots:
 
   tlds@1.261.0: {}
 
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
   tlhunter-sorted-set@0.1.0: {}
 
   tmpl@1.0.5: {}
@@ -21649,7 +22847,15 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
@@ -21772,6 +22978,8 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  uhyphen@0.2.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -21785,6 +22993,10 @@ snapshots:
 
   undici-types@7.25.0: {}
 
+  undici@7.29.0: {}
+
+  undici@8.10.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -21795,6 +23007,14 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
 
   unique-string@2.0.0:
     dependencies:
@@ -21825,6 +23045,13 @@ snapshots:
       tslib: 2.8.1
 
   url-join@4.0.1: {}
+
+  url-regex-safe@4.0.0(re2@1.26.1):
+    dependencies:
+      ip-regex: 4.3.0
+      tlds: 1.261.0
+    optionalDependencies:
+      re2: 1.26.1
 
   url-template@2.0.8: {}
 
@@ -21890,6 +23117,8 @@ snapshots:
 
   vary@1.1.2: {}
 
+  video-extensions@2.0.0: {}
+
   vscode-apollo-relay@1.5.2(relay-compiler@21.0.1)(relay-config@12.0.1):
     dependencies:
       relay-compiler: 21.0.1
@@ -21898,6 +23127,10 @@ snapshots:
   vscode-languageserver-types@3.17.5: {}
 
   w3c-keyname@2.2.8: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walker@1.0.8:
     dependencies:
@@ -21915,6 +23148,8 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-bundle-analyzer@5.3.1:
     dependencies:
@@ -21950,7 +23185,7 @@ snapshots:
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 5.3.1
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
+      webpack-dev-server: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.107.0):
     dependencies:
@@ -21965,7 +23200,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0):
+  webpack-dev-server@5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.107.0):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -21983,7 +23218,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.2
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3)
       ipaddr.js: 2.4.0
       launch-editor: 2.14.1
       open: 10.2.0
@@ -22075,9 +23310,31 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -22128,6 +23385,12 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  whoops@5.1.4: {}
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
 
   wildcard@2.0.1: {}
 
@@ -22307,9 +23570,13 @@ snapshots:
 
   xml-escape@1.1.0: {}
 
+  xml-name-validator@5.0.0: {}
+
   xml-naming@0.1.0: {}
 
   xml@1.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   xpath@0.0.32: {}
 
@@ -22346,6 +23613,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@1.10.3: {}
 

--- a/scripts/webpack/dev.servers.config.js
+++ b/scripts/webpack/dev.servers.config.js
@@ -87,6 +87,11 @@ module.exports = [
         contextRegExp: /pg\/lib/
       }),
       new webpack.IgnorePlugin({
+        // metascraper's url-regex-safe prefers the re2 native binding but falls back to RegExp
+        resourceRegExp: /^re2$/,
+        contextRegExp: /url-regex-safe/
+      }),
+      new webpack.IgnorePlugin({
         resourceRegExp: /^exiftool-vendored$/,
         contextRegExp: /@dicebear/
       }),

--- a/scripts/webpack/prod.servers.config.js
+++ b/scripts/webpack/prod.servers.config.js
@@ -117,6 +117,11 @@ module.exports = (config) => {
         contextRegExp: /pg\/lib/
       }),
       new webpack.IgnorePlugin({
+        // metascraper's url-regex-safe prefers the re2 native binding but falls back to RegExp
+        resourceRegExp: /^re2$/,
+        contextRegExp: /url-regex-safe/
+      }),
+      new webpack.IgnorePlugin({
         resourceRegExp: /^exiftool-vendored$/,
         contextRegExp: /@dicebear/
       }),


### PR DESCRIPTION
PR 1 → PR 2 changes:

- New resolveEmbedUrl query returning EmbedMetadata (authenticated and rate-limited 30/min)
- Server resolver chain: curated providers → oEmbed → Open Graph → hostname fallback
- oEmbed via @extractus/oembed-extractor; Open Graph via metascraper plugins; both fetched through the SSRF guard with byte caps
- extractIframeSrc pulls a single allow-listed iframe src from oEmbed HTML, never injects provider markup
- redisStaleWhileRevalidate cache helper: single-flight lock, jittered TTL, 7-day hit / 5-min fallback TTL, refresh bypass
- Client useResolveEmbedUrl hook. EmbedBlockView resolves non-curated URLs, clears stale metadata on URL change, and auto-resolves pasted or collaborator-inserted URLs lacking fetchedAt
- Claude's suite of tests, ofc

# Demo

Loom: https://www.loom.com/share/88ced169c3504f2c985d86205d329b83