### PR TITLE
fix(theme): adjust theme contrast and adds --shadow-bar-up

### DIFF
--- a/packages/client/components/MeetingCard.tsx
+++ b/packages/client/components/MeetingCard.tsx
@@ -229,7 +229,7 @@ const MeetingCard = (props: Props) => {
                     </span>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <div className='cursor-pointer text-sm'>{dateLabel}</div>
+                        <div className='cursor-pointer text-fg-secondary text-sm'>{dateLabel}</div>
                       </TooltipTrigger>
                       <TooltipContent side='bottom'>{readableNextMeetingDate}</TooltipContent>
                     </Tooltip>
@@ -269,7 +269,7 @@ const MeetingCard = (props: Props) => {
               </Tooltip>
             </div>
             <Link to={meetingLink}>
-              <span className='wrap-break-word block pt-1 pb-2 text-fg-secondary text-sm'>
+              <span className='wrap-break-word block pt-1 pb-2 text-fg-muted text-sm'>
                 {teamName} • {meetingPhaseLabel}
               </span>
             </Link>

--- a/packages/client/components/MeetingControlBar.tsx
+++ b/packages/client/components/MeetingControlBar.tsx
@@ -186,10 +186,7 @@ const MeetingControlBar = (props: Props) => {
       ref={ref}
       className={cn(
         'fixed bottom-0 single-reflection-column:bottom-2 flex h-14 min-h-14 single-reflection-column:w-auto w-full flex-nowrap items-center justify-between single-reflection-column:rounded bg-surface-card p-2 text-fg-primary text-sm',
-        isDesktop
-          ? 'shadow-[var(--shadow-bar)]'
-          : // bottomBarShadow (Elevation.Z8)
-            'shadow-[0px_5px_5px_-3px_rgba(0,0,0,.2),0px_8px_10px_1px_rgba(0,0,0,.14),0px_3px_14px_2px_rgba(0,0,0,.12)]'
+        isDesktop ? 'shadow-[var(--shadow-bar)]' : 'shadow-[var(--shadow-bar-up)]'
       )}
       style={{
         left: controlBarLeft,

--- a/packages/client/components/MeetingSeriesGroupCard.tsx
+++ b/packages/client/components/MeetingSeriesGroupCard.tsx
@@ -168,7 +168,7 @@ const MeetingSeriesGroupCard = (props: Props) => {
                 <span className='wrap-break-word block pt-1 pr-8 text-fg-primary text-xl leading-6'>
                   {title}
                 </span>
-                <div className='text-fg-primary text-sm'>{label}</div>
+                <div className='text-fg-secondary text-sm'>{label}</div>
               </div>
               <Menu
                 trigger={
@@ -203,7 +203,7 @@ const MeetingSeriesGroupCard = (props: Props) => {
                 </MenuContent>
               </Menu>
             </div>
-            <span className='wrap-break-word block pt-1 pb-2 text-fg-secondary text-sm'>
+            <span className='wrap-break-word block pt-1 pb-2 text-fg-muted text-sm'>
               {`Meeting series group • ${recurrenceLabel}`}
             </span>
             <div className='flex pl-1.5'>

--- a/packages/client/components/ScheduledSeriesCard.tsx
+++ b/packages/client/components/ScheduledSeriesCard.tsx
@@ -158,7 +158,7 @@ const ScheduledSeriesCard = (props: Props) => {
                 </span>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <div className='text-sm'>{label}</div>
+                    <div className='text-fg-secondary text-sm'>{label}</div>
                   </TooltipTrigger>
                   {tooltip && <TooltipContent>{tooltip}</TooltipContent>}
                 </Tooltip>
@@ -185,7 +185,7 @@ const ScheduledSeriesCard = (props: Props) => {
               </Menu>
             </div>
             <Link to={seriesLink} onClick={openEdit}>
-              <span className='block pt-1 pb-2 text-fg-secondary text-sm'>
+              <span className='block pt-1 pb-2 text-fg-muted text-sm'>
                 {MeetingTypeToReadable[meetingType]} • Awaiting first meeting
               </span>
             </Link>

--- a/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
+++ b/packages/client/components/TeamPrompt/TeamPromptResponseCard.tsx
@@ -200,7 +200,7 @@ const TeamPromptResponseCard = (props: Props) => {
         className={cn(
           'flex flex-1 flex-col justify-between rounded-card p-4',
           isEmptyResponse
-            ? 'bg-surface-well text-fg-muted'
+            ? 'bg-surface-well text-fg-secondary'
             : 'bg-surface-card shadow-[var(--shadow-card)]',
           meeting?.rightDrawerOpen != null && meeting?.localStageId === responseStage.id
             ? 'outline-2 outline-sky-300'

--- a/packages/client/modules/userDashboard/components/OrgBilling/DowngradeModal.tsx
+++ b/packages/client/modules/userDashboard/components/OrgBilling/DowngradeModal.tsx
@@ -103,7 +103,7 @@ const DowngradeModal = (props: Props) => {
                     placeholder='Please enter the name of the tool'
                     rows={2}
                     value={otherTool ?? ''}
-                    className='mt-4 rounded border border-hairline-field bg-surface-well px-4 py-3 text-fg-primary outline-none [font:inherit] placeholder:text-fg-muted'
+                    className='mt-4 rounded border border-hairline-field bg-surface-well px-4 py-3 text-fg-primary outline-none [font:inherit] placeholder:text-fg-secondary'
                   />
                   <div
                     className={cn(

--- a/packages/client/styles/theme/__tests__/themeContrast.test.ts
+++ b/packages/client/styles/theme/__tests__/themeContrast.test.ts
@@ -1,0 +1,288 @@
+const {readFileSync} = jest.requireActual<{
+  readFileSync: (path: string, encoding: 'utf8') => string
+}>('fs')
+const {dirname, join} = jest.requireActual<{
+  dirname: (path: string) => string
+  join: (...parts: string[]) => string
+}>('path')
+
+const css = readFileSync(join(dirname(expect.getState().testPath!), '..', 'global.css'), 'utf8')
+
+const blockAfter = (marker: string) => {
+  const start = css.indexOf(marker)
+  if (start === -1) throw new Error(`missing block: ${marker}`)
+  const open = css.indexOf('{', start)
+  let depth = 0
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}') {
+      depth--
+      if (depth === 0) return css.slice(open + 1, i)
+    }
+  }
+  throw new Error(`unterminated block: ${marker}`)
+}
+
+const declarationsIn = (block: string) => {
+  const out: Record<string, string> = {}
+  const uncommented = block.replace(/\/\*[\s\S]*?\*\//g, '')
+  for (const match of uncommented.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    out[match[1]!] = match[2]!.trim()
+  }
+  return out
+}
+
+const themeLayer = declarationsIn(blockAfter('@theme static'))
+const darkLayer = declarationsIn(blockAfter('\n.theme-dark {'))
+const islandLayer = declarationsIn(blockAfter('\n.light-island {'))
+
+const resolve = (name: string, layers: Record<string, string>[]): string => {
+  for (const layer of layers) {
+    const raw = layer[name]
+    if (raw === undefined) continue
+    const reference = raw.match(/^var\((--[\w-]+)\)$/)
+    return reference ? resolve(reference[1]!, layers) : raw
+  }
+  throw new Error(`unresolved token: ${name}`)
+}
+
+const channel = (value: number) =>
+  value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+
+const luminance = (hex: string) => {
+  const digits = hex.trim().replace('#', '')
+  const full =
+    digits.length === 3
+      ? digits
+          .split('')
+          .map((character) => character + character)
+          .join('')
+      : digits
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) throw new Error(`not a hex colour: ${hex}`)
+  const [red, green, blue] = [0, 2, 4].map(
+    (offset) => Number.parseInt(full.slice(offset, offset + 2), 16) / 255
+  ) as [number, number, number]
+  return 0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
+}
+
+const contrast = (a: string, b: string) => {
+  const [lighter, darker] = [luminance(a), luminance(b)].sort(
+    (first, second) => second - first
+  ) as [number, number]
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+const AA_TEXT = 4.5
+const UI_FLOOR = 3
+
+const READING_SURFACES = [
+  '--color-surface-card',
+  '--color-surface-app',
+  '--color-surface-raised',
+  '--color-surface-input',
+  '--color-surface-sidebar'
+]
+const WELL_SURFACES = ['--color-surface-well']
+const NAV_SURFACES = ['--color-surface-app', '--color-surface-sidebar']
+const NAV_WELL_SURFACES = ['--color-surface-nav-active']
+
+const ratioOn = (fg: string, surface: string, layers: Record<string, string>[]) =>
+  contrast(resolve(fg, layers), resolve(surface, layers))
+
+const ratioBetween = (tokenA: string, tokenB: string, layers: Record<string, string>[]) =>
+  contrast(resolve(tokenA, layers), resolve(tokenB, layers))
+
+describe('light theme contrast', () => {
+  const layers = [themeLayer]
+
+  it.each(READING_SURFACES)('fg-primary clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-primary', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each([...READING_SURFACES, ...WELL_SURFACES])('fg-secondary clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-secondary', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each(READING_SURFACES)('fg-muted clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-muted', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each(WELL_SURFACES)('fg-muted clears the UI floor on %s', (surface) => {
+    expect(ratioOn('--color-fg-muted', surface, layers)).toBeGreaterThanOrEqual(UI_FLOOR)
+  })
+
+  it.each(NAV_SURFACES)('fg-nav-muted clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-nav-muted', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each(NAV_WELL_SURFACES)('fg-nav-muted clears the UI floor on %s', (surface) => {
+    expect(ratioOn('--color-fg-nav-muted', surface, layers)).toBeGreaterThanOrEqual(UI_FLOOR)
+  })
+
+  it('keeps primary darker than secondary darker than muted', () => {
+    const onCard = (fg: string) => ratioOn(fg, '--color-surface-card', layers)
+    expect(onCard('--color-fg-primary')).toBeGreaterThan(onCard('--color-fg-secondary'))
+    expect(onCard('--color-fg-secondary')).toBeGreaterThan(onCard('--color-fg-muted'))
+  })
+
+  it.each(NAV_SURFACES)('fg-nav clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-nav', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each(NAV_WELL_SURFACES)('fg-nav clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-nav', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it('keeps fg-nav equal to fg-primary', () => {
+    expect(resolve('--color-fg-nav', layers)).toBe(resolve('--color-fg-primary', layers))
+  })
+
+  it('separates primary from secondary by at least 1.8x', () => {
+    expect(
+      ratioBetween('--color-fg-primary', '--color-fg-secondary', layers)
+    ).toBeGreaterThanOrEqual(1.8)
+  })
+
+  it('separates secondary from muted by at least 1.3x', () => {
+    expect(ratioBetween('--color-fg-secondary', '--color-fg-muted', layers)).toBeGreaterThanOrEqual(
+      1.3
+    )
+  })
+})
+
+describe('dark theme contrast', () => {
+  const layers = [darkLayer, themeLayer]
+  const NAV_MUTED_RATCHET: Record<string, number> = {
+    '--color-surface-app': 6.8,
+    '--color-surface-sidebar': 7.1,
+    '--color-surface-nav-active': 4.7
+  }
+
+  it.each([...READING_SURFACES, ...WELL_SURFACES])('fg-primary clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-primary', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each([...READING_SURFACES, ...WELL_SURFACES])('fg-secondary clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-secondary', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each(READING_SURFACES)('fg-muted clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-muted', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it.each(WELL_SURFACES)('fg-muted clears AA on %s', (surface) => {
+    expect(ratioOn('--color-fg-muted', surface, layers)).toBeGreaterThanOrEqual(AA_TEXT)
+  })
+
+  it('keeps primary lighter than secondary lighter than muted', () => {
+    const onCard = (fg: string) => ratioOn(fg, '--color-surface-card', layers)
+    expect(onCard('--color-fg-primary')).toBeGreaterThan(onCard('--color-fg-secondary'))
+    expect(onCard('--color-fg-secondary')).toBeGreaterThan(onCard('--color-fg-muted'))
+  })
+
+  it.each([...NAV_SURFACES, ...NAV_WELL_SURFACES])(
+    'fg-nav-muted holds its floor on %s',
+    (surface) => {
+      const floor = NAV_MUTED_RATCHET[surface] ?? AA_TEXT
+      expect(ratioOn('--color-fg-nav-muted', surface, layers)).toBeGreaterThanOrEqual(floor)
+    }
+  )
+
+  it('ratchets the dark primary/secondary step', () => {
+    expect(
+      ratioBetween('--color-fg-primary', '--color-fg-secondary', layers)
+    ).toBeGreaterThanOrEqual(1.35)
+  })
+
+  it('ratchets the dark secondary/muted step', () => {
+    expect(ratioBetween('--color-fg-secondary', '--color-fg-muted', layers)).toBeGreaterThanOrEqual(
+      1.3
+    )
+  })
+})
+
+describe('light-island parity', () => {
+  const shared = Object.keys(islandLayer).filter((token) => token in themeLayer)
+  const themedByDark = Object.keys(darkLayer).filter((token) =>
+    /^--color-(?:fg|surface)-/.test(token)
+  )
+
+  it.each(shared)('%s matches the @theme light value', (token) => {
+    expect(resolve(token, [islandLayer, themeLayer])).toBe(resolve(token, [themeLayer]))
+  })
+
+  it.each(themedByDark)('%s is re-declared by .light-island', (token) => {
+    expect(islandLayer[token]).toBeDefined()
+  })
+})
+
+const shadowLayers = (value: string) => {
+  const layers: string[] = []
+  let depth = 0
+  let current = ''
+  for (const character of value) {
+    if (character === '(') depth++
+    else if (character === ')') depth--
+    if (character === ',' && depth === 0) {
+      layers.push(current)
+      current = ''
+    } else {
+      current += character
+    }
+  }
+  layers.push(current)
+  return layers.map((layer) => layer.trim()).filter(Boolean)
+}
+
+const withoutFunctions = (value: string) => {
+  let out = ''
+  let depth = 0
+  for (const character of value) {
+    if (character === '(') {
+      if (depth === 0) out = out.replace(/[\w-]+$/, '')
+      depth++
+    } else if (character === ')') {
+      depth = Math.max(0, depth - 1)
+    } else if (depth === 0) {
+      out += character
+    }
+  }
+  return out
+}
+
+const verticalOffsets = (value: string) =>
+  shadowLayers(value).map((layer) => {
+    const terms = withoutFunctions(layer)
+      .replace(/#[0-9a-fA-F]{3,8}/g, '')
+      .replace(/\binset\b/g, '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+    const offset = terms[1]
+    if (terms.length < 3 || offset === undefined) {
+      throw new Error(`no y-offset in shadow layer: ${layer}`)
+    }
+    return Number.parseFloat(offset)
+  })
+
+describe('bottom-bar shadow direction', () => {
+  it.each([
+    ['light', themeLayer],
+    ['dark', darkLayer]
+  ])('%s shadow-bar points down for the floating pill', (_theme, layer) => {
+    const offsets = verticalOffsets(layer['--shadow-bar']!)
+    expect(offsets.some((offset) => offset > 0)).toBe(true)
+    expect(offsets.some((offset) => offset < 0)).toBe(false)
+  })
+
+  it.each([
+    ['light', themeLayer],
+    ['dark', darkLayer]
+  ])('%s shadow-bar-up points up for the flush bar', (_theme, layer) => {
+    const value = layer['--shadow-bar-up']
+    expect(value).toBeDefined()
+    const offsets = verticalOffsets(value!)
+    expect(offsets.some((offset) => offset < 0)).toBe(true)
+    expect(offsets.some((offset) => offset > 0)).toBe(false)
+  })
+})

--- a/packages/client/styles/theme/global.css
+++ b/packages/client/styles/theme/global.css
@@ -185,12 +185,12 @@
   --color-surface-cta: var(--color-grape-700);
   --color-surface-cta-hover: var(--color-grape-600);
   --color-fg-selected: var(--color-white);
-  --color-fg-primary: #444258;
-  --color-fg-secondary: #82809a;
-  --color-fg-muted: #a7a3c2;
+  --color-fg-primary: #2d2d39;
+  --color-fg-secondary: #57556c;
+  --color-fg-muted: #6c6a83;
   --color-fg-topbar: #f1f0fa;
-  --color-fg-nav: #444258;
-  --color-fg-nav-muted: #82809a;
+  --color-fg-nav: #2d2d39;
+  --color-fg-nav-muted: #6c6a83;
   --color-hairline: #e0ddec;
   --color-hairline-strong: #c3c0d8;
   --color-hairline-field: #c3c0d8;
@@ -226,6 +226,8 @@
   --shadow-discussion-thread: rgba(0, 0, 0, 0.2) 0px 3px 1px -2px,
     rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px;
   --shadow-bar: 0 4px 8px rgba(0, 0, 0, 0.14), 0 0 2px rgba(0, 0, 0, 0.12);
+  --shadow-bar-up: 0 -5px 5px -3px rgba(0, 0, 0, 0.2), 0 -8px 10px 1px rgba(0, 0, 0, 0.14),
+    0 -3px 14px 2px rgba(0, 0, 0, 0.12);
   --shadow-status-ring: 0 0 0 0 transparent;
   --shadow-snackbar: rgba(0, 0, 0, 0.2) 0px 3px 5px -1px, rgba(0, 0, 0, 0.14) 0px 6px 10px 0px,
     rgba(0, 0, 0, 0.12) 0px 1px 18px 0px;
@@ -391,7 +393,7 @@
   --color-fg-selected: var(--color-white);
   --color-fg-primary: #eeedf7;
   --color-fg-secondary: #cac7f2;
-  --color-fg-muted: #938cbf;
+  --color-fg-muted: #aeaad8;
   --color-fg-topbar: #eeedf7;
   --color-fg-nav: #d4d2ef;
   /* lifted from #9b94c2 (exactly 4.50:1 on surface-nav-active — zero AA margin)
@@ -421,6 +423,7 @@
   --shadow-card-raised: inset 0 0 0 1px var(--color-hairline-strong),
     inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 16px 32px -10px rgba(0, 0, 0, 0.7);
   --shadow-bar: 0 4px 12px rgba(0, 0, 0, 0.55);
+  --shadow-bar-up: 0 -4px 12px rgba(0, 0, 0, 0.55);
   --shadow-status-ring: 0 0 0 1px rgba(238, 237, 247, 0.28);
 }
 
@@ -452,12 +455,12 @@
   --color-surface-cta: var(--color-grape-700);
   --color-surface-cta-hover: var(--color-grape-600);
   --color-fg-selected: var(--color-white);
-  --color-fg-primary: #444258;
-  --color-fg-secondary: #82809a;
-  --color-fg-muted: #a7a3c2;
+  --color-fg-primary: #2d2d39;
+  --color-fg-secondary: #57556c;
+  --color-fg-muted: #6c6a83;
   --color-fg-topbar: #f1f0fa;
-  --color-fg-nav: #444258;
-  --color-fg-nav-muted: #82809a;
+  --color-fg-nav: #2d2d39;
+  --color-fg-nav-muted: #6c6a83;
   --color-hairline: #e0ddec;
   --color-hairline-strong: #c3c0d8;
   --color-hairline-field: #c3c0d8;


### PR DESCRIPTION
# Description

Very subtle changes fable 5.1 recommended after performing implementation work for structured standups.

- flush bottom bars styled with new `--shawdow-bar-up`
  - avoids `bottom-0 `bars reading like a hairline, which they do when they have a downward shadow

- darken light `fg-primary` and `fg-nav` to `slate-800`
- changes some text from `muted` to `secondary`
- adjusts AA and contrast ramp across theme to improve contrast

Low risk, will merge directly.

## Demo

<img width="1392" height="1480" alt="card-text-ramp-light-and-dark" src="https://github.com/user-attachments/assets/695d5dca-c8f6-4c6e-9a32-279fe62fb87b" />