### PR TITLE
fix: hide Next button for participants if next stage isn't navigable

### DIFF
--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -80,6 +80,7 @@ const MeetingControlBar = (props: Props) => {
           phaseType
           stages {
             id
+            isNavigable
           }
         }
       }
@@ -107,13 +108,16 @@ const MeetingControlBar = (props: Props) => {
   const {id: localStageId, isComplete} = localStage
   const isCheckIn = phaseType === 'checkin'
   const isPoker = meetingType === 'poker'
+  const nextStage = findStageAfterId(phases, localStageId)?.stage
+  // poker participants advance themselves, but only through stages the facilitator has unlocked
+  const canGotoNext = !!nextStage && (isFacilitating || (isPoker && nextStage.isNavigable))
   const getPossibleButtons = () => {
     const buttons = ['music']
     if (isFacilitating && !isComplete && showTimerInPhase(phaseType)) buttons.push('timer')
     if (isDesktop) buttons.push('tips')
     if (!isFacilitating && !isCheckIn && !isComplete && !isPoker) buttons.push('ready')
     if (!isFacilitating && localStageId !== facilitatorStageId) buttons.push('rejoin')
-    if ((isFacilitating || isPoker) && findStageAfterId(phases, localStageId)) buttons.push('next')
+    if (canGotoNext) buttons.push('next')
     if (isFacilitating) buttons.push('end')
     return buttons.map((key) => ({key}))
   }

--- a/packages/client/utils/meetings/findStageAfterId.ts
+++ b/packages/client/utils/meetings/findStageAfterId.ts
@@ -1,4 +1,4 @@
-import type {FindStageByIdPhase} from './findStageById'
+import type {FindStageByIdPhase, FindStageByIdStage} from './findStageById'
 
 const findStageAfterId = <T extends FindStageByIdPhase>(
   phases: readonly T[] | null | undefined,
@@ -10,7 +10,7 @@ const findStageAfterId = <T extends FindStageByIdPhase>(
     const phase = phases[ii]!
     const {stages} = phase
     for (let jj = 0; jj < stages.length; jj++) {
-      const stage = stages[jj]!
+      const stage = stages[jj] as T['stages'][number] & FindStageByIdStage
       if (stageFound) {
         return {phase, stage}
       }


### PR DESCRIPTION
# Description

false positive on the jira suspended account, it was actually because i wasn't facilitator, but the facilitator bar still showed the "Next" button!

